### PR TITLE
cmd/kraft, machine/qemu: Fix reduntant error checks

### DIFF
--- a/cmd/kraft/pkg/pull/pull.go
+++ b/cmd/kraft/pkg/pull/pull.go
@@ -64,15 +64,11 @@ func New() *cobra.Command {
 }
 
 func (opts *Pull) Pre(cmd *cobra.Command, args []string) error {
-	if err := cmdfactory.MutuallyExclusive(
+	return cmdfactory.MutuallyExclusive(
 		"the `--with-deps` option is not supported with `--no-deps`",
 		opts.WithDeps,
 		opts.NoDeps,
-	); err != nil {
-		return err
-	}
-
-	return nil
+	)
 }
 
 func (opts *Pull) Run(cmd *cobra.Command, args []string) error {

--- a/cmd/kraft/pkg/source/source.go
+++ b/cmd/kraft/pkg/source/source.go
@@ -47,9 +47,5 @@ func (opts *Source) Run(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	if err = pm.AddSource(ctx, source); err != nil {
-		return err
-	}
-
-	return nil
+	return pm.AddSource(ctx, source)
 }

--- a/cmd/kraft/pkg/update/update.go
+++ b/cmd/kraft/pkg/update/update.go
@@ -75,9 +75,5 @@ func (opts *Update) Run(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	if err := model.Start(); err != nil {
-		return err
-	}
-
-	return nil
+	return model.Start()
 }

--- a/machine/qemu/qemu.go
+++ b/machine/qemu/qemu.go
@@ -958,11 +958,7 @@ func (qd *QemuDriver) Pause(ctx context.Context, mid machine.MachineID) error {
 		return err
 	}
 
-	if err := qd.dopts.Store.SaveMachineState(mid, machine.MachineStatePaused); err != nil {
-		return err
-	}
-
-	return nil
+	return qd.dopts.Store.SaveMachineState(mid, machine.MachineStatePaused)
 }
 
 func (qd *QemuDriver) TailWriter(ctx context.Context, mid machine.MachineID, writer io.Writer) error {
@@ -1167,11 +1163,7 @@ func (qd *QemuDriver) Stop(ctx context.Context, mid machine.MachineID) error {
 		return err
 	}
 
-	if err := qd.dopts.Store.SaveMachineState(mid, machine.MachineStateExited); err != nil {
-		return err
-	}
-
-	return nil
+	return qd.dopts.Store.SaveMachineState(mid, machine.MachineStateExited)
 }
 
 func (qd *QemuDriver) Destroy(ctx context.Context, mid machine.MachineID) error {


### PR DESCRIPTION
Fixes [codacy `if-return` warnings](https://app.codacy.com/gh/unikraft/kraftkit/issues?&filters=W3siaWQiOiJMYW5ndWFnZSIsInZhbHVlcyI6W119LHsiaWQiOiJDYXRlZ29yeSIsInZhbHVlcyI6WyJDb2RlU3R5bGUiXX0seyJpZCI6IkxldmVsIiwidmFsdWVzIjpbXX0seyJpZCI6IlBhdHRlcm4iLCJ2YWx1ZXMiOlsiMTcxNTkiXX0seyJpZCI6IkF1dGhvciIsInZhbHVlcyI6W119XQ==). 

Signed-off-by: Stefan Jumarea <stefanjumarea02@gmail.com>