### PR TITLE
Revert "fix(make): runtime agnostic container detection"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,8 +60,6 @@ ifeq ($(DOCKER),)
 DOCKER_RUN  :=
 else ifneq ($(wildcard /.dockerenv),)
 DOCKER_RUN  :=
-else ifeq ($(shell grep '3:cpu:/$$' /proc/1/cgroup),)
-DOCKER_RUN  :=
 endif
 .PROXY      :=
 ifneq ($(DOCKER_RUN),)


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [x] Updated relevant documentation.

### Description of changes

This reverts commit 9af809bfd227604640474fdedad5ad0ce435bc30.

Fixes #270

We pass `-e DOCKER=` to `DOCKER_RUN` make commands, which should be robust enough on its own to avoid the need for this extra check.

IMO the check on `/.dockerenv` might also be unnecessary for day-to-day development.