### PR TITLE
cmd/kraft: Add ability to check for an update

### DIFF
--- a/cmd/kraft/kraft.go
+++ b/cmd/kraft/kraft.go
@@ -32,8 +32,17 @@
 package main
 
 import (
+	"fmt"
+	"io/ioutil"
 	"os"
+	"time"
+	"strings"
+	"encoding/json"
+	"net/http"
 
+	"kraftkit.sh/config"
+
+	"github.com/spf13/cobra"
 	"github.com/MakeNowJust/heredoc"
 
 	"kraftkit.sh/internal/cmdfactory"
@@ -46,10 +55,39 @@ import (
 	"kraftkit.sh/cmd/kraft/rm"
 	"kraftkit.sh/cmd/kraft/run"
 	"kraftkit.sh/cmd/kraft/stop"
+	"kraftkit.sh/iostreams"
+	"kraftkit.sh/log"
+	"kraftkit.sh/packmanager"
 
 	// Additional initializers
 	_ "kraftkit.sh/manifest"
+	"kraftkit.sh/internal/version"
 )
+
+// The releases structure contains the relevant fields
+// from a github API release query response
+type releases []struct {
+	HtmlUrl string `json:"html_url"`
+	Id int `json:"id"`
+	IsPreRelease bool `json:"prerelease"`
+	Assets Assets `json:"assets"`
+	Name string `json:"name"`
+}
+
+type Assets []struct {
+	Name string `json:"name"`
+	Url string `json:"browser_download_url"`
+}
+
+type kraftOptions struct {
+	PackageManager func(opts ...packmanager.PackageManagerOption) (packmanager.PackageManager, error)
+	ConfigManager  func() (*config.ConfigManager, error)
+	Logger         func() (log.Logger, error)
+	IO             *iostreams.IOStreams
+
+	// Command line arguments
+	checkPreRelease		bool
+}
 
 func main() {
 	f := cmdfactory.New(
@@ -70,6 +108,13 @@ func main() {
 		panic("could not initialize root commmand")
 	}
 
+	opts := &kraftOptions{
+		PackageManager: f.PackageManager,
+		ConfigManager:  f.ConfigManager,
+		Logger:         f.Logger,
+		IO:             f.IOStreams,
+	}
+
 	cmd.Short = "Build and use highly customized and ultra-lightweight unikernels"
 	cmd.Long = heredoc.Docf(`
 
@@ -81,6 +126,146 @@ func main() {
    (_:| |:_)  Issues & support: https://github.com/unikraft/kraftkit/issues
       v v 
       ' '`)
+	cmd.RunE = func(cmd *cobra.Command, args []string) error {
+		return kraftRun(opts, f)
+	}
+
+	cmd.Flags().BoolVar(
+		&opts.checkPreRelease,
+		"check-prerelease",
+		false,
+		"Check for an available prerelease",
+	)
 
 	os.Exit(int(cmdutil.Execute(f, cmd)))
+}
+
+func kraftRun(opts *kraftOptions, cmdFactory *cmdfactory.Factory) error {
+	var err error
+
+	klog, err := opts.Logger()
+	if err != nil {
+		return err
+	}
+
+
+	// Check for a new prerelease
+	if opts.checkPreRelease {
+		updateAvail, err := checkForUpdate(cmdFactory, true)
+
+		if err != nil {
+			fmt.Errorf("Could not check for new prereleases: %s\n", err)
+		} else if updateAvail {
+			klog.Info("New version available!")
+		}
+	} else {
+
+		// If the check for prerelease option is not given, check for an update
+		updateAvail, err := checkForUpdate(cmdFactory, false)
+
+		if err != nil {
+			fmt.Errorf("Could not check for new releases: %s\n", err)
+		} else if updateAvail {
+			klog.Warn("New version available!")
+		}
+	}
+
+	return nil
+}
+
+// Check for an update, return true is an update is available
+// If the checkPrerelease param is true, check for a prerelease,
+// else check for a release
+func checkForUpdate(cmdFactory *cmdfactory.Factory, checkPrerelease bool) (bool, error) {
+	cfgm, err := cmdFactory.ConfigManager()
+	if err != nil {
+		return false, err
+	}
+
+	var token string
+	token = cfgm.Config.Auth["github"].Token
+
+	resp, err := makeReleasesReq(token)
+	if err != nil {
+		return false, err
+	}
+
+	var rel_arr releases
+	err = json.Unmarshal([]byte(resp), &rel_arr)
+	if err != nil {
+		return false, err
+	}
+
+	var index int
+	if checkPrerelease {
+		index = getLatestPreRelease(rel_arr)
+	} else {
+		index = getLatestRelease(rel_arr)
+	}
+
+	if index == -1 {
+		return false, nil
+	}
+
+	if !strings.Contains(version.Version(), rel_arr[index].Name) {
+		return true, nil
+	}
+	return false, nil
+}
+
+// Make a request to the github API to get an array of
+// all available releases for the kraftkit repo
+func makeReleasesReq(token string) (string, error) {
+	timeout := time.Duration(5 + time.Second)
+	client := http.Client {
+		Timeout: timeout,
+	}
+
+	req, err := http.NewRequest("GET",
+		"https://api.github.com/repos/unikraft/kraftkit/releases",
+		nil)
+
+	if err != nil {
+		return "", err
+	}
+
+	req.Header.Set("Accept", "application/vnd.github+json")
+
+	if token != "" {
+		req.Header.Set("Authorization", "token " + token)
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", err
+	}
+
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
+
+	return string(body), nil
+}
+
+// Get index of the first release in array
+func getLatestRelease(releaseArray releases) int {
+	for i := range releaseArray {
+		if !releaseArray[i].IsPreRelease {
+			return i
+		}
+	}
+
+	return -1
+}
+
+// Get index of the first prerelease in array
+func getLatestPreRelease(releaseArray releases) int {
+	for i := range releaseArray {
+		if releaseArray[i].IsPreRelease {
+			return i
+		}
+	}
+
+	return -1
 }

--- a/config/feeder_env.go
+++ b/config/feeder_env.go
@@ -1,0 +1,89 @@
+package config
+
+import (
+	"os"
+	"reflect"
+	"strconv"
+	"strings"
+
+	"github.com/halorium/env"
+
+	"kraftkit.sh/utils"
+)
+
+type EnvFeeder struct{}
+
+func (f EnvFeeder) Feed(structure interface{}) error {
+	err := env.Unmarshal(*structure.(**Config))
+
+	var obj AuthConfig
+	rv := reflect.ValueOf(obj)
+
+	cfg := *structure.(**Config)
+	cfg.Auth = make(map[string]AuthConfig)
+	for i := 0; i < rv.NumField(); i++ {
+
+		rsf := rv.Type().Field(i)
+		tag := rsf.Tag.Get("env")
+
+		if !strings.Contains(tag, "%s") {
+			continue
+		}
+
+		prefix := strings.Split(tag, "%s")[0]
+		suffix := strings.Split(tag, "%s")[1]
+
+		envVars := utils.Filter(os.Environ(), func(s string) bool {
+			return strings.HasPrefix(s, prefix) &&
+				strings.HasSuffix(strings.Split(s, "=")[0], suffix)
+		})
+
+		for _, s := range envVars {
+			index := utils.GetStringInBetween(s, prefix, suffix)
+			index = strings.ToLower(index)
+
+			entry, exists := cfg.Auth[index]
+			if !exists {
+				entry = *new(AuthConfig)
+			}
+
+			authRv := reflect.ValueOf(&entry).Elem()
+			for j := 0; j < authRv.NumField(); j++ {
+				authRsf := authRv.Type().Field(j)
+				authRf := authRv.Field(j)
+				authTag := authRsf.Tag.Get("env")
+
+				stringValue := strings.Split(s, "=")[1]
+
+				if strings.HasSuffix(strings.Split(s, "=")[0],
+					strings.Split(authTag, "%s")[1]) {
+
+					switch authRf.Type().Kind() {
+					case reflect.String:
+						authRf.SetString(stringValue)
+					case reflect.Bool:
+						val, err := strconv.ParseBool(stringValue)
+						if err != nil {
+							return err
+						}
+						authRf.SetBool(val)
+					case reflect.Int:
+						val, err := strconv.ParseInt(stringValue, 0, 32)
+						if err != nil {
+							return err
+						}
+						authRf.SetInt(val)
+					}
+				}
+			}
+			cfg.Auth[index] = entry
+
+		}
+	}
+
+	return err
+}
+
+func (f EnvFeeder) Write(structure interface{}, merge bool) error {
+	return nil
+}

--- a/config/manager.go
+++ b/config/manager.go
@@ -57,6 +57,14 @@ func WithFeeder(feeder Feeder) ConfigManagerOption {
 	}
 }
 
+func WithEnv() ConfigManagerOption {
+	return func(cm *ConfigManager) error {
+		envf := EnvFeeder{}
+		err := WithFeeder(envf)(cm)
+		return err
+	}
+}
+
 func WithFile(file string, forceCreate bool) ConfigManagerOption {
 	return func(cm *ConfigManager) error {
 		ext := strings.Split(file, ".")

--- a/internal/cmdfactory/cmdfactory.go
+++ b/internal/cmdfactory/cmdfactory.go
@@ -117,6 +117,7 @@ func configManagerFunc() func() (*config.ConfigManager, error) {
 
 		cfgm, cfge = config.NewConfigManager(
 			config.WithDefaultConfigFile(),
+			config.WithEnv(),
 		)
 
 		return cfgm, cfge

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -156,3 +156,26 @@ func HumanizeDuration(dur time.Duration) string {
 
 	return fmt.Sprintf("%d.%ds", sec, ms)
 }
+
+func Filter(data []string, f func(string) bool) []string {
+	fltd := make([]string, 0)
+	for _, e := range data {
+		if f(e) {
+			fltd = append(fltd, e)
+		}
+	}
+	return fltd
+}
+
+func GetStringInBetween(str string, start string, end string) (result string) {
+	s := strings.Index(str, start)
+	if s == -1 {
+		return
+	}
+	s += len(start)
+	e := strings.Index(str[s:], end)
+	if e == -1 {
+		return
+	}
+	return str[s : s+e]
+}


### PR DESCRIPTION
Add an automatic check for available updates on every kraftkit run.
Add option to check for new prereleases.

Solves: #1 

Signed-off-by: Stefan Jumarea <stefanjumarea02@gmail.com>

If `kraft` is run without the `--check-prerelease` option, it automatically checks for a new release.
If the `--check-prerelease` option is set, it looks for a new prerelease. This is disabled by default.