### PR TITLE
Add the Make target `git2go` as a pre-hook in GoReleaser

### DIFF
--- a/.github/workflows/release-stable.yaml
+++ b/.github/workflows/release-stable.yaml
@@ -37,7 +37,8 @@ jobs:
         run: |
           apt-get update;
           apt-get install -y --no-install-recommends \
-            cmake;
+            cmake \
+            make;
       
       - name: Generate GoReleaser configuration
         run: |

--- a/.github/workflows/release-staging.yaml
+++ b/.github/workflows/release-staging.yaml
@@ -37,7 +37,8 @@ jobs:
         run: |
           apt-get update;
           apt-get install -y --no-install-recommends \
-            cmake;
+            cmake \
+            make;
       
       - name: Generate GoReleaser configuration
         run: |

--- a/.goreleaser-stable.yaml
+++ b/.goreleaser-stable.yaml
@@ -51,4 +51,6 @@ builds:
       - -X {{ .Env.GOMOD }}/internal/version.buildTime={{ .Date }}
     tags:
       - static
+    hooks:
+      pre: make git2go
 #@ end

--- a/.goreleaser-staging.yaml
+++ b/.goreleaser-staging.yaml
@@ -51,4 +51,6 @@ builds:
       - -X {{ .Env.GOMOD }}/internal/version.buildTime={{ .Date }}
     tags:
       - static
+    hooks:
+      pre: make git2go
 #@ end


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

Due to partial vendoring of libgit2, we must build the shared object which will be later statically linked.  In this commit, we task GoReleaser with the "pre-hook" to invoke this build.