### PR TITLE
tui/processtree: Provide stdin to avoid fetching terminal

### DIFF
--- a/tui/paraprogress/paraprogress.go
+++ b/tui/paraprogress/paraprogress.go
@@ -12,6 +12,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 	"golang.org/x/term"
+	"kraftkit.sh/iostreams"
 	// "kraftkit.sh/log"
 )
 
@@ -75,7 +76,7 @@ func (pd *ParaProgress) Start() error {
 	teaOpts := []tea.ProgramOption{}
 
 	if pd.norender {
-		teaOpts = append(teaOpts, tea.WithoutRenderer())
+		teaOpts = append(teaOpts, tea.WithoutRenderer(), tea.WithInput(iostreams.G(pd.ctx).In))
 	} else {
 		// Set this super early (even before bubbletea), as fast exiting processes
 		// may not have received the window size update and therefore pd.width is

--- a/tui/processtree/processtree.go
+++ b/tui/processtree/processtree.go
@@ -135,7 +135,7 @@ func (pt *ProcessTree) Start() error {
 	var teaOpts []tea.ProgramOption
 
 	if pt.norender {
-		teaOpts = []tea.ProgramOption{tea.WithoutRenderer()}
+		teaOpts = []tea.ProgramOption{tea.WithoutRenderer(), tea.WithInput(iostreams.G(pt.ctx).In)}
 	} else {
 		// Set this super early (even before bubbletea), as fast exiting processes
 		// may not have received the window size update and therefore pt.width is


### PR DESCRIPTION
This fixes the several issues that everyone had with running kraftkit inside a dockerfile, or any other environment without a terminal.

In order to test this, you will have to set the output to `none`:
`sed -i 's/fancy/none/g' ${HOME}/.config/kraftkit/config.yaml;`

Then you need to run without a terminal, like this, or by using a `docker build` environment:
`true | (setsid ./dist/kraft pkg update) 2>&1 | cat`

Signed-off-by: Cezar Craciunoiu <cezar.craciunoiu@unikraft.io>

Closes: #178 