### PR TITLE
cmd: Add kraft setup command

### DIFF
--- a/cmd/kraft/kraft.go
+++ b/cmd/kraft/kraft.go
@@ -31,6 +31,7 @@ import (
 	"kraftkit.sh/cmd/kraft/rm"
 	"kraftkit.sh/cmd/kraft/run"
 	"kraftkit.sh/cmd/kraft/set"
+	"kraftkit.sh/cmd/kraft/setup"
 	"kraftkit.sh/cmd/kraft/stop"
 	"kraftkit.sh/cmd/kraft/unset"
 	"kraftkit.sh/cmd/kraft/version"
@@ -77,6 +78,7 @@ func New() *cobra.Command {
 	cmd.AddCommand(ps.New())
 	cmd.AddCommand(rm.New())
 	cmd.AddCommand(run.New())
+	cmd.AddCommand(setup.New())
 	cmd.AddCommand(stop.New())
 
 	cmd.AddGroup(&cobra.Group{ID: "misc", Title: "MISCELLANEOUS COMMANDS"})

--- a/cmd/kraft/setup/setup.go
+++ b/cmd/kraft/setup/setup.go
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2022, Unikraft GmbH and The KraftKit Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+
+package setup
+
+import (
+	"github.com/MakeNowJust/heredoc"
+	"github.com/spf13/cobra"
+
+	"kraftkit.sh/cmdfactory"
+	"kraftkit.sh/internal/setup"
+)
+
+type Setup struct {
+	WithOS   string `long:"with-os" usage:"Force the host OS"`
+	WithArch string `long:"with-arch" usage:"Force the architecture of the host"`
+	WithVMM  string `long:"with-vmm" usage:"Force the use of a specific VMM on the host"`
+	WithPM   string `long:"with-pm" usage:"Force the use of a specific package manager on the host"`
+}
+
+func New() *cobra.Command {
+	return cmdfactory.New(&Setup{}, cobra.Command{
+		Short:   "Setup the working environment for building and running unikernels",
+		Use:     "setup",
+		Aliases: []string{"sup"},
+		Args:    cmdfactory.MaxDirArgs(0),
+		Long: heredoc.Doc(`
+		Setup the working environment for building and running unikernels`),
+		Example: heredoc.Doc(`
+			# Setup the environment
+			$ kraft setup`),
+		Annotations: map[string]string{
+			"help:group": "build",
+		},
+	})
+}
+
+func (opts *Setup) Run(cmd *cobra.Command, args []string) error {
+	var err error
+	var sopts []setup.SetupOption
+
+	ctx := cmd.Context()
+
+	if opts.WithOS != "" {
+		sopts = append(sopts, setup.WithOS(opts.WithOS))
+	} else {
+		sopts = append(sopts, setup.WithDetectHostOS())
+	}
+
+	if opts.WithArch != "" {
+		sopts = append(sopts, setup.WithArch(opts.WithArch))
+	} else {
+		sopts = append(sopts, setup.WithDetectArch())
+	}
+
+	if opts.WithVMM != "" {
+		sopts = append(sopts, setup.WithVMM(opts.WithVMM))
+	} else {
+		sopts = append(sopts, setup.WithDetectVMM())
+	}
+
+	if opts.WithPM != "" {
+		sopts = append(sopts, setup.WithPM(opts.WithPM))
+	} else {
+		sopts = append(sopts, setup.WithDetectPM())
+	}
+
+	if err := setup.DoSetup(ctx, sopts...); err != nil {
+		return err
+	}
+
+	return err
+}

--- a/internal/setup/options.go
+++ b/internal/setup/options.go
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2022, Unikraft GmbH and The KraftKit Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+
+package setup
+
+import (
+	"context"
+
+	"github.com/shirou/gopsutil/v3/host"
+)
+
+type SetupOption func(*Setup) error
+
+type HostPackageManager interface {
+	Install(context.Context, ...string) error
+}
+
+// Check if the provided `os` variable is valid in format and supported.
+func WithOS(os string) SetupOption {
+	switch os {
+	case "ubuntu", "linux/ubuntu":
+		return NotSupported
+	case "windows":
+		return NotSupported
+	}
+
+	return NotSupported
+}
+
+// Check if the provided `arch` variable is valid in format and supported.
+func WithArch(arch string) SetupOption {
+	switch arch {
+	case "x86_64":
+		return NotSupported
+	case "arm64":
+		return NotSupported
+	}
+
+	return NotSupported
+}
+
+// Check if the provided `vmm` variable is valid in format and supported.
+func WithVMM(vmm string) SetupOption {
+	switch vmm {
+	case "kvm":
+		return NotSupported
+	case "xen":
+		return NotSupported
+	}
+
+	return NotSupported
+}
+
+// Check if the provided `pm` variable is valid in format and supported.
+func WithPM(pm string) SetupOption {
+	return NotSupported
+}
+
+func WithDetectHostOS() SetupOption {
+	os_name := detect_os()
+	return WithOS(os_name)
+}
+
+func WithDetectArch() SetupOption {
+	arch := detect_arch()
+	return WithArch(arch)
+}
+
+func WithDetectVMM() SetupOption {
+	vmm := detect_vmm()
+	return WithVMM(vmm)
+}
+
+func WithDetectPM() SetupOption {
+	return NotSupported
+}
+
+func detect_os() string {
+	os_info, _ := host.Info()
+	os_name := os_info.OS + "/" + os_info.Platform
+
+	return os_name
+}
+
+func detect_arch() string {
+	os_info, _ := host.Info()
+	arch := os_info.KernelArch
+
+	return arch
+}
+
+func detect_vmm() string {
+	os_virt, role, _ := host.Virtualization()
+	vmm := os_virt + "/" + role
+
+	return vmm
+}
+
+func NotSupported(*Setup) error {
+	return nil
+}

--- a/internal/setup/setup.go
+++ b/internal/setup/setup.go
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2022, Unikraft GmbH and The KraftKit Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+
+package setup
+
+import (
+	"context"
+)
+
+type Setup struct {
+	WithOS   string `long:"with-os" usage:"Force the host OS"`
+	WithArch string `long:"with-arch" usage:"Force the architecture of the host"`
+	WithVMM  string `long:"with-vmm" usage:"Force the use of a specific VMM on the host"`
+	WithPM   string `long:"with-pm" usage:"Force the use of a specific package manager on the host"`
+}
+
+func DoSetup(ctx context.Context, sopts ...SetupOption) error {
+	s := Setup{}
+	for _, opts := range sopts {
+		if err := opts(&s); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
The `kraft setup` command will install the required dependencies for building and running unikernels. It will also check the virtualization support of the environment, check if we are running kraft from inside a conainter or a virtual machine and give a warning about enabling nested virtualization

<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [ ] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [ ] Tested your changes against relevant architectures and platforms;
  - [ ] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->
