### PR TITLE
.github/workflows: Add dependabot workflow

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -1,0 +1,17 @@
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/"
+    target-branch: "staging"
+    schedule:
+      interval: "weekly"
+      day: "sunday"
+      time: "09:00"
+    commit-message:
+      prefix: "gomod" # Prefix messages with
+      include: "scope" # List all updated dependencies
+    reviewers:
+      - "nderjung"
+      - "craciunoiuc"
+    assignees:
+      - "nderjung"


### PR DESCRIPTION
To fully enable dependabot we also need to enable it in the github repository.

GitHub-Fixes: #137
Signed-off-by: Cezar Craciunoiu <cezar.craciunoiu@unikraft.io>