### PR TITLE
fix(make): runtime agnostic container detection

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,6 +60,8 @@ ifeq ($(DOCKER),)
 DOCKER_RUN  :=
 else ifneq ($(wildcard /.dockerenv),)
 DOCKER_RUN  :=
+else ifeq ($(shell grep '3:cpu:/$$' /proc/1/cgroup),)
+DOCKER_RUN  :=
 endif
 .PROXY      :=
 ifneq ($(DOCKER_RUN),)


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [x] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

Using `make` commands has been working poorly with non-Docker container runtimes (containerd, podman).

Checking the existence of the `/.dockerenv` file is only valid with the Docker runtime. A fairly reliable runtime agnostic alternative is to inspect the PID 1 cgroup. On most hosts, the PID 1 cgroup is the root cgroup (`/`).

Checking the first line of `/proc/1/sched` is another alternative, albeit less reliable.
