### PR TITLE
fix(kraft): Fix checking for an update

### DIFF
--- a/cmd/kraft/kraft.go
+++ b/cmd/kraft/kraft.go
@@ -86,15 +86,6 @@ func New() *cobra.Command {
 	return cmd
 }
 
-func (k *Kraft) PersistentPre(cmd *cobra.Command, args []string) error {
-	ctx := cmd.Context()
-	if err := kitupdate.CheckForUpdates(ctx); err != nil {
-		log.G(ctx).Debugf("could not check for updates: %v", err)
-	}
-
-	return nil
-}
-
 func (k *Kraft) Run(cmd *cobra.Command, args []string) error {
 	return cmd.Help()
 }
@@ -131,6 +122,10 @@ func main() {
 	// Set up the iostreams in the context if it is available
 	if copts.ioStreams != nil {
 		ctx = iostreams.WithIOStreams(ctx, copts.ioStreams)
+	}
+
+	if err := kitupdate.CheckForUpdates(ctx); err != nil {
+		log.G(ctx).Debugf("could not check for updates: %v", err)
 	}
 
 	cmdfactory.Main(ctx, cmd)

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -24,6 +24,10 @@ import (
 const KraftKitLatestPath = "https://get.kraftkit.sh/latest.txt"
 
 func CheckForUpdates(ctx context.Context) error {
+	if kitversion.Version() == "" {
+		return nil
+	}
+
 	if config.G[config.KraftKit](ctx).NoCheckUpdates {
 		return nil
 	}


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

This PR fixes a race condition with KraftKit's use of contexts.  The use of `Pre` is not possible with the root command because the context is populated in `Run` and so invocations and access to the provided `ctx` returns unfufilled values.  In this case, an attempt to retrieve the latest version of KraftKit is made in the `Pre` method.  Since this invocation relies on the `ConfigManager` to be initialized, it has insufficient knowledge to continue.  The result of invoking the `ConfigManager` via `ctx` before its instantiation is that default values would not be properly fufilled.  Following commands, such as `kraft pkg update` would be improperly set.

Additionally, if the version is unset, a version check should not occur.

This PR therefore moves the check for an update after the instantiation of the general context for the main programs invocation and prevents any check from occurring if the version is unknown.