### PR TITLE
fix(lib): Always set the library's KConfig option

### DIFF
--- a/unikraft/lib/library.go
+++ b/unikraft/lib/library.go
@@ -188,6 +188,10 @@ func (lc LibraryConfig) KConfig() kconfig.KeyValueMap {
 	values.OverrideBy(lc.kconfig)
 
 	if menu == nil {
+		// Naively set the KConfig option for this library based on Unikraft
+		// convention.
+		values.Set(kconfig.Prefix+"LIB"+strings.ToUpper(lc.name), kconfig.Yes)
+
 		return values
 	}
 


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

This PR fixes setting the library's KConfig value which would otherwise not be set if the library's `Config.uk` file could not be parsed. The KConfig parser is currently broken for Unikraft microlibraries which do not generally wrap `menuconfig` with `endmenu`.  Additional changes are required such that this is recognised for each microlibrary by the parser OR a fix occurs in each microlibrary up stream (which is unlikely).  Either way, if the menu cannot be read, naively set the KConfig name for this library.