### PR TITLE
"`Nameable`" components and packages

### DIFF
--- a/cmd/kraft/build/build.go
+++ b/cmd/kraft/build/build.go
@@ -112,7 +112,9 @@ func (opts *Build) Run(cmd *cobra.Command, args []string) error {
 	if err != nil && project.Template().Name() != "" {
 		var packages []pack.Package
 		search := processtree.NewProcessTreeItem(
-			fmt.Sprintf("finding %s/%s:%s...", project.Template().Type(), project.Template().Name(), project.Template().Version()), "",
+			fmt.Sprintf("finding %s...",
+				unikraft.TypeNameVersion(project.Template()),
+			), "",
 			func(ctx context.Context) error {
 				packages, err = packmanager.G(ctx).Catalog(ctx, packmanager.CatalogQuery{
 					Name:    project.Template().Name(),
@@ -125,9 +127,13 @@ func (opts *Build) Run(cmd *cobra.Command, args []string) error {
 				}
 
 				if len(packages) == 0 {
-					return fmt.Errorf("could not find: %s", project.Template().Name())
+					return fmt.Errorf("could not find: %s",
+						unikraft.TypeNameVersion(project.Template()),
+					)
 				} else if len(packages) > 1 {
-					return fmt.Errorf("too many options for %s", project.Template().Name())
+					return fmt.Errorf("too many options for %s",
+						unikraft.TypeNameVersion(project.Template()),
+					)
 				}
 
 				return nil
@@ -152,7 +158,9 @@ func (opts *Build) Run(cmd *cobra.Command, args []string) error {
 		}
 
 		proc := paraprogress.NewProcess(
-			fmt.Sprintf("pulling %s", packages[0].Name()),
+			fmt.Sprintf("pulling %s",
+				unikraft.TypeNameVersion(packages[0]),
+			),
 			func(ctx context.Context, w func(progress float64)) error {
 				return packages[0].Pull(
 					ctx,
@@ -212,7 +220,9 @@ func (opts *Build) Run(cmd *cobra.Command, args []string) error {
 		component := component // loop closure
 
 		searches = append(searches, processtree.NewProcessTreeItem(
-			fmt.Sprintf("finding %s/%s:%s...", component.Type(), component.Name(), component.Version()), "",
+			fmt.Sprintf("finding %s...",
+				unikraft.TypeNameVersion(component),
+			), "",
 			func(ctx context.Context) error {
 				p, err := packmanager.G(ctx).Catalog(ctx, packmanager.CatalogQuery{
 					Name: component.Name(),
@@ -227,9 +237,13 @@ func (opts *Build) Run(cmd *cobra.Command, args []string) error {
 				}
 
 				if len(p) == 0 {
-					return fmt.Errorf("could not find: %s", component.Name())
+					return fmt.Errorf("could not find: %s",
+						unikraft.TypeNameVersion(component),
+					)
 				} else if len(p) > 1 {
-					return fmt.Errorf("too many options for %s", component.Name())
+					return fmt.Errorf("too many options for %s",
+						unikraft.TypeNameVersion(component),
+					)
 				}
 
 				missingPacks = append(missingPacks, p...)
@@ -261,7 +275,9 @@ func (opts *Build) Run(cmd *cobra.Command, args []string) error {
 		for _, p := range missingPacks {
 			p := p // loop closure
 			processes = append(processes, paraprogress.NewProcess(
-				fmt.Sprintf("pulling %s", p.Name()),
+				fmt.Sprintf("pulling %s",
+					unikraft.TypeNameVersion(p),
+				),
 				func(ctx context.Context, w func(progress float64)) error {
 					return p.Pull(
 						ctx,

--- a/cmd/kraft/pkg/pull/pull.go
+++ b/cmd/kraft/pkg/pull/pull.go
@@ -120,7 +120,9 @@ func (opts *Pull) Run(cmd *cobra.Command, args []string) error {
 			// Pull the template from the package manager
 			var packages []pack.Package
 			search := processtree.NewProcessTreeItem(
-				fmt.Sprintf("finding %s/%s:%s...", project.Template().Type(), project.Template().Name(), project.Template().Version()), "",
+				fmt.Sprintf("finding %s...",
+					unikraft.TypeNameVersion(project.Template()),
+				), "",
 				func(ctx context.Context) error {
 					packages, err = pm.Catalog(ctx, packmanager.CatalogQuery{
 						Name:    project.Template().Name(),
@@ -133,9 +135,9 @@ func (opts *Pull) Run(cmd *cobra.Command, args []string) error {
 					}
 
 					if len(packages) == 0 {
-						return fmt.Errorf("could not find: %s", project.Template().Name())
+						return fmt.Errorf("could not find: %s", unikraft.TypeNameVersion(project.Template()))
 					} else if len(packages) > 1 {
-						return fmt.Errorf("too many options for %s", project.Template().Name())
+						return fmt.Errorf("too many options for %s", unikraft.TypeNameVersion(project.Template()))
 					}
 					return nil
 				},
@@ -159,7 +161,9 @@ func (opts *Pull) Run(cmd *cobra.Command, args []string) error {
 			}
 
 			proc := paraprogress.NewProcess(
-				fmt.Sprintf("pulling %s", packages[0].Name()),
+				fmt.Sprintf("pulling %s...",
+					unikraft.TypeNameVersion(packages[0]),
+				),
 				func(ctx context.Context, w func(progress float64)) error {
 					return packages[0].Pull(
 						ctx,
@@ -262,7 +266,9 @@ func (opts *Pull) Run(cmd *cobra.Command, args []string) error {
 		for _, p := range next {
 			p := p
 			processes = append(processes, paraprogress.NewProcess(
-				fmt.Sprintf("pulling %s", p.Name()),
+				fmt.Sprintf("pulling %s...",
+					unikraft.TypeNameVersion(p),
+				),
 				func(ctx context.Context, w func(progress float64)) error {
 					return p.Pull(
 						ctx,

--- a/pack/package.go
+++ b/pack/package.go
@@ -11,14 +11,7 @@ import (
 )
 
 type Package interface {
-	// Type returns the component type that this package encapsulates.
-	Type() unikraft.ComponentType
-
-	// Name returns the name of the component within this package.
-	Name() string
-
-	// Version returns the version that is contained within this package.
-	Version() string
+	unikraft.Nameable
 
 	// Metadata returns any additional metadata associated with this package.
 	Metadata() any

--- a/unikraft/component/component.go
+++ b/unikraft/component/component.go
@@ -14,17 +14,10 @@ import (
 
 // Component is the abstract interface for managing the individual microlibrary
 type Component interface {
-	// Name returns the component name
-	Name() string
+	unikraft.Nameable
 
 	// Source returns the component source
 	Source() string
-
-	// Version returns the component version
-	Version() string
-
-	// Type returns the component's static constant type
-	Type() unikraft.ComponentType
 
 	// Path is the location to this library within the context of a project.
 	Path() string

--- a/unikraft/type.go
+++ b/unikraft/type.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"path/filepath"
 	"regexp"
+	"strings"
 )
 
 type ComponentType string
@@ -103,4 +104,23 @@ func PlaceComponent(workdir string, t ComponentType, name string) (string, error
 	}
 
 	return "", fmt.Errorf("cannot place component of unknown type")
+}
+
+// TypeNameVersion returns the canonical name of the component using the format
+// <TYPE>/<NAME>:<VERSION>
+func TypeNameVersion(entity Nameable) string {
+	var ret strings.Builder
+	if entity.Type() != ComponentTypeUnknown {
+		ret.WriteString(string(entity.Type()))
+		ret.WriteString("/")
+	}
+
+	ret.WriteString(entity.Name())
+
+	if entity.Version() != "" {
+		ret.WriteString(":")
+		ret.WriteString(entity.Version())
+	}
+
+	return ret.String()
 }

--- a/unikraft/type.go
+++ b/unikraft/type.go
@@ -44,6 +44,20 @@ func (ct ComponentType) Plural() string {
 	return string(ct) + "s"
 }
 
+// Nameable represents an abstract interface which can be cast to structures
+// which contain canonical information about a component.  This allows us to
+// generate a string representation of the entity.
+type Nameable interface {
+	// Type returns the entity's static component type.
+	Type() ComponentType
+
+	// Name returns the entity name.
+	Name() string
+
+	// Version returns the entity version.
+	Version() string
+}
+
 // GuessNameAndType attempts to parse the input string, which could be formatted
 // such that its type, name and version are present
 func GuessTypeNameVersion(input string) (ComponentType, string, string, error) {

--- a/unikraft/type.go
+++ b/unikraft/type.go
@@ -1,33 +1,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
-//
-// Authors: Alexander Jung <alex@unikraft.io>
-//
-// Copyright (c) 2022, Unikraft GmbH.  All rights reserved.
-//
-// Redistribution and use in source and binary forms, with or without
-// modification, are permitted provided that the following conditions
-// are met:
-//
-// 1. Redistributions of source code must retain the above copyright
-//    notice, this list of conditions and the following disclaimer.
-// 2. Redistributions in binary form must reproduce the above copyright
-//    notice, this list of conditions and the following disclaimer in the
-//    documentation and/or other materials provided with the distribution.
-// 3. Neither the name of the copyright holder nor the names of its
-//    contributors may be used to endorse or promote products derived from
-//    this software without specific prior written permission.
-//
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-// POSSIBILITY OF SUCH DAMAGE.
+// Copyright (c) 2022, Unikraft GmbH and The KraftKit Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
 
 package unikraft
 


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [x] Updated relevant documentation.

### Description of changes

Introduce a `Nameable` interface which allows for the abstraction of naming a component, whether defined through the `Component` interface or otherwise.  In this PR, the `Nameable` is also applied to the `Package` interface which wraps a `Component`.

By abstracting an implementation as `Nameable` we are able to consistently represent its name in the format `<TYPE>/<NAME>:<VERSION>`, e.g.`lib/nginx:staging` regardless of the implementation or purpose of the implementing structure.
