### PR TITLE
Expose CLI builder package as public package

### DIFF
--- a/cmd/kraft/build/build.go
+++ b/cmd/kraft/build/build.go
@@ -13,12 +13,11 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
+	"kraftkit.sh/cmdfactory"
 	"kraftkit.sh/config"
 	"kraftkit.sh/exec"
 	"kraftkit.sh/pack"
 	"kraftkit.sh/unikraft"
-
-	"kraftkit.sh/internal/cli"
 
 	"kraftkit.sh/iostreams"
 	"kraftkit.sh/log"
@@ -47,10 +46,10 @@ type Build struct {
 }
 
 func New() *cobra.Command {
-	return cli.New(&Build{}, cobra.Command{
+	return cmdfactory.New(&Build{}, cobra.Command{
 		Short: "Configure and build Unikraft unikernels ",
 		Use:   "build [FLAGS] [SUBCOMMAND|DIR]",
-		Args:  cli.MaxDirArgs(1),
+		Args:  cmdfactory.MaxDirArgs(1),
 		Long: heredoc.Docf(`
 			Configure and build Unikraft unikernels.
 

--- a/cmd/kraft/clean/clean.go
+++ b/cmd/kraft/clean/clean.go
@@ -37,18 +37,17 @@ import (
 	"github.com/MakeNowJust/heredoc"
 	"github.com/spf13/cobra"
 
+	"kraftkit.sh/cmdfactory"
 	"kraftkit.sh/unikraft/app"
-
-	"kraftkit.sh/internal/cli"
 )
 
 type Clean struct{}
 
 func New() *cobra.Command {
-	return cli.New(&Clean{}, cobra.Command{
+	return cmdfactory.New(&Clean{}, cobra.Command{
 		Short: "Remove the build object files of a Unikraft project",
 		Use:   "clean [DIR]",
-		Args:  cli.MaxDirArgs(1),
+		Args:  cmdfactory.MaxDirArgs(1),
 		Long: heredoc.Doc(`
 			Remove the build object files of a Unikraft project`),
 		Example: heredoc.Doc(`

--- a/cmd/kraft/configure/configure.go
+++ b/cmd/kraft/configure/configure.go
@@ -10,18 +10,17 @@ import (
 	"github.com/MakeNowJust/heredoc"
 	"github.com/spf13/cobra"
 
+	"kraftkit.sh/cmdfactory"
 	"kraftkit.sh/unikraft/app"
-
-	"kraftkit.sh/internal/cli"
 )
 
 type Configure struct{}
 
 func New() *cobra.Command {
-	return cli.New(&Configure{}, cobra.Command{
+	return cmdfactory.New(&Configure{}, cobra.Command{
 		Short: "Configure a Unikraft unikernel its dependencies",
 		Use:   "configure [DIR]",
-		Args:  cli.MaxDirArgs(1),
+		Args:  cmdfactory.MaxDirArgs(1),
 		Long: heredoc.Doc(`
 			Configure a Unikraft unikernel its dependencies`),
 		Example: heredoc.Doc(`

--- a/cmd/kraft/events/events.go
+++ b/cmd/kraft/events/events.go
@@ -18,14 +18,13 @@ import (
 	"github.com/MakeNowJust/heredoc"
 	"github.com/spf13/cobra"
 
+	"kraftkit.sh/cmdfactory"
 	"kraftkit.sh/config"
 	"kraftkit.sh/log"
 	"kraftkit.sh/machine"
 	machinedriver "kraftkit.sh/machine/driver"
 	"kraftkit.sh/machine/driveropts"
 	"kraftkit.sh/machine/qemu/qmp"
-
-	"kraftkit.sh/internal/cli"
 )
 
 type Events struct {
@@ -34,7 +33,7 @@ type Events struct {
 }
 
 func New() *cobra.Command {
-	return cli.New(&Events{}, cobra.Command{
+	return cmdfactory.New(&Events{}, cobra.Command{
 		Short:   "Follow the events of a unikernel",
 		Hidden:  true,
 		Use:     "events [FLAGS] [MACHINE ID]",

--- a/cmd/kraft/fetch/fetch.go
+++ b/cmd/kraft/fetch/fetch.go
@@ -10,9 +10,8 @@ import (
 	"github.com/MakeNowJust/heredoc"
 	"github.com/spf13/cobra"
 
+	"kraftkit.sh/cmdfactory"
 	"kraftkit.sh/unikraft/app"
-
-	"kraftkit.sh/internal/cli"
 )
 
 type Fetch struct {
@@ -21,11 +20,11 @@ type Fetch struct {
 }
 
 func New() *cobra.Command {
-	return cli.New(&Fetch{}, cobra.Command{
+	return cmdfactory.New(&Fetch{}, cobra.Command{
 		Short:   "Fetch a Unikraft unikernel's dependencies",
 		Use:     "fetch [DIR]",
 		Aliases: []string{"f"},
-		Args:    cli.MaxDirArgs(1),
+		Args:    cmdfactory.MaxDirArgs(1),
 		Long: heredoc.Doc(`
 			Fetch a Unikraft unikernel's dependencies`),
 		Example: heredoc.Doc(`

--- a/cmd/kraft/kraft.go
+++ b/cmd/kraft/kraft.go
@@ -8,7 +8,7 @@ import (
 	"github.com/MakeNowJust/heredoc"
 	"github.com/spf13/cobra"
 
-	"kraftkit.sh/internal/cli"
+	"kraftkit.sh/cmdfactory"
 
 	"kraftkit.sh/cmd/kraft/build"
 	"kraftkit.sh/cmd/kraft/clean"
@@ -33,7 +33,7 @@ import (
 type Kraft struct{}
 
 func New() *cobra.Command {
-	cmd := cli.New(&Kraft{}, cobra.Command{
+	cmd := cmdfactory.New(&Kraft{}, cobra.Command{
 		Short: "Build and use highly customized and ultra-lightweight unikernels",
 		Long: heredoc.Docf(`
         .
@@ -88,5 +88,5 @@ func (k *Kraft) Run(cmd *cobra.Command, args []string) error {
 }
 
 func main() {
-	cli.Main(New())
+	cmdfactory.Main(New())
 }

--- a/cmd/kraft/menu/menu.go
+++ b/cmd/kraft/menu/menu.go
@@ -10,20 +10,19 @@ import (
 	"github.com/MakeNowJust/heredoc"
 	"github.com/spf13/cobra"
 
+	"kraftkit.sh/cmdfactory"
 	"kraftkit.sh/make"
 	"kraftkit.sh/unikraft/app"
-
-	"kraftkit.sh/internal/cli"
 )
 
 type Menu struct{}
 
 func New() *cobra.Command {
-	return cli.New(&Menu{}, cobra.Command{
+	return cmdfactory.New(&Menu{}, cobra.Command{
 		Short:   "Open's Unikraft configuration editor TUI",
 		Use:     "menu [DIR]",
 		Aliases: []string{"m", "menuconfig"},
-		Args:    cli.MaxDirArgs(1),
+		Args:    cmdfactory.MaxDirArgs(1),
 		Long: heredoc.Doc(`
 			Open Unikraft's configuration editor TUI`),
 		Example: heredoc.Doc(`

--- a/cmd/kraft/pkg/list/list.go
+++ b/cmd/kraft/pkg/list/list.go
@@ -12,14 +12,13 @@ import (
 
 	"kraftkit.sh/unikraft/app"
 
+	"kraftkit.sh/cmdfactory"
 	"kraftkit.sh/iostreams"
 	"kraftkit.sh/log"
 	"kraftkit.sh/pack"
 	"kraftkit.sh/packmanager"
 	"kraftkit.sh/unikraft"
 	"kraftkit.sh/utils"
-
-	"kraftkit.sh/internal/cli"
 )
 
 type List struct {
@@ -34,11 +33,11 @@ type List struct {
 }
 
 func New() *cobra.Command {
-	return cli.New(&List{}, cobra.Command{
+	return cmdfactory.New(&List{}, cobra.Command{
 		Short:   "List installed Unikraft component packages",
 		Use:     "list [FLAGS] [DIR]",
 		Aliases: []string{"l", "ls"},
-		Args:    cli.MaxDirArgs(1),
+		Args:    cmdfactory.MaxDirArgs(1),
 		Long: heredoc.Doc(`
 			List installed Unikraft component packages.
 		`),

--- a/cmd/kraft/pkg/pkg.go
+++ b/cmd/kraft/pkg/pkg.go
@@ -15,6 +15,7 @@ import (
 	"kraftkit.sh/config"
 	"kraftkit.sh/unikraft"
 
+	"kraftkit.sh/cmdfactory"
 	"kraftkit.sh/initrd"
 	"kraftkit.sh/log"
 	"kraftkit.sh/pack"
@@ -22,8 +23,6 @@ import (
 	"kraftkit.sh/tui/processtree"
 	"kraftkit.sh/unikraft/app"
 	"kraftkit.sh/unikraft/target"
-
-	"kraftkit.sh/internal/cli"
 
 	"kraftkit.sh/cmd/kraft/pkg/list"
 	"kraftkit.sh/cmd/kraft/pkg/pull"
@@ -48,10 +47,10 @@ type Pkg struct {
 }
 
 func New() *cobra.Command {
-	cmd := cli.New(&Pkg{}, cobra.Command{
+	cmd := cmdfactory.New(&Pkg{}, cobra.Command{
 		Short: "Package and distribute Unikraft unikernels and their dependencies",
 		Use:   "pkg [FLAGS] [SUBCOMMAND|DIR]",
-		Args:  cli.MaxDirArgs(1),
+		Args:  cmdfactory.MaxDirArgs(1),
 		Long: heredoc.Docf(`
 			Package and distribute Unikraft unikernels and their dependencies.
 

--- a/cmd/kraft/pkg/pull/pull.go
+++ b/cmd/kraft/pkg/pull/pull.go
@@ -13,6 +13,7 @@ import (
 	"github.com/MakeNowJust/heredoc"
 	"github.com/spf13/cobra"
 
+	"kraftkit.sh/cmdfactory"
 	"kraftkit.sh/config"
 	"kraftkit.sh/iostreams"
 	"kraftkit.sh/log"
@@ -22,8 +23,6 @@ import (
 	"kraftkit.sh/tui/processtree"
 	"kraftkit.sh/unikraft"
 	"kraftkit.sh/unikraft/app"
-
-	"kraftkit.sh/internal/cli"
 )
 
 type Pull struct {
@@ -39,7 +38,7 @@ type Pull struct {
 }
 
 func New() *cobra.Command {
-	return cli.New(&Pull{}, cobra.Command{
+	return cmdfactory.New(&Pull{}, cobra.Command{
 		Short:   "Pull a Unikraft unikernel and/or its dependencies",
 		Use:     "pull [FLAGS] [PACKAGE|DIR]",
 		Aliases: []string{"p"},
@@ -65,7 +64,7 @@ func New() *cobra.Command {
 }
 
 func (opts *Pull) Pre(cmd *cobra.Command, args []string) error {
-	if err := cli.MutuallyExclusive(
+	if err := cmdfactory.MutuallyExclusive(
 		"the `--with-deps` option is not supported with `--no-deps`",
 		opts.WithDeps,
 		opts.NoDeps,

--- a/cmd/kraft/pkg/source/source.go
+++ b/cmd/kraft/pkg/source/source.go
@@ -8,18 +8,17 @@ import (
 	"github.com/MakeNowJust/heredoc"
 	"github.com/spf13/cobra"
 
+	"kraftkit.sh/cmdfactory"
 	"kraftkit.sh/packmanager"
-
-	"kraftkit.sh/internal/cli"
 )
 
 type Source struct{}
 
 func New() *cobra.Command {
-	return cli.New(&Source{}, cobra.Command{
+	return cmdfactory.New(&Source{}, cobra.Command{
 		Short: "Add Unikraft component manifests",
 		Use:   "source [FLAGS] [SOURCE]",
-		Args:  cli.MinimumArgs(1, "must specify component or manifest"),
+		Args:  cmdfactory.MinimumArgs(1, "must specify component or manifest"),
 		Example: heredoc.Docf(`
 			# Add a single component as a Git repository
 			$ kraft pkg source https://github.com/unikraft/unikraft.git

--- a/cmd/kraft/pkg/update/update.go
+++ b/cmd/kraft/pkg/update/update.go
@@ -10,12 +10,11 @@ import (
 	"github.com/MakeNowJust/heredoc"
 	"github.com/spf13/cobra"
 
+	"kraftkit.sh/cmdfactory"
 	"kraftkit.sh/config"
 	"kraftkit.sh/log"
 	"kraftkit.sh/packmanager"
 	"kraftkit.sh/tui/processtree"
-
-	"kraftkit.sh/internal/cli"
 )
 
 type Update struct {
@@ -23,7 +22,7 @@ type Update struct {
 }
 
 func New() *cobra.Command {
-	return cli.New(&Update{}, cobra.Command{
+	return cmdfactory.New(&Update{}, cobra.Command{
 		Short: "Retrieve new lists of Unikraft components, libraries and packages",
 		Use:   "update [FLAGS]",
 		Long: heredoc.Doc(`

--- a/cmd/kraft/prepare/prepare.go
+++ b/cmd/kraft/prepare/prepare.go
@@ -10,19 +10,18 @@ import (
 	"github.com/MakeNowJust/heredoc"
 	"github.com/spf13/cobra"
 
+	"kraftkit.sh/cmdfactory"
 	"kraftkit.sh/unikraft/app"
-
-	"kraftkit.sh/internal/cli"
 )
 
 type Prepare struct{}
 
 func New() *cobra.Command {
-	return cli.New(&Prepare{}, cobra.Command{
+	return cmdfactory.New(&Prepare{}, cobra.Command{
 		Short:   "Prepare a Unikraft unikernel",
 		Use:     "prepare [DIR]",
 		Aliases: []string{"p"},
-		Args:    cli.MaxDirArgs(1),
+		Args:    cmdfactory.MaxDirArgs(1),
 		Long: heredoc.Doc(`
 			prepare a Unikraft unikernel`),
 		Example: heredoc.Doc(`

--- a/cmd/kraft/properclean/properclean.go
+++ b/cmd/kraft/properclean/properclean.go
@@ -37,19 +37,18 @@ import (
 	"github.com/MakeNowJust/heredoc"
 	"github.com/spf13/cobra"
 
+	"kraftkit.sh/cmdfactory"
 	"kraftkit.sh/unikraft/app"
-
-	"kraftkit.sh/internal/cli"
 )
 
 type ProperClean struct{}
 
 func New() *cobra.Command {
-	cmd := cli.New(&ProperClean{}, cobra.Command{
+	cmd := cmdfactory.New(&ProperClean{}, cobra.Command{
 		Short:   "Completely remove the build artifacts of a Unikraft project",
 		Use:     "properclean [DIR]",
 		Aliases: []string{"pc"},
-		Args:    cli.MaxDirArgs(1),
+		Args:    cmdfactory.MaxDirArgs(1),
 		Long: heredoc.Doc(`
 			Remove the Unikraft project build folder containing all build artifacts`),
 		Example: heredoc.Doc(`

--- a/cmd/kraft/ps/ps.go
+++ b/cmd/kraft/ps/ps.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 	"strings"
 
+	"kraftkit.sh/cmdfactory"
 	"kraftkit.sh/config"
 	"kraftkit.sh/iostreams"
 	"kraftkit.sh/log"
@@ -16,8 +17,6 @@ import (
 	machinedriver "kraftkit.sh/machine/driver"
 	machinedriveropts "kraftkit.sh/machine/driveropts"
 	"kraftkit.sh/utils"
-
-	"kraftkit.sh/internal/cli"
 
 	"github.com/dustin/go-humanize"
 	"github.com/spf13/cobra"
@@ -33,7 +32,7 @@ type Ps struct {
 }
 
 func New() *cobra.Command {
-	cmd := cli.New(&Ps{}, cobra.Command{
+	cmd := cmdfactory.New(&Ps{}, cobra.Command{
 		Short: "List running unikernels",
 		Use:   "ps [FLAGS]",
 		Args:  cobra.MaximumNArgs(0),
@@ -44,7 +43,7 @@ func New() *cobra.Command {
 	})
 
 	cmd.Flags().VarP(
-		cli.NewEnumFlag(machinedriver.DriverNames(), "all"),
+		cmdfactory.NewEnumFlag(machinedriver.DriverNames(), "all"),
 		"hypervisor",
 		"H",
 		"Set the hypervisor driver.",

--- a/cmd/kraft/rm/rm.go
+++ b/cmd/kraft/rm/rm.go
@@ -11,19 +11,18 @@ import (
 	"github.com/MakeNowJust/heredoc"
 	"github.com/spf13/cobra"
 
+	"kraftkit.sh/cmdfactory"
 	"kraftkit.sh/config"
 	"kraftkit.sh/log"
 	"kraftkit.sh/machine"
 	machinedriver "kraftkit.sh/machine/driver"
 	"kraftkit.sh/machine/driveropts"
-
-	"kraftkit.sh/internal/cli"
 )
 
 type Rm struct{}
 
 func New() *cobra.Command {
-	return cli.New(&Rm{}, cobra.Command{
+	return cmdfactory.New(&Rm{}, cobra.Command{
 		Short:   "Remove one or more running unikernels",
 		Use:     "rm [FLAGS] MACHINE [MACHINE [...]]",
 		Args:    cobra.MinimumNArgs(1),

--- a/cmd/kraft/run/run.go
+++ b/cmd/kraft/run/run.go
@@ -18,6 +18,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
+	"kraftkit.sh/cmdfactory"
 	"kraftkit.sh/config"
 	"kraftkit.sh/exec"
 	"kraftkit.sh/iostreams"
@@ -27,8 +28,6 @@ import (
 	machinedriveropts "kraftkit.sh/machine/driveropts"
 	"kraftkit.sh/unikraft/app"
 	"kraftkit.sh/utils"
-
-	"kraftkit.sh/internal/cli"
 )
 
 type Run struct {
@@ -47,7 +46,7 @@ type Run struct {
 }
 
 func New() *cobra.Command {
-	cmd := cli.New(&Run{}, cobra.Command{
+	cmd := cmdfactory.New(&Run{}, cobra.Command{
 		Short:   "Run a unikernel",
 		Use:     "run [FLAGS] [PROJECT|KERNEL] [ARGS]",
 		Aliases: []string{"launch", "r"},
@@ -65,7 +64,7 @@ func New() *cobra.Command {
 	})
 
 	cmd.Flags().VarP(
-		cli.NewEnumFlag(machinedriver.DriverNames(), "auto"),
+		cmdfactory.NewEnumFlag(machinedriver.DriverNames(), "auto"),
 		"hypervisor",
 		"H",
 		"Set the hypervisor machine driver.",

--- a/cmd/kraft/set/set.go
+++ b/cmd/kraft/set/set.go
@@ -39,9 +39,8 @@ import (
 	"github.com/MakeNowJust/heredoc"
 	"github.com/spf13/cobra"
 
+	"kraftkit.sh/cmdfactory"
 	"kraftkit.sh/unikraft/app"
-
-	"kraftkit.sh/internal/cli"
 )
 
 type Set struct {
@@ -49,7 +48,7 @@ type Set struct {
 }
 
 func New() *cobra.Command {
-	return cli.New(&Set{}, cobra.Command{
+	return cmdfactory.New(&Set{}, cobra.Command{
 		Short:   "Set a variable for a Unikraft project",
 		Use:     "set [OPTIONS] [param=value ...]",
 		Aliases: []string{"s"},

--- a/cmd/kraft/stop/stop.go
+++ b/cmd/kraft/stop/stop.go
@@ -11,19 +11,18 @@ import (
 	"github.com/MakeNowJust/heredoc"
 	"github.com/spf13/cobra"
 
+	"kraftkit.sh/cmdfactory"
 	"kraftkit.sh/config"
 	"kraftkit.sh/log"
 	"kraftkit.sh/machine"
 	machinedriver "kraftkit.sh/machine/driver"
 	"kraftkit.sh/machine/driveropts"
-
-	"kraftkit.sh/internal/cli"
 )
 
 type Stop struct{}
 
 func New() *cobra.Command {
-	return cli.New(&Stop{}, cobra.Command{
+	return cmdfactory.New(&Stop{}, cobra.Command{
 		Short: "Stop one or more running unikernels",
 		Use:   "stop [FLAGS] MACHINE [MACHINE [...]]",
 		Args:  cobra.MinimumNArgs(1),

--- a/cmd/kraft/unset/unset.go
+++ b/cmd/kraft/unset/unset.go
@@ -38,9 +38,8 @@ import (
 	"github.com/MakeNowJust/heredoc"
 	"github.com/spf13/cobra"
 
+	"kraftkit.sh/cmdfactory"
 	"kraftkit.sh/unikraft/app"
-
-	"kraftkit.sh/internal/cli"
 )
 
 type Unset struct {
@@ -48,7 +47,7 @@ type Unset struct {
 }
 
 func New() *cobra.Command {
-	return cli.New(&Unset{}, cobra.Command{
+	return cmdfactory.New(&Unset{}, cobra.Command{
 		Short:   "Unset a variable for a Unikraft project",
 		Use:     "unset [OPTIONS] [param ...]",
 		Aliases: []string{"u"},

--- a/cmdfactory/args.go
+++ b/cmdfactory/args.go
@@ -3,7 +3,7 @@
 // Copyright (c) 2022, Unikraft GmbH and The KraftKit Authors.
 // Licensed under the MIT License (the "License").
 // You may not use this file expect in compliance with the License.
-package cli
+package cmdfactory
 
 import (
 	"fmt"

--- a/cmdfactory/builder.go
+++ b/cmdfactory/builder.go
@@ -3,7 +3,7 @@
 // Copyright 2022 Unikraft GmbH; All rights reserved.
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
-package cli
+package cmdfactory
 
 import (
 	"context"

--- a/cmdfactory/errors.go
+++ b/cmdfactory/errors.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2019 GitHub Inc.
 // Copyright (c) 2022 Unikraft GmbH.
-package cli
+package cmdfactory
 
 import (
 	"errors"

--- a/cmdfactory/flags.go
+++ b/cmdfactory/flags.go
@@ -4,7 +4,7 @@
 // Copyright (c) 2022, Unikraft GmbH and The KraftKit Authors.
 // Licensed under the BSD-3-Clause License (the "License").
 // You may not use this file expect in compliance with the License.
-package cli
+package cmdfactory
 
 import (
 	"github.com/spf13/pflag"

--- a/cmdfactory/flags_bool.go
+++ b/cmdfactory/flags_bool.go
@@ -4,7 +4,7 @@
 // Copyright (c) 2022, Unikraft GmbH and The KraftKit Authors.
 // Licensed under the BSD-3-Clause License (the "License").
 // You may not use this file expect in compliance with the License.
-package cli
+package cmdfactory
 
 import (
 	"strconv"

--- a/cmdfactory/flags_enum.go
+++ b/cmdfactory/flags_enum.go
@@ -2,7 +2,7 @@
 // Copyright (c) 2022, Unikraft GmbH and The KraftKit Authors.
 // Licensed under the BSD-3-Clause License (the "License").
 // You may not use this file expect in compliance with the License.
-package cli
+package cmdfactory
 
 import (
 	"fmt"

--- a/cmdfactory/flags_string.go
+++ b/cmdfactory/flags_string.go
@@ -4,7 +4,7 @@
 // Copyright (c) 2022, Unikraft GmbH and The KraftKit Authors.
 // Licensed under the BSD-3-Clause License (the "License").
 // You may not use this file expect in compliance with the License.
-package cli
+package cmdfactory
 
 import (
 	"github.com/spf13/pflag"

--- a/cmdfactory/help.go
+++ b/cmdfactory/help.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2019 GitHub Inc.
 // Copyright (c) 2022 Unikraft GmbH.
-package cli
+package cmdfactory
 
 import (
 	"bytes"

--- a/cmdfactory/options.go
+++ b/cmdfactory/options.go
@@ -2,7 +2,7 @@
 // Copyright (c) 2022, Unikraft GmbH and The KraftKit Authors.
 // Licensed under the BSD-3-Clause License (the "License").
 // You may not use this file expect in compliance with the License.
-package cli
+package cmdfactory
 
 import (
 	"fmt"

--- a/manifest/manager.go
+++ b/manifest/manager.go
@@ -16,13 +16,12 @@ import (
 	"github.com/gobwas/glob"
 	"github.com/sirupsen/logrus"
 
+	"kraftkit.sh/cmdfactory"
 	"kraftkit.sh/config"
 	"kraftkit.sh/log"
 	"kraftkit.sh/pack"
 	"kraftkit.sh/packmanager"
 	"kraftkit.sh/unikraft"
-
-	"kraftkit.sh/internal/cli"
 )
 
 type ManifestManager struct {
@@ -48,9 +47,9 @@ func init() {
 	packmanager.RegisterPackageManager(ManifestContext, manager)
 
 	// Register additional command-line flags
-	cli.RegisterFlag(
+	cmdfactory.RegisterFlag(
 		"kraft pkg pull",
-		cli.BoolVarP(
+		cmdfactory.BoolVarP(
 			&useGit,
 			"git", "g",
 			false,


### PR DESCRIPTION
This PR migrates `internal/cli` into the top-level and public package of `cmdfactory` such that it can be used externally by other Go modules and programs.