### PR TITLE
feat(Makefile): Add `help` target providing details of PHONY targets

### DIFF
--- a/.github/workflows/gobuild.yaml
+++ b/.github/workflows/gobuild.yaml
@@ -25,7 +25,7 @@ jobs:
         run: |
           set -xe
           git config --global --add safe.directory /__w/kraftkit/kraftkit
-          make
+          make kraft
 
       - name: Run Help Message
         run: |


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [x] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

This PR introduces a helper target via `make help` which provides details to KraftKit hackers of "PHONY" targets available by the top-level Makefile.  These targets are useful for the development of KraftKit itself. A preview of the result is presented below:

<img width="688" alt="image" src="https://user-images.githubusercontent.com/905927/228021065-3c884dd3-f503-438d-b9ff-9dee16170155.png">
