### PR TITLE
everywhere: The PR to end all PRs

### DIFF
--- a/cmd/kraft/kraft.go
+++ b/cmd/kraft/kraft.go
@@ -41,6 +41,7 @@ import (
 
 	"kraftkit.sh/cmd/kraft/build"
 	"kraftkit.sh/cmd/kraft/pkg"
+	"kraftkit.sh/cmd/kraft/tidy"
 )
 
 func main() {
@@ -51,6 +52,7 @@ func main() {
 		cmdutil.WithSubcmds(
 			pkg.PkgCmd(f),
 			build.BuildCmd(f),
+			tidy.TidyCmd(f),
 		),
 	)
 	if err != nil {

--- a/cmd/kraft/tidy/tidy.go
+++ b/cmd/kraft/tidy/tidy.go
@@ -1,0 +1,151 @@
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// Authors: Cezar Craciunoiu <cezar.craciunoiu@unikraft.io>
+//
+// Copyright (c) 2022, Unikraft GmbH.  All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+// 3. Neither the name of the copyright holder nor the names of its
+//    contributors may be used to endorse or promote products derived from
+//    this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+package tidy
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/MakeNowJust/heredoc"
+	"github.com/spf13/cobra"
+	"kraftkit.sh/config"
+	"kraftkit.sh/internal/cmdfactory"
+	"kraftkit.sh/internal/cmdutil"
+	"kraftkit.sh/schema"
+)
+
+type tidyOptions struct {
+	ConfigManager func() (*config.ConfigManager, error)
+
+	TidyConfig bool
+}
+
+func TidyCmd(f *cmdfactory.Factory) *cobra.Command {
+	cmd, err := cmdutil.NewCmd(f, "tidy")
+	if err != nil {
+		panic("could not initialize 'tidy' commmand")
+	}
+
+	opts := &tidyOptions{
+		ConfigManager: f.ConfigManager,
+	}
+
+	cmd.Short = "Clean up kraftkit and unikraft configuration files"
+	cmd.Use = "tidy [FLAGS] [DIR]"
+	cmd.Args = cmdutil.MaxDirArgs(1)
+	cmd.Long = heredoc.Docf(`
+		Clean up kraftkit and unikraft configuration files.
+
+		The default behaviour of %[1]skraft tidy%[1]s is to tidy a kraftfile. Given no
+		arguments, it will clean up in the current directory. %[1]skraft tidy%[1]s can
+		also be used to tidy kraftkit configuration files.
+	`, "`")
+	cmd.Example = heredoc.Doc(`
+		# Clean the current unikraft project kraftfile (cwd)
+		$ kraft tidy
+
+		# Clean a unikraft project kraftfile at a given path
+		$ kraft tidy path/to/app
+
+		# Clean the kraftkit configuration files (default path)
+		$ kraft tidy --config
+
+		# Clean the kraftkit configuration files at a given path
+		$ kraft tidy --config path/to/config
+	`)
+	cmd.RunE = func(cmd *cobra.Command, args []string) error {
+		var err error
+		var workdir string
+		if len(args) == 0 {
+			workdir, err = os.Getwd()
+			if err != nil {
+				return err
+			}
+		} else {
+			workdir = args[0]
+		}
+
+		return tidyRun(opts, workdir)
+	}
+
+	cmd.Flags().BoolVar(
+		&opts.TidyConfig,
+		"config",
+		false,
+		"Clean the kraftkit configuration files instead",
+	)
+
+	return cmd
+}
+
+func tidyRun(opts *tidyOptions, workdir string) error {
+	var err error
+
+	cfgm, err := opts.ConfigManager()
+	if err != nil {
+		return err
+	}
+
+	// TODO: tidy kraftkit configuration files
+	if opts.TidyConfig {
+		return fmt.Errorf("not implemented yet")
+	}
+
+	// Initialize at least the configuration options for a project
+	projectOpts, err := schema.NewProjectOptions(
+		nil,
+		schema.WithWorkingDirectory(workdir),
+		schema.WithDefaultConfigPath(),
+		schema.WithResolvedPaths(true),
+	)
+	if err != nil {
+		return err
+	}
+
+	if !schema.IsWorkdirInitialized(workdir) {
+		return fmt.Errorf("cannot build uninitialized project! start with: kraft build init")
+	}
+
+	// Interpret the application
+	project, err := schema.NewApplicationFromOptions(projectOpts)
+	if err != nil {
+		return err
+	}
+
+	if err := schema.SaveApplicationConfig(project,
+		schema.WithSaveOldConfig(cfgm.Config.SaveOldKraftfile),
+	); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/config/config.go
+++ b/config/config.go
@@ -49,14 +49,15 @@ type AuthConfig struct {
 }
 
 type Config struct {
-	NoPrompt       bool   `json:"no_prompt"        yaml:"no_prompt"                  env:"KRAFTKIT_NO_PROMPT"    default:"false"`
-	NoParallel     bool   `json:"no_parallel"      yaml:"no_parallel"                env:"KRAFTKIT_NO_PARALLEL"  default:"true"`
-	Editor         string `json:"editor"           yaml:"editor,omitempty"           env:"KRAFTKIT_EDITOR"`
-	Browser        string `json:"browser"          yaml:"browser,omitempty"          env:"KRAFTKIT_BROWSER"`
-	GitProtocol    string `json:"git_protocol"     yaml:"git_protocol"               env:"KRAFTKIT_GIT_PROTOCOL" default:"https"`
-	Pager          string `json:"pager"            yaml:"pager,omitempty"            env:"KRAFTKIT_PAGER"`
-	Emojis         bool   `json:"emojis"           yaml:"emojis"                     env:"KRAFTKIT_EMOJIS"       default:"true"`
-	HTTPUnixSocket string `json:"http_unix_socket" yaml:"http_unix_socket,omitempty" env:"KRAFTKIT_HTTP_UNIX_SOCKET"`
+	NoPrompt         bool   `json:"no_prompt"        yaml:"no_prompt"                  env:"KRAFTKIT_NO_PROMPT"    default:"false"`
+	NoParallel       bool   `json:"no_parallel"      yaml:"no_parallel"                env:"KRAFTKIT_NO_PARALLEL"  default:"true"`
+	Editor           string `json:"editor"           yaml:"editor,omitempty"           env:"KRAFTKIT_EDITOR"`
+	Browser          string `json:"browser"          yaml:"browser,omitempty"          env:"KRAFTKIT_BROWSER"`
+	GitProtocol      string `json:"git_protocol"     yaml:"git_protocol"               env:"KRAFTKIT_GIT_PROTOCOL" default:"https"`
+	Pager            string `json:"pager"            yaml:"pager,omitempty"            env:"KRAFTKIT_PAGER"`
+	SaveOldKraftfile bool   `json:"save_old_kraftfile" yaml:"save_old_kraftfile"     env:"KRAFTKIT_SAVE_OLD_KRAFTFILE" default:"true"`
+	Emojis           bool   `json:"emojis"           yaml:"emojis"                     env:"KRAFTKIT_EMOJIS"       default:"true"`
+	HTTPUnixSocket   string `json:"http_unix_socket" yaml:"http_unix_socket,omitempty" env:"KRAFTKIT_HTTP_UNIX_SOCKET"`
 
 	Paths struct {
 		Plugins   string `json:"plugins"   yaml:"plugins,omitempty"   env:"KRAFTKIT_PATHS_PLUGINS"`
@@ -112,6 +113,10 @@ var configDetails = []ConfigDetail{
 	{
 		Key:         "pager",
 		Description: "the terminal pager program to send standard output to",
+	},
+	{
+		Key:         "save_old_kraftfile",
+		Description: "toggle copying the kraftfile to a backup file before modifying it",
 	},
 	{
 		Key:         "log.level",

--- a/schema/loader.go
+++ b/schema/loader.go
@@ -201,6 +201,7 @@ func Load(details config.ConfigDetails, options ...func(*LoaderOptions)) (*app.A
 		ComponentConfig: component.ComponentConfig{
 			Name: projectName,
 		},
+		Specification: model.Specification,
 		WorkingDir:    details.WorkingDir,
 		Filename:      model.Filename,
 		OutDir:        model.OutDir,
@@ -247,6 +248,16 @@ func loadSections(filename string, cfgIface map[string]interface{}, configDetail
 			return nil, errors.New("output directory must be a string")
 		}
 	}
+
+	specification := "0.0"
+	if n, ok := cfgIface["specification"]; ok {
+		specification, ok = n.(string)
+		if !ok {
+			// Interpreted as a number
+			specification = fmt.Sprintf("%v", n)
+		}
+	}
+	cfg.Specification = specification
 
 	if opts.ResolvePaths {
 		cfg.OutDir = configDetails.RelativePath(outdir)

--- a/schema/loader.go
+++ b/schema/loader.go
@@ -191,6 +191,12 @@ func Load(details config.ConfigDetails, options ...func(*LoaderOptions)) (*app.A
 		details.Configuration[k] = *v
 	}
 
+	for _, library := range model.Libraries {
+		for k, v := range library.Configuration {
+			details.Configuration[k] = *v
+		}
+	}
+
 	project := &app.ApplicationConfig{
 		ComponentConfig: component.ComponentConfig{
 			Name: projectName,

--- a/schema/loader.go
+++ b/schema/loader.go
@@ -187,6 +187,10 @@ func Load(details config.ConfigDetails, options ...func(*LoaderOptions)) (*app.A
 		}
 	}
 
+	for k, v := range model.Unikraft.Configuration {
+		details.Configuration[k] = *v
+	}
+
 	project := &app.ApplicationConfig{
 		ComponentConfig: component.ComponentConfig{
 			Name: projectName,

--- a/schema/project.go
+++ b/schema/project.go
@@ -42,6 +42,7 @@ type ProjectOptions struct {
 	ConfigPaths   []string
 	Configuration map[string]string
 	DotConfigFile string
+	SaveSymbols   bool
 	log           log.Logger
 	loadOptions   []func(*LoaderOptions)
 }
@@ -67,6 +68,14 @@ func NewProjectOptions(configs []string, opts ...ProjectOptionsFn) (*ProjectOpti
 func WithLogger(l log.Logger) ProjectOptionsFn {
 	return func(o *ProjectOptions) error {
 		o.log = l
+		return nil
+	}
+}
+
+// WithSaveSymbols defines whether to save symbols in the configuration file
+func WithSaveSymbols(saveSymbols bool) ProjectOptionsFn {
+	return func(o *ProjectOptions) error {
+		o.SaveSymbols = saveSymbols
 		return nil
 	}
 }
@@ -375,6 +384,7 @@ func NewApplicationFromOptions(popts *ProjectOptions, copts ...component.Compone
 		return nil, err
 	}
 
+	project.SaveSymbols = popts.SaveSymbols
 	project.KraftFiles = configPaths
 	return project, nil
 }

--- a/schema/saver.go
+++ b/schema/saver.go
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Copyright 2020 The Compose Specification Authors.
+// Copyright 2022 Unikraft GmbH. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+// 		http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package schema
+
+import (
+	"io"
+	"io/ioutil"
+	"os"
+
+	"gopkg.in/yaml.v2"
+	"kraftkit.sh/unikraft/app"
+)
+
+type SaverOptions struct {
+	// Whether or not to save the old kraftfile
+	saveOldKraftfile bool
+	// // Slice of component options to apply to each loaded component
+	// componentOptions []component.ComponentOption
+	// // Access to a general purpose logger
+	// log log.Logger
+}
+
+type SaverOption func(so *SaverOptions) error
+
+func WithSaveOldConfig(saveOldKraftfile bool) SaverOption {
+	return func(so *SaverOptions) error {
+		so.saveOldKraftfile = saveOldKraftfile
+		return nil
+	}
+}
+
+func SaveApplicationConfig(project *app.ApplicationConfig, sopts ...SaverOption) error {
+	options := &SaverOptions{}
+	for _, o := range sopts {
+		err := o(options)
+		if err != nil {
+			return err
+		}
+	}
+
+	// Marshal the application config
+	b, err := yaml.Marshal(project)
+	if err != nil {
+		return err
+	}
+
+	// Write the application config to the first kraft config file
+	kraftFile := project.KraftFiles[0]
+
+	// Copy the old file to a backup with .old appended
+	if options.saveOldKraftfile {
+		source, err := os.Open(kraftFile)
+		if err != nil {
+			return err
+		}
+
+		destination, err := os.Create(kraftFile + ".old")
+		if err != nil {
+			return err
+		}
+
+		_, err = io.Copy(destination, source)
+		if err != nil {
+			return err
+		}
+		source.Close()
+		destination.Close()
+	}
+
+	if err := ioutil.WriteFile(kraftFile, b, 0644); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/unikraft/app/application.go
+++ b/unikraft/app/application.go
@@ -327,6 +327,15 @@ func (a *ApplicationConfig) Build(opts ...BuildOption) error {
 	}...)
 
 	if !bopts.noSyncConfig {
+		// Ensure that the configuration is up-to-date
+		if err := a.Set(append(
+			bopts.mopts,
+			make.WithProgressFunc(nil),
+		)...); err != nil {
+			return err
+		}
+
+		// Calculate progress for the build
 		if err := a.SyncConfig(append(
 			bopts.mopts,
 			make.WithProgressFunc(nil),

--- a/unikraft/app/application.go
+++ b/unikraft/app/application.go
@@ -33,7 +33,6 @@ package app
 
 import (
 	"fmt"
-	"io"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -42,7 +41,6 @@ import (
 	"strings"
 
 	"github.com/xlab/treeprint"
-	"gopkg.in/yaml.v2"
 
 	"kraftkit.sh/exec"
 	"kraftkit.sh/iostreams"
@@ -227,7 +225,7 @@ func (a *ApplicationConfig) Fetch(mopts ...make.MakeOption) error {
 	)...)
 }
 
-// Write the symbol to the kraft config file
+// Update symbols inside the configuration
 func (a *ApplicationConfig) writeToConfig(libraries, symbols, values []string) error {
 	numSymbols := len(symbols)
 
@@ -250,38 +248,6 @@ func (a *ApplicationConfig) writeToConfig(libraries, symbols, values []string) e
 		} else {
 			return fmt.Errorf("library %s not found in kraft.yaml", libraries[i])
 		}
-	}
-
-	// Marshal the application config
-	b, err := yaml.Marshal(a)
-	if err != nil {
-		return err
-	}
-
-	// Write the application config to the first kraft config file
-	kraftFile := a.KraftFiles[0]
-
-	// Copy the old file to a backup with .old appended
-	// TODO check if option to save is false
-	source, err := os.Open(kraftFile)
-	if err != nil {
-		return err
-	}
-
-	destination, err := os.Create(kraftFile + ".old")
-	if err != nil {
-		return err
-	}
-
-	_, err = io.Copy(destination, source)
-	if err != nil {
-		return err
-	}
-	source.Close()
-	destination.Close()
-
-	if err := ioutil.WriteFile(kraftFile, b, 0644); err != nil {
-		return err
 	}
 	return nil
 }

--- a/unikraft/app/application.go
+++ b/unikraft/app/application.go
@@ -344,6 +344,18 @@ func (a *ApplicationConfig) Unset(mopts ...make.MakeOption) error {
 	for k, v := range a.Configuration {
 		var line string
 
+		if a.SaveSymbols && strings.ContainsRune(k, '.') {
+			// Split on '.' - should have two parts
+			parts := strings.Split(k, ".")
+
+			if len(parts) != 2 {
+				return fmt.Errorf("invalid configuration key \"%s\"", k)
+			}
+
+			k = parts[1]
+			a.writeToConfig(parts[0], k, v)
+		}
+
 		if _, err := strconv.ParseFloat(v, 64); err == nil || v == "y" {
 			line = fmt.Sprintf("%s=%s\n", k, v)
 		} else if v == "n" {

--- a/unikraft/app/application.go
+++ b/unikraft/app/application.go
@@ -61,7 +61,7 @@ type Application interface {
 }
 
 type ApplicationConfig struct {
-	component.ComponentConfig
+	component.ComponentConfig `yaml:"-" json:"-"`
 
 	Specification string               `yaml:"specification" json:"specification"`
 	WorkingDir    string               `yaml:"-" json:"-"`
@@ -492,4 +492,39 @@ func (ac ApplicationConfig) PrintInfo(io *iostreams.IOStreams) error {
 	fmt.Fprintln(io.Out, tree.String())
 
 	return nil
+}
+
+func (ac ApplicationConfig) MarshalYAML() (interface{}, error) {
+	type applicationConfigYAML struct {
+		component.ComponentConfig `yaml:"-" json:"-"`
+
+		Specification string               `yaml:"specification" json:""`
+		NameYAML      string               `yaml:"name" json:"name"`
+		WorkingDir    string               `yaml:"-" json:"-"`
+		Filename      string               `yaml:"-" json:"-"`
+		OutDir        string               `yaml:",omitempty" json:"outdir,omitempty"`
+		Unikraft      core.UnikraftConfig  `yaml:",omitempty" json:"unikraft,omitempty"`
+		Libraries     lib.Libraries        `yaml:",omitempty" json:"libraries,omitempty"`
+		Targets       target.Targets       `yaml:",omitempty" json:"targets,omitempty"`
+		Extensions    component.Extensions `yaml:",inline" json:"-"`
+		KraftFiles    []string             `yaml:"-" json:"-"`
+		Configuration map[string]string    `yaml:"-" json:"-"`
+		SaveSymbols   bool                 `yaml:"-" json:"-"`
+	}
+
+	return applicationConfigYAML{
+		ComponentConfig: ac.ComponentConfig,
+		Specification:   ac.Specification,
+		NameYAML:        ac.ComponentConfig.Name,
+		WorkingDir:      ac.WorkingDir,
+		Filename:        ac.Filename,
+		OutDir:          ac.OutDir,
+		Unikraft:        ac.Unikraft,
+		Libraries:       ac.Libraries,
+		Targets:         ac.Targets,
+		Extensions:      ac.Extensions,
+		KraftFiles:      ac.KraftFiles,
+		Configuration:   ac.Configuration,
+		SaveSymbols:     ac.SaveSymbols,
+	}, nil
 }

--- a/unikraft/app/application.go
+++ b/unikraft/app/application.go
@@ -61,6 +61,7 @@ type Application interface {
 type ApplicationConfig struct {
 	component.ComponentConfig
 
+	Specification string               `yaml:"specification" json:"specification"`
 	WorkingDir    string               `yaml:"-" json:"-"`
 	Filename      string               `yaml:"-" json:"-"`
 	OutDir        string               `yaml:",omitempty" json:"outdir,omitempty"`

--- a/unikraft/app/build_options.go
+++ b/unikraft/app/build_options.go
@@ -120,8 +120,8 @@ func WithBuildLogFile(path string) BuildOption {
 	}
 }
 
-// WithBuildNoSyncConfig disables calling `make syncconfig` befere invoking the
-// main Unikraft's build invocation.
+// WithBuildNoSyncConfig disables calling `make syncconfig/defconfig` before
+// invoking the main Unikraft's build invocation.
 func WithBuildNoSyncConfig(noSyncConfig bool) BuildOption {
 	return func(bo *BuildOptions) error {
 		bo.noSyncConfig = noSyncConfig

--- a/unikraft/arch/architecture.go
+++ b/unikraft/arch/architecture.go
@@ -44,7 +44,7 @@ type Architecture interface {
 }
 
 type ArchitectureConfig struct {
-	component.ComponentConfig
+	component.ComponentConfig `yaml:"-" json:"-"`
 }
 
 // ParseArchitectureConfig parse short syntax for architecture configuration
@@ -75,4 +75,9 @@ func (ac ArchitectureConfig) Type() unikraft.ComponentType {
 func (ac ArchitectureConfig) PrintInfo(io *iostreams.IOStreams) error {
 	fmt.Fprint(io.Out, "not implemented: unikraft.arch.ArchitectureConfig.PrintInfo")
 	return nil
+}
+
+func (ac ArchitectureConfig) MarshalYAML() (interface{}, error) {
+
+	return ac.ComponentConfig.Name, nil
 }

--- a/unikraft/component/component.go
+++ b/unikraft/component/component.go
@@ -46,7 +46,7 @@ import (
 // microlibraries, whether they are a library, platform, architecture, an
 // application itself or the Unikraft core.
 type ComponentConfig struct {
-	Name          string  `yaml:",omitempty" json:"-"`
+	Name          string  `yaml:"-" json:"-"`
 	Version       string  `yaml:",omitempty" json:"version,omitempty"`
 	Source        string  `yaml:",omitempty" json:"source,omitempty"`
 	Configuration KConfig `yaml:",omitempty" json:"kconfig,omitempty"`

--- a/unikraft/component/kconfig.go
+++ b/unikraft/component/kconfig.go
@@ -70,3 +70,15 @@ func (e KConfig) RemoveEmpty() KConfig {
 	}
 	return e
 }
+
+func (e KConfig) MarshalYAML() (interface{}, error) {
+	var values []string
+	for k, v := range e {
+		if v == nil {
+			values = append(values, k)
+		} else {
+			values = append(values, k+"="+*v)
+		}
+	}
+	return values, nil
+}

--- a/unikraft/config/config.go
+++ b/unikraft/config/config.go
@@ -84,12 +84,13 @@ type ConfigFile struct {
 
 // Config is a full kraft file configuration and model
 type Config struct {
-	Filename  string              `yaml:"-" json:"-"`
-	Name      string              `yaml:",omitempty" json:"name,omitempty"`
-	OutDir    string              `yaml:",omitempty" json:"outdir,omitempty"`
-	Unikraft  core.UnikraftConfig `yaml:",omitempty" json:"unikraft,omitempty"`
-	Libraries lib.Libraries       `yaml:",omitempty" json:"libraries,omitempty"`
-	Targets   target.Targets      `yaml:",omitempty" json:"targets,omitempty"`
+	Filename      string              `yaml:"-" json:"-"`
+	Specification string              `yaml:",omitempty" json:"specification,omitempty"`
+	Name          string              `yaml:",omitempty" json:"name,omitempty"`
+	OutDir        string              `yaml:",omitempty" json:"outdir,omitempty"`
+	Unikraft      core.UnikraftConfig `yaml:",omitempty" json:"unikraft,omitempty"`
+	Libraries     lib.Libraries       `yaml:",omitempty" json:"libraries,omitempty"`
+	Targets       target.Targets      `yaml:",omitempty" json:"targets,omitempty"`
 
 	Extensions component.Extensions `yaml:",inline" json:"-"`
 }

--- a/unikraft/core/core.go
+++ b/unikraft/core/core.go
@@ -44,7 +44,7 @@ type Unikraft interface {
 }
 
 type UnikraftConfig struct {
-	component.ComponentConfig
+	component.ComponentConfig `yaml:",inline" json:",inline"`
 }
 
 func (uc UnikraftConfig) Name() string {

--- a/unikraft/plat/platform.go
+++ b/unikraft/plat/platform.go
@@ -44,7 +44,7 @@ type Platform interface {
 }
 
 type PlatformConfig struct {
-	component.ComponentConfig
+	component.ComponentConfig `yaml:"-" json:"-"`
 }
 
 // ParsePlatformConfig parse short syntax for platform configuration
@@ -75,4 +75,9 @@ func (pc PlatformConfig) Type() unikraft.ComponentType {
 func (pc PlatformConfig) PrintInfo(io *iostreams.IOStreams) error {
 	fmt.Fprint(io.Out, "not implemented: unikraft.plat.PlatformConfig.PrintInfo")
 	return nil
+}
+
+func (pc PlatformConfig) MarshalYAML() (interface{}, error) {
+
+	return pc.ComponentConfig.Name, nil
 }

--- a/unikraft/target/target.go
+++ b/unikraft/target/target.go
@@ -43,14 +43,14 @@ import (
 )
 
 type TargetConfig struct {
-	component.ComponentConfig
+	component.ComponentConfig `yaml:"-" json:"-"`
 
 	Architecture arch.ArchitectureConfig `yaml:",omitempty" json:"architecture,omitempty"`
 	Platform     plat.PlatformConfig     `yaml:",omitempty" json:"platform,omitempty"`
 	Format       string                  `yaml:",omitempty" json:"format,omitempty"`
-	Kernel       string                  `yaml:",omitempty" json:"kernel,omitempty"`
-	KernelDbg    string                  `yaml:",omitempty" json:"kerneldbg,omitempty"`
-	Initrd       *initrd.InitrdConfig    `yaml:",omitempty" json:"initrd,omitempty"`
+	Kernel       string                  `yaml:"-" json:"-"`
+	KernelDbg    string                  `yaml:"-" json:"-"`
+	Initrd       *initrd.InitrdConfig    `yaml:"-" json:"-"`
 	Command      []string                `yaml:",omitempty" json:"commands"`
 
 	Extensions map[string]interface{} `yaml:",inline" json:"-"`
@@ -79,4 +79,34 @@ func (tc *TargetConfig) ArchPlatString() string {
 func (tc TargetConfig) PrintInfo(io *iostreams.IOStreams) error {
 	fmt.Fprint(io.Out, "not implemented: unikraft.plat.TargetConfig.PrintInfo")
 	return nil
+}
+
+func (tc TargetConfig) MarshalYAML() (interface{}, error) {
+	type targetConfigYAML struct {
+		component.ComponentConfig `yaml:"-" json:"-"`
+
+		NameYAML     string                  `yaml:"name,omitempty" json:"name,omitempty"`
+		Architecture arch.ArchitectureConfig `yaml:",omitempty" json:"architecture,omitempty"`
+		Platform     plat.PlatformConfig     `yaml:",omitempty" json:"platform,omitempty"`
+		Format       string                  `yaml:",omitempty" json:"format,omitempty"`
+		Kernel       string                  `yaml:"-" json:"-"`
+		KernelDbg    string                  `yaml:"-" json:"-"`
+		Initrd       *initrd.InitrdConfig    `yaml:"-" json:"-"`
+		Command      []string                `yaml:",omitempty" json:"commands"`
+
+		Extensions map[string]interface{} `yaml:",inline" json:"-"`
+	}
+
+	return targetConfigYAML{
+		ComponentConfig: tc.ComponentConfig,
+		NameYAML:        tc.ComponentConfig.Name,
+		Architecture:    tc.Architecture,
+		Platform:        tc.Platform,
+		Format:          tc.Format,
+		Kernel:          tc.Kernel,
+		KernelDbg:       tc.KernelDbg,
+		Initrd:          tc.Initrd,
+		Command:         tc.Command,
+		Extensions:      tc.Extensions,
+	}, nil
 }


### PR DESCRIPTION
This PR adds the option to save options given to `set/unset` in the kraft file.

This also fixes a bug which made kraftkit not take in consideration new kconfig options.
This also fixes a bug which made kraftkit not take in consideration kconfig options from `kraft.yaml`.
This also fixes the formatting of structures when marshalling into yaml (partially done).
This also implements the `kraft tidy` command to clean up yaml files.

This PR is a draft.

Closes: #94 