### PR TITLE
Add nix flake

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,26 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1666837999,
+        "narHash": "sha256-hI7+s1UVDsJNqNn9UGV6xTBGqMC4dqOyVpeDf+su7JU=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "1c6eb4876f71e8903ae9f73e6adf45fdbebc0292",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "ref": "nixpkgs-unstable",
+        "type": "indirect"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -11,7 +11,7 @@
       # Generate a user-friendly version number.
       version = builtins.substring 0 8 lastModifiedDate;
 
-      supportedSystems = [ "x86_64-linux" "x86_64-darwin" "aarch64-linux" "aarch64-darwin" ];
+      supportedSystems = [ "x86_64-linux" ];
       forAllSystems = nixpkgs.lib.genAttrs supportedSystems;
       nixpkgsFor = forAllSystems (system: import nixpkgs { inherit system; });
     in

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,40 @@
+{
+  description = "Build and use highly customized and ultra-lightweight unikernel VMs. ";
+
+  # Nixpkgs / NixOS version to use.
+  inputs.nixpkgs.url = "nixpkgs/nixpkgs-unstable";
+
+  outputs = { self, nixpkgs }:
+    let
+      # to work with older version of flakes
+      lastModifiedDate = self.lastModifiedDate or self.lastModified or "19700101";
+      # Generate a user-friendly version number.
+      version = builtins.substring 0 8 lastModifiedDate;
+
+      supportedSystems = [ "x86_64-linux" "x86_64-darwin" "aarch64-linux" "aarch64-darwin" ];
+      forAllSystems = nixpkgs.lib.genAttrs supportedSystems;
+      nixpkgsFor = forAllSystems (system: import nixpkgs { inherit system; });
+    in
+    {
+      packages = forAllSystems (system:
+        let
+          pkgs = nixpkgsFor.${system};
+        in
+        {
+          kraft = pkgs.buildGo118Module {
+            pname = "kraft";
+            inherit version;
+            src = ./.;
+
+            buildInputs = [ pkgs.libgit2_1_3_0 ];
+            nativeBuildInputs = [ pkgs.pkg-config ];
+
+            subPackages = [ "cmd/kraft" ];
+            #vendorSha256 = pkgs.lib.fakeSha256;
+            vendorSha256 = "sha256-cQkX3333pkRkXk2Y43buUvBosXtBdfig+kvMRwD0Iew=";
+          };
+        });
+
+      defaultPackage = forAllSystems (system: self.packages.${system}.kraft);
+    };
+}


### PR DESCRIPTION
This allows installing kraftkit using an flakes-enabled nix installation.