### PR TITLE
fix(gomod): Do not use relative replacement

### DIFF
--- a/go.work.sum
+++ b/go.work.sum
@@ -8,3 +8,4 @@ github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/f
 golang.org/x/net v0.6.0/go.mod h1:2Tu9+aMcznHK/AK1HMvgo6xiTLG5rD5rZLDS+rp2Bjs=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
+kraftkit.sh v0.4.0/go.mod h1:Vsmx8KWlS0yp5F7uSwh9wJK/RaMPLHt2lFX0tboBghI=

--- a/tools/go-generate-qemu-devices/go.mod
+++ b/tools/go-generate-qemu-devices/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/Masterminds/sprig/v3 v3.2.3
 	github.com/golang/glog v1.0.0
 	github.com/iancoleman/strcase v0.2.0
-	kraftkit.sh v0.4.0
+	kraftkit.sh v0.4.1
 	mvdan.cc/gofumpt v0.4.0
 )
 
@@ -40,5 +40,3 @@ require (
 	golang.org/x/term v0.5.0 // indirect
 	golang.org/x/tools v0.6.0 // indirect
 )
-
-replace kraftkit.sh => ../..

--- a/tools/go-generate-qemu-devices/go.sum
+++ b/tools/go-generate-qemu-devices/go.sum
@@ -124,5 +124,7 @@ gopkg.in/yaml.v2 v2.3.0/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.0/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+kraftkit.sh v0.4.1 h1:3cH8yvaD01/MR8uF0doMwYUA9oqjZoHexpWe+AK7Xlo=
+kraftkit.sh v0.4.1/go.mod h1:wWDrfSS1S/2quPVId97axZndL/aC/0hl9p7VHcAraKE=
 mvdan.cc/gofumpt v0.4.0 h1:JVf4NN1mIpHogBj7ABpgOyZc65/UUOkKQFkoURsz4MM=
 mvdan.cc/gofumpt v0.4.0/go.mod h1:PljLOHDeZqgS8opHRKLzp2It2VBuSdteAgqUfzMTxlQ=


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

Statically set KraftKit's version within the tools/ package.  The relative import makes updating the top-level go.{mod,sum} tedious as each tool will require updating as well.  Since these are "independent" from KraftKit distributables (they are tools for the development of KraftKit itself), we can statically set their version to a known and working version.
