### PR TITLE
feat(run): append arch/plat to duplicate tgt names

### DIFF
--- a/unikraft/app/merge.go
+++ b/unikraft/app/merge.go
@@ -20,6 +20,7 @@ package app
 import (
 	"github.com/imdario/mergo"
 	"github.com/pkg/errors"
+
 	"kraftkit.sh/unikraft/core"
 	"kraftkit.sh/unikraft/lib"
 	"kraftkit.sh/unikraft/target"

--- a/unikraft/app/project.go
+++ b/unikraft/app/project.go
@@ -66,7 +66,7 @@ func NewProjectFromOptions(ctx context.Context, opts ...ProjectOption) (Applicat
 	}
 
 	if len(popts.kraftfiles) < 1 {
-		return nil, fmt.Errorf("no Kraft files specified")
+		return nil, fmt.Errorf("no Kraftfile specified")
 	}
 
 	var all []*application


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [x] Updated relevant documentation.

### Description of changes

Fixes #256.

When the returned list of targets contains multiple entries with the same name attribute, append the arch/plat to these entries to be able to tell them apart in the output of `kraft run`.

I originally tried to remove the automatic [name injection at load time](https://github.com/unikraft/kraftkit/blob/9b2664e3ec86d3929e7b3c8ed1ffba41d236be59/unikraft/target/transform.go#L24-L26), but there are a few code paths that require targets to have a name. Refactoring that logic sounds too intrusive for a UI change.

---

:warning: This doesn't entirely fix the `kraft run` command, because this code can't possibly do the right thing when duplicate names exist:

https://github.com/unikraft/kraftkit/blob/9b2664e3ec86d3929e7b3c8ed1ffba41d236be59/cmd/kraft/run/run.go#L215-L218

In a future PR, I think we should consider attaching an ID to each target.

---

Result:

![krun1](https://user-images.githubusercontent.com/3299086/223344327-357f1580-886d-4cd4-ad43-a9aa8a4e641a.png)
![krun2](https://user-images.githubusercontent.com/3299086/223344331-4cd3096d-7c37-4daa-b5f1-d7f852061250.png)
![krun3](https://user-images.githubusercontent.com/3299086/223344332-d66ed611-36f2-4167-9851-d0c8688d107c.png)