### PR TITLE
Fix added bugs and inconsistencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,10 @@ dist/
 # Ignore vscode folder
 .vscode/
 
+# Ignore tool binaries
+tools/go-generate-qemu-devices/go-generate-qemu-devices
+tools/protoc-gen-go-netconn/protoc-gen-go-netconn
+
 # Ignore swap files
 *.swp
 *.swo

--- a/tui/paraprogress/paraprogress.go
+++ b/tui/paraprogress/paraprogress.go
@@ -168,7 +168,11 @@ func (md *ParaProgress) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	if complete == len(md.processes) {
 		md.quitting = true
-		return md, tea.Sequence(tea.Batch(cmds...), tea.Quit)
+		batch := tea.Batch(cmds...)
+		if batch == nil {
+			return md, tea.Quit
+		}
+		return md, tea.Sequence(batch, tea.Quit)
 	}
 
 	return md, tea.Batch(cmds...)


### PR DESCRIPTION
First two commits remove a wrongly added binary and then ignore tool binaries from now on.

The last reverts a function from bubbletea that currently breaks when running in kraftkit.