### PR TITLE
Add `kraft.yaml` templating

### DIFF
--- a/cmd/kraft/build/build.go
+++ b/cmd/kraft/build/build.go
@@ -391,6 +391,14 @@ func buildRun(opts *buildOptions, workdir string) error {
 	if err != nil {
 		return err
 	}
+
+	templateProject, err := schema.NewApplicationFromOptions(templateOps)
+	if err != nil {
+		return err
+	}
+
+	project = templateProject.MergeTemplate(project)
+
 	// Overwrite template with user options
 	components, err := project.Components()
 	if err != nil {

--- a/cmd/kraft/build/build.go
+++ b/cmd/kraft/build/build.go
@@ -289,7 +289,17 @@ func buildRun(opts *buildOptions, workdir string) error {
 	var processes []*paraprogress.Process
 	var searches []*processtree.ProcessTreeItem
 
-	for _, component := range project.Components() {
+	_, err = project.Components()
+	if err != nil {
+	}
+	}
+
+	// Overwrite template with user options
+	components, err := project.Components()
+	if err != nil {
+		return err
+	}
+	for _, component := range components {
 		component := component // loop closure
 
 		searches = append(searches, processtree.NewProcessTreeItem(

--- a/cmd/kraft/build/build.go
+++ b/cmd/kraft/build/build.go
@@ -42,6 +42,7 @@ import (
 	"kraftkit.sh/exec"
 	"kraftkit.sh/pack"
 	"kraftkit.sh/schema"
+	"kraftkit.sh/unikraft"
 
 	"kraftkit.sh/internal/cmdfactory"
 	"kraftkit.sh/internal/cmdutil"
@@ -54,7 +55,6 @@ import (
 	"kraftkit.sh/tui/paraprogress"
 	"kraftkit.sh/unikraft/app"
 	"kraftkit.sh/unikraft/component"
-	"kraftkit.sh/unikraft/target"
 
 	// Subcommands
 	"kraftkit.sh/cmd/kraft/build/clean"
@@ -291,9 +291,106 @@ func buildRun(opts *buildOptions, workdir string) error {
 
 	_, err = project.Components()
 	if err != nil {
-	}
+		var packages []pack.Package
+		search := processtree.NewProcessTreeItem(
+			fmt.Sprintf("finding %s/%s:%s...", project.Template().Type(), project.Template().Name(), project.Template().Version()), "",
+			func(l log.Logger) error {
+				// Apply the incoming logger which is tailored to display as a
+				// sub-terminal within the fancy processtree.
+				pm.ApplyOptions(
+					packmanager.WithLogger(l),
+				)
+
+				packages, err = pm.Catalog(packmanager.CatalogQuery{
+					Name:    project.Template().Name(),
+					Types:   []unikraft.ComponentType{unikraft.ComponentTypeApp},
+					Version: project.Template().Version(),
+					NoCache: opts.NoCache,
+				})
+				if err != nil {
+					return err
+				}
+
+				if len(packages) == 0 {
+					return fmt.Errorf("could not find: %s", project.Template().Name())
+				} else if len(packages) > 1 {
+					return fmt.Errorf("too many options for %s", project.Template().Name())
+				}
+
+				return nil
+			},
+		)
+
+		treemodel, err := processtree.NewProcessTree(
+			[]processtree.ProcessTreeOption{
+				processtree.WithFailFast(true),
+				processtree.WithRenderer(false),
+				processtree.WithLogger(plog),
+			},
+			[]*processtree.ProcessTreeItem{search}...,
+		)
+		if err != nil {
+			return err
 	}
 
+		if err := treemodel.Start(); err != nil {
+			return fmt.Errorf("could not complete search: %v", err)
+	}
+
+		proc := paraprogress.NewProcess(
+			fmt.Sprintf("pulling %s", packages[0].Options().TypeNameVersion()),
+			func(l log.Logger, w func(progress float64)) error {
+				// Apply the incoming logger which is tailored to display as a
+				// sub-terminal within the fancy processtree.
+				packages[0].ApplyOptions(
+					pack.WithLogger(l),
+				)
+
+				return packages[0].Pull(
+					pack.WithPullProgressFunc(w),
+					pack.WithPullWorkdir(workdir),
+					pack.WithPullLogger(l),
+					// pack.WithPullChecksum(!opts.NoChecksum),
+					// pack.WithPullCache(!opts.NoCache),
+				)
+			},
+		)
+
+		processes = append(processes, proc)
+
+		paramodel, err := paraprogress.NewParaProgress(
+			processes,
+			paraprogress.IsParallel(parallel),
+			paraprogress.WithRenderer(norender),
+			paraprogress.WithLogger(plog),
+			paraprogress.WithFailFast(true),
+		)
+		if err != nil {
+			return err
+		}
+
+		if err := paramodel.Start(); err != nil {
+			return fmt.Errorf("could not pull all components: %v", err)
+		}
+	}
+
+	templateWorkdir, err := unikraft.PlaceComponent(workdir, project.Template().Type(), project.Template().Name())
+	if err != nil {
+		return err
+	}
+
+	templateOps, err := schema.NewProjectOptions(
+		nil,
+		schema.WithLogger(plog),
+		schema.WithWorkingDirectory(templateWorkdir),
+		schema.WithDefaultConfigPath(),
+		schema.WithPackageManager(&pm),
+		schema.WithResolvedPaths(true),
+		schema.WithDotConfig(false),
+	)
+	if err != nil {
+		return err
+	}
 	// Overwrite template with user options
 	components, err := project.Components()
 	if err != nil {
@@ -312,8 +409,13 @@ func buildRun(opts *buildOptions, workdir string) error {
 				)
 
 				p, err := pm.Catalog(packmanager.CatalogQuery{
-					Name:    component.Name(),
-					Source:  component.Source(),
+					Name: component.Name(),
+					Types: []unikraft.ComponentType{
+						unikraft.ComponentTypeCore,
+						unikraft.ComponentTypeLib,
+						unikraft.ComponentTypePlat,
+						unikraft.ComponentTypeArch,
+					},
 					Version: component.Version(),
 					NoCache: opts.NoCache,
 				})

--- a/cmd/kraft/build/build.go
+++ b/cmd/kraft/build/build.go
@@ -290,7 +290,7 @@ func buildRun(opts *buildOptions, workdir string) error {
 	var searches []*processtree.ProcessTreeItem
 
 	_, err = project.Components()
-	if err != nil {
+	if err != nil && project.Template().Name() != "" {
 		var packages []pack.Package
 		search := processtree.NewProcessTreeItem(
 			fmt.Sprintf("finding %s/%s:%s...", project.Template().Type(), project.Template().Name(), project.Template().Version()), "",
@@ -374,30 +374,32 @@ func buildRun(opts *buildOptions, workdir string) error {
 		}
 	}
 
-	templateWorkdir, err := unikraft.PlaceComponent(workdir, project.Template().Type(), project.Template().Name())
-	if err != nil {
-		return err
-	}
+	if project.Template().Name() != "" {
+		templateWorkdir, err := unikraft.PlaceComponent(workdir, project.Template().Type(), project.Template().Name())
+		if err != nil {
+			return err
+		}
 
-	templateOps, err := schema.NewProjectOptions(
-		nil,
-		schema.WithLogger(plog),
-		schema.WithWorkingDirectory(templateWorkdir),
-		schema.WithDefaultConfigPath(),
-		schema.WithPackageManager(&pm),
-		schema.WithResolvedPaths(true),
-		schema.WithDotConfig(false),
-	)
-	if err != nil {
-		return err
-	}
+		templateOps, err := schema.NewProjectOptions(
+			nil,
+			schema.WithLogger(plog),
+			schema.WithWorkingDirectory(templateWorkdir),
+			schema.WithDefaultConfigPath(),
+			schema.WithPackageManager(&pm),
+			schema.WithResolvedPaths(true),
+			schema.WithDotConfig(false),
+		)
+		if err != nil {
+			return err
+		}
 
-	templateProject, err := schema.NewApplicationFromOptions(templateOps)
-	if err != nil {
-		return err
-	}
+		templateProject, err := schema.NewApplicationFromOptions(templateOps)
+		if err != nil {
+			return err
+		}
 
-	project = templateProject.MergeTemplate(project)
+		project = templateProject.MergeTemplate(project)
+	}
 
 	// Overwrite template with user options
 	components, err := project.Components()

--- a/cmd/kraft/build/build.go
+++ b/cmd/kraft/build/build.go
@@ -331,11 +331,11 @@ func buildRun(opts *buildOptions, workdir string) error {
 		)
 		if err != nil {
 			return err
-	}
+		}
 
 		if err := treemodel.Start(); err != nil {
 			return fmt.Errorf("could not complete search: %v", err)
-	}
+		}
 
 		proc := paraprogress.NewProcess(
 			fmt.Sprintf("pulling %s", packages[0].Options().TypeNameVersion()),
@@ -508,10 +508,13 @@ func buildRun(opts *buildOptions, workdir string) error {
 
 	processes = []*paraprogress.Process{} // reset
 
-	var targets []target.TargetConfig
+	targets, err := project.Targets()
+	if err != nil {
+		return err
+	}
 
 	// Filter the targets by CLI selection
-	for _, targ := range project.Targets {
+	for _, targ := range targets {
 		switch true {
 		case
 			// If no arguments are supplied

--- a/cmd/kraft/pkg/pkg.go
+++ b/cmd/kraft/pkg/pkg.go
@@ -296,7 +296,11 @@ func pkgRun(opts *pkgOptions, workdir string) error {
 	var packages []pack.Package
 
 	// Generate a package for every matching requested target
-	for _, targ := range project.Targets {
+	targets, err := project.Targets()
+	if err != nil {
+		return err
+	}
+	for _, targ := range targets {
 		switch true {
 		case
 			// If no arguments are supplied
@@ -424,11 +428,16 @@ func initAppPackage(ctx context.Context,
 
 	name := opts.Name
 
+	targets, err := project.Targets()
+	if err != nil {
+		return nil, err
+	}
+
 	// This is a built in naming convention format, which for now allows us to
 	// differentiate between different targets.  This should be further discussed
 	// the community if this is the best approach.  This can ultimately be
 	// overwritten using the --tag flag.
-	if len(name) == 0 && len(project.Targets) == 1 {
+	if len(name) == 0 && len(targets) == 1 {
 		name = project.Name()
 	} else if len(name) == 0 {
 		name = project.Name() + "-" + targ.Name()

--- a/cmd/kraft/pkg/pull/pull.go
+++ b/cmd/kraft/pkg/pull/pull.go
@@ -245,8 +245,16 @@ func pullRun(opts *PullOptions, query string) error {
 			return err
 		}
 
+		_, err = project.Components()
+		if err != nil {
+		}
+
 		// List the components
-		for _, c := range project.Components() {
+		components, err := project.Components()
+		if err != nil {
+			return err
+		}
+		for _, c := range components {
 			queries = append(queries, packmanager.CatalogQuery{
 				Name:    c.Name(),
 				Version: c.Version(),

--- a/cmd/kraft/pkg/pull/pull.go
+++ b/cmd/kraft/pkg/pull/pull.go
@@ -347,6 +347,12 @@ func pullRun(opts *PullOptions, query string) error {
 			return err
 		}
 
+		templateProject, err := schema.NewApplicationFromOptions(templateOps)
+		if err != nil {
+			return err
+		}
+
+		project = templateProject.MergeTemplate(project)
 		// List the components
 		components, err := project.Components()
 		if err != nil {

--- a/schema/kraft-spec.json
+++ b/schema/kraft-spec.json
@@ -14,6 +14,13 @@
 
     "outdir": { "type": "string" },
 
+    "template": {
+      "id": "#/properties/template",
+      "$ref": "#/definitions/template",
+      "type": "string",
+      "additionalProperties": true
+    },
+
     "unikraft": {
       "id": "#/properties/unikraft",
       "$ref": "#/definitions/unikraft",
@@ -56,6 +63,16 @@
       "additionalProperties": true
     },
 
+    "template": {
+      "id": "#/definitions/template",
+      "type": [ "string", "object", "number" ],
+      "properties": {
+        "source": { "type": "string" },
+        "version": { "type": [ "string", "number" ] }
+      },
+      "additionalProperties": true
+    },
+  
     "target": {
       "id": "#/definitions/target",
       "type": [ "object" ],

--- a/schema/loader.go
+++ b/schema/loader.go
@@ -193,20 +193,22 @@ func Load(details config.ConfigDetails, options ...func(*LoaderOptions)) (*app.A
 	for _, library := range model.Libraries {
 		details.Configuration.OverrideBy(library.Configuration)
 	}
-
-	project := &app.ApplicationConfig{
-		ComponentConfig: component.ComponentConfig{
-			Name: projectName,
-		},
-		WorkingDir:    details.WorkingDir,
-		Filename:      model.Filename,
-		OutDir:        model.OutDir,
-		Unikraft:      model.Unikraft,
-		Libraries:     model.Libraries,
-		Targets:       model.Targets,
-		Configuration: details.Configuration,
-		Extensions:    model.Extensions,
+	project, err := app.NewApplicationOptions(
+		app.WithWorkingDir(details.WorkingDir),
+		app.WithFilename(model.Filename),
+		app.WithOutDir(model.OutDir),
+		app.WithUnikraft(model.Unikraft),
+		app.WithTemplate(model.Template),
+		app.WithLibraries(model.Libraries),
+		app.WithTargets(model.Targets),
+		app.WithConfiguration(details.Configuration),
+		app.WithExtensions(model.Extensions),
+	)
+	if err != nil {
+		return nil, err
 	}
+
+	project.ComponentConfig.Name = projectName
 
 	project.ApplyOptions(append(opts.componentOptions,
 		component.WithType(unikraft.ComponentTypeApp),

--- a/schema/normalize.go
+++ b/schema/normalize.go
@@ -42,17 +42,19 @@ import (
 // normalize a kraft project by moving deprecated attributes to their canonical
 // position and injecting implicit defaults
 func normalize(project *app.ApplicationConfig, resolvePaths bool) error {
-	absWorkingDir, err := filepath.Abs(project.WorkingDir)
+	absWorkingDir, err := filepath.Abs(project.WorkingDir())
 	if err != nil {
 		return err
 	}
-	project.WorkingDir = absWorkingDir
+	project.SetWorkdir(absWorkingDir)
 
-	absKraftFiles, err := absKraftFiles(project.KraftFiles)
+	// Ignore the error here, as it's a false positive
+	krafFiles, _ := project.KraftFiles()
+	absKraftFiles, err := absKraftFiles(krafFiles)
 	if err != nil {
 		return err
 	}
-	project.KraftFiles = absKraftFiles
+	app.WithKraftFiles(absKraftFiles)(project)
 
 	return nil
 }

--- a/schema/project.go
+++ b/schema/project.go
@@ -385,7 +385,7 @@ func NewApplicationFromOptions(popts *ProjectOptions, copts ...component.Compone
 		return nil, err
 	}
 
-	project.KraftFiles = configPaths
+	app.WithKraftFiles(configPaths)(project)
 	return project, nil
 }
 

--- a/unikraft/app/application.go
+++ b/unikraft/app/application.go
@@ -447,10 +447,17 @@ func (a *ApplicationConfig) TargetByName(name string) (*target.TargetConfig, err
 
 // Components returns a unique list of Unikraft components which this
 // applicatiton consists of
-func (ac *ApplicationConfig) Components() []component.Component {
+func (ac *ApplicationConfig) Components() ([]component.Component, error) {
 	components := []component.Component{
 		ac.Unikraft,
 	}
+
+	// Change to error and correctly check if structure is uninitialized
+	if ac.Template.Source() != "" && !ac.Template.IsUnpackedInProject() {
+		return nil, fmt.Errorf("template source is not unpacked in project")
+	}
+
+	components = append(components, ac.Template)
 
 	for _, library := range ac.Libraries {
 		components = append(components, library)
@@ -464,7 +471,7 @@ func (ac *ApplicationConfig) Components() []component.Component {
 	// 	components = append(components, targ)
 	// }
 
-	return components
+	return components, nil
 }
 
 func (ac ApplicationConfig) Type() unikraft.ComponentType {

--- a/unikraft/app/application.go
+++ b/unikraft/app/application.go
@@ -153,6 +153,49 @@ func (ac ApplicationConfig) Configuration() (kconfig.KConfigValues, error) {
 
 	return ac.configuration, nil
 }
+
+func (a *ApplicationConfig) MergeTemplate(app *ApplicationConfig) *ApplicationConfig {
+	a.ComponentConfig = app.ComponentConfig
+
+	a.workingDir = app.workingDir
+	a.filename = app.filename
+	a.outDir = app.outDir
+	a.template = app.template
+
+	// Change all workdirs
+	for i := range a.libraries {
+		lib := a.libraries[i]
+		lib.SetWorkdir(a.workingDir)
+		a.libraries[i] = lib
+	}
+
+	for id, lib := range app.libraries {
+		a.libraries[id] = lib
+	}
+
+	a.targets = app.targets
+
+	for id, ext := range app.extensions {
+		a.extensions[id] = ext
+	}
+
+	a.kraftFiles = append(a.kraftFiles, app.kraftFiles...)
+
+	for id, val := range app.configuration {
+		a.configuration[id] = val
+	}
+
+	// Need to first merge the app configuration over the template
+	uk := app.unikraft
+	uk.Configuration = a.unikraft.Configuration
+	for id, val := range app.unikraft.Configuration {
+		uk.Configuration[id] = val
+	}
+	a.unikraft = uk
+
+	return a
+}
+
 func (ac ApplicationConfig) KConfigMenu() (*kconfig.KConfigFile, error) {
 	config_uk := filepath.Join(ac.workingDir, unikraft.Config_uk)
 	if _, err := os.Stat(config_uk); err != nil {

--- a/unikraft/app/application.go
+++ b/unikraft/app/application.go
@@ -165,46 +165,46 @@ func (ac ApplicationConfig) Configuration() (kconfig.KConfigValues, error) {
 }
 
 // MergeTemplate merges the application's configuration with the given configuration
-func (a *ApplicationConfig) MergeTemplate(app *ApplicationConfig) *ApplicationConfig {
-	a.ComponentConfig = app.ComponentConfig
+func (ac *ApplicationConfig) MergeTemplate(app *ApplicationConfig) *ApplicationConfig {
+	ac.ComponentConfig = app.ComponentConfig
 
-	a.workingDir = app.workingDir
-	a.filename = app.filename
-	a.outDir = app.outDir
-	a.template = app.template
+	ac.workingDir = app.workingDir
+	ac.filename = app.filename
+	ac.outDir = app.outDir
+	ac.template = app.template
 
 	// Change all workdirs
-	for i := range a.libraries {
-		lib := a.libraries[i]
-		lib.SetWorkdir(a.workingDir)
-		a.libraries[i] = lib
+	for i := range ac.libraries {
+		lib := ac.libraries[i]
+		lib.SetWorkdir(ac.workingDir)
+		ac.libraries[i] = lib
 	}
 
 	for id, lib := range app.libraries {
-		a.libraries[id] = lib
+		ac.libraries[id] = lib
 	}
 
-	a.targets = app.targets
+	ac.targets = app.targets
 
 	for id, ext := range app.extensions {
-		a.extensions[id] = ext
+		ac.extensions[id] = ext
 	}
 
-	a.kraftFiles = append(a.kraftFiles, app.kraftFiles...)
+	ac.kraftFiles = append(ac.kraftFiles, app.kraftFiles...)
 
 	for id, val := range app.configuration {
-		a.configuration[id] = val
+		ac.configuration[id] = val
 	}
 
 	// Need to first merge the app configuration over the template
 	uk := app.unikraft
-	uk.Configuration = a.unikraft.Configuration
+	uk.Configuration = ac.unikraft.Configuration
 	for id, val := range app.unikraft.Configuration {
 		uk.Configuration[id] = val
 	}
-	a.unikraft = uk
+	ac.unikraft = uk
 
-	return a
+	return ac
 }
 
 func (ac ApplicationConfig) KConfigMenu() (*kconfig.KConfigFile, error) {
@@ -239,8 +239,8 @@ func (ac ApplicationConfig) KConfigValues() (kconfig.KConfigValues, error) {
 }
 
 // KConfigFile returns the path to the application's .config file
-func (a *ApplicationConfig) KConfigFile() (string, error) {
-	return filepath.Join(a.workingDir, DefaultKConfigFile), nil
+func (ac *ApplicationConfig) KConfigFile() (string, error) {
+	return filepath.Join(ac.workingDir, DefaultKConfigFile), nil
 }
 
 // IsConfigured returns a boolean to indicate whether the application has been

--- a/unikraft/app/application.go
+++ b/unikraft/app/application.go
@@ -90,22 +90,27 @@ func (ac ApplicationConfig) Component() component.ComponentConfig {
 	return ac.ComponentConfig
 }
 
+// WorkingDir returns the path to the application's working directory
 func (ac ApplicationConfig) WorkingDir() string {
 	return ac.workingDir
 }
 
+// Filename returns the path to the application's executable
 func (ac ApplicationConfig) Filename() string {
 	return ac.filename
 }
 
+// OutDir returns the path to the application's output directory
 func (ac ApplicationConfig) OutDir() string {
 	return ac.outDir
 }
 
+// Template returns the application's template
 func (ac ApplicationConfig) Template() template.TemplateConfig {
 	return ac.template
 }
 
+// Unikraft returns the application's unikraft configuration
 func (ac ApplicationConfig) Unikraft() (core.UnikraftConfig, error) {
 	if ac.template.Source() != "" && !ac.template.IsUnpackedInProject() {
 		return core.UnikraftConfig{}, fmt.Errorf("Unikraft(): template source is not unpacked in project")
@@ -114,6 +119,7 @@ func (ac ApplicationConfig) Unikraft() (core.UnikraftConfig, error) {
 	return ac.unikraft, nil
 }
 
+// Libraries returns the application libraries' configurations
 func (ac ApplicationConfig) Libraries() (lib.Libraries, error) {
 	if ac.template.Source() != "" && !ac.template.IsUnpackedInProject() {
 		return lib.Libraries{}, fmt.Errorf("Libraries(): template source is not unpacked in project")
@@ -122,6 +128,7 @@ func (ac ApplicationConfig) Libraries() (lib.Libraries, error) {
 	return ac.libraries, nil
 }
 
+// Targets returns the application's targets
 func (ac ApplicationConfig) Targets() (target.Targets, error) {
 	if ac.template.Source() != "" && !ac.template.IsUnpackedInProject() {
 		return target.Targets{}, fmt.Errorf("Targets(): template source is not unpacked in project")
@@ -130,6 +137,7 @@ func (ac ApplicationConfig) Targets() (target.Targets, error) {
 	return ac.targets, nil
 }
 
+// Extensions returns the application's extensions
 func (ac ApplicationConfig) Extensions() (component.Extensions, error) {
 	if ac.template.Source() != "" && !ac.template.IsUnpackedInProject() {
 		return component.Extensions{}, fmt.Errorf("Extensions(): template source is not unpacked in project")
@@ -138,6 +146,7 @@ func (ac ApplicationConfig) Extensions() (component.Extensions, error) {
 	return ac.extensions, nil
 }
 
+// KraftFiles returns the application's kraft configuration files
 func (ac ApplicationConfig) KraftFiles() ([]string, error) {
 	if ac.template.Source() != "" && !ac.template.IsUnpackedInProject() {
 		return []string{}, fmt.Errorf("KraftFiles(): template source is not unpacked in project")
@@ -146,6 +155,7 @@ func (ac ApplicationConfig) KraftFiles() ([]string, error) {
 	return ac.kraftFiles, nil
 }
 
+// Configuration returns the application's kconfig list
 func (ac ApplicationConfig) Configuration() (kconfig.KConfigValues, error) {
 	if ac.template.Source() != "" && !ac.template.IsUnpackedInProject() {
 		return kconfig.KConfigValues{}, fmt.Errorf("Configuration(): template source is not unpacked in project")
@@ -154,6 +164,7 @@ func (ac ApplicationConfig) Configuration() (kconfig.KConfigValues, error) {
 	return ac.configuration, nil
 }
 
+// MergeTemplate merges the application's configuration with the given configuration
 func (a *ApplicationConfig) MergeTemplate(app *ApplicationConfig) *ApplicationConfig {
 	a.ComponentConfig = app.ComponentConfig
 

--- a/unikraft/app/application.go
+++ b/unikraft/app/application.go
@@ -50,6 +50,7 @@ import (
 	"kraftkit.sh/unikraft/core"
 	"kraftkit.sh/unikraft/lib"
 	"kraftkit.sh/unikraft/target"
+	"kraftkit.sh/unikraft/template"
 )
 
 const DefaultKConfigFile = ".config"
@@ -61,15 +62,16 @@ type Application interface {
 type ApplicationConfig struct {
 	component.ComponentConfig
 
-	WorkingDir    string                `yaml:"-" json:"-"`
-	Filename      string                `yaml:"-" json:"-"`
-	OutDir        string                `yaml:",omitempty" json:"outdir,omitempty"`
-	Unikraft      core.UnikraftConfig   `yaml:",omitempty" json:"unikraft,omitempty"`
-	Libraries     lib.Libraries         `yaml:",omitempty" json:"libraries,omitempty"`
-	Targets       target.Targets        `yaml:",omitempty" json:"targets,omitempty"`
-	Extensions    component.Extensions  `yaml:",inline" json:"-"` // https://github.com/golang/go/issues/6213
-	KraftFiles    []string              `yaml:"-" json:"-"`
-	Configuration kconfig.KConfigValues `yaml:"-" json:"-"`
+	WorkingDir    string                  `yaml:"-" json:"-"`
+	Filename      string                  `yaml:"-" json:"-"`
+	OutDir        string                  `yaml:",omitempty"`
+	Template      template.TemplateConfig `yaml:",omitempty"`
+	Unikraft      core.UnikraftConfig     `yaml:",omitempty"`
+	Libraries     lib.Libraries           `yaml:",omitempty"`
+	Targets       target.Targets          `yaml:",omitempty"`
+	Extensions    component.Extensions    `yaml:",inline" json:"-"` // https://github.com/golang/go/issues/6213
+	KraftFiles    []string                `yaml:"-" json:"-"`
+	Configuration kconfig.KConfigValues   `yaml:"-" json:"-"`
 }
 
 func (ac ApplicationConfig) Name() string {

--- a/unikraft/app/application.go
+++ b/unikraft/app/application.go
@@ -574,7 +574,9 @@ func (ac *ApplicationConfig) Components() ([]component.Component, error) {
 		return nil, fmt.Errorf("template source is not unpacked in project")
 	}
 
-	components = append(components, ac.template)
+	if ac.template.Name() != "" {
+		components = append(components, ac.template)
+	}
 
 	for _, library := range ac.libraries {
 		components = append(components, library)

--- a/unikraft/app/options.go
+++ b/unikraft/app/options.go
@@ -1,0 +1,129 @@
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// Authors: Cezar Craciunoiu <cezar@unikraft.io>
+//
+// Copyright (c) 2022, Unikraft GmbH.  All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+// 3. Neither the name of the copyright holder nor the names of its
+//    contributors may be used to endorse or promote products derived from
+//    this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+package app
+
+import (
+	"fmt"
+
+	"kraftkit.sh/kconfig"
+	"kraftkit.sh/unikraft/component"
+	"kraftkit.sh/unikraft/core"
+	"kraftkit.sh/unikraft/lib"
+	"kraftkit.sh/unikraft/target"
+	"kraftkit.sh/unikraft/template"
+)
+
+type ApplicationOption func(ao *ApplicationConfig) error
+
+// NewApplicationOptions accepts a series of options and returns a rendered
+// *ApplicationOptions structure
+func NewApplicationOptions(aopts ...ApplicationOption) (*ApplicationConfig, error) {
+	ao := &ApplicationConfig{}
+
+	for _, o := range aopts {
+		if err := o(ao); err != nil {
+			return nil, fmt.Errorf("could not apply option: %v", err)
+		}
+	}
+
+	return ao, nil
+}
+
+func WithWorkingDir(workingDir string) ApplicationOption {
+	return func(ao *ApplicationConfig) error {
+		ao.workingDir = workingDir
+		return nil
+	}
+}
+
+func WithFilename(filename string) ApplicationOption {
+	return func(ao *ApplicationConfig) error {
+		ao.filename = filename
+		return nil
+	}
+}
+
+func WithOutDir(outDir string) ApplicationOption {
+	return func(ao *ApplicationConfig) error {
+		ao.outDir = outDir
+		return nil
+	}
+}
+
+func WithTemplate(template template.TemplateConfig) ApplicationOption {
+	return func(ao *ApplicationConfig) error {
+		ao.template = template
+		return nil
+	}
+}
+
+func WithUnikraft(unikraft core.UnikraftConfig) ApplicationOption {
+	return func(ao *ApplicationConfig) error {
+		ao.unikraft = unikraft
+		return nil
+	}
+}
+
+func WithLibraries(libraries lib.Libraries) ApplicationOption {
+	return func(ao *ApplicationConfig) error {
+		ao.libraries = libraries
+		return nil
+	}
+}
+
+func WithTargets(targets target.Targets) ApplicationOption {
+	return func(ao *ApplicationConfig) error {
+		ao.targets = targets
+		return nil
+	}
+}
+
+func WithExtensions(extensions component.Extensions) ApplicationOption {
+	return func(ao *ApplicationConfig) error {
+		ao.extensions = extensions
+		return nil
+	}
+}
+
+func WithKraftFiles(kraftFiles []string) ApplicationOption {
+	return func(ao *ApplicationConfig) error {
+		ao.kraftFiles = kraftFiles
+		return nil
+	}
+}
+
+func WithConfiguration(configuration kconfig.KConfigValues) ApplicationOption {
+	return func(ao *ApplicationConfig) error {
+		ao.configuration = configuration
+		return nil
+	}
+}

--- a/unikraft/app/options.go
+++ b/unikraft/app/options.go
@@ -42,6 +42,7 @@ import (
 	"kraftkit.sh/unikraft/template"
 )
 
+// ApplicationOption is a function that operates on an ApplicationConfig
 type ApplicationOption func(ao *ApplicationConfig) error
 
 // NewApplicationOptions accepts a series of options and returns a rendered

--- a/unikraft/app/options.go
+++ b/unikraft/app/options.go
@@ -58,6 +58,7 @@ func NewApplicationOptions(aopts ...ApplicationOption) (*ApplicationConfig, erro
 	return ao, nil
 }
 
+// WithWorkingDir sets the application's working directory
 func WithWorkingDir(workingDir string) ApplicationOption {
 	return func(ao *ApplicationConfig) error {
 		ao.workingDir = workingDir
@@ -65,6 +66,7 @@ func WithWorkingDir(workingDir string) ApplicationOption {
 	}
 }
 
+// WithFilename sets the application's file name
 func WithFilename(filename string) ApplicationOption {
 	return func(ao *ApplicationConfig) error {
 		ao.filename = filename
@@ -72,6 +74,7 @@ func WithFilename(filename string) ApplicationOption {
 	}
 }
 
+// WithOutDir sets the application's output directory
 func WithOutDir(outDir string) ApplicationOption {
 	return func(ao *ApplicationConfig) error {
 		ao.outDir = outDir
@@ -79,6 +82,7 @@ func WithOutDir(outDir string) ApplicationOption {
 	}
 }
 
+// WithTemplate sets the application's template
 func WithTemplate(template template.TemplateConfig) ApplicationOption {
 	return func(ao *ApplicationConfig) error {
 		ao.template = template
@@ -86,6 +90,7 @@ func WithTemplate(template template.TemplateConfig) ApplicationOption {
 	}
 }
 
+// WithUnikraft sets the application's core
 func WithUnikraft(unikraft core.UnikraftConfig) ApplicationOption {
 	return func(ao *ApplicationConfig) error {
 		ao.unikraft = unikraft
@@ -93,6 +98,7 @@ func WithUnikraft(unikraft core.UnikraftConfig) ApplicationOption {
 	}
 }
 
+// WithLibraries sets the application's library list
 func WithLibraries(libraries lib.Libraries) ApplicationOption {
 	return func(ao *ApplicationConfig) error {
 		ao.libraries = libraries
@@ -100,6 +106,7 @@ func WithLibraries(libraries lib.Libraries) ApplicationOption {
 	}
 }
 
+// WithTargets sets the application's target list
 func WithTargets(targets target.Targets) ApplicationOption {
 	return func(ao *ApplicationConfig) error {
 		ao.targets = targets
@@ -107,6 +114,7 @@ func WithTargets(targets target.Targets) ApplicationOption {
 	}
 }
 
+// WithExtensions sets the application's extension list
 func WithExtensions(extensions component.Extensions) ApplicationOption {
 	return func(ao *ApplicationConfig) error {
 		ao.extensions = extensions
@@ -114,6 +122,7 @@ func WithExtensions(extensions component.Extensions) ApplicationOption {
 	}
 }
 
+// WithKraftFiles sets the application's kraft yaml files
 func WithKraftFiles(kraftFiles []string) ApplicationOption {
 	return func(ao *ApplicationConfig) error {
 		ao.kraftFiles = kraftFiles
@@ -121,6 +130,7 @@ func WithKraftFiles(kraftFiles []string) ApplicationOption {
 	}
 }
 
+// WithConfiguration sets the application's kconfig list
 func WithConfiguration(configuration kconfig.KConfigValues) ApplicationOption {
 	return func(ao *ApplicationConfig) error {
 		ao.configuration = configuration

--- a/unikraft/component/component.go
+++ b/unikraft/component/component.go
@@ -178,6 +178,7 @@ func (cc *ComponentConfig) Workdir() string {
 	return cc.workdir
 }
 
+// SetWorkdir sets the instantiated component's working directory
 func (cc *ComponentConfig) SetWorkdir(workdir string) {
 	cc.workdir = workdir
 }

--- a/unikraft/component/component.go
+++ b/unikraft/component/component.go
@@ -178,6 +178,10 @@ func (cc *ComponentConfig) Workdir() string {
 	return cc.workdir
 }
 
+func (cc *ComponentConfig) SetWorkdir(workdir string) {
+	cc.workdir = workdir
+}
+
 // SourceDir returns the well-known location of the component given its working
 // directory, type and name.
 func (cc *ComponentConfig) SourceDir() (string, error) {

--- a/unikraft/config/config.go
+++ b/unikraft/config/config.go
@@ -40,6 +40,7 @@ import (
 	"kraftkit.sh/unikraft/core"
 	"kraftkit.sh/unikraft/lib"
 	"kraftkit.sh/unikraft/target"
+	"kraftkit.sh/unikraft/template"
 )
 
 // ConfigDetails are the details about a group of ConfigFiles
@@ -85,12 +86,13 @@ type ConfigFile struct {
 
 // Config is a full kraft file configuration and model
 type Config struct {
-	Filename  string              `yaml:"-" json:"-"`
-	Name      string              `yaml:",omitempty" json:"name,omitempty"`
-	OutDir    string              `yaml:",omitempty" json:"outdir,omitempty"`
-	Unikraft  core.UnikraftConfig `yaml:",omitempty" json:"unikraft,omitempty"`
-	Libraries lib.Libraries       `yaml:",omitempty" json:"libraries,omitempty"`
-	Targets   target.Targets      `yaml:",omitempty" json:"targets,omitempty"`
+	Filename  string                  `yaml:"-" json:"-"`
+	Name      string                  `yaml:",omitempty" json:"name,omitempty"`
+	OutDir    string                  `yaml:",omitempty" json:"outdir,omitempty"`
+	Template  template.TemplateConfig `yaml:",omitempty" json:"template,omitempty"`
+	Unikraft  core.UnikraftConfig     `yaml:",omitempty" json:"unikraft,omitempty"`
+	Libraries lib.Libraries           `yaml:",omitempty" json:"libraries,omitempty"`
+	Targets   target.Targets          `yaml:",omitempty" json:"targets,omitempty"`
 
 	Extensions component.Extensions `yaml:",inline" json:"-"`
 }

--- a/unikraft/template/template.go
+++ b/unikraft/template/template.go
@@ -50,26 +50,32 @@ type TemplateConfig struct {
 	component.ComponentConfig
 }
 
+// Name returns the name of the template
 func (tc TemplateConfig) Name() string {
 	return tc.ComponentConfig.Name
 }
 
+// Source returns the source of the template
 func (tc TemplateConfig) Source() string {
 	return tc.ComponentConfig.Source
 }
 
+// Version returns the version of the template
 func (tc TemplateConfig) Version() string {
 	return tc.ComponentConfig.Version
 }
 
+// Type returns the type of the template
 func (tc TemplateConfig) Type() unikraft.ComponentType {
 	return unikraft.ComponentTypeApp
 }
 
+// Component returns the component of the template
 func (tc TemplateConfig) Component() component.ComponentConfig {
 	return tc.ComponentConfig
 }
 
+// KConfigMenu returns the path to the kconfig file of the template
 func (tc TemplateConfig) KConfigMenu() (*kconfig.KConfigFile, error) {
 	sourceDir, err := tc.ComponentConfig.SourceDir()
 	if err != nil {
@@ -84,6 +90,7 @@ func (tc TemplateConfig) KConfigMenu() (*kconfig.KConfigFile, error) {
 	return kconfig.Parse(config_uk)
 }
 
+// KConfigValues returns the kconfig values of the template
 func (tc TemplateConfig) KConfigValues() (kconfig.KConfigValues, error) {
 	menu, err := tc.KConfigMenu()
 	if err != nil {
@@ -102,6 +109,7 @@ func (tc TemplateConfig) KConfigValues() (kconfig.KConfigValues, error) {
 	return values, nil
 }
 
+// PrintInfo prints information about the template
 func (tc TemplateConfig) PrintInfo(io *iostreams.IOStreams) error {
 	fmt.Fprint(io.Out, "not implemented: unikraft.lib.LibraryConfig.PrintInfo")
 	return nil

--- a/unikraft/template/template.go
+++ b/unikraft/template/template.go
@@ -29,6 +29,8 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
+// Package template implements the interface through which templates can
+// be edited and configured.
 package template
 
 import (
@@ -42,10 +44,13 @@ import (
 	"kraftkit.sh/unikraft/component"
 )
 
+// Template interfaces with the standard component in Unikraft
 type Template interface {
 	component.Component
 }
 
+// TemplateConfig is the configuration of a template. It is identical to
+// the component configuration
 type TemplateConfig struct {
 	component.ComponentConfig
 }

--- a/unikraft/template/template.go
+++ b/unikraft/template/template.go
@@ -1,0 +1,108 @@
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// Authors: Cezar Craciunoiu <cezar@unikraft.io>
+//
+// Copyright (c) 2022, Unikraft GmbH.  All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+// 3. Neither the name of the copyright holder nor the names of its
+//    contributors may be used to endorse or promote products derived from
+//    this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+package template
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"kraftkit.sh/iostreams"
+	"kraftkit.sh/kconfig"
+	"kraftkit.sh/unikraft"
+	"kraftkit.sh/unikraft/component"
+)
+
+type Template interface {
+	component.Component
+}
+
+type TemplateConfig struct {
+	component.ComponentConfig
+}
+
+func (tc TemplateConfig) Name() string {
+	return tc.ComponentConfig.Name
+}
+
+func (tc TemplateConfig) Source() string {
+	return tc.ComponentConfig.Source
+}
+
+func (tc TemplateConfig) Version() string {
+	return tc.ComponentConfig.Version
+}
+
+func (tc TemplateConfig) Type() unikraft.ComponentType {
+	return unikraft.ComponentTypeApp
+}
+
+func (tc TemplateConfig) Component() component.ComponentConfig {
+	return tc.ComponentConfig
+}
+
+func (tc TemplateConfig) KConfigMenu() (*kconfig.KConfigFile, error) {
+	sourceDir, err := tc.ComponentConfig.SourceDir()
+	if err != nil {
+		return nil, fmt.Errorf("could not get library source directory: %v", err)
+	}
+
+	config_uk := filepath.Join(sourceDir, unikraft.Config_uk)
+	if _, err := os.Stat(config_uk); err != nil {
+		return nil, fmt.Errorf("could not read component Config.uk: %v", err)
+	}
+
+	return kconfig.Parse(config_uk)
+}
+
+func (tc TemplateConfig) KConfigValues() (kconfig.KConfigValues, error) {
+	menu, err := tc.KConfigMenu()
+	if err != nil {
+		return nil, fmt.Errorf("could not list KConfig values: %v", err)
+	}
+
+	values := kconfig.KConfigValues{}
+	values.OverrideBy(tc.Configuration)
+
+	if menu == nil {
+		return values, nil
+	}
+
+	values.Set(kconfig.Prefix+menu.Root.Name, kconfig.Yes)
+
+	return values, nil
+}
+
+func (tc TemplateConfig) PrintInfo(io *iostreams.IOStreams) error {
+	fmt.Fprint(io.Out, "not implemented: unikraft.lib.LibraryConfig.PrintInfo")
+	return nil
+}


### PR DESCRIPTION
Introduce the possibility to use templates in Unikraft applications. More details in the linked issue. 

The PR follows the Issue steps, but some are reordered, as to be logical from a commit-steps point-of-view.

Will have to fix the checks.

Closes: #27