### PR TITLE
refactor(cmd): turn help:group annotation into const

### DIFF
--- a/cmd/kraft/build/build.go
+++ b/cmd/kraft/build/build.go
@@ -63,7 +63,7 @@ func New() *cobra.Command {
 			# Build path to a Unikraft project
 			$ kraft build path/to/app`),
 		Annotations: map[string]string{
-			"help:group": "build",
+			cmdfactory.AnnotationHelpGroup: "build",
 		},
 	})
 }

--- a/cmd/kraft/clean/clean.go
+++ b/cmd/kraft/clean/clean.go
@@ -57,7 +57,7 @@ func New() *cobra.Command {
 			# clean a project at a path
 			$ kraft build clean path/to/app`),
 		Annotations: map[string]string{
-			"help:group": "build",
+			cmdfactory.AnnotationHelpGroup: "build",
 		},
 	})
 }

--- a/cmd/kraft/configure/configure.go
+++ b/cmd/kraft/configure/configure.go
@@ -30,7 +30,7 @@ func New() *cobra.Command {
 			# Configure a project at a path
 			$ kraft build configure path/to/app`),
 		Annotations: map[string]string{
-			"help:group": "build",
+			cmdfactory.AnnotationHelpGroup: "build",
 		},
 	})
 }

--- a/cmd/kraft/events/events.go
+++ b/cmd/kraft/events/events.go
@@ -42,7 +42,7 @@ func New() *cobra.Command {
 		Long: heredoc.Doc(`
 			Follow the events of a unikernel`),
 		Annotations: map[string]string{
-			"help:group": "run",
+			cmdfactory.AnnotationHelpGroup: "run",
 		},
 	})
 }

--- a/cmd/kraft/fetch/fetch.go
+++ b/cmd/kraft/fetch/fetch.go
@@ -34,7 +34,7 @@ func New() *cobra.Command {
 			# Fetch a project at a path
 			$ kraft build fetch path/to/app`),
 		Annotations: map[string]string{
-			"help:group": "build",
+			cmdfactory.AnnotationHelpGroup: "build",
 		},
 	})
 }

--- a/cmd/kraft/menu/menu.go
+++ b/cmd/kraft/menu/menu.go
@@ -32,7 +32,7 @@ func New() *cobra.Command {
 			# Open configuration editor for a project at a path
 			$ kraft build menu path/to/app`),
 		Annotations: map[string]string{
-			"help:group": "build",
+			cmdfactory.AnnotationHelpGroup: "build",
 		},
 	})
 }

--- a/cmd/kraft/pkg/list/list.go
+++ b/cmd/kraft/pkg/list/list.go
@@ -44,7 +44,7 @@ func New() *cobra.Command {
 		Example: heredoc.Doc(`
 			$ kraft pkg list`),
 		Annotations: map[string]string{
-			"help:group": "pkg",
+			cmdfactory.AnnotationHelpGroup: "pkg",
 		},
 	})
 }

--- a/cmd/kraft/pkg/pkg.go
+++ b/cmd/kraft/pkg/pkg.go
@@ -75,7 +75,7 @@ func New() *cobra.Command {
 			# Same as above but also save the resulting CPIO artifact locally
 			$ kraft pkg --initrd ./root-fs:./root-fs.cpio .`),
 		Annotations: map[string]string{
-			"help:group": "pkg",
+			cmdfactory.AnnotationHelpGroup: "pkg",
 		},
 	})
 

--- a/cmd/kraft/pkg/pull/pull.go
+++ b/cmd/kraft/pkg/pull/pull.go
@@ -58,7 +58,7 @@ func New() *cobra.Command {
 			# Pull from a manifest
 			$ kraft pkg pull nginx:1.21.6`),
 		Annotations: map[string]string{
-			"help:group": "pkg",
+			cmdfactory.AnnotationHelpGroup: "pkg",
 		},
 	})
 }

--- a/cmd/kraft/pkg/source/source.go
+++ b/cmd/kraft/pkg/source/source.go
@@ -26,7 +26,7 @@ func New() *cobra.Command {
 			# Add a manifest of components
 			$ kraft pkg source https://raw.github.com/unikraft/index/stable/index.yaml`),
 		Annotations: map[string]string{
-			"help:group": "pkg",
+			cmdfactory.AnnotationHelpGroup: "pkg",
 		},
 	})
 }

--- a/cmd/kraft/pkg/unsource/unsource.go
+++ b/cmd/kraft/pkg/unsource/unsource.go
@@ -29,7 +29,7 @@ func New() *cobra.Command {
 		$ kraft pkg unsource https://manifests.kraftkit.sh/index.yaml
 	`),
 		Annotations: map[string]string{
-			"help:group": "pkg",
+			cmdfactory.AnnotationHelpGroup: "pkg",
 		},
 	})
 }

--- a/cmd/kraft/pkg/update/update.go
+++ b/cmd/kraft/pkg/update/update.go
@@ -32,7 +32,7 @@ func New() *cobra.Command {
 			$ kraft pkg update
 		`),
 		Annotations: map[string]string{
-			"help:group": "pkg",
+			cmdfactory.AnnotationHelpGroup: "pkg",
 		},
 	})
 }

