### PR TITLE
.github/workflows: Add dependency on coding style for releases

### DIFF
--- a/.github/workflows/release-staging.yaml
+++ b/.github/workflows/release-staging.yaml
@@ -10,8 +10,12 @@ permissions:
   packages: write
 
 jobs:
+  gochecks:
+    uses: ./.github/workflows/gochecks.yaml
+
   goreleaser:
     runs-on: ubuntu-latest
+    needs: gochecks
     container: goreleaser/goreleaser-cross:v1.18.3
     steps:
       - name: Checkout


### PR DESCRIPTION
Please actually test this before merging.

The support for this is a bit sketchy, as there is no formal way to retrieve the status from previous jobs.
Also, if a job depends on multiple previous steps, it can't retrieve their status.

There are workarounds, but they aren't needed at the moment.

https://stackoverflow.com/questions/63148639/create-dependencies-between-jobs-in-github-actions

Closes: #33 