### PR TITLE
Pass KraftKit config as global CLI flags

### DIFF
--- a/cmd/kraft/kraft.go
+++ b/cmd/kraft/kraft.go
@@ -6,6 +6,7 @@ package main
 
 import (
 	"github.com/MakeNowJust/heredoc"
+	"github.com/rancher/wrangler/pkg/signals"
 	"github.com/spf13/cobra"
 
 	"kraftkit.sh/cmdfactory"
@@ -88,5 +89,5 @@ func (k *Kraft) Run(cmd *cobra.Command, args []string) error {
 }
 
 func main() {
-	cmdfactory.Main(New())
+	cmdfactory.Main(signals.SetupSignalContext(), New())
 }

--- a/cmd/kraft/kraft.go
+++ b/cmd/kraft/kraft.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 // Copyright (c) 2022, Unikraft GmbH and The KraftKit Authors.
 // Licensed under the BSD-3-Clause License (the "License").
-// You may not use this file expect in compliance with the License.
+// You may not use this file except in compliance with the License.
 package main
 
 import (

--- a/cmdfactory/builder.go
+++ b/cmdfactory/builder.go
@@ -15,7 +15,6 @@ import (
 	"strings"
 	"unsafe"
 
-	"github.com/rancher/wrangler/pkg/signals"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 
@@ -51,8 +50,13 @@ type fieldInfo struct {
 }
 
 func fields(obj any) []fieldInfo {
+	var objValue reflect.Value
 	ptrValue := reflect.ValueOf(obj)
-	objValue := ptrValue.Elem()
+	if ptrValue.Kind() == reflect.Ptr {
+		objValue = ptrValue.Elem()
+	} else {
+		objValue = ptrValue
+	}
 
 	var result []fieldInfo
 
@@ -94,23 +98,15 @@ func expandRegisteredFlags(cmd *cobra.Command) {
 	}
 }
 
-func Main(cmd *cobra.Command) {
-	expandRegisteredFlags(cmd)
-	ctx := signals.SetupSignalContext()
-	if err := cmd.ExecuteContext(ctx); err != nil {
-		fmt.Println(err)
-		os.Exit(1)
-	}
-}
-
 // defaultOptions is a cache of previously instantiated default cli options.
 var defaultOptions *CliOptions
 
-func contextualize(ctx context.Context, opts ...CliOption) context.Context {
+// Main executes the given command
+func Main(ctx context.Context, cmd *cobra.Command, opts ...CliOption) {
 	if defaultOptions == nil {
 		defaultOptions = &CliOptions{}
 		for _, o := range []CliOption{
-			WithDefaultConfigManager(),
+			WithDefaultConfigManager(cmd),
 			WithDefaultIOStreams(),
 			WithDefaultPackageManager(),
 			WithDefaultPluginManager(),
@@ -127,14 +123,19 @@ func contextualize(ctx context.Context, opts ...CliOption) context.Context {
 	// programmed in a way such to prefer exiting values (set initially by any
 	// user-specified options).
 	for _, o := range opts {
-		o(copts)
+		if err := o(copts); err != nil {
+			fmt.Println(err)
+			os.Exit(1)
+		}
 	}
 
 	// Set up the config manager in the context if it is available
-	cfgm, err := copts.configManager()
-	if err == nil {
-		ctx = config.WithConfigManager(ctx, cfgm)
+	if copts.configManager != nil {
+		ctx = config.WithConfigManager(ctx, copts.configManager)
 	}
+
+	// Expand flag all dynamically registered flag overrides.
+	expandRegisteredFlags(cmd)
 
 	// Set up the logger in the context if it is available
 	if copts.logger != nil {
@@ -146,13 +147,16 @@ func contextualize(ctx context.Context, opts ...CliOption) context.Context {
 		ctx = iostreams.WithIOStreams(ctx, copts.ioStreams)
 	}
 
-	return ctx
+	if err := cmd.ExecuteContext(ctx); err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
 }
 
-// New populates a cobra.Command object by extracting args from struct tags of the
-// Runnable obj passed.  Also the Run method is assigned to the RunE of the command.
-// name = Override the struct field with
-func New(obj Runnable, cmd cobra.Command, opts ...CliOption) *cobra.Command {
+// AttributeFlags associates a given struct with public attributes and a set of
+// tags with the provided cobra command so as to enable dynamic population of
+// CLI flags.
+func AttributeFlags(c *cobra.Command, obj any) {
 	var (
 		envs      []func()
 		arrays    = map[string]reflect.Value{}
@@ -161,20 +165,18 @@ func New(obj Runnable, cmd cobra.Command, opts ...CliOption) *cobra.Command {
 		optString = map[string]reflect.Value{}
 		optBool   = map[string]reflect.Value{}
 		optInt    = map[string]reflect.Value{}
-		ptrValue  = reflect.ValueOf(obj)
-		objValue  = ptrValue.Elem()
 	)
-
-	c := cmd
-	if c.Use == "" {
-		c.Use = fmt.Sprintf("%s [SUBCOMMAND] [FLAGS]", Name(obj))
-	}
 
 	for _, info := range fields(obj) {
 		fieldType := info.FieldType
 		v := info.FieldValue
 
 		if strings.ToUpper(fieldType.Name[0:1]) != fieldType.Name[0:1] {
+			continue
+		}
+
+		// Any structure attribute which has the tag `noattribute:"true"` is skipped
+		if fieldType.Tag.Get("noattribute") == "true" {
 			continue
 		}
 
@@ -189,6 +191,7 @@ func New(obj Runnable, cmd cobra.Command, opts ...CliOption) *cobra.Command {
 		if err != nil {
 			defInt = 0
 		}
+		strValue := v.String()
 
 		flags := c.PersistentFlags()
 		if fieldType.Tag.Get("local") == "true" {
@@ -198,10 +201,13 @@ func New(obj Runnable, cmd cobra.Command, opts ...CliOption) *cobra.Command {
 		switch fieldType.Type.Kind() {
 		case reflect.Int:
 			flags.IntVarP((*int)(unsafe.Pointer(v.Addr().Pointer())), name, alias, defInt, usage)
+			flags.Set(name, strValue)
 		case reflect.Int64:
 			flags.IntVarP((*int)(unsafe.Pointer(v.Addr().Pointer())), name, alias, defInt, usage)
+			flags.Set(name, strValue)
 		case reflect.String:
 			flags.StringVarP((*string)(unsafe.Pointer(v.Addr().Pointer())), name, alias, defValue, usage)
+			flags.Set(name, strValue)
 		case reflect.Slice:
 			switch fieldType.Tag.Get("split") {
 			case "false":
@@ -216,20 +222,32 @@ func New(obj Runnable, cmd cobra.Command, opts ...CliOption) *cobra.Command {
 			flags.StringSliceP(name, alias, nil, usage)
 		case reflect.Bool:
 			flags.BoolVarP((*bool)(unsafe.Pointer(v.Addr().Pointer())), name, alias, false, usage)
+			flags.Set(name, strValue)
 		case reflect.Pointer:
 			switch fieldType.Type.Elem().Kind() {
 			case reflect.Int:
 				optInt[name] = v
 				flags.IntP(name, alias, defInt, usage)
+				flags.Set(name, strValue)
 			case reflect.String:
 				optString[name] = v
 				flags.StringP(name, alias, defValue, usage)
+				flags.Set(name, strValue)
 			case reflect.Bool:
 				optBool[name] = v
 				flags.BoolP(name, alias, false, usage)
+				flags.Set(name, strValue)
 			}
+		case reflect.Struct:
+			if !v.CanAddr() {
+				continue
+			}
+
+			// Recursively set embedded anonymous structs
+			AttributeFlags(c, v.Addr().Interface())
 		default:
-			panic("Unknown kind on field " + fieldType.Name + " on " + objValue.Type().Name())
+			// Unknown kind on field " + fieldType.Name + " on " + objValue.Type().Name()
+			continue
 		}
 
 		for _, env := range env {
@@ -245,16 +263,18 @@ func New(obj Runnable, cmd cobra.Command, opts ...CliOption) *cobra.Command {
 		}
 	}
 
-	if p, ok := obj.(PersistentPreRunnable); ok {
-		c.PersistentPreRunE = func(cmd *cobra.Command, args []string) error {
-			cmd.SetContext(contextualize(cmd.Context(), opts...))
-			return p.PersistentPre(cmd, args)
-		}
-	} else {
-		c.PersistentPreRunE = func(cmd *cobra.Command, args []string) error {
-			cmd.SetContext(contextualize(cmd.Context(), opts...))
-			return nil
-		}
+	c.PersistentPreRunE = bind(c.PersistentPreRunE, arrays, slices, maps, optInt, optBool, optString, envs)
+	c.PreRunE = bind(c.PreRunE, arrays, slices, maps, optInt, optBool, optString, envs)
+	c.RunE = bind(c.RunE, arrays, slices, maps, optInt, optBool, optString, envs)
+}
+
+// New populates a cobra.Command object by extracting args from struct tags of the
+// Runnable obj passed.  Also the Run method is assigned to the RunE of the command.
+// name = Override the struct field with
+func New(obj Runnable, cmd cobra.Command) *cobra.Command {
+	c := cmd
+	if c.Use == "" {
+		c.Use = fmt.Sprintf("%s [SUBCOMMAND] [FLAGS]", Name(obj))
 	}
 
 	if p, ok := obj.(PreRunnable); ok {
@@ -264,11 +284,10 @@ func New(obj Runnable, cmd cobra.Command, opts ...CliOption) *cobra.Command {
 	c.SilenceErrors = true
 	c.SilenceUsage = true
 	c.DisableFlagsInUseLine = true
-
 	c.RunE = obj.Run
-	c.PersistentPreRunE = bind(c.PersistentPreRunE, arrays, slices, maps, optInt, optBool, optString, envs)
-	c.PreRunE = bind(c.PreRunE, arrays, slices, maps, optInt, optBool, optString, envs)
-	c.RunE = bind(c.RunE, arrays, slices, maps, optInt, optBool, optString, envs)
+
+	// Parse the attributes of this object into addressable flags for this command
+	AttributeFlags(&c, obj)
 
 	// Set help and usage methods
 	c.SetHelpFunc(func(cmd *cobra.Command, args []string) {

--- a/cmdfactory/options.go
+++ b/cmdfactory/options.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 // Copyright (c) 2022, Unikraft GmbH and The KraftKit Authors.
 // Licensed under the BSD-3-Clause License (the "License").
-// You may not use this file expect in compliance with the License.
+// You may not use this file except in compliance with the License.
 package cmdfactory
 
 import (

--- a/cmdfactory/options.go
+++ b/cmdfactory/options.go
@@ -10,6 +10,7 @@ import (
 	"os"
 
 	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
 
 	"kraftkit.sh/config"
 	"kraftkit.sh/iostreams"
@@ -23,25 +24,25 @@ import (
 type CliOptions struct {
 	ioStreams      *iostreams.IOStreams
 	logger         *logrus.Entry
-	configManager  func() (*config.ConfigManager, error)
-	packageManager func() (packmanager.PackageManager, error)
-	pluginManager  func() (*plugins.PluginManager, error)
-	httpClient     func() (*http.Client, error)
+	configManager  *config.ConfigManager
+	packageManager packmanager.PackageManager
+	pluginManager  *plugins.PluginManager
+	httpClient     *http.Client
 }
 
-type CliOption func(*CliOptions)
+type CliOption func(*CliOptions) error
 
 // WithDefaultLogger sets up the built in logger based on provided conifg found
 // from the ConfigManager.
 func WithDefaultLogger() CliOption {
-	return func(copts *CliOptions) {
+	return func(copts *CliOptions) error {
 		if copts.logger != nil {
-			return
+			return nil
 		}
 
 		if copts.configManager == nil {
 			copts.logger = log.L
-			return
+			return nil
 		}
 
 		// Set up a default logger based on the internal TextFormatter
@@ -49,12 +50,11 @@ func WithDefaultLogger() CliOption {
 
 		// Configure the logger based on parameters set by in KraftKit's
 		// configuration
-		cfgm, err := copts.configManager()
-		if err != nil {
+		if copts.configManager == nil {
 			copts.logger = log.L
 		}
 
-		switch log.LoggerTypeFromString(cfgm.Config.Log.Type) {
+		switch log.LoggerTypeFromString(copts.configManager.Config.Log.Type) {
 		case log.QUIET:
 			formatter := new(logrus.TextFormatter)
 			logger.Formatter = formatter
@@ -64,7 +64,7 @@ func WithDefaultLogger() CliOption {
 			formatter.FullTimestamp = true
 			formatter.DisableTimestamp = true
 
-			if cfgm.Config.Log.Timestamps {
+			if copts.configManager.Config.Log.Timestamps {
 				formatter.DisableTimestamp = false
 			} else {
 				formatter.TimestampFormat = ">"
@@ -77,7 +77,7 @@ func WithDefaultLogger() CliOption {
 			formatter.FullTimestamp = true
 			formatter.DisableTimestamp = true
 
-			if cfgm.Config.Log.Timestamps {
+			if copts.configManager.Config.Log.Timestamps {
 				formatter.DisableTimestamp = false
 			} else {
 				formatter.TimestampFormat = ">"
@@ -89,14 +89,14 @@ func WithDefaultLogger() CliOption {
 			formatter := new(logrus.JSONFormatter)
 			formatter.DisableTimestamp = true
 
-			if cfgm.Config.Log.Timestamps {
+			if copts.configManager.Config.Log.Timestamps {
 				formatter.DisableTimestamp = false
 			}
 
 			logger.Formatter = formatter
 		}
 
-		level, ok := log.Levels()[cfgm.Config.Log.Level]
+		level, ok := log.Levels()[copts.configManager.Config.Log.Level]
 		if !ok {
 			logger.Level = logrus.InfoLevel
 		} else {
@@ -109,72 +109,67 @@ func WithDefaultLogger() CliOption {
 
 		// Save the logger
 		copts.logger = logrus.NewEntry(logger)
+
+		return nil
 	}
 }
 
 // WithConfigManager sets a previously instantiate ConfigManager to be used as
 // part of the CLI options.
 func WithConfigManager(cfgm *config.ConfigManager) CliOption {
-	return func(copts *CliOptions) {
-		copts.configManager = func() (*config.ConfigManager, error) {
-			return cfgm, nil
-		}
+	return func(copts *CliOptions) error {
+		copts.configManager = cfgm
+		return nil
 	}
 }
 
 // WithDefaultConfigManager instantiates a configuration manager based on
 // default options.
-func WithDefaultConfigManager() CliOption {
-	return func(copts *CliOptions) {
-		if copts.configManager != nil {
-			return
+func WithDefaultConfigManager(cmd *cobra.Command) CliOption {
+	return func(copts *CliOptions) error {
+		cfgm, err := config.NewConfigManager(
+			config.WithDefaultConfigFile(),
+		)
+		if err != nil {
+			return err
 		}
 
-		var cfgm *config.ConfigManager
-		var cfge error
+		// Attribute all arguments with configuration
+		AttributeFlags(cmd, cfgm.Config)
+		cmd.ParseFlags(os.Args[1:])
 
-		copts.configManager = func() (*config.ConfigManager, error) {
-			if cfgm != nil || cfge != nil {
-				return cfgm, cfge
-			}
+		copts.configManager = cfgm
 
-			cfgm, cfge := config.NewConfigManager(
-				config.WithDefaultConfigFile(),
-			)
-
-			return cfgm, cfge
-		}
+		return nil
 	}
 }
 
 // WithIOStreams sets a previously instantiated iostreams.IOStreams structure to
 // be used within the command.
 func WithIOStreams(io *iostreams.IOStreams) CliOption {
-	return func(copts *CliOptions) {
+	return func(copts *CliOptions) error {
 		copts.ioStreams = io
+		return nil
 	}
 }
 
 // WithDefaultIOStreams instantiates ta new IO streams using environmental
 // variables and host-provided configuration.
 func WithDefaultIOStreams() CliOption {
-	return func(copts *CliOptions) {
+	return func(copts *CliOptions) error {
 		if copts.ioStreams != nil {
-			return
+			return nil
 		}
 
 		io := iostreams.System()
 
 		if copts.configManager != nil {
-			cfgm, err := copts.configManager()
-			if err != nil {
-				if cfgm.Config.NoPrompt {
-					io.SetNeverPrompt(true)
-				}
+			if copts.configManager.Config.NoPrompt {
+				io.SetNeverPrompt(true)
+			}
 
-				if pager := cfgm.Config.Pager; pager != "" {
-					io.SetPager(pager)
-				}
+			if pager := copts.configManager.Config.Pager; pager != "" {
+				io.SetPager(pager)
 			}
 		}
 
@@ -187,93 +182,99 @@ func WithDefaultIOStreams() CliOption {
 		}
 
 		copts.ioStreams = io
+
+		return nil
 	}
 }
 
 // WithHTTPClient sets a previously instantiated http.Client to be used within
 // the command.
 func WithHTTPClient(httpClient *http.Client) CliOption {
-	return func(copts *CliOptions) {
-		copts.httpClient = func() (*http.Client, error) {
-			return httpClient, nil
-		}
+	return func(copts *CliOptions) error {
+		copts.httpClient = httpClient
+		return nil
 	}
 }
 
 // WithDefaultHTTPClient initializes a HTTP client using host-provided
 // configuration.
 func WithDefaultHTTPClient() CliOption {
-	return func(copts *CliOptions) {
+	return func(copts *CliOptions) error {
 		if copts.httpClient != nil {
-			return
+			return nil
 		}
 
-		copts.httpClient = func() (*http.Client, error) {
-			cfgm, err := copts.configManager()
-			if err != nil {
-				return nil, fmt.Errorf("cannot access config manager")
-			}
-
-			return httpclient.NewHTTPClient(
-				copts.ioStreams,
-				cfgm.Config.HTTPUnixSocket,
-				true,
-			)
+		if copts.configManager == nil {
+			return fmt.Errorf("cannot access config manager")
 		}
+
+		if copts.ioStreams == nil {
+			return fmt.Errorf("cannot access IO streams")
+		}
+
+		httpClient, err := httpclient.NewHTTPClient(
+			copts.ioStreams,
+			copts.configManager.Config.HTTPUnixSocket,
+			true,
+		)
+		if err != nil {
+			return err
+		}
+
+		copts.httpClient = httpClient
+
+		return nil
 	}
 }
 
 // WithPackageManager sets a previously initialized package manager to be used
 // with the command.
 func WithPackageManager(pm packmanager.PackageManager) CliOption {
-	return func(copts *CliOptions) {
-		copts.packageManager = func() (packmanager.PackageManager, error) {
-			return pm, nil
-		}
+	return func(copts *CliOptions) error {
+		copts.packageManager = pm
+		return nil
 	}
 }
 
 // WithDefaultPackageManager initializes a new package manager based on the
 // umbrella package manager using host-provided configuration.
 func WithDefaultPackageManager() CliOption {
-	return func(copts *CliOptions) {
+	return func(copts *CliOptions) error {
 		if copts.packageManager != nil {
-			return
+			return nil
 		}
 
-		copts.packageManager = func() (packmanager.PackageManager, error) {
-			// TODO: Add configuration option that allows us to statically set a
-			// preferred package manager.
-			return packmanager.NewUmbrellaManager(), nil
-		}
+		// TODO: Add configuration option that allows us to statically set a
+		// preferred package manager.
+		copts.packageManager = packmanager.NewUmbrellaManager()
+
+		return nil
 	}
 }
 
 // WithPluginManager sets a previously instantiated plugin manager to be used
 // withthe command.
 func WithPluginManager(pm *plugins.PluginManager) CliOption {
-	return func(copts *CliOptions) {
-		copts.pluginManager = func() (*plugins.PluginManager, error) {
-			return pm, nil
-		}
+	return func(copts *CliOptions) error {
+		copts.pluginManager = pm
+		return nil
 	}
 }
 
 // WithDefaultPluginManager returns an initialized plugin manager using the
 // host-provided configuration plugin path.
 func WithDefaultPluginManager() CliOption {
-	return func(copts *CliOptions) {
+	return func(copts *CliOptions) error {
 		if copts.pluginManager != nil {
-			return
+			return nil
 		}
 
-		copts.pluginManager = func() (*plugins.PluginManager, error) {
-			cfgm, err := copts.configManager()
-			if err != nil {
-				return nil, err
-			}
-
-			return plugins.NewPluginManager(cfgm.Config.Paths.Plugins, nil), nil
+		if copts.configManager == nil {
+			return fmt.Errorf("cannot access config manager")
 		}
+
+		copts.pluginManager = plugins.NewPluginManager(copts.configManager.Config.Paths.Plugins, nil)
+
+		return nil
 	}
 }

--- a/config/config.go
+++ b/config/config.go
@@ -8,47 +8,46 @@ package config
 // by some service.  Most APIs and services which can be authenticated have the
 // defined four parameters found within AuthConfig.
 type AuthConfig struct {
-	User      string `json:"user"       yaml:"user"       env:"KRAFTKIT_AUTH_%s_USER"`
-	Token     string `json:"token"      yaml:"token"      env:"KRAFTKIT_AUTH_%s_TOKEN"`
-	Endpoint  string `json:"endpoint"   yaml:"endpoint"   env:"KRAFTKIT_AUTH_%s_ENDPOINT"`
-	VerifySSL bool   `json:"verify_ssl" yaml:"verify_ssl" env:"KRAFTKIT_AUTH_%s_VERIFY_SSL"`
+	User      string `yaml:"user" env:"KRAFTKIT_AUTH_%s_USER" long:"auth-%s-user"`
+	Token     string `yaml:"token" env:"KRAFTKIT_AUTH_%s_TOKEN" long:"auth-%s-token"`
+	Endpoint  string `yaml:"endpoint" env:"KRAFTKIT_AUTH_%s_ENDPOINT" long:"auth-%s-endpoint"`
+	VerifySSL bool   `yaml:"verify_ssl" env:"KRAFTKIT_AUTH_%s_VERIFY_SSL" long:"auth-%s-verify-ssl"`
 }
 
 type Config struct {
-	NoPrompt       bool   `json:"no_prompt"        yaml:"no_prompt"                  env:"KRAFTKIT_NO_PROMPT"`
-	NoParallel     bool   `json:"no_parallel"      yaml:"no_parallel"                env:"KRAFTKIT_NO_PARALLEL"`
-	Emojis         bool   `json:"no_emojis"        yaml:"no_emojis"                  env:"KRAFTKIT_NO_EMOJIS"`
-	Editor         string `json:"editor"           yaml:"editor,omitempty"           env:"KRAFTKIT_EDITOR"`
-	Browser        string `json:"browser"          yaml:"browser,omitempty"          env:"KRAFTKIT_BROWSER"`
-	GitProtocol    string `json:"git_protocol"     yaml:"git_protocol"               env:"KRAFTKIT_GIT_PROTOCOL"`
-	Pager          string `json:"pager"            yaml:"pager,omitempty"            env:"KRAFTKIT_PAGER"`
-	HTTPUnixSocket string `json:"http_unix_socket" yaml:"http_unix_socket,omitempty" env:"KRAFTKIT_HTTP_UNIX_SOCKET"`
-	RuntimeDir     string `json:"runtime_dir"      yaml:"runtime_dir"                env:"KRAFTKIT_RUNTIME_DIR"`
-	DefaultPlat    string `json:"default_plat"     yaml:"default_plat"               env:"KRAFTKIT_DEFAULT_PLAT"`
-	DefaultArch    string `json:"default_arch"     yaml:"default_arch"               env:"KRAFTKIT_DEFAULT_ARCH"`
-	EventsPidFile  string `json:"events_pidfile"   yaml:"events_pidfile"             env:"KRAFTKIT_EVENTS_PIDFILE"`
+	NoPrompt       bool   `yaml:"no_prompt" env:"KRAFTKIT_NO_PROMPT" long:"no-prompt" usage:"Do not prompt for user interaction" default:"false"`
+	NoParallel     bool   `yaml:"no_parallel" env:"KRAFTKIT_NO_PARALLEL" long:"no-parallel" usage:"Do not run internal tasks in parallel" default:"true"`
+	NoEmojis       bool   `yaml:"no_emojis" env:"KRAFTKIT_NO_EMOJIS" long:"no-emojis" usage:"Do not use emojis in any console output" default:"true"`
+	Editor         string `yaml:"editor" env:"KRAFTKIT_EDITOR" long:"editor" usage:"Set the text editor to open when prompt to edit a file"`
+	GitProtocol    string `yaml:"git_protocol" env:"KRAFTKIT_GIT_PROTOCOL" long:"git-protocol" usage:"Preferred Git protocol to use" default:"https"`
+	Pager          string `yaml:"pager,omitempty" env:"KRAFTKIT_PAGER" long:"pager" usage:"System pager to pipe output to"`
+	HTTPUnixSocket string `yaml:"http_unix_socket,omitempty" env:"KRAFTKIT_HTTP_UNIX_SOCKET" long:"http-unix-sock" usage:"When making HTTP(S) connections, pipe requests via this shared socket"`
+	RuntimeDir     string `yaml:"runtime_dir" env:"KRAFTKIT_RUNTIME_DIR" long:"runtime-dir" usage:"Directory for placing runtime files (e.g. pidfiles)" default:"/var/kraftkit"`
+	DefaultPlat    string `yaml:"default_plat" env:"KRAFTKIT_DEFAULT_PLAT" usage:"The default platform to use when invoking platform-specific code" noattribute:"true"`
+	DefaultArch    string `yaml:"default_arch" env:"KRAFTKIT_DEFAULT_ARCH" usage:"The default architecture to use when invoking architecture-specific code" noattribute:"true"`
+	EventsPidFile  string `yaml:"events_pidfile" env:"KRAFTKIT_EVENTS_PIDFILE" long:"events-pid-file" usage:"Events process ID used when running multiple unikernels" default:"/var/kraftkit/events.pid"`
 
 	Paths struct {
-		Plugins   string `json:"plugins"   yaml:"plugins,omitempty"   env:"KRAFTKIT_PATHS_PLUGINS"`
-		Config    string `json:"config"    yaml:"config,omitempty"    env:"KRAFTKIT_PATHS_CONFIG"`
-		Manifests string `json:"manifests" yaml:"manifests,omitempty" env:"KRAFTKIT_PATHS_MANIFESTS"`
-		Sources   string `json:"sources"   yaml:"sources,omitempty"   env:"KRAFTKIT_PATHS_SOURCES"`
-	} `json:"paths" yaml:"paths,omitempty"`
+		Plugins   string `yaml:"plugins,omitempty" env:"KRAFTKIT_PATHS_PLUGINS" long:"plugins-dir" usage:"Path to KraftKit plugin directory"`
+		Config    string `yaml:"config,omitempty" env:"KRAFTKIT_PATHS_CONFIG" long:"config-dir" usage:"Path to KraftKit config file"`
+		Manifests string `yaml:"manifests,omitempty" env:"KRAFTKIT_PATHS_MANIFESTS" long:"manifests-dir" usage:"Path to Unikraft manifest cache"`
+		Sources   string `yaml:"sources,omitempty" env:"KRAFTKIT_PATHS_SOURCES" long:"sources-dir" usage:"Path to Unikraft component cache"`
+	} `yaml:"paths,omitempty"`
 
 	Log struct {
-		Level      string `json:"level"      yaml:"level"      env:"KRAFTKIT_LOG_LEVEL"`
-		Timestamps bool   `json:"timestamps" yaml:"timestamps" env:"KRAFTKIT_LOG_TIMESTAMPS"`
-		Type       string `json:"type"       yaml:"type"       env:"KRAFTKIT_LOG_TYPE"`
-	} `json:"log" yaml:"log"`
+		Level      string `yaml:"level" env:"KRAFTKIT_LOG_LEVEL" long:"log-level" usage:"Log level verbosity" default:"info"`
+		Timestamps bool   `yaml:"timestamps" env:"KRAFTKIT_LOG_TIMESTAMPS" long:"log-timestamps" usage:"Enable log timestamps"`
+		Type       string `yaml:"type" env:"KRAFTKIT_LOG_TYPE" long:"log-type" usage:"Log type" default:"fancy"`
+	} `yaml:"log"`
 
 	Unikraft struct {
-		Mirrors   []string `json:"mirrors"   yaml:"mirrors"   env:"KRAFTKIT_UNIKRAFT_MIRRORS"`
-		Manifests []string `json:"manifests" yaml:"manifests" env:"KRAFTKIT_UNIKRAFT_MANIFESTS"`
-	} `json:"unikraft" yaml:"unikraft"`
+		Mirrors   []string `yaml:"mirrors" env:"KRAFTKIT_UNIKRAFT_MIRRORS" long:"with-mirror" usage:"Paths to mirrors of Unikraft component artifacts"`
+		Manifests []string `yaml:"manifests" env:"KRAFTKIT_UNIKRAFT_MANIFESTS" long:"with-manifest" usage:"Paths to package or component manifests"`
+	} `yaml:"unikraft"`
 
-	Auth map[string]AuthConfig `json:"auth" yaml:"auth,omitempty"`
+	Auth map[string]AuthConfig `yaml:"auth,omitempty" noattribute:"true"`
 
-	Aliases map[string]map[string]string `json:"aliases" yaml:"aliases"`
+	Aliases map[string]map[string]string `yaml:"aliases" noattribute:"true"`
 }
 
 type ConfigDetail struct {

--- a/config/config.go
+++ b/config/config.go
@@ -1,34 +1,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
-//
-// Authors: Alexander Jung <alex@unikraft.io>
-//
-// Copyright (c) 2022, Unikraft GmbH.  All rights reserved.
-//
-// Redistribution and use in source and binary forms, with or without
-// modification, are permitted provided that the following conditions
-// are met:
-//
-// 1. Redistributions of source code must retain the above copyright
-//    notice, this list of conditions and the following disclaimer.
-// 2. Redistributions in binary form must reproduce the above copyright
-//    notice, this list of conditions and the following disclaimer in the
-//    documentation and/or other materials provided with the distribution.
-// 3. Neither the name of the copyright holder nor the names of its
-//    contributors may be used to endorse or promote products derived from
-//    this software without specific prior written permission.
-//
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-// POSSIBILITY OF SUCH DAMAGE.
-
+// Copyright (c) 2022, Unikraft GmbH and The KraftKit Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
 package config
 
 // AuthConfig represents a very abstract representation of authentication used

--- a/config/defaults.go
+++ b/config/defaults.go
@@ -12,31 +12,10 @@ import (
 )
 
 const (
-	DefaultNoPrompt      = "false"
-	DefaultNoParallel    = "true"
-	DefaultNoEmojis      = "false"
-	DefaultGitProtocol   = "https"
-	DefaultLogLevel      = "info"
-	DefaultLogTimestamps = "false"
-	DefaultLogType       = "fancy"
 	DefaultRuntimeDir    = "/var/kraftkit"
 	DefaultEventsPidFile = "/var/kraftkit/events.pid"
-	DefaultManifestIndex = "https://manifests.kraftkit.sh/index.yaml"
+	defaultManifestIndex = "https://manifests.kraftkit.sh/index.yaml"
 )
-
-func Defaults() map[string]string {
-	return map[string]string{
-		"KRAFTKIT_NO_PROMPT":      DefaultNoPrompt,
-		"KRAFTKIT_NO_PARALLEL":    DefaultNoParallel,
-		"KRAFTKIT_NO_EMOJIS":      DefaultNoEmojis,
-		"KRAFTKIT_GIT_PROTOCOL":   DefaultGitProtocol,
-		"KRAFTKIT_LOG_LEVEL":      DefaultLogLevel,
-		"KRAFTKIT_LOG_TIMESTAMPS": DefaultLogTimestamps,
-		"KRAFTKIT_LOG_TYPE":       DefaultLogType,
-		"KRAFTKIT_RUNTIME_DIR":    DefaultRuntimeDir,
-		"KRAFTKIT_EVENTS_PIDFILE": DefaultEventsPidFile,
-	}
-}
 
 func NewDefaultConfig() (*Config, error) {
 	c := &Config{}
@@ -66,7 +45,7 @@ func NewDefaultConfig() (*Config, error) {
 	}
 
 	if len(c.Unikraft.Manifests) == 0 {
-		c.Unikraft.Manifests = append(c.Unikraft.Manifests, DefaultManifestIndex)
+		c.Unikraft.Manifests = append(c.Unikraft.Manifests, defaultManifestIndex)
 	}
 
 	return c, nil
@@ -114,7 +93,7 @@ func setDefaultValue(v reflect.Value, def string) error {
 		// Iterate over the struct fields
 		for i := 0; i < v.NumField(); i++ {
 			// Use the `env` tag to look up the default value
-			def = Defaults()[v.Type().Field(i).Tag.Get("env")]
+			def = v.Type().Field(i).Tag.Get("default")
 			if err := setDefaultValue(
 				v.Field(i).Addr(),
 				def,

--- a/config/defaults.go
+++ b/config/defaults.go
@@ -1,34 +1,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
-//
-// Authors: Alexander Jung <alex@unikraft.io>
-//
-// Copyright (c) 2022, Unikraft GmbH.  All rights reserved.
-//
-// Redistribution and use in source and binary forms, with or without
-// modification, are permitted provided that the following conditions
-// are met:
-//
-// 1. Redistributions of source code must retain the above copyright
-//    notice, this list of conditions and the following disclaimer.
-// 2. Redistributions in binary form must reproduce the above copyright
-//    notice, this list of conditions and the following disclaimer in the
-//    documentation and/or other materials provided with the distribution.
-// 3. Neither the name of the copyright holder nor the names of its
-//    contributors may be used to endorse or promote products derived from
-//    this software without specific prior written permission.
-//
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-// POSSIBILITY OF SUCH DAMAGE.
-
+// Copyright (c) 2022, Unikraft GmbH and The KraftKit Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
 package config
 
 import (


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [x] Updated relevant documentation.

### Description of changes
This PR dynamically injects all configuration options for KraftKit into the cmdfactory's `Main` method which is used to setup the execution of a binary built with this system.  This allows us to dynamically at the command-line set global configuration options.  For example, to change the log type and level, one can simply invoke:

```shell
kraft --log-type basic --log-level debug pkg update
```

This will show a more verbose output without having to manually edit the configuration file (i.e. on Linux it's `~/.config/kraftkit/config.yaml`).

To make this possible, the cmdfactory had to be slightly re-arranged to expose a new method `AttributeFlags` which takes a given `obj` which is a struct and associate all attributes to the given `cobra.Command`. Previously, this was used exclusively when instantiating new commands, but now occurs also if choosing to run through the globally used `Main` method.  This association required changes to the default CLI options too, particularly removing the fact that each option returned a function.  This is no longer the case, we have all information associated at "option instantiation time".

Finally, to combat the fact that an object may already have values set when passed to `AttributeFlags`, the field's value is set right after the flag is created for said field.