--- a/cmd/kraft/prepare/prepare.go
+++ b/cmd/kraft/prepare/prepare.go
@@ -31,7 +31,7 @@ func New() *cobra.Command {
 			# Prepare a project at a path
 			$ kraft build prepare path/to/app`),
 		Annotations: map[string]string{
-			"help:group": "build",
+			cmdfactory.AnnotationHelpGroup: "build",
 		},
 	})
 }

--- a/cmd/kraft/properclean/properclean.go
+++ b/cmd/kraft/properclean/properclean.go
@@ -58,7 +58,7 @@ func New() *cobra.Command {
 			# Properclean a project at a path
 			$ kraft build properclean path/to/app`),
 		Annotations: map[string]string{
-			"help:group": "build",
+			cmdfactory.AnnotationHelpGroup: "build",
 		},
 	})
 

--- a/cmd/kraft/ps/ps.go
+++ b/cmd/kraft/ps/ps.go
@@ -38,7 +38,7 @@ func New() *cobra.Command {
 		Args:  cobra.MaximumNArgs(0),
 		Long:  "List running unikernels",
 		Annotations: map[string]string{
-			"help:group": "run",
+			cmdfactory.AnnotationHelpGroup: "run",
 		},
 	})
 

--- a/cmd/kraft/rm/rm.go
+++ b/cmd/kraft/rm/rm.go
@@ -30,7 +30,7 @@ func New() *cobra.Command {
 		Long: heredoc.Doc(`
 			Remove one or more running unikernels`),
 		Annotations: map[string]string{
-			"help:group": "run",
+			cmdfactory.AnnotationHelpGroup: "run",
 		},
 	})
 }

--- a/cmd/kraft/run/run.go
+++ b/cmd/kraft/run/run.go
@@ -60,7 +60,7 @@ func New() *cobra.Command {
 			# Run a project which only has one target
 			kraft run path/to/project`),
 		Annotations: map[string]string{
-			"help:group": "run",
+			cmdfactory.AnnotationHelpGroup: "run",
 		},
 	})
 

--- a/cmd/kraft/set/set.go
+++ b/cmd/kraft/set/set.go
@@ -61,7 +61,7 @@ func New() *cobra.Command {
 			# Set variables in a project at a path
 			$ kraft build set -w path/to/app LIBDEVFS_DEV_STDOUT=/dev/null LWIP_TCP_SND_BUF=4096`),
 		Annotations: map[string]string{
-			"help:group": "build",
+			cmdfactory.AnnotationHelpGroup: "build",
 		},
 	})
 }

--- a/cmd/kraft/stop/stop.go
+++ b/cmd/kraft/stop/stop.go
@@ -29,7 +29,7 @@ func New() *cobra.Command {
 		Long: heredoc.Doc(`
 			Stop one or more running unikernels`),
 		Annotations: map[string]string{
-			"help:group": "run",
+			cmdfactory.AnnotationHelpGroup: "run",
 		},
 	})
 }

--- a/cmd/kraft/unset/unset.go
+++ b/cmd/kraft/unset/unset.go
@@ -60,7 +60,7 @@ func New() *cobra.Command {
 			# Unset variables in a project at a path
 			$ kraft build unset -w path/to/app LIBDEVFS_DEV_STDOUT LWIP_TCP_SND_BUF`),
 		Annotations: map[string]string{
-			"help:group": "build",
+			cmdfactory.AnnotationHelpGroup: "build",
 		},
 	})
 }

--- a/cmd/kraft/version/version.go
+++ b/cmd/kraft/version/version.go
@@ -23,7 +23,7 @@ func New() *cobra.Command {
 		Aliases: []string{"v"},
 		Args:    cobra.NoArgs,
 		Annotations: map[string]string{
-			"help:group": "misc",
+			cmdfactory.AnnotationHelpGroup: "misc",
 		},
 	})
 }

--- a/cmdfactory/help.go
+++ b/cmdfactory/help.go
@@ -17,6 +17,9 @@ import (
 	"kraftkit.sh/internal/text"
 )
 
+// AnnotationHelpGroup is used to indicate in which help group a command belongs.
+const AnnotationHelpGroup = "help:group"
+
 func rootUsageFunc(command *cobra.Command) error {
 	command.Printf("Usage:  %s", command.UseLine())
 
@@ -149,7 +152,7 @@ func rootHelpFunc(cmd *cobra.Command, args []string) {
 				continue
 			}
 
-			group, ok := c.Annotations["help:group"]
+			group, ok := c.Annotations[AnnotationHelpGroup]
 			if !ok {
 				continue
 			}


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [x] Updated relevant documentation.

### Description of changes

Turning the `help:group` string into a constant for good measure. It makes it easier to understand its purpose while working with `cmdfactory` (e.g. language servers show its meaning when hovering).

![image](https://user-images.githubusercontent.com/3299086/223698998-0fd87cfd-ab26-4d24-aa7d-aa68c1c95822.png)