### PR TITLE
.github: Add PR and Issue templating

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,79 @@
+name: 🐞 Report a bug
+description: Create a bug report about unexpected behavior.
+labels: [kind/bug]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this bug report!
+
+        Please only use this form to submit problems with building Kraftkit or it's interaction with Unikraft unikernels.  This includes unexpected or undefined behavior, stacktraces, critical messages, and things just breaking or exploding.
+        
+        **Ensure you have tested against the latest changes on `staging` branch before submitting this form.**
+
+        For questions, concerns or help with running Kraftkit, please check out our additional resources:
+
+        * [Unikraft Documentation](https://unikraft.org/docs/)
+        * [Unikraft Discussions Forum](https://github.com/unikraft/unikraft/discussions)
+  - type: textarea
+    id: bug-description
+    attributes:
+      label: Describe the bug
+      description: Please provide a clear and concise description of the bug.
+    validations:
+      required: true
+  - type: textarea
+    id: steps-to-reproduce
+    attributes:
+      label: Steps to reproduce
+      description: Please provide the steps necessary to reproduce the behavior, for example the command used to run Kraftkit, or the sequence of actions, auxiliary components, networking setup, etc. leading up to the error or bug.  Please also include any `kraft.yaml` files you used.
+      placeholder: |
+        For example, I used this kraft configuration:
+
+         ```
+         specification: "0.5"
+         name: helloworld
+         outdir:
+         ...
+         ```
+         - ...
+    validations:
+      required: false
+  - type: textarea
+    id: expected-behavior
+    attributes:
+      label: Expected behavior
+      description: A clear and concise description of what you expected to happen.
+      placeholder: For example, I expected the unikernel to boot and print "Hello, world!"
+    validations:
+      required: false
+  - type: dropdown
+    id: architectures
+    attributes:
+      label: Which architectures were you using or does this bug affect?
+      description: If this bug is architecture agnostic or you are unsure then please do not select an architecture listed below.
+      multiple: true
+      options:
+        - x86_64
+        - arm
+        - arm64
+  - type: dropdown
+    id: platforms
+    attributes:
+      label: Which operating system were you using or does this bug affect?
+      description: If this bug is operating system agnostic or you are unsure then please do not select an platform listed below.
+      multiple: true
+      options:
+        - linux/debian
+        - linux/fedora
+        - linux/alpine
+        - linux/arch
+        - linux/other
+        - windows
+        - macOS
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant log output
+      description: Please copy and paste any relevant log output.  This will be automatically formatted into code, so no need for backticks.
+      render: shell

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,6 @@
+blank_issues_enabled: false
+
+contact_links:
+  - name: 💡 Discuss an idea
+    url: https://github.com/unikraft/unikraft/discussions/new
+    about: Discuss a feature or usecase which Kraftkit could support.

--- a/.github/ISSUE_TEMPLATE/project_backlog.yml
+++ b/.github/ISSUE_TEMPLATE/project_backlog.yml
@@ -1,0 +1,55 @@
+name: 📥 Add to the backlog
+description: Create an issue for new work to be done which has been discussed.
+labels: [kind/enhancement]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Please only use this form to submit new, well-defined work to the Kraftkit project's backlog.  Issues under this category have been discussed with the Kraftkit team.
+
+        If you're intending to request a feature, please [open a discussion using the "Ideas" category](https://github.com/unikraft/unikraft/discussions/new) instead so we can understand your workflow first.  If you are unsure about a feature, please [check out our documentation](https://docs.unikraft.org/) which covers existing features and possibilities with Unikraft or filter existing issues labeled under [`kind/enhancement`](https://github.com/unikraft/kraftkit/labels/kind/enhancement) to prevent double-posting.
+  - type: textarea
+    id: feature-request-summary
+    attributes:
+      label: Feature request summary
+      description: Please provide a quick summary which clearly and concisely describes the feature.  For example, highlights of new functionality; proposal of a new architecture or operating system support; additions to documentation; etc.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Describe alternatives
+      description: A clear and concise description of any alternative solutions or features considered.
+    validations:
+      required: false
+  - type: dropdown
+    id: related-architectures
+    attributes:
+      label: Related architectures
+      description: Please indicate whether the feature request is related to a specific architecture.  If this feature is architecture agnostic or you are unsure then please do not select an architecture listed below.
+      multiple: false
+      options:
+        - x86_64
+        - arm
+        - arm64
+  - type: dropdown
+    id: related-platforms
+    attributes:
+      label: Related platforms
+      description: Please indicate whether the feature request is related to a specific operating system.  If this feature is operating system agnostic or you are unsure then please do not select an operating system listed below.
+      multiple: false
+      options:
+        - linux/debian
+        - linux/fedora
+        - linux/alpine
+        - linux/arch
+        - linux/other
+        - windows
+        - macOS
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional context
+      description: Add any other context, longer descriptions, screenshot/mock-ups, or links to related material about the feature request.
+    validations:
+      required: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,29 @@
+<!--
+
+Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
+new changes, features, fixes, and more!  Please fill in this form to indicate
+the status of your PR.  Please ensure you have read the contribution guidelines
+before opening a new PR as this will cover the PR process:
+
+  https://unikraft.org/docs/contributing/
+
+  Kraftkit follows the same guidelines as the Unikraft Open Source Project.
+
+-->
+
+### Prerequisite checklist
+
+<!--
+Please mark items appropriately:
+-->
+
+  - [ ] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
+  - [ ] Tested your changes against relevant architectures and platforms;
+  - [ ] Ran `make fmt` on your commit series before opening this PR;
+  - [ ] Updated relevant documentation.
+
+### Description of changes
+
+<!--
+Please provide a detailed description of the changes made in this new PR.
+-->


### PR DESCRIPTION
The template is imported and modified from the main unikraft repository.