### PR TITLE
Add new remote flag types

### DIFF
--- a/cmdfactory/flags.go
+++ b/cmdfactory/flags.go
@@ -10,6 +10,19 @@ import (
 	"github.com/spf13/pflag"
 )
 
+// VarF returns and instantiated flag based on a pointer value, a name and
+// usage line.
+func VarF(value pflag.Value, name, usage string) *pflag.Flag {
+	flag := &pflag.Flag{
+		Name:     name,
+		Usage:    usage,
+		Value:    value,
+		DefValue: value.String(),
+	}
+
+	return flag
+}
+
 // VarPF is like VarP, but returns the flag created
 func VarPF(value pflag.Value, name, shorthand, usage string) *pflag.Flag {
 	flag := &pflag.Flag{

--- a/cmdfactory/flags.go
+++ b/cmdfactory/flags.go
@@ -3,7 +3,7 @@
 // Copyright (c) 2012 The Go Authors.
 // Copyright (c) 2022, Unikraft GmbH and The KraftKit Authors.
 // Licensed under the BSD-3-Clause License (the "License").
-// You may not use this file expect in compliance with the License.
+// You may not use this file except in compliance with the License.
 package cmdfactory
 
 import (

--- a/cmdfactory/flags_bool.go
+++ b/cmdfactory/flags_bool.go
@@ -31,6 +31,14 @@ func (b *boolValue) Type() string {
 
 func (b *boolValue) String() string { return strconv.FormatBool(bool(*b)) }
 
+// BoolVar returns an instantiated flag for to an associated pointer boolean
+// value with a given name, default value and usage line.
+func BoolVar(p *bool, name string, value bool, usage string) *pflag.Flag {
+	flag := VarF(newBoolValue(value, p), name, usage)
+	flag.NoOptDefVal = "true"
+	return flag
+}
+
 // BoolVarP is like BoolVar, but accepts a shorthand letter that can be used
 // after a single dash.
 func BoolVarP(p *bool, name, shorthand string, value bool, usage string) *pflag.Flag {

--- a/cmdfactory/flags_bool.go
+++ b/cmdfactory/flags_bool.go
@@ -3,7 +3,7 @@
 // Copyright (c) 2012 The Go Authors.
 // Copyright (c) 2022, Unikraft GmbH and The KraftKit Authors.
 // Licensed under the BSD-3-Clause License (the "License").
-// You may not use this file expect in compliance with the License.
+// You may not use this file except in compliance with the License.
 package cmdfactory
 
 import (

--- a/cmdfactory/flags_string.go
+++ b/cmdfactory/flags_string.go
@@ -28,6 +28,12 @@ func (s *stringValue) Type() string {
 
 func (s *stringValue) String() string { return string(*s) }
 
+// StringVar returns an instantiated flag for to an associated pointer string
+// value with a given name, default value and usage line.
+func StringVar(p *string, name string, value string, usage string) *pflag.Flag {
+	return VarF(newStringValue(value, p), name, usage)
+}
+
 // StringVarP is like StringVar, but accepts a shorthand letter that can be used
 // after a single dash.
 func StringVarP(p *string, name, shorthand string, value string, usage string) *pflag.Flag {

--- a/cmdfactory/flags_string.go
+++ b/cmdfactory/flags_string.go
@@ -3,7 +3,7 @@
 // Copyright (c) 2012 The Go Authors.
 // Copyright (c) 2022, Unikraft GmbH and The KraftKit Authors.
 // Licensed under the BSD-3-Clause License (the "License").
-// You may not use this file expect in compliance with the License.
+// You may not use this file except in compliance with the License.
 package cmdfactory
 
 import (


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [x] Updated relevant documentation.

### Description of changes

This PR adds additional exposed flag types to `cmdfactory`. These can be used to register ad-hoc flags by init packages to a specific command. 