### PR TITLE
Add target to install `golangci-lint`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,6 +49,7 @@ GOFUMPT     ?= gofumpt
 GOCILINT    ?= golangci-lint
 MKDIR       ?= mkdir
 GIT         ?= git
+CURL        ?= curl
 
 # Misc
 Q           ?= @
@@ -131,6 +132,12 @@ fmt:
 .PHONY: cicheck
 cicheck:
 	$(GOCILINT) run
+
+.PHONY: install-golangci-lint
+install-golangci-lint: GOLANGCI_LINT_VERSION     ?= 1.51.2
+install-golangci-lint: GOLANGCI_LINT_INSTALL_DIR ?= $$($(GO) env GOPATH)/bin
+install-golangci-lint: ## Install the Golang CI lint tool
+	$(CURL) -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(GOLANGCI_LINT_INSTALL_DIR) v$(GOLANGCI_LINT_VERSION)
 
 .PHONY: clean
 clean:


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

This PR introduces a `Makefile` target which installs the Go lint too [`glangci-lint`](https://golangci/golangci-lint) which is used in the `gocheck` GitHub actions workflow. A dependency is explicitly not made to `cicheck` since this program is installed in the workflow. Probably we should add some `Makefile` magic that checks if the binary is available and install the target based on whether it's available via `which`.