### PR TITLE
Add unsource subcommand to pkg

### DIFF
--- a/cmd/kraft/pkg/pkg.go
+++ b/cmd/kraft/pkg/pkg.go
@@ -27,6 +27,7 @@ import (
 	"kraftkit.sh/cmd/kraft/pkg/list"
 	"kraftkit.sh/cmd/kraft/pkg/pull"
 	"kraftkit.sh/cmd/kraft/pkg/source"
+	"kraftkit.sh/cmd/kraft/pkg/unsource"
 	"kraftkit.sh/cmd/kraft/pkg/update"
 )
 
@@ -87,6 +88,7 @@ func New() *cobra.Command {
 	cmd.AddCommand(list.New())
 	cmd.AddCommand(pull.New())
 	cmd.AddCommand(source.New())
+	cmd.AddCommand(unsource.New())
 	cmd.AddCommand(update.New())
 
 	return cmd

--- a/cmd/kraft/pkg/unsource/unsource.go
+++ b/cmd/kraft/pkg/unsource/unsource.go
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2022, Unikraft GmbH and The KraftKit Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+
+// Package unsource implements the `kraft pkg unsource` command
+package unsource
+
+import (
+	"github.com/MakeNowJust/heredoc"
+	"github.com/spf13/cobra"
+
+	"kraftkit.sh/cmdfactory"
+	"kraftkit.sh/packmanager"
+)
+
+// Unsource is the command to remove a manifest pull location from the local config
+type Unsource struct{}
+
+// New returns a new unsource command
+func New() *cobra.Command {
+	return cmdfactory.New(&Unsource{}, cobra.Command{
+		Short: "Remove Unikraft component manifests",
+		Use:   "unsource [FLAGS] [SOURCE]",
+		Args:  cmdfactory.MinimumArgs(1, "must specify component or manifest"),
+		Example: heredoc.Docf(`
+		# Remove a single component as a Git repository or manifest
+		$ kraft pkg unsource https://github.com/unikraft/unikraft.git
+		$ kraft pkg unsource https://manifests.kraftkit.sh/index.yaml
+	`),
+		Annotations: map[string]string{
+			"help:group": "pkg",
+		},
+	})
+}
+
+// Run executes the unsource command
+func (opts *Unsource) Run(cmd *cobra.Command, args []string) error {
+	var err error
+	source := ""
+
+	if len(args) > 0 {
+		source = args[0]
+	}
+
+	ctx := cmd.Context()
+	pm := packmanager.G(ctx)
+
+	pm, err = pm.IsCompatible(ctx, source)
+	if err != nil {
+		return err
+	}
+
+	return pm.RemoveSource(ctx, source)
+}


### PR DESCRIPTION
This worked out of the box because there was already existing functionality for it.

Currently gives no error if the source didn't exist in the first place (not sure if it should).

Closes: #18 