### PR TITLE
Fix instantiating unikernels and tailing logs

### DIFF
--- a/cmd/kraft/events/events.go
+++ b/cmd/kraft/events/events.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 // Copyright (c) 2022, Unikraft GmbH and The KraftKit Authors.
 // Licensed under the BSD-3-Clause License (the "License").
-// You may not use this file expect in compliance with the License.
+// You may not use this file except in compliance with the License.
 package events
 
 import (
@@ -102,7 +102,7 @@ func (opts *Events) Run(cmd *cobra.Command, args []string) error {
 		cancel()
 	}()
 
-	// TODO: Should we thrown an error here if a process file already exists? We
+	// TODO: Should we throw an error here if a process file already exists?  We
 	// use a pid file for `kraft run` to continuously monitor running machines.
 
 	// Actively seek for machines whose events we wish to monitor.  The thread

--- a/cmd/kraft/events/events.go
+++ b/cmd/kraft/events/events.go
@@ -220,7 +220,7 @@ seek:
 						if mcfg.DestroyOnExit {
 							log.G(ctx).Infof("removing %s...", mid.ShortString())
 							if err := driver.Destroy(ctx, mid); err != nil {
-								log.G(ctx).Errorf("could not remove machine: %v: ", err)
+								log.G(ctx).Errorf("could not remove machine: %v", err)
 							}
 						}
 					case machine.MachineStateRunning:

--- a/cmd/kraft/events/events.go
+++ b/cmd/kraft/events/events.go
@@ -206,7 +206,7 @@ seek:
 
 				events, errs, err := driver.ListenStatusUpdate(ctx, mid)
 				if err != nil {
-					log.G(ctx).Warnf("could not listen for status updates for %s: %v", mid.ShortString(), err)
+					log.G(ctx).Debugf("could not listen for status updates for %s: %v", mid.ShortString(), err)
 
 					// Check the state of the machine using the driver, for a more
 					// accurate read

--- a/cmd/kraft/kraft.go
+++ b/cmd/kraft/kraft.go
@@ -23,6 +23,7 @@ import (
 	"kraftkit.sh/cmd/kraft/configure"
 	"kraftkit.sh/cmd/kraft/events"
 	"kraftkit.sh/cmd/kraft/fetch"
+	"kraftkit.sh/cmd/kraft/logs"
 	"kraftkit.sh/cmd/kraft/menu"
 	"kraftkit.sh/cmd/kraft/pkg"
 	"kraftkit.sh/cmd/kraft/prepare"
@@ -74,6 +75,7 @@ func New() *cobra.Command {
 
 	cmd.AddGroup(&cobra.Group{ID: "run", Title: "RUNTIME COMMANDS"})
 	cmd.AddCommand(events.New())
+	cmd.AddCommand(logs.New())
 	cmd.AddCommand(ps.New())
 	cmd.AddCommand(rm.New())
 	cmd.AddCommand(run.New())

--- a/cmd/kraft/logs/logs.go
+++ b/cmd/kraft/logs/logs.go
@@ -1,0 +1,147 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2022, Unikraft GmbH and The KraftKit Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+package logs
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+
+	"kraftkit.sh/cmdfactory"
+	"kraftkit.sh/config"
+	"kraftkit.sh/exec"
+	"kraftkit.sh/iostreams"
+	"kraftkit.sh/log"
+	"kraftkit.sh/machine"
+	machinedriver "kraftkit.sh/machine/driver"
+	machinedriveropts "kraftkit.sh/machine/driveropts"
+)
+
+type Logs struct {
+	Follow bool `long:"follow" short:"f" usage:"Follow log output"`
+}
+
+func New() *cobra.Command {
+	cmd := cmdfactory.New(&Logs{}, cobra.Command{
+		Short:   "Fetch the logs of a unikernel.",
+		Use:     "logs [FLAGS] MACHINE",
+		Args:    cobra.MaximumNArgs(1),
+		GroupID: "run",
+	})
+
+	cmd.Flags().VarP(
+		cmdfactory.NewEnumFlag(machinedriver.DriverNames(), "auto"),
+		"hypervisor",
+		"H",
+		"Set the hypervisor machine driver.",
+	)
+
+	return cmd
+}
+
+func (opts *Logs) Run(cmd *cobra.Command, args []string) error {
+	var err error
+
+	ctx := cmd.Context()
+
+	debug := log.Levels()[config.G[config.KraftKit](ctx).Log.Level] >= logrus.DebugLevel
+	store, err := machine.NewMachineStoreFromPath(config.G[config.KraftKit](ctx).RuntimeDir)
+	if err != nil {
+		return fmt.Errorf("could not access machine store: %v", err)
+	}
+
+	mcfgs, err := store.ListAllMachineConfigs()
+	if err != nil {
+		return err
+	}
+
+	var mcfg *machine.MachineConfig
+
+	for _, candidate := range mcfgs {
+		if machine.MachineName(args[0]) == candidate.Name {
+			mcfg = &candidate
+			break
+		} else if candidate.ID.Short().String() == args[0] {
+			mcfg = &candidate
+			break
+		} else if candidate.ID.String() == args[0] {
+			mcfg = &candidate
+			break
+		}
+	}
+
+	if mcfg == nil {
+		return fmt.Errorf("could not find instance %s", args[0])
+	}
+
+	driver, err := machinedriver.New(machinedriver.DriverTypeFromName(mcfg.DriverName),
+		machinedriveropts.WithBackground(false),
+		machinedriveropts.WithRuntimeDir(config.G[config.KraftKit](ctx).RuntimeDir),
+		machinedriveropts.WithMachineStore(store),
+		machinedriveropts.WithDebug(debug),
+		machinedriveropts.WithExecOptions(
+			exec.WithStdout(os.Stdout),
+			exec.WithStderr(os.Stderr),
+		),
+	)
+	if err != nil {
+		return err
+	}
+
+	mid := mcfg.ID
+
+	// Skip checking the error, if we receive an error, we will not tail the logs.
+	state, _ := driver.State(ctx, mid)
+
+	if opts.Follow && state == machine.MachineStateRunning {
+		ctx, cancel := context.WithCancel(ctx)
+
+		go func() {
+			events, errs, err := driver.ListenStatusUpdate(ctx, mid)
+			if err != nil {
+				log.G(ctx).Errorf("could not listen for machine updates: %v", err)
+				return
+			}
+
+		loop:
+			for {
+				// Wait on either channel
+				select {
+				case status := <-events:
+					store.SaveMachineState(mid, status)
+
+					switch status {
+					case machine.MachineStateExited, machine.MachineStateDead:
+						break loop
+					}
+
+				case err := <-errs:
+					log.G(ctx).Errorf("received event error: %v", err)
+					break loop
+
+				case <-ctx.Done():
+					break loop
+				}
+			}
+		}()
+
+		driver.TailWriter(ctx, mid, iostreams.G(ctx).Out)
+		cancel()
+		return err
+	} else {
+		fd, err := os.Open(mcfg.LogFile)
+		if err != nil {
+			return err
+		}
+
+		io.Copy(iostreams.G(ctx).Out, fd)
+	}
+
+	return nil
+}

--- a/cmd/kraft/rm/rm.go
+++ b/cmd/kraft/rm/rm.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 // Copyright (c) 2022, Unikraft GmbH and The KraftKit Authors.
 // Licensed under the BSD-3-Clause License (the "License").
-// You may not use this file expect in compliance with the License.
+// You may not use this file except in compliance with the License.
 package rm
 
 import (

--- a/cmd/kraft/rm/rm.go
+++ b/cmd/kraft/rm/rm.go
@@ -19,13 +19,15 @@ import (
 	"kraftkit.sh/machine/driveropts"
 )
 
-type Rm struct{}
+type Rm struct {
+	All bool `long:"all" usage:"Remove all machines"`
+}
 
 func New() *cobra.Command {
 	return cmdfactory.New(&Rm{}, cobra.Command{
 		Short:   "Remove one or more running unikernels",
 		Use:     "rm [FLAGS] MACHINE [MACHINE [...]]",
-		Args:    cobra.MinimumNArgs(1),
+		Args:    cobra.MinimumNArgs(0),
 		Aliases: []string{"remove"},
 		Long: heredoc.Doc(`
 			Remove one or more running unikernels`),
@@ -120,10 +122,17 @@ func (opts *Rm) Run(cmd *cobra.Command, args []string) error {
 		}
 	}
 
+	if len(args) == 0 && opts.All {
+		mids = []machine.MachineID{}
+		for _, mcfg := range mcfgs {
+			mids = append(mids, mcfg.ID)
+		}
+	}
+
 	for _, mid := range mids {
 		mid := mid // loop closure
 
-		if observations.Contains(mid) {
+		if !opts.All && observations.Contains(mid) {
 			continue
 		}
 

--- a/cmd/kraft/rm/rm.go
+++ b/cmd/kraft/rm/rm.go
@@ -101,7 +101,7 @@ func (opts *Rm) Run(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("could not access machine store: %v", err)
 	}
 
-	allMids, err := store.ListAllMachineIDs()
+	mcfgs, err := store.ListAllMachineConfigs()
 	if err != nil {
 		return fmt.Errorf("could not list machines: %v", err)
 	}
@@ -110,9 +110,9 @@ func (opts *Rm) Run(cmd *cobra.Command, args []string) error {
 
 	for _, mid1 := range args {
 		found := false
-		for _, mid2 := range allMids {
-			if mid1 == mid2.ShortString() || mid1 == mid2.String() {
-				mids = append(mids, mid2)
+		for _, mid2 := range mcfgs {
+			if mid1 == mid2.ID.ShortString() || mid1 == mid2.ID.String() || mid1 == string(mid2.Name) {
+				mids = append(mids, mid2.ID)
 				found = true
 			}
 		}

--- a/cmd/kraft/run/run.go
+++ b/cmd/kraft/run/run.go
@@ -48,7 +48,7 @@ type Run struct {
 func New() *cobra.Command {
 	cmd := cmdfactory.New(&Run{}, cobra.Command{
 		Short:   "Run a unikernel",
-		Use:     "run [FLAGS] [PROJECT|KERNEL] [ARGS]",
+		Use:     "run [FLAGS] PROJECT|KERNEL -- [UNIKRAFT ARGS] -- [APP ARGS]",
 		Aliases: []string{"launch", "r"},
 		Long: heredoc.Doc(`
 			Launch a unikernel`),

--- a/cmd/kraft/run/run.go
+++ b/cmd/kraft/run/run.go
@@ -49,6 +49,7 @@ func New() *cobra.Command {
 	cmd := cmdfactory.New(&Run{}, cobra.Command{
 		Short:   "Run a unikernel",
 		Use:     "run [FLAGS] PROJECT|KERNEL -- [UNIKRAFT ARGS] -- [APP ARGS]",
+		Args:    cobra.MaximumNArgs(1),
 		Aliases: []string{"launch", "r"},
 		Long: heredoc.Doc(`
 			Launch a unikernel`),

--- a/cmd/kraft/run/run.go
+++ b/cmd/kraft/run/run.go
@@ -37,6 +37,7 @@ type Run struct {
 	Detach        bool   `long:"detach" short:"d" usage:"Run unikernel in background"`
 	DisableAccel  bool   `long:"disable-acceleration" short:"W" usage:"Disable acceleration of CPU (usually enables TCG)"`
 	Hypervisor    string
+	InitRd        string `long:"initrd" short:"i" usage:"Use the specified initrd"`
 	Memory        int    `long:"memory" short:"M" usage:"Assign MB memory to the unikernel"`
 	Name          string `long:"name" short:"n" usage:"Name of the instance"`
 	NoMonitor     bool   `long:"no-monitor" usage:"Do not spawn a (or attach to an existing) an instance monitor"`
@@ -194,6 +195,7 @@ func (opts *Run) Run(cmd *cobra.Command, args []string) error {
 			machine.WithName(machine.MachineName(opts.Name)),
 			machine.WithKernel(entity),
 			machine.WithSource("kernel://"+filepath.Base(entity)),
+			machine.WithInitRd(opts.InitRd),
 		)
 
 		// c). use a defined working directory as a Unikraft project
@@ -257,6 +259,7 @@ func (opts *Run) Run(cmd *cobra.Command, args []string) error {
 			machine.WithName(machine.MachineName(name)),
 			machine.WithAcceleration(!opts.DisableAccel),
 			machine.WithSource("project://"+project.Name()+":"+t.Name()),
+			machine.WithInitRd(opts.InitRd),
 		)
 
 		// Use the symbolic debuggable kernel image?
@@ -287,6 +290,7 @@ func (opts *Run) Run(cmd *cobra.Command, args []string) error {
 			machine.WithName(machine.MachineName(opts.Name)),
 			machine.WithKernel(entity),
 			machine.WithSource("kernel://"+filepath.Base(entity)),
+			machine.WithInitRd(opts.InitRd),
 		)
 	} else {
 		return fmt.Errorf("could not determine what to run: %s", entity)

--- a/cmd/kraft/run/run.go
+++ b/cmd/kraft/run/run.go
@@ -38,6 +38,7 @@ type Run struct {
 	DisableAccel  bool   `long:"disable-acceleration" short:"W" usage:"Disable acceleration of CPU (usually enables TCG)"`
 	Hypervisor    string
 	Memory        int    `long:"memory" short:"M" usage:"Assign MB memory to the unikernel"`
+	Name          string `long:"name" short:"n" usage:"Name of the instance"`
 	NoMonitor     bool   `long:"no-monitor" usage:"Do not spawn a (or attach to an existing) an instance monitor"`
 	Platform      string `long:"plat" short:"p" usage:"Set the platform"`
 	Remove        bool   `long:"rm" usage:"Automatically remove the unikernel when it shutsdown"`
@@ -183,9 +184,14 @@ func (opts *Run) Run(cmd *cobra.Command, args []string) error {
 			return fmt.Errorf("cannot use `kraft run KERNEL` without specifying --arch and --plat")
 		}
 
+		if opts.Name == "" {
+			opts.Name = namesgenerator.GetRandomName(0)
+		}
+
 		mopts = append(mopts,
 			machine.WithArchitecture(opts.Architecture),
 			machine.WithPlatform(opts.Platform),
+			machine.WithName(machine.MachineName(opts.Name)),
 			machine.WithKernel(entity),
 			machine.WithSource("kernel://"+filepath.Base(entity)),
 		)
@@ -240,10 +246,15 @@ func (opts *Run) Run(cmd *cobra.Command, args []string) error {
 			return fmt.Errorf("selected target (%s) does not match specified platform (%s)", t.ArchPlatString(), opts.Platform)
 		}
 
+		name := t.Name()
+		if opts.Name != "" {
+			name = opts.Name
+		}
+
 		mopts = append(mopts,
 			machine.WithArchitecture(t.Architecture().Name()),
 			machine.WithPlatform(t.Platform().Name()),
-			machine.WithName(machine.MachineName(t.Name())),
+			machine.WithName(machine.MachineName(name)),
 			machine.WithAcceleration(!opts.DisableAccel),
 			machine.WithSource("project://"+project.Name()+":"+t.Name()),
 		)
@@ -266,10 +277,14 @@ func (opts *Run) Run(cmd *cobra.Command, args []string) error {
 			return fmt.Errorf("cannot use `kraft run KERNEL` without specifying --arch and --plat")
 		}
 
+		if opts.Name == "" {
+			opts.Name = namesgenerator.GetRandomName(0)
+		}
+
 		mopts = append(mopts,
 			machine.WithArchitecture(opts.Architecture),
 			machine.WithPlatform(opts.Platform),
-			machine.WithName(machine.MachineName(namesgenerator.GetRandomName(0))),
+			machine.WithName(machine.MachineName(opts.Name)),
 			machine.WithKernel(entity),
 			machine.WithSource("kernel://"+filepath.Base(entity)),
 		)

--- a/cmd/kraft/run/run.go
+++ b/cmd/kraft/run/run.go
@@ -307,7 +307,7 @@ func (opts *Run) Run(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	log.G(ctx).Infof("created %s instance %s", driverType.String(), mid.ShortString())
+	log.G(ctx).Debugf("created %s instance %s", driverType.String(), mid.ShortString())
 
 	// Start the machine
 	if err := driver.Start(ctx, mid); err != nil {

--- a/cmd/kraft/run/run.go
+++ b/cmd/kraft/run/run.go
@@ -37,13 +37,12 @@ type Run struct {
 	Detach        bool   `long:"detach" short:"d" usage:"Run unikernel in background"`
 	DisableAccel  bool   `long:"disable-acceleration" short:"W" usage:"Disable acceleration of CPU (usually enables TCG)"`
 	Hypervisor    string
-	Memory        int      `long:"memory" short:"M" usage:"Assign MB memory to the unikernel"`
-	NoMonitor     bool     `long:"no-monitor" usage:"Do not spawn a (or attach to an existing) an instance monitor"`
-	Platform      string   `long:"plat" short:"p" usage:"Set the platform"`
-	Remove        bool     `long:"rm" usage:"Automatically remove the unikernel when it shutsdown"`
-	Target        string   `long:"target" short:"t" usage:"Explicitly use the defined project target"`
-	Volumes       []string `long:"" short:"" usage:""`
-	WithKernelDbg bool     `long:"symbolic" usage:"Use the debuggable (symbolic) unikernel"`
+	Memory        int    `long:"memory" short:"M" usage:"Assign MB memory to the unikernel"`
+	NoMonitor     bool   `long:"no-monitor" usage:"Do not spawn a (or attach to an existing) an instance monitor"`
+	Platform      string `long:"plat" short:"p" usage:"Set the platform"`
+	Remove        bool   `long:"rm" usage:"Automatically remove the unikernel when it shutsdown"`
+	Target        string `long:"target" short:"t" usage:"Explicitly use the defined project target"`
+	WithKernelDbg bool   `long:"symbolic" usage:"Use the debuggable (symbolic) unikernel"`
 }
 
 func New() *cobra.Command {

--- a/cmd/kraft/stop/stop.go
+++ b/cmd/kraft/stop/stop.go
@@ -133,20 +133,6 @@ func (opts *Stop) Run(cmd *cobra.Command, args []string) error {
 
 			log.G(ctx).Infof("stopping %s...", mid.ShortString())
 
-			state, err := store.LookupMachineState(mid)
-			if err != nil {
-				log.G(ctx).Errorf("could not look up machine state: %v", err)
-				observations.Done(mid)
-				return
-			}
-
-			switch state {
-			case machine.MachineStateDead, machine.MachineStateExited:
-				log.G(ctx).Errorf("%s has exited", mid.ShortString())
-				observations.Done(mid)
-				return
-			}
-
 			mcfg := &machine.MachineConfig{}
 			if err := store.LookupMachineConfig(mid, mcfg); err != nil {
 				log.G(ctx).Errorf("could not look up machine config: %v", err)

--- a/cmd/kraft/stop/stop.go
+++ b/cmd/kraft/stop/stop.go
@@ -19,13 +19,15 @@ import (
 	"kraftkit.sh/machine/driveropts"
 )
 
-type Stop struct{}
+type Stop struct {
+	All bool `long:"all" usage:"Remove all machines"`
+}
 
 func New() *cobra.Command {
 	return cmdfactory.New(&Stop{}, cobra.Command{
 		Short: "Stop one or more running unikernels",
 		Use:   "stop [FLAGS] MACHINE [MACHINE [...]]",
-		Args:  cobra.MinimumNArgs(1),
+		Args:  cobra.MinimumNArgs(0),
 		Long: heredoc.Doc(`
 			Stop one or more running unikernels`),
 		Annotations: map[string]string{
@@ -116,6 +118,13 @@ func (opts *Stop) Run(cmd *cobra.Command, args []string) error {
 
 		if !found {
 			return fmt.Errorf("could not find machine %s", mid1)
+		}
+	}
+
+	if len(args) == 0 && opts.All {
+		mids = []machine.MachineID{}
+		for _, mcfg := range mcfgs {
+			mids = append(mids, mcfg.ID)
 		}
 	}
 

--- a/cmd/kraft/stop/stop.go
+++ b/cmd/kraft/stop/stop.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 // Copyright (c) 2022, Unikraft GmbH and The KraftKit Authors.
 // Licensed under the BSD-3-Clause License (the "License").
-// You may not use this file expect in compliance with the License.
+// You may not use this file except in compliance with the License.
 package stop
 
 import (

--- a/cmd/kraft/stop/stop.go
+++ b/cmd/kraft/stop/stop.go
@@ -100,7 +100,7 @@ func (opts *Stop) Run(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("could not access machine store: %v", err)
 	}
 
-	allMids, err := store.ListAllMachineIDs()
+	mcfgs, err := store.ListAllMachineConfigs()
 	if err != nil {
 		return fmt.Errorf("could not list machines: %v", err)
 	}
@@ -109,9 +109,9 @@ func (opts *Stop) Run(cmd *cobra.Command, args []string) error {
 
 	for _, mid1 := range args {
 		found := false
-		for _, mid2 := range allMids {
-			if mid1 == mid2.ShortString() || mid1 == mid2.String() {
-				mids = append(mids, mid2)
+		for _, mid2 := range mcfgs {
+			if mid1 == mid2.ID.ShortString() || mid1 == mid2.ID.String() || mid1 == string(mid2.Name) {
+				mids = append(mids, mid2.ID)
 				found = true
 			}
 		}

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/dgraph-io/badger/v3 v3.2103.5
 	github.com/dustin/go-humanize v1.0.1
 	github.com/erikgeiser/promptkit v0.8.0
+	github.com/fsnotify/fsnotify v1.4.7
 	github.com/go-git/go-git/v5 v5.5.2
 	github.com/gobwas/glob v0.2.3
 	github.com/google/go-github/v32 v32.1.0

--- a/go.sum
+++ b/go.sum
@@ -90,6 +90,7 @@ github.com/erikgeiser/promptkit v0.8.0/go.mod h1:QxyFbCrrj20PyvV5b+ckWPozbgX11s0
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fatih/color v1.14.1 h1:qfhVLaG5s+nCROl1zJsZRxFeYrHLqWroPOQ8BWiNb4w=
 github.com/fatih/color v1.14.1/go.mod h1:2oHN61fhTpgcxD3TSWCgKDiH1+x4OiDVVGH8WlgGZGg=
+github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/gliderlabs/ssh v0.3.5 h1:OcaySEmAQJgyYcArR+gGGTHCyE7nvhEMTlYY+Dp8CpY=
 github.com/gliderlabs/ssh v0.3.5/go.mod h1:8XB4KraRrX39qHhT6yxPsHedjA08I/uBVwj4xC+/+z4=

--- a/internal/waitgroup/doc.go
+++ b/internal/waitgroup/doc.go
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2022, Unikraft GmbH and The KraftKit Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+
+/*
+The internal `waitgroup` package is a generic which provides a synchronization
+lock to read observe a list of provided entities.
+*/
+package waitgroup

--- a/internal/waitgroup/waitgroup.go
+++ b/internal/waitgroup/waitgroup.go
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2022, Unikraft GmbH and The KraftKit Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+
+package waitgroup
+
+import "sync"
+
+type WaitGroup[T comparable] struct {
+	mu sync.RWMutex
+	li []T
+}
+
+// Add to the wait group.
+func (wg *WaitGroup[T]) Add(k T) {
+	wg.mu.Lock()
+	defer wg.mu.Unlock()
+
+	if wg.Contains(k) {
+		return
+	}
+
+	wg.li = append(wg.li, k)
+}
+
+// Done signals that the provided entity can be removed from the wait group.
+func (wg *WaitGroup[T]) Done(needle T) {
+	wg.mu.Lock()
+	defer wg.mu.Unlock()
+
+	if !wg.Contains(needle) {
+		return
+	}
+
+	for i, k := range wg.li {
+		if k == needle {
+			wg.li = append(wg.li[:i], wg.li[i+1:]...)
+			return
+		}
+	}
+}
+
+// Wait for all items in the wait group to be removed.
+func (wg *WaitGroup[T]) Wait() {
+	for {
+		if len(wg.li) == 0 {
+			break
+		}
+	}
+}
+
+// Contains checks if the provided entity is still in the wait group.
+func (wg *WaitGroup[T]) Contains(needle T) bool {
+	for _, mid := range wg.li {
+		if mid == needle {
+			return true
+		}
+	}
+
+	return false
+}
+
+// Items returns the list of items in the wait group.
+func (wg *WaitGroup[T]) Items() []T {
+	return wg.li
+}

--- a/machine/config.go
+++ b/machine/config.go
@@ -58,6 +58,9 @@ type MachineConfig struct {
 	// exists
 	DestroyOnExit bool
 
+	// LogFile is the path to use for saving the serial console to file.
+	LogFile string `json:"log_file"`
+
 	// CreatedAt represents when the machine was created with its respected driver
 	// or VMM.
 	CreatedAt time.Time `json:"created_at"`
@@ -190,6 +193,13 @@ func WithMemorySize(memorySize uint64) MachineOption {
 func WithDestroyOnExit(destroyOnExit bool) MachineOption {
 	return func(mo *MachineConfig) error {
 		mo.DestroyOnExit = destroyOnExit
+		return nil
+	}
+}
+
+func WithLogFile(file string) MachineOption {
+	return func(mo *MachineConfig) error {
+		mo.LogFile = file
 		return nil
 	}
 }

--- a/machine/config.go
+++ b/machine/config.go
@@ -1,34 +1,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
-//
-// Authors: Alexander Jung <alex@unikraft.io>
-//
-// Copyright (c) 2022, Unikraft GmbH.  All rights reserved.
-//
-// Redistribution and use in source and binary forms, with or without
-// modification, are permitted provided that the following conditions
-// are met:
-//
-// 1. Redistributions of source code must retain the above copyright
-//    notice, this list of conditions and the following disclaimer.
-// 2. Redistributions in binary form must reproduce the above copyright
-//    notice, this list of conditions and the following disclaimer in the
-//    documentation and/or other materials provided with the distribution.
-// 3. Neither the name of the copyright holder nor the names of its
-//    contributors may be used to endorse or promote products derived from
-//    this software without specific prior written permission.
-//
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-// POSSIBILITY OF SUCH DAMAGE.
-
+// Copyright (c) 2022, Unikraft GmbH and The KraftKit Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
 package machine
 
 import (

--- a/machine/qemu/qemu.go
+++ b/machine/qemu/qemu.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 // Copyright (c) 2022, Unikraft GmbH and The KraftKit Authors.
 // Licensed under the BSD-3-Clause License (the "License").
-// You may not use this file expect in compliance with the License.
+// You may not use this file except in compliance with the License.
 package qemu
 
 import (

--- a/machine/qemu/qemu.go
+++ b/machine/qemu/qemu.go
@@ -512,6 +512,12 @@ func (qd *QemuDriver) Create(ctx context.Context, opts ...machine.MachineOption)
 	mcfg.ID = mid
 
 	pidFile := filepath.Join(qd.dopts.RuntimeDir, mid.String()+".pid")
+
+	// Set and create the log file for this machine
+	if mcfg.LogFile == "" {
+		mcfg.LogFile = filepath.Join(qd.dopts.RuntimeDir, mid.String()+".log")
+	}
+
 	qopts := []QemuOption{
 		WithDaemonize(true),
 		WithEnableKVM(true),

--- a/machine/qemu/qemu.go
+++ b/machine/qemu/qemu.go
@@ -1113,9 +1113,8 @@ func (qd *QemuDriver) State(ctx context.Context, mid machine.MachineID) (state m
 
 	// Check if the process is alive, which ultimately indicates to us whether we
 	// able to speak to the exposed QMP socket
-	process, err := processFromPidFile(qcfg.PidFile)
 	activeProcess := false
-	if err == nil {
+	if process, err := processFromPidFile(qcfg.PidFile); err == nil {
 		activeProcess, err = process.IsRunning()
 		if err != nil {
 			state = machine.MachineStateDead
@@ -1150,6 +1149,10 @@ func (qd *QemuDriver) State(ctx context.Context, mid machine.MachineID) (state m
 	}()
 
 	if !activeProcess {
+		if savedState == machine.MachineStateRunning {
+			state = machine.MachineStateDead
+			exitStatus = 1
+		}
 		return
 	}
 


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

This makes several changes across subsystems to fix the instantiation and tailing of unikernels via `kraft run`. A number of changes were required, particularly:

 - Deprecating the use of a UNIX socket for the logs of a QEMU instance -- since there could be a synchronization issue if the consumer was not fast enough to start receiving logs. Instead, the logs are written verbatim to log file which itself has been made available in `machine.MachineConfig`. Necessary adjustments are made to facilitate "tailing" from a log file from QEMU. This has the added benefit being able to retrieved after the unikernel has ended its life.
 - Fixing the instantiation, tailing and monitoring of a unikernel in `kraft run`. The instantiation of the events monitor is made to be completely silent such that sub-process noise does not spill over into the executor's parent's stdout. The actual instantiation of the unikernel via `driver.Start()` is moved as late-as-possible such that go-routines can be established first. Additionally, the manipulation of the cancalable-context is fixed with respect to the fixed `TailWriter`.
 - Introduce an optional CLI argument for setting the name of the unikernel;
 - Introduce an optional CLI argument for setting the initrd (CPIO) file for the unikernel.

### How to test

I used a simple "Hello, World" C unikernel, with 1 target (kvm-x86_64) and a simple loop in `main.c`, e.g.:

```c
#include <stdio.h>
#include <time.h>
#include <errno.h>

static void millisleep(unsigned int millisec)
{
        struct timespec ts;
        int ret;

        ts.tv_sec = millisec / 1000;
        ts.tv_nsec = (millisec % 1000) * 1000000;
        do
                ret = nanosleep(&ts, &ts);
        while (ret && errno == EINTR);
}


int main(int argc, char *argv[])
{
        for (;;) {
                printf("Hello world!\n");
                millisleep(1000);
        }

        return 0;
}
```

Once built as a unikernel, I could do the following:

```
# this will instantiate `hello1` and immediately detach.
kraft run --detach --name hello1

# i can now see there `kraft events` and `qemu-system-x86_64` running in the background

# starting another unikernel will start to tail the logs
kraft run --name hello2

# Ctrl+C will stop tailing

# i can kill them both
kraft stop --all

# see that they are both exited
kraft ps

# clean up
kraft rm --all

# no lingering process should be on the system (aka `kraft events [...]`)
```