### PR TITLE
cmd/build: Run the prepare step before building

### DIFF
--- a/cmd/kraft/build/build.go
+++ b/cmd/kraft/build/build.go
@@ -227,6 +227,13 @@ func BuildCmd(f *cmdfactory.Factory) *cobra.Command {
 		"Do not run Unikraft's configure step before building",
 	)
 
+	cmd.Flags().BoolVar(
+		&opts.NoPrepare,
+		"no-prepare",
+		false,
+		"Do not run Unikraft's prepare step before building",
+	)
+
 	return cmd
 }
 
@@ -456,6 +463,23 @@ func buildRun(opts *buildOptions, workdir string) error {
 							exec.WithStderr(l.Output()),
 						),
 					)
+				},
+			))
+		}
+
+		if !opts.NoPrepare {
+			processes = append(processes, paraprogress.NewProcess(
+				fmt.Sprintf("preparing %s (%s)", targ.Name(), targ.ArchPlatString()),
+				func(l log.Logger, w func(progress float64)) error {
+					// Apply the incoming logger which is tailored to display as a
+					// sub-terminal within the fancy processtree.
+					targ.ApplyOptions(
+						component.WithLogger(l),
+					)
+
+					return project.Prepare(append(mopts,
+						make.WithLogger(l),
+					)...)
 				},
 			))
 		}

--- a/unikraft/app/application.go
+++ b/unikraft/app/application.go
@@ -392,6 +392,15 @@ func (a *ApplicationConfig) Build(opts ...BuildOption) error {
 		}
 	}
 
+	if !bopts.noPrepare {
+		if err := a.Prepare(append(
+			bopts.mopts,
+			make.WithProgressFunc(nil),
+		)...); err != nil {
+			return err
+		}
+	}
+
 	return a.Make(bopts.mopts...)
 }
 

--- a/unikraft/app/build_options.go
+++ b/unikraft/app/build_options.go
@@ -47,6 +47,7 @@ type BuildOptions struct {
 	mopts        []make.MakeOption
 	onProgress   func(progress float64)
 	noSyncConfig bool
+	noPrepare    bool
 }
 
 type BuildOption func(opts *BuildOptions) error
@@ -125,6 +126,15 @@ func WithBuildLogFile(path string) BuildOption {
 func WithBuildNoSyncConfig(noSyncConfig bool) BuildOption {
 	return func(bo *BuildOptions) error {
 		bo.noSyncConfig = noSyncConfig
+		return nil
+	}
+}
+
+// WithBuildNoPrepare disables calling `make prepare` befere invoking the
+// main Unikraft's build invocation.
+func WithBuildNoPrepare(noPrepare bool) BuildOption {
+	return func(bo *BuildOptions) error {
+		bo.noPrepare = noPrepare
 		return nil
 	}
 }


### PR DESCRIPTION
Run the prepare step before the build step.
Add a new option if you don't want to
preemptively run the prepare step.

Closes: #81 

Signed-off-by: Stefan Jumarea <stefanjumarea02@gmail.com>