### PR TITLE
KConfig: KConfig Tree Dump

### DIFF
--- a/cmd/kraft/kconfig/dump/dump.go
+++ b/cmd/kraft/kconfig/dump/dump.go
@@ -1,0 +1,91 @@
+package dump
+
+import (
+	"os"
+	"path/filepath"
+
+	"kraftkit.sh/kconfig"
+	"kraftkit.sh/unikraft/core"
+
+	"github.com/MakeNowJust/heredoc"
+	"github.com/sanity-io/litter"
+	"github.com/spf13/cobra"
+	"kraftkit.sh/cmdfactory"
+	"kraftkit.sh/unikraft/app"
+)
+
+type KConfigDump struct {
+	Workdir string `long:"workdir" short:"w" usage:"Set a path to working directory to dump"`
+}
+
+func New() *cobra.Command {
+	return cmdfactory.New(&KConfigDump{}, cobra.Command{
+		Short:   "Dump KConfig Tree",
+		Use:     "dump",
+		Aliases: []string{"d"},
+		Long: heredoc.Doc(`
+			Dump KConfig Tree for Unikraft and dependencies`),
+		Example: heredoc.Doc(`
+			# Dump KConfig tree
+			$ kraft kconfig dump`),
+
+		Annotations: map[string]string{
+			cmdfactory.AnnotationHelpGroup: "misc",
+		},
+	})
+}
+
+func (k *KConfigDump) Run(cmd *cobra.Command, args []string) error {
+	ctx := cmd.Context()
+	var err error
+
+	if len(args) == 0 {
+		k.Workdir, err = os.Getwd()
+		if err != nil {
+			return err
+		}
+	} else {
+		k.Workdir = args[0]
+	}
+
+	// Interpret the project directory
+	project, err := app.NewProjectFromOptions(
+		ctx,
+		app.WithProjectWorkdir(k.Workdir),
+		app.WithProjectDefaultKraftfiles(),
+	)
+	if err != nil {
+		return err
+	}
+
+	components, err := project.Components()
+	if err != nil {
+		return err
+	}
+
+	tree, err := components[0].(core.UnikraftConfig).KConfigTree(
+		&kconfig.KeyValue{Key: "UK_BASE", Value: filepath.Join(k.Workdir, ".unikraft/unikraft")},
+		&kconfig.KeyValue{Key: "UK_APP", Value: k.Workdir},
+
+		&kconfig.KeyValue{Key: "UK_NAME", Value: "test"},
+		&kconfig.KeyValue{Key: "BUILD_DIR", Value: filepath.Join(k.Workdir, "build")},
+
+		&kconfig.KeyValue{Key: "ELIB_DIR", Value: ""},
+		&kconfig.KeyValue{Key: "EPLAT_DIR", Value: ""},
+
+		// Should be populated by kraftkit
+		&kconfig.KeyValue{Key: "UK_FULLVERSION", Value: "0.12.0"},
+		&kconfig.KeyValue{Key: "UK_CODENAME", Value: "JANUS"},
+		&kconfig.KeyValue{Key: "UK_ARCH", Value: "x86_64"},
+		&kconfig.KeyValue{Key: "UK_PLAT", Value: "kvm"},
+
+		// Needed in arch/Config.uk to figure determine arm and arm64 support
+		&kconfig.KeyValue{Key: "CC", Value: "clang"},
+	)
+	if err != nil {
+		return err
+	}
+
+	litter.Dump(tree)
+	return nil
+}

--- a/cmd/kraft/kconfig/kconfig.go
+++ b/cmd/kraft/kconfig/kconfig.go
@@ -1,0 +1,34 @@
+package kconfig
+
+import (
+	"github.com/spf13/cobra"
+	"kraftkit.sh/cmd/kraft/kconfig/dump"
+	"kraftkit.sh/cmdfactory"
+	"kraftkit.sh/log"
+)
+
+type KConfig struct{}
+
+func New() *cobra.Command {
+	// generate a Library command that does not do anything but allows me to register a subcommand called info
+
+	cmd := cmdfactory.New(&KConfig{}, cobra.Command{
+		Short: "Managing dependencies",
+		Use:   "kconfig [FLAGS] [SUBCOMMAND|DIR]",
+		Args:  cmdfactory.MaxDirArgs(1),
+		Annotations: map[string]string{
+			cmdfactory.AnnotationHelpGroup: "misc",
+		},
+	})
+
+	cmd.AddCommand(dump.New())
+
+	return cmd
+}
+
+func (k *KConfig) Run(cmd *cobra.Command, args []string) error {
+	ctx := cmd.Context()
+
+	log.G(ctx).Infof("Usage: kraft kconfig dump")
+	return nil
+}

--- a/cmd/kraft/kraft.go
+++ b/cmd/kraft/kraft.go
@@ -22,6 +22,7 @@ import (
 	"kraftkit.sh/cmd/kraft/clean"
 	"kraftkit.sh/cmd/kraft/events"
 	"kraftkit.sh/cmd/kraft/fetch"
+	"kraftkit.sh/cmd/kraft/kconfig"
 	"kraftkit.sh/cmd/kraft/logs"
 	"kraftkit.sh/cmd/kraft/menu"
 	"kraftkit.sh/cmd/kraft/pkg"
@@ -81,6 +82,7 @@ func New() *cobra.Command {
 
 	cmd.AddGroup(&cobra.Group{ID: "misc", Title: "MISCELLANEOUS COMMANDS"})
 	cmd.AddCommand(version.New())
+	cmd.AddCommand(kconfig.New())
 
 	return cmd
 }

--- a/go.mod
+++ b/go.mod
@@ -35,6 +35,7 @@ require (
 	github.com/muesli/termenv v0.14.0
 	github.com/pkg/errors v0.9.1
 	github.com/rancher/wrangler v1.0.2
+	github.com/sanity-io/litter v1.5.5
 	github.com/shirou/gopsutil/v3 v3.23.1
 	github.com/sirupsen/logrus v1.9.0
 	github.com/spf13/cobra v1.6.1

--- a/go.sum
+++ b/go.sum
@@ -68,6 +68,7 @@ github.com/cpuguy83/go-md2man v1.0.10/go.mod h1:SmD6nW6nTyfqj6ABTjUi3V3JVMnlJmwc
 github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/creack/pty v1.1.17/go.mod h1:MOBLtS5ELjhRRrroQr9kyvTxUAFNvYEK993ew/Vr4O4=
+github.com/davecgh/go-spew v0.0.0-20161028175848-04cdfd42973b/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -239,6 +240,7 @@ github.com/pjbgf/sha1cd v0.2.3 h1:uKQP/7QOzNtKYH7UTohZLcjF5/55EnTw0jO/Ru4jZwI=
 github.com/pjbgf/sha1cd v0.2.3/go.mod h1:HOK9QrgzdHpbc2Kzip0Q1yi3M2MFGPADtR6HjG65m5M=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pmezard/go-difflib v0.0.0-20151028094244-d8ed2627bdf0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c/go.mod h1:OmDBASR4679mdNQnz2pUhc2G8CO2JrUAVFDRBDP/hJE=
@@ -254,6 +256,8 @@ github.com/rivo/uniseg v0.4.3/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUc
 github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR/rfWxYHBV53g=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/sahilm/fuzzy v0.1.0/go.mod h1:VFvziUEIMCrT6A6tw2RFIXPXXmzXbOsSHF0DOI8ZK9Y=
+github.com/sanity-io/litter v1.5.5 h1:iE+sBxPBzoK6uaEP5Lt3fHNgpKcHXc/A2HGETy0uJQo=
+github.com/sanity-io/litter v1.5.5/go.mod h1:9gzJgR2i4ZpjZHsKvUXIRQVk7P+yM3e+jAF7bU2UI5U=
 github.com/sergi/go-diff v1.1.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=
 github.com/sergi/go-diff v1.3.1 h1:xkr+Oxo4BOQKmkn/B9eMK0g5Kg/983T9DqqPHwYqD+8=
 github.com/sergi/go-diff v1.3.1/go.mod h1:aMJSSKb2lpPvRNec0+w3fl7LP9IOFzdc9Pa4NFbPK1I=
@@ -280,6 +284,7 @@ github.com/spf13/viper v1.3.2/go.mod h1:ZiWeW+zYFKm7srdB9IoDzzZXaJaI5eL9QjNiN/DM
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
+github.com/stretchr/testify v0.0.0-20161117074351-18a02ba4a312/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=

--- a/kconfig/parser.go
+++ b/kconfig/parser.go
@@ -184,7 +184,7 @@ func (p *parser) TryQuotedString() (string, bool) {
 	return "", false
 }
 
-func (p *parser) Ident() string {
+func (p *parser) TryIdent() string {
 	var str []byte
 	for !p.eol() {
 		ch := p.peek()
@@ -199,32 +199,19 @@ func (p *parser) Ident() string {
 		break
 	}
 
-	if len(str) == 0 {
-		p.failf("expected an identifier")
-	}
-
 	p.skipSpaces()
 	return string(str)
 }
 
+func (p *parser) Ident() string {
+	str := p.TryIdent()
+	if len(str) == 0 {
+		p.failf("expected an identifier")
+	}
+	return str
+}
+
 func (p *parser) Shell() string {
-	start := p.col
-	p.MustConsume("(")
-	for !p.eol() && p.peek() != ')' {
-		if p.peek() == '"' {
-			p.QuotedString()
-		} else if p.peek() == '(' {
-			p.Shell()
-		} else {
-			p.col++
-		}
-	}
-
-	if ch := p.char(); ch != ')' {
-		p.failf("shell expression is not terminated")
-	}
-
-	res := p.current[start:p.col]
-	p.skipSpaces()
-	return res
+	p.failf("Substitution should have been expanded before parsing")
+	return ""
 }

--- a/kconfig/preprocessor.go
+++ b/kconfig/preprocessor.go
@@ -1,0 +1,395 @@
+package kconfig
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os/exec"
+	"strings"
+
+	"github.com/pkg/errors"
+
+	"kraftkit.sh/log"
+)
+
+const makefilePreamble = `
+	CONFIG_UK_BASE				:= $(UK_BASE)
+	CONFIG_UK_APP					:= $(UK_APP)
+	CONFIG_UK_PLAT        := $(CONFIG_UK_BASE)/plat/
+	CONFIG_UK_LIB         := $(CONFIG_UK_BASE)/lib/
+	CONFIG_CONFIG_IN      := $(CONFIG_UK_BASE)/Config.uk
+	CONFIG                := $(CONFIG_UK_BASE)/support/kconfig
+	CONFIGLIB	      := $(CONFIG_UK_BASE)/support/kconfiglib
+	UK_CONFIG_OUT         := $(BUILD_DIR)/config
+	UK_GENERATED_INCLUDES := $(BUILD_DIR)/include
+	KCONFIG_DIR           := $(BUILD_DIR)/kconfig
+	UK_FIXDEP             := $(KCONFIG_DIR)/fixdep
+	KCONFIG_AUTOCONFIG    := $(KCONFIG_DIR)/auto.conf
+	KCONFIG_TRISTATE      := $(KCONFIG_DIR)/tristate.config
+	KCONFIG_AUTOHEADER    := $(UK_GENERATED_INCLUDES)/uk/_config.h
+	KCONFIG_APP_DIR       := $(CONFIG_UK_APP)
+	KCONFIG_LIB_IN        := $(KCONFIG_DIR)/libs.uk
+	KCONFIG_DEF_PLATS     := $(shell, find $(CONFIG_UK_PLAT)/* -maxdepth 0 \
+				-type d \( -path $(CONFIG_UK_PLAT)/common -o \
+				-path $(CONFIG_UK_PLAT)/drivers \
+				\) -prune -o  -type d -print)
+	KCONFIG_LIB_DIR       := $(shell, find $(CONFIG_UK_LIB)/* -maxdepth 0 -type d) \
+				$(CONFIG_UK_BASE)/lib $(ELIB_DIR)
+	KCONFIG_PLAT_DIR      := $(KCONFIG_DEF_PLATS) $(EPLAT_DIR) $(CONFIG_UK_PLAT)
+	KCONFIG_PLAT_IN       := $(KCONFIG_DIR)/plat.uk
+
+	# Makefile support scripts
+	SCRIPTS_DIR := $(CONFIG_UK_BASE)/support/scripts
+`
+
+type kconfigPreprocessor struct {
+	ctx                     context.Context
+	data                    []byte
+	file                    string
+	current                 string
+	col                     int
+	line                    int
+	inComment               bool
+	currentLineIsAssignment bool
+	err                     error
+	env                     KeyValueMap
+	stack                   []*bytes.Buffer
+}
+
+var handler = map[string]func(ctx context.Context, args ...string) (string, error){
+	"shell": evaluateShell,
+	// other handlers defined here
+}
+
+func evaluateShell(ctx context.Context, args ...string) (string, error) {
+	log.G(ctx).Debugf("Shell: %v", args)
+	cmd := exec.Command("sh", "-c", strings.Join(args, " "))
+	// TODO: use the proper working directory here!
+	var outb, errb bytes.Buffer
+	cmd.Stdout = &outb
+	cmd.Stderr = &errb
+
+	err := cmd.Run()
+	if err != nil {
+		return "", errors.Wrap(err, errb.String())
+	}
+
+	value := outb.String()
+	value = strings.TrimSpace(strings.Replace(value, "\n", " ", -1))
+	log.G(ctx).Debugf("Evaluates to : %q", value)
+	return value, nil
+}
+
+func preambleEnv(env KeyValueMap) KeyValueMap {
+	preambleParser := &kconfigPreprocessor{
+		ctx:   context.Background(),
+		data:  []byte(makefilePreamble),
+		file:  "preamble",
+		env:   env,
+		stack: []*bytes.Buffer{new(bytes.Buffer)},
+	}
+
+	_, err := preambleParser.process()
+	if err != nil {
+		return nil
+	}
+
+	return preambleParser.env
+}
+
+func newPreprocessor(data []byte, file string, env KeyValueMap) *kconfigPreprocessor {
+	return &kconfigPreprocessor{
+		ctx:   context.Background(),
+		data:  data,
+		file:  file,
+		env:   env,
+		stack: []*bytes.Buffer{new(bytes.Buffer)},
+	}
+}
+
+func (p *kconfigPreprocessor) process() ([]byte, error) {
+	for p.nextLine() {
+		p.parseLine()
+		if p.currentLineIsAssignment {
+			p.handleAssignment()
+		}
+		p.writeByte('\n')
+	}
+
+	if p.err != nil {
+		return nil, p.err
+	}
+	// println(p.stack[0].String())
+	return p.stack[0].Bytes(), nil
+}
+
+func (p *kconfigPreprocessor) handleAssignment() {
+	if p.err != nil {
+		return
+	}
+
+	if p.inSubstitution() {
+		p.failf("assignment in substitution not supported")
+		return
+	}
+
+	// go backwards through the byte buffer and look for ':='
+	top := p.stack[len(p.stack)-1]
+	var rhsStartingIndex int
+	var lhsStartingIndex int
+	for i := top.Len() - 2; i >= 0; i-- {
+		if top.Bytes()[i] == ':' && top.Bytes()[i+1] == '=' {
+			rhsStartingIndex = i + 2
+		}
+
+		if top.Bytes()[i] == '\n' {
+			lhsStartingIndex = i + 1
+			break
+		}
+	}
+
+	lhs := strings.TrimSpace(string(top.Bytes()[lhsStartingIndex : rhsStartingIndex-2]))
+	rhs := strings.TrimSpace(string(top.Bytes()[rhsStartingIndex:]))
+
+	p.env[lhs] = &KeyValue{Key: lhs, Value: rhs}
+	log.G(p.ctx).Debugf("assignment: %s = %s", lhs, rhs)
+}
+
+func (p *kconfigPreprocessor) inSubstitution() bool {
+	return len(p.stack) > 1
+}
+
+func (p *kconfigPreprocessor) parseLine() {
+	for p.err == nil && !p.eol() {
+		if p.inComment {
+			p.char()
+			continue
+		}
+
+		switch p.peek() {
+		case '#':
+			p.inComment = true
+			p.char()
+		case '$':
+			p.skip()
+			if p.peek() == '(' {
+				p.skip()
+				p.pushSubstitution()
+			} else {
+				p.writeByte('$')
+			}
+		case ':':
+			p.char()
+
+			if p.inSubstitution() {
+				continue
+			}
+
+			if p.peek() == '=' {
+				p.char()
+				p.currentLineIsAssignment = true
+			}
+
+		case ')':
+			if p.inSubstitution() {
+				p.skip()
+				p.popSubstitution()
+			} else {
+				p.char()
+			}
+		case '\\':
+			p.char()
+			p.char()
+		default:
+			p.char()
+		}
+	}
+}
+
+func (p *kconfigPreprocessor) pushSubstitution() {
+	if p.err != nil {
+		return
+	}
+
+	p.stack = append(p.stack, new(bytes.Buffer))
+}
+
+func (p *kconfigPreprocessor) popSubstitution() {
+	if p.err != nil {
+		return
+	}
+
+	if len(p.stack) == 1 {
+		// no substitution happening right now
+		p.char()
+		return
+	}
+
+	top := p.stack[len(p.stack)-1]
+	p.stack = p.stack[:len(p.stack)-1]
+	substitution := top.String()
+	substituted := p.evaluate(substitution)
+	p.writeString(substituted)
+}
+
+func (p *kconfigPreprocessor) evaluate(substitution string) string {
+	if p.err != nil {
+		return ""
+	}
+
+	log.G(p.ctx).Debugf("evaluating substitution %q", substitution)
+
+	splits := strings.Split(strings.TrimSpace(substitution), ",")
+	if len(splits) == 1 {
+		return p.lookupEnv(substitution)
+	}
+
+	// first split is the key command
+	command := strings.TrimSpace(splits[0])
+	if handler, ok := handler[command]; ok {
+		// call the handler
+		value, err := handler(p.ctx, splits[1:]...)
+		if err != nil {
+			p.failf("error evaluating %q: %v", substitution, err)
+			return ""
+		}
+		return value
+	}
+
+	p.failf("unknown substitution handler %q", command)
+	return ""
+}
+
+func (p *kconfigPreprocessor) lookupEnv(key string) string {
+	if p.err != nil {
+		return ""
+	}
+
+	if v, ok := p.env[key]; ok {
+		return v.Value
+	}
+
+	p.failf("unknown substitution %q", key)
+	return ""
+}
+
+func (p *kconfigPreprocessor) writeByte(c byte) {
+	if p.err != nil {
+		return
+	}
+
+	if len(p.stack) == 0 {
+		p.failf("bug: no preprocessor buffer")
+		return
+	}
+	p.stack[len(p.stack)-1].WriteByte(c)
+}
+
+func (p *kconfigPreprocessor) writeString(s string) {
+	if p.err != nil {
+		return
+	}
+
+	if len(p.stack) == 0 {
+		p.failf("bug: no preprocessor buffer")
+	}
+
+	p.stack[len(p.stack)-1].WriteString(s)
+}
+
+// nextLine resets the parser to the next line.
+// Automatically concatenates lines split with \ at the end.
+func (p *kconfigPreprocessor) nextLine() bool {
+	if !p.eol() {
+		p.failf("tailing data at the end of line")
+		return false
+	}
+
+	if p.err != nil || len(p.data) == 0 {
+		return false
+	}
+
+	p.col = 0
+	p.line++
+	p.current = p.readNextLine()
+	p.inComment = false
+	p.currentLineIsAssignment = false
+
+	for p.current != "" && p.current[len(p.current)-1] == '\\' && len(p.data) != 0 {
+		p.current = p.current[:len(p.current)-1] + p.readNextLine()
+		p.line++
+	}
+
+	p.skipSpaces()
+	return true
+}
+
+func (p *kconfigPreprocessor) eol() bool {
+	return p.col == len(p.current)
+}
+
+func (p *kconfigPreprocessor) peek() byte {
+	if p.err != nil || p.eol() {
+		return 0
+	}
+
+	return p.current[p.col]
+}
+
+func (p *kconfigPreprocessor) skip() byte {
+	if p.err != nil {
+		return 0
+	}
+
+	if p.eol() {
+		p.failf("unexpected end of line")
+		return 0
+	}
+
+	v := p.current[p.col]
+	p.col++
+	return v
+}
+
+func (p *kconfigPreprocessor) char() byte {
+	if p.err != nil {
+		return 0
+	}
+
+	if p.eol() {
+		p.failf("unexpected end of line")
+		return 0
+	}
+
+	v := p.current[p.col]
+	p.writeByte(v)
+	p.col++
+	return v
+}
+
+func (p *kconfigPreprocessor) skipSpaces() {
+	for p.col < len(p.current) && (p.current[p.col] == ' ' || p.current[p.col] == '\t') {
+		p.writeByte(p.current[p.col])
+		p.col++
+	}
+}
+
+func (p *kconfigPreprocessor) failf(msg string, args ...interface{}) {
+	if p.err == nil {
+		p.err = fmt.Errorf("%v:%v:%v: %v\n%v", p.file, p.line, p.col, fmt.Sprintf(msg, args...), p.current)
+	}
+}
+
+func (p *kconfigPreprocessor) readNextLine() string {
+	line := ""
+	nextLine := bytes.IndexByte(p.data, '\n')
+	if nextLine != -1 {
+		line = string(p.data[:nextLine])
+		p.data = p.data[nextLine+1:]
+	} else {
+		line = string(p.data)
+		p.data = nil
+	}
+
+	return line
+}

--- a/unikraft/lib/library.go
+++ b/unikraft/lib/library.go
@@ -182,7 +182,23 @@ func (lc LibraryConfig) KConfigTree(env ...*kconfig.KeyValue) (*kconfig.KConfigF
 }
 
 func (lc LibraryConfig) KConfig() kconfig.KeyValueMap {
-	menu, _ := lc.KConfigTree()
+	wd, err := os.Getwd()
+	if err != nil {
+		return nil
+	}
+
+	// Assumes the project is called test
+	// unikraft + deps are placed within the .unikraft folder inside the working directory
+	// blatantly ignores the face that the wd might have been overwritten
+	// No external libs + plats
+	menu, _ := lc.KConfigTree(
+		&kconfig.KeyValue{Key: "UK_BASE", Value: filepath.Join(wd, ".unikraft/unikraft")},
+		&kconfig.KeyValue{Key: "BUILD_DIR", Value: filepath.Join(wd, "build")},
+		&kconfig.KeyValue{Key: "UK_NAME", Value: "test"},
+		&kconfig.KeyValue{Key: "CONFIG_UK_APP", Value: wd},
+		&kconfig.KeyValue{Key: "ELIB_DIR", Value: ""},
+		&kconfig.KeyValue{Key: "EPLAT_DIR", Value: ""},
+	)
 
 	values := kconfig.KeyValueMap{}
 	values.OverrideBy(lc.kconfig)


### PR DESCRIPTION
This PR enables the KConfig Parser to process KConfig Substitutions, e.g., `$(UK_BASE)` or `$(shell, $(UK_BASE)/scripts.sh...)`.

It enhances the current Parser with a preprocessor that resolves all substitutions before the parsing step. A new command, `kraft kconfig dump` was added to dump the kconfig tree, generated by the parser, of the current working directory.

To verify the changes, one needs to create a new Unikraft Application called `test`

- test
  - .unikraft
    - unikraft
    - libs
  - Makefile
  - Config.uk
  - Kraftfile

Running `kraft kconfig dump` will dump the KConfig Tree. [Example output](https://gist.github.com/ls-1801/83c72d6fa66869e2f9ce1c242442b813)


<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [ ] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

This PR contains a few changes to the existing parser that were encountered while parsing the complete KConfig Tree:
- `choice` directive has an optional identifier
- `source` directive is not relative
- Shell substitution during parsing is an error
- Preprocessor is called before the parser

The Unikraft KConfig Tree is based on exported Environment Variables from the Makefile. I stubbed most of them out with plausible values. In the future, many of them should be populated by Kraftkit.

This had to be done twice:
- Within the dump command, which is to be expected!
- Inside the `LibraryConfig` KConfig Tree parsing, which is invoked by `Application.NewProjectFromOptions`, there was no way to inject environments from the dump command directly
