### PR TITLE
Use Go generics in contextual config manager

### DIFF
--- a/cmd/kraft/build/build.go
+++ b/cmd/kraft/build/build.go
@@ -101,8 +101,8 @@ func (opts *Build) Run(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("cannot build uninitialized project! start with: ukbuild init")
 	}
 
-	parallel := !config.G(ctx).NoParallel
-	norender := log.LoggerTypeFromString(config.G(ctx).Log.Type) != log.FANCY
+	parallel := !config.G[config.KraftKit](ctx).NoParallel
+	norender := log.LoggerTypeFromString(config.G[config.KraftKit](ctx).Log.Type) != log.FANCY
 
 	var missingPacks []pack.Package
 	var processes []*paraprogress.Process

--- a/cmd/kraft/events/events.go
+++ b/cmd/kraft/events/events.go
@@ -106,7 +106,7 @@ func (opts *Events) Run(cmd *cobra.Command, args []string) error {
 	var err error
 
 	ctx, cancel := context.WithCancel(cmd.Context())
-	store, err := machine.NewMachineStoreFromPath(config.G(ctx).RuntimeDir)
+	store, err := machine.NewMachineStoreFromPath(config.G[config.KraftKit](ctx).RuntimeDir)
 	if err != nil {
 		cancel()
 		return fmt.Errorf("could not access machine store: %v", err)
@@ -115,13 +115,13 @@ func (opts *Events) Run(cmd *cobra.Command, args []string) error {
 	var pidfile *os.File
 
 	// Check if a pid has already been enabled
-	if _, err := os.Stat(config.G(ctx).EventsPidFile); err != nil && os.IsNotExist(err) {
-		if err := os.MkdirAll(filepath.Dir(config.G(ctx).EventsPidFile), 0o755); err != nil {
+	if _, err := os.Stat(config.G[config.KraftKit](ctx).EventsPidFile); err != nil && os.IsNotExist(err) {
+		if err := os.MkdirAll(filepath.Dir(config.G[config.KraftKit](ctx).EventsPidFile), 0o755); err != nil {
 			cancel()
 			return err
 		}
 
-		pidfile, err = os.OpenFile(config.G(ctx).EventsPidFile, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0o666)
+		pidfile, err = os.OpenFile(config.G[config.KraftKit](ctx).EventsPidFile, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0o666)
 		if err != nil {
 			cancel()
 			return fmt.Errorf("could not create pidfile: %v", err)
@@ -130,7 +130,8 @@ func (opts *Events) Run(cmd *cobra.Command, args []string) error {
 		defer func() {
 			pidfile.Close()
 
-			if err := os.Remove(config.G(ctx).EventsPidFile); err != nil {
+			log.G(ctx).Info("removing pid file")
+			if err := os.Remove(config.G[config.KraftKit](ctx).EventsPidFile); err != nil {
 				log.G(ctx).Errorf("could not remove pid file: %v", err)
 			}
 		}()
@@ -235,7 +236,7 @@ seek:
 				if _, ok := drivers[driverType]; !ok {
 					driver, err := machinedriver.New(driverType,
 						driveropts.WithMachineStore(store),
-						driveropts.WithRuntimeDir(config.G(ctx).RuntimeDir),
+						driveropts.WithRuntimeDir(config.G[config.KraftKit](ctx).RuntimeDir),
 					)
 					if err != nil {
 						log.G(ctx).Errorf("could not instantiate machine driver for %s: %v", mid, err)

--- a/cmd/kraft/options.go
+++ b/cmd/kraft/options.go
@@ -120,7 +120,7 @@ func withDefaultLogger() CliOption {
 func withDefaultConfigManager(cmd *cobra.Command) CliOption {
 	return func(copts *CliOptions) error {
 		cfgm, err := config.NewConfigManager(
-			config.WithFile(config.ConfigFile(), true),
+			config.WithFile(config.DefaultConfigFile(), true),
 		)
 		if err != nil {
 			return err

--- a/cmd/kraft/options.go
+++ b/cmd/kraft/options.go
@@ -25,7 +25,7 @@ import (
 type CliOptions struct {
 	ioStreams      *iostreams.IOStreams
 	logger         *logrus.Entry
-	configManager  *config.ConfigManager
+	configManager  *config.ConfigManager[config.KraftKit]
 	packageManager packmanager.PackageManager
 	pluginManager  *plugins.PluginManager
 	httpClient     *http.Client
@@ -119,8 +119,13 @@ func withDefaultLogger() CliOption {
 // default options.
 func withDefaultConfigManager(cmd *cobra.Command) CliOption {
 	return func(copts *CliOptions) error {
+		cfg, err := config.NewDefaultKraftKitConfig()
+		if err != nil {
+			return err
+		}
 		cfgm, err := config.NewConfigManager(
-			config.WithFile(config.DefaultConfigFile(), true),
+			cfg,
+			config.WithFile[config.KraftKit](config.DefaultConfigFile(), true),
 		)
 		if err != nil {
 			return err

--- a/cmd/kraft/pkg/pkg.go
+++ b/cmd/kraft/pkg/pkg.go
@@ -123,8 +123,8 @@ func (opts *Pkg) Run(cmd *cobra.Command, args []string) error {
 
 	var tree []*processtree.ProcessTreeItem
 
-	parallel := !config.G(ctx).NoParallel
-	norender := log.LoggerTypeFromString(config.G(ctx).Log.Type) != log.FANCY
+	parallel := !config.G[config.KraftKit](ctx).NoParallel
+	norender := log.LoggerTypeFromString(config.G[config.KraftKit](ctx).Log.Type) != log.FANCY
 
 	// Generate a package for every matching requested target
 	for _, targ := range project.Targets() {

--- a/cmd/kraft/pkg/pull/pull.go
+++ b/cmd/kraft/pkg/pull/pull.go
@@ -92,8 +92,8 @@ func (opts *Pull) Run(cmd *cobra.Command, args []string) error {
 	workdir := opts.Workdir
 	ctx := cmd.Context()
 	pm := packmanager.G(ctx)
-	parallel := !config.G(ctx).NoParallel
-	norender := log.LoggerTypeFromString(config.G(ctx).Log.Type) != log.FANCY
+	parallel := !config.G[config.KraftKit](ctx).NoParallel
+	norender := log.LoggerTypeFromString(config.G[config.KraftKit](ctx).Log.Type) != log.FANCY
 
 	// Force a particular package manager
 	if len(opts.Manager) > 0 && opts.Manager != "auto" {

--- a/cmd/kraft/pkg/update/update.go
+++ b/cmd/kraft/pkg/update/update.go
@@ -51,8 +51,8 @@ func (opts *Update) Run(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	parallel := !config.G(ctx).NoParallel
-	norender := log.LoggerTypeFromString(config.G(ctx).Log.Type) != log.FANCY
+	parallel := !config.G[config.KraftKit](ctx).NoParallel
+	norender := log.LoggerTypeFromString(config.G[config.KraftKit](ctx).Log.Type) != log.FANCY
 
 	model, err := processtree.NewProcessTree(
 		ctx,

--- a/cmd/kraft/ps/ps.go
+++ b/cmd/kraft/ps/ps.go
@@ -85,7 +85,7 @@ func (opts *Ps) Run(cmd *cobra.Command, args []string) error {
 
 	var items []psTable
 
-	store, err := machine.NewMachineStoreFromPath(config.G(ctx).RuntimeDir)
+	store, err := machine.NewMachineStoreFromPath(config.G[config.KraftKit](ctx).RuntimeDir)
 	if err != nil {
 		return err
 	}
@@ -110,7 +110,7 @@ func (opts *Ps) Run(cmd *cobra.Command, args []string) error {
 
 		if _, ok := drivers[driverType]; !ok {
 			driver, err := machinedriver.New(driverType,
-				machinedriveropts.WithRuntimeDir(config.G(ctx).RuntimeDir),
+				machinedriveropts.WithRuntimeDir(config.G[config.KraftKit](ctx).RuntimeDir),
 				machinedriveropts.WithMachineStore(store),
 			)
 			if err != nil {

--- a/cmd/kraft/rm/rm.go
+++ b/cmd/kraft/rm/rm.go
@@ -94,7 +94,7 @@ func (opts *Rm) Run(cmd *cobra.Command, args []string) error {
 	var err error
 
 	ctx := cmd.Context()
-	store, err := machine.NewMachineStoreFromPath(config.G(ctx).RuntimeDir)
+	store, err := machine.NewMachineStoreFromPath(config.G[config.KraftKit](ctx).RuntimeDir)
 	if err != nil {
 		return fmt.Errorf("could not access machine store: %v", err)
 	}
@@ -146,7 +146,7 @@ func (opts *Rm) Run(cmd *cobra.Command, args []string) error {
 			if _, ok := drivers[driverType]; !ok {
 				driver, err := machinedriver.New(driverType,
 					driveropts.WithMachineStore(store),
-					driveropts.WithRuntimeDir(config.G(ctx).RuntimeDir),
+					driveropts.WithRuntimeDir(config.G[config.KraftKit](ctx).RuntimeDir),
 				)
 				if err != nil {
 					log.G(ctx).Errorf("could not instantiate machine driver for %s: %v", mid.ShortString(), err)

--- a/cmd/kraft/run/run.go
+++ b/cmd/kraft/run/run.go
@@ -89,7 +89,7 @@ func (opts *Run) Run(cmd *cobra.Command, args []string) error {
 			return err
 		}
 	} else if opts.Hypervisor == "config" {
-		opts.Hypervisor = config.G(ctx).DefaultPlat
+		opts.Hypervisor = config.G[config.KraftKit](ctx).DefaultPlat
 	} else {
 		driverType = machinedriver.DriverTypeFromName(opts.Hypervisor)
 	}
@@ -98,15 +98,15 @@ func (opts *Run) Run(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("unknown hypervisor driver: %s", opts.Hypervisor)
 	}
 
-	debug := log.Levels()[config.G(ctx).Log.Level] >= logrus.DebugLevel
-	store, err := machine.NewMachineStoreFromPath(config.G(ctx).RuntimeDir)
+	debug := log.Levels()[config.G[config.KraftKit](ctx).Log.Level] >= logrus.DebugLevel
+	store, err := machine.NewMachineStoreFromPath(config.G[config.KraftKit](ctx).RuntimeDir)
 	if err != nil {
 		return fmt.Errorf("could not access machine store: %v", err)
 	}
 
 	driver, err := machinedriver.New(driverType,
 		machinedriveropts.WithBackground(opts.Detach),
-		machinedriveropts.WithRuntimeDir(config.G(ctx).RuntimeDir),
+		machinedriveropts.WithRuntimeDir(config.G[config.KraftKit](ctx).RuntimeDir),
 		machinedriveropts.WithMachineStore(store),
 		machinedriveropts.WithDebug(debug),
 		machinedriveropts.WithExecOptions(
@@ -194,7 +194,7 @@ func (opts *Run) Run(cmd *cobra.Command, args []string) error {
 			}
 
 		} else if len(target) == 0 && len(project.TargetNames()) > 1 {
-			if config.G(ctx).NoPrompt {
+			if config.G[config.KraftKit](ctx).NoPrompt {
 				return fmt.Errorf("with 'no prompt' enabled please select a target")
 			}
 
@@ -282,7 +282,7 @@ func (opts *Run) Run(cmd *cobra.Command, args []string) error {
 
 	if !opts.NoMonitor {
 		// Spawn an event monitor or attach to an existing monitor
-		_, err = os.Stat(config.G(ctx).EventsPidFile)
+		_, err = os.Stat(config.G[config.KraftKit](ctx).EventsPidFile)
 		if err != nil && os.IsNotExist(err) {
 			log.G(ctx).Debugf("launching event monitor...")
 

--- a/cmd/kraft/stop/stop.go
+++ b/cmd/kraft/stop/stop.go
@@ -93,7 +93,7 @@ func (opts *Stop) Run(cmd *cobra.Command, args []string) error {
 	var err error
 
 	ctx := cmd.Context()
-	store, err := machine.NewMachineStoreFromPath(config.G(ctx).RuntimeDir)
+	store, err := machine.NewMachineStoreFromPath(config.G[config.KraftKit](ctx).RuntimeDir)
 	if err != nil {
 		return fmt.Errorf("could not access machine store: %v", err)
 	}
@@ -159,7 +159,7 @@ func (opts *Stop) Run(cmd *cobra.Command, args []string) error {
 			if _, ok := drivers[driverType]; !ok {
 				driver, err := machinedriver.New(driverType,
 					driveropts.WithMachineStore(store),
-					driveropts.WithRuntimeDir(config.G(ctx).RuntimeDir),
+					driveropts.WithRuntimeDir(config.G[config.KraftKit](ctx).RuntimeDir),
 				)
 				if err != nil {
 					log.G(ctx).Errorf("could not instantiate machine driver for %s: %v", mid.ShortString(), err)

--- a/config/config.go
+++ b/config/config.go
@@ -14,7 +14,7 @@ type AuthConfig struct {
 	VerifySSL bool   `yaml:"verify_ssl" env:"KRAFTKIT_AUTH_%s_VERIFY_SSL" long:"auth-%s-verify-ssl"`
 }
 
-type Config struct {
+type KraftKit struct {
 	NoPrompt       bool   `yaml:"no_prompt" env:"KRAFTKIT_NO_PROMPT" long:"no-prompt" usage:"Do not prompt for user interaction" default:"false"`
 	NoParallel     bool   `yaml:"no_parallel" env:"KRAFTKIT_NO_PARALLEL" long:"no-parallel" usage:"Do not run internal tasks in parallel" default:"true"`
 	NoEmojis       bool   `yaml:"no_emojis" env:"KRAFTKIT_NO_EMOJIS" long:"no-emojis" usage:"Do not use emojis in any console output" default:"true"`

--- a/config/config_file.go
+++ b/config/config_file.go
@@ -176,7 +176,7 @@ func fileExists(path string) bool {
 	return err == nil && !f.IsDir()
 }
 
-func ConfigFile() string {
+func DefaultConfigFile() string {
 	return filepath.Join(ConfigDir(), "config.yaml")
 }
 

--- a/config/context.go
+++ b/config/context.go
@@ -8,43 +8,30 @@ import (
 	"context"
 )
 
-var (
-	// G is an alias for FromContext.
-	//
-	// We may want to define this locally to a package to get package tagged
-	// config.
-	G = ConfigFromContext
-
-	// M is an alias for FromContext
-	M = FromContext
-
-	// C is the default configuration manager
-	C, _ = NewConfigManager()
-)
-
 // contextKey is used to retrieve the logger from the context.
 type contextKey struct{}
 
 // WithConfigManager returns a new context with the provided logger. Use in
 // combination with logger.WithField(s) for great effect.
-func WithConfigManager(ctx context.Context, cfgm *ConfigManager) context.Context {
+func WithConfigManager[C any](ctx context.Context, cfgm *ConfigManager[C]) context.Context {
 	return context.WithValue(ctx, contextKey{}, cfgm)
 }
 
 // FromContext returns the Config Manager for kraftkit in the context, or an
 // inert configuration that results in default values.
-func FromContext(ctx context.Context) *ConfigManager {
+func M[T any](ctx context.Context) *ConfigManager[T] {
 	l := ctx.Value(contextKey{})
 
 	if l == nil {
-		return C
+		l, _ := NewConfigManager(new(T))
+		return l
 	}
 
-	return l.(*ConfigManager)
+	return l.(*ConfigManager[T])
 }
 
 // ConfigFromContext returns the config for kraftkit in the context, or an inert
 // configuration that results in default values.
-func ConfigFromContext(ctx context.Context) *Config {
-	return FromContext(ctx).Config
+func G[T any](ctx context.Context) *T {
+	return M[T](ctx).Config
 }

--- a/config/context.go
+++ b/config/context.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 // Copyright (c) 2022, Unikraft GmbH and The KraftKit Authors.
 // Licensed under the BSD-3-Clause License (the "License").
-// You may not use this file expect in compliance with the License.
+// You may not use this file except in compliance with the License.
 package config
 
 import (

--- a/config/defaults.go
+++ b/config/defaults.go
@@ -17,8 +17,8 @@ const (
 	defaultManifestIndex = "https://manifests.kraftkit.sh/index.yaml"
 )
 
-func NewDefaultConfig() (*Config, error) {
-	c := &Config{}
+func NewDefaultKraftKitConfig() (*KraftKit, error) {
+	c := &KraftKit{}
 
 	if err := setDefaults(c); err != nil {
 		return nil, fmt.Errorf("could not set defaults for config: %s", err)

--- a/config/manager.go
+++ b/config/manager.go
@@ -86,7 +86,7 @@ func WithFile(file string, forceCreate bool) ConfigManagerOption {
 
 func WithDefaultConfigFile() ConfigManagerOption {
 	return func(cm *ConfigManager) error {
-		return WithFile(ConfigFile(), true)(cm)
+		return WithFile(DefaultConfigFile(), true)(cm)
 	}
 }
 

--- a/config/manager.go
+++ b/config/manager.go
@@ -1,34 +1,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
-//
-// Authors: Alexander Jung <alex@unikraft.io>
-//
-// Copyright (c) 2022, Unikraft GmbH.  All rights reserved.
-//
-// Redistribution and use in source and binary forms, with or without
-// modification, are permitted provided that the following conditions
-// are met:
-//
-// 1. Redistributions of source code must retain the above copyright
-//    notice, this list of conditions and the following disclaimer.
-// 2. Redistributions in binary form must reproduce the above copyright
-//    notice, this list of conditions and the following disclaimer in the
-//    documentation and/or other materials provided with the distribution.
-// 3. Neither the name of the copyright holder nor the names of its
-//    contributors may be used to endorse or promote products derived from
-//    this software without specific prior written permission.
-//
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-// POSSIBILITY OF SUCH DAMAGE.
-
+// Copyright (c) 2022, Unikraft GmbH and The KraftKit Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
 package config
 
 import (

--- a/manifest/manager.go
+++ b/manifest/manager.go
@@ -55,7 +55,7 @@ func NewManifestManager() packmanager.PackageManager {
 
 // update retrieves and returns a cache of the upstream manifest registry
 func (m manager) update(ctx context.Context) (*ManifestIndex, error) {
-	if len(config.G(ctx).Unikraft.Manifests) == 0 {
+	if len(config.G[config.KraftKit](ctx).Unikraft.Manifests) == 0 {
 		return nil, fmt.Errorf("no manifests specified in config")
 	}
 
@@ -64,11 +64,11 @@ func (m manager) update(ctx context.Context) (*ManifestIndex, error) {
 	}
 
 	mopts := []ManifestOption{
-		WithAuthConfig(config.G(ctx).Auth),
-		WithSourcesRootDir(config.G(ctx).Paths.Sources),
+		WithAuthConfig(config.G[config.KraftKit](ctx).Auth),
+		WithSourcesRootDir(config.G[config.KraftKit](ctx).Paths.Sources),
 	}
 
-	for _, manipath := range config.G(ctx).Unikraft.Manifests {
+	for _, manipath := range config.G[config.KraftKit](ctx).Unikraft.Manifests {
 		// If the path of the manipath is the same as the current manifest or it
 		// resides in the same directory as KraftKit's configured path for manifests
 		// then we can skip this since we don't want to update ourselves.
@@ -140,7 +140,7 @@ func (m manager) Update(ctx context.Context) error {
 }
 
 func (m manager) AddSource(ctx context.Context, source string) error {
-	for _, manifest := range config.G(ctx).Unikraft.Manifests {
+	for _, manifest := range config.G[config.KraftKit](ctx).Unikraft.Manifests {
 		if source == manifest {
 			log.G(ctx).Warnf("manifest already saved: %s", source)
 			return nil
@@ -148,22 +148,25 @@ func (m manager) AddSource(ctx context.Context, source string) error {
 	}
 
 	log.G(ctx).Infof("adding to list of manifests: %s", source)
-	config.G(ctx).Unikraft.Manifests = append(config.G(ctx).Unikraft.Manifests, source)
-	return config.M(ctx).Write(true)
+	config.G[config.KraftKit](ctx).Unikraft.Manifests = append(
+		config.G[config.KraftKit](ctx).Unikraft.Manifests,
+		source,
+	)
+	return config.M[config.KraftKit](ctx).Write(true)
 }
 
 func (m manager) RemoveSource(ctx context.Context, source string) error {
 	manifests := []string{}
 
-	for _, manifest := range config.G(ctx).Unikraft.Manifests {
+	for _, manifest := range config.G[config.KraftKit](ctx).Unikraft.Manifests {
 		if source != manifest {
 			manifests = append(manifests, manifest)
 		}
 	}
 
 	log.G(ctx).Infof("removing from list of manifests: %s", source)
-	config.G(ctx).Unikraft.Manifests = manifests
-	return config.M(ctx).Write(false)
+	config.G[config.KraftKit](ctx).Unikraft.Manifests = manifests
+	return config.M[config.KraftKit](ctx).Write(false)
 }
 
 func (m manager) Pack(ctx context.Context, c component.Component, opts ...packmanager.PackOption) ([]pack.Package, error) {
@@ -184,8 +187,8 @@ func (m manager) Catalog(ctx context.Context, query packmanager.CatalogQuery) ([
 	var allManifests []*Manifest
 
 	mopts := []ManifestOption{
-		WithAuthConfig(config.G(ctx).Auth),
-		WithSourcesRootDir(config.G(ctx).Paths.Sources),
+		WithAuthConfig(config.G[config.KraftKit](ctx).Auth),
+		WithSourcesRootDir(config.G[config.KraftKit](ctx).Paths.Sources),
 	}
 
 	log.G(ctx).WithFields(logrus.Fields{
@@ -369,8 +372,8 @@ func (m manager) IsCompatible(ctx context.Context, source string) (packmanager.P
 
 // LocalManifestDir returns the user configured path to all the manifests
 func (m manager) LocalManifestsDir(ctx context.Context) string {
-	if len(config.G(ctx).Paths.Manifests) > 0 {
-		return config.G(ctx).Paths.Manifests
+	if len(config.G[config.KraftKit](ctx).Paths.Manifests) > 0 {
+		return config.G[config.KraftKit](ctx).Paths.Manifests
 	}
 
 	return filepath.Join(config.DataDir(), "manifests")


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

This PR converts the use of the globally accessible configuration, typically accessed via `config.G(ctx)` into a generic such that the use of the `kraftkit.sh/config` is abstract to KraftKit. Whilst KraftKit configuration is still embedded, now at
`config.KraftKit`, this is not enforced in the package's instantiation. This is enforced only when the manager is invoked and the initial type is provided.