### PR TITLE
Set the static tag in the GoReleaser build

### DIFF
--- a/.goreleaser-stable.yaml
+++ b/.goreleaser-stable.yaml
@@ -49,4 +49,6 @@ builds:
       - -X {{ .Env.GOMOD }}/internal/version.version={{ .Version }}
       - -X {{ .Env.GOMOD }}/internal/version.commit={{ .Commit }}
       - -X {{ .Env.GOMOD }}/internal/version.buildTime={{ .Date }}
+    tags:
+      - static
 #@ end

--- a/.goreleaser-staging.yaml
+++ b/.goreleaser-staging.yaml
@@ -49,4 +49,6 @@ builds:
       - -X {{ .Env.GOMOD }}/internal/version.version={{ .Version }}
       - -X {{ .Env.GOMOD }}/internal/version.commit={{ .Commit }}
       - -X {{ .Env.GOMOD }}/internal/version.buildTime={{ .Date }}
+    tags:
+      - static
 #@ end


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

With partial vendoring of libgit2, we must include the `static` tag in any `go build` invocation such that we use the locally vendored shared object file.  This commit updates GoReleaser's configuration to set this tag and to signify this tag to `go build` such that the relevant tag-specific Go files which link against the shared object are indeed made.
