### PR TITLE
cmd/build: Run the fetch step before building

### DIFF
--- a/unikraft/app/application.go
+++ b/unikraft/app/application.go
@@ -392,6 +392,15 @@ func (a *ApplicationConfig) Build(opts ...BuildOption) error {
 		}
 	}
 
+	if !bopts.noFetch {
+		if err := a.Fetch(append(
+			bopts.mopts,
+			make.WithProgressFunc(nil),
+		)...); err != nil {
+			return err
+		}
+	}
+
 	return a.Make(bopts.mopts...)
 }
 

--- a/unikraft/app/build_options.go
+++ b/unikraft/app/build_options.go
@@ -47,6 +47,7 @@ type BuildOptions struct {
 	mopts        []make.MakeOption
 	onProgress   func(progress float64)
 	noSyncConfig bool
+	noFetch      bool
 }
 
 type BuildOption func(opts *BuildOptions) error
@@ -125,6 +126,15 @@ func WithBuildLogFile(path string) BuildOption {
 func WithBuildNoSyncConfig(noSyncConfig bool) BuildOption {
 	return func(bo *BuildOptions) error {
 		bo.noSyncConfig = noSyncConfig
+		return nil
+	}
+}
+
+// WithBuildNoFetch disables calling `make fetch` befere invoking the
+// main Unikraft's build invocation.
+func WithBuildNoFetch(noFetch bool) BuildOption {
+	return func(bo *BuildOptions) error {
+		bo.noFetch = noFetch
 		return nil
 	}
 }


### PR DESCRIPTION
Run the fetch step before the build step.
Add a new option if you don't want to
preemptively run the fetch step.

Closes: #82 

Signed-off-by: Stefan Jumarea <stefanjumarea02@gmail.com>