### PR TITLE
refactor!: Adjust `Package` and `PackageManager` usage

### DIFF
--- a/cmd/kraft/kraft.go
+++ b/cmd/kraft/kraft.go
@@ -19,6 +19,7 @@ import (
 	kitversion "kraftkit.sh/internal/version"
 	"kraftkit.sh/iostreams"
 	"kraftkit.sh/log"
+	"kraftkit.sh/packmanager"
 
 	"kraftkit.sh/cmd/kraft/build"
 	"kraftkit.sh/cmd/kraft/clean"
@@ -99,7 +100,6 @@ func main() {
 	for _, o := range []cli.CliOption{
 		cli.WithDefaultConfigManager(cmd),
 		cli.WithDefaultIOStreams(),
-		cli.WithDefaultPackageManager(),
 		cli.WithDefaultPluginManager(),
 		cli.WithDefaultLogger(),
 		cli.WithDefaultHTTPClient(),
@@ -124,6 +124,13 @@ func main() {
 	if copts.IOStreams != nil {
 		ctx = iostreams.WithIOStreams(ctx, copts.IOStreams)
 	}
+
+	pm, err := packmanager.NewUmbrellaManager(ctx)
+	if err != nil {
+		log.G(ctx).Fatal(err)
+	}
+
+	ctx = packmanager.WithPackageManager(ctx, pm)
 
 	if !config.G[config.KraftKit](ctx).NoCheckUpdates {
 		if err := kitupdate.Check(ctx); err != nil {

--- a/cmd/kraft/pkg/list/list.go
+++ b/cmd/kraft/pkg/list/list.go
@@ -143,7 +143,7 @@ func (opts *List) Run(cmd *cobra.Command, args []string) error {
 		table.AddField(string(pack.Type()), nil, nil)
 		table.AddField(pack.Name(), nil, nil)
 		table.AddField(pack.Version(), nil, nil)
-		table.AddField(pack.Format(), nil, nil)
+		table.AddField(pack.Format().String(), nil, nil)
 		table.EndRow()
 	}
 

--- a/cmd/kraft/pkg/pkg.go
+++ b/cmd/kraft/pkg/pkg.go
@@ -159,15 +159,15 @@ func (opts *Pkg) Run(cmd *cobra.Command, args []string) error {
 				targ.Architecture().Name() == opts.Architecture &&
 				targ.Platform().Name() == opts.Platform:
 
-			format := opts.Format
-			name := "Packaging " + targ.Name()
+			var format pack.PackageFormat
+			name := "packaging " + targ.Name()
 			if opts.Format != "auto" {
-				format = opts.Format
-			} else if targ.Format() != "" {
+				format = pack.PackageFormat(opts.Format)
+			} else if targ.Format().String() != "" {
 				format = targ.Format()
 			}
-			if format != "auto" {
-				name += " (" + format + ")"
+			if format.String() != "auto" {
+				name += " (" + format.String() + ")"
 			}
 
 			tree = append(tree, processtree.NewProcessTreeItem(
@@ -179,7 +179,7 @@ func (opts *Pkg) Run(cmd *cobra.Command, args []string) error {
 
 					// Switch the package manager the desired format for this target
 					if format != "auto" {
-						pm, err = pm.From(pack.PackageFormat(format))
+						pm, err = pm.From(format)
 						if err != nil {
 							return err
 						}

--- a/cmd/kraft/pkg/pkg.go
+++ b/cmd/kraft/pkg/pkg.go
@@ -13,6 +13,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"kraftkit.sh/config"
+	"kraftkit.sh/pack"
 
 	"kraftkit.sh/cmdfactory"
 	"kraftkit.sh/log"
@@ -178,7 +179,7 @@ func (opts *Pkg) Run(cmd *cobra.Command, args []string) error {
 
 					// Switch the package manager the desired format for this target
 					if format != "auto" {
-						pm, err = pm.From(format)
+						pm, err = pm.From(pack.PackageFormat(format))
 						if err != nil {
 							return err
 						}

--- a/cmd/kraft/pkg/pull/pull.go
+++ b/cmd/kraft/pkg/pull/pull.go
@@ -97,7 +97,7 @@ func (opts *Pull) Run(cmd *cobra.Command, args []string) error {
 
 	// Force a particular package manager
 	if len(opts.Manager) > 0 && opts.Manager != "auto" {
-		pm, err = pm.From(opts.Manager)
+		pm, err = pm.From(pack.PackageFormat(opts.Manager))
 		if err != nil {
 			return err
 		}

--- a/cmd/kraft/pkg/source/source.go
+++ b/cmd/kraft/pkg/source/source.go
@@ -5,6 +5,8 @@
 package source
 
 import (
+	"errors"
+
 	"github.com/MakeNowJust/heredoc"
 	"github.com/spf13/cobra"
 
@@ -33,6 +35,7 @@ func New() *cobra.Command {
 
 func (opts *Source) Run(cmd *cobra.Command, args []string) error {
 	var err error
+	var compatible bool
 
 	source := ""
 	if len(args) > 0 {
@@ -42,9 +45,11 @@ func (opts *Source) Run(cmd *cobra.Command, args []string) error {
 	ctx := cmd.Context()
 	pm := packmanager.G(ctx)
 
-	pm, err = pm.IsCompatible(ctx, source)
+	pm, compatible, err = pm.IsCompatible(ctx, source)
 	if err != nil {
 		return err
+	} else if !compatible {
+		return errors.New("incompatible package manager")
 	}
 
 	return pm.AddSource(ctx, source)

--- a/cmd/kraft/pkg/source/source.go
+++ b/cmd/kraft/pkg/source/source.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 // Copyright (c) 2022, Unikraft GmbH and The KraftKit Authors.
 // Licensed under the BSD-3-Clause License (the "License").
-// You may not use this file expect in compliance with the License.
+// You may not use this file except in compliance with the License.
 package source
 
 import (

--- a/cmd/kraft/pkg/unsource/unsource.go
+++ b/cmd/kraft/pkg/unsource/unsource.go
@@ -7,6 +7,8 @@
 package unsource
 
 import (
+	"errors"
+
 	"github.com/MakeNowJust/heredoc"
 	"github.com/spf13/cobra"
 
@@ -37,6 +39,8 @@ func New() *cobra.Command {
 // Run executes the unsource command
 func (opts *Unsource) Run(cmd *cobra.Command, args []string) error {
 	var err error
+	var compatible bool
+
 	source := ""
 
 	if len(args) > 0 {
@@ -46,9 +50,11 @@ func (opts *Unsource) Run(cmd *cobra.Command, args []string) error {
 	ctx := cmd.Context()
 	pm := packmanager.G(ctx)
 
-	pm, err = pm.IsCompatible(ctx, source)
+	pm, compatible, err = pm.IsCompatible(ctx, source)
 	if err != nil {
 		return err
+	} else if !compatible {
+		return errors.New("incompatible package manager")
 	}
 
 	return pm.RemoveSource(ctx, source)

--- a/cmd/kraft/pkg/update/update.go
+++ b/cmd/kraft/pkg/update/update.go
@@ -13,6 +13,7 @@ import (
 	"kraftkit.sh/cmdfactory"
 	"kraftkit.sh/config"
 	"kraftkit.sh/log"
+	"kraftkit.sh/pack"
 	"kraftkit.sh/packmanager"
 	"kraftkit.sh/tui/processtree"
 )
@@ -45,7 +46,7 @@ func (opts *Update) Run(cmd *cobra.Command, args []string) error {
 
 	// Force a particular package manager
 	if len(opts.Manager) > 0 && opts.Manager != "auto" {
-		pm, err = pm.From(opts.Manager)
+		pm, err = pm.From(pack.PackageFormat(opts.Manager))
 		if err != nil {
 			return err
 		}

--- a/internal/cli/options.go
+++ b/internal/cli/options.go
@@ -210,22 +210,6 @@ func WithDefaultHTTPClient() CliOption {
 	}
 }
 
-// WithDefaultPackageManager initializes a new package manager based on the
-// umbrella package manager using host-provided configuration.
-func WithDefaultPackageManager() CliOption {
-	return func(copts *CliOptions) error {
-		if copts.PackageManager != nil {
-			return nil
-		}
-
-		// TODO: Add configuration option that allows us to statically set a
-		// preferred package manager.
-		copts.PackageManager = packmanager.NewUmbrellaManager()
-
-		return nil
-	}
-}
-
 // WithDefaultPluginManager returns an initialized plugin manager using the
 // host-provided configuration plugin path.
 func WithDefaultPluginManager() CliOption {

--- a/manifest/manager.go
+++ b/manifest/manager.go
@@ -359,15 +359,15 @@ func (m manager) Catalog(ctx context.Context, query packmanager.CatalogQuery) ([
 	return packages, nil
 }
 
-func (m manager) IsCompatible(ctx context.Context, source string) (packmanager.PackageManager, error) {
+func (m manager) IsCompatible(ctx context.Context, source string) (packmanager.PackageManager, bool, error) {
 	log.G(ctx).WithFields(logrus.Fields{
 		"source": source,
 	}).Debug("checking if source is compatible with the manifest manager")
 	if _, err := NewProvider(ctx, source); err != nil {
-		return nil, fmt.Errorf("incompatible source")
+		return nil, false, fmt.Errorf("incompatible source")
 	}
 
-	return m, nil
+	return m, true, nil
 }
 
 // LocalManifestDir returns the user configured path to all the manifests

--- a/manifest/manager.go
+++ b/manifest/manager.go
@@ -33,7 +33,7 @@ var useGit = false
 
 func init() {
 	// Register a new pack.Package type
-	packmanager.RegisterPackageManager(ManifestContext, NewManifestManager())
+	packmanager.RegisterPackageManager(ManifestFormat, NewManifestManager())
 
 	// Register additional command-line flags
 	cmdfactory.RegisterFlag(
@@ -177,7 +177,7 @@ func (m manager) Unpack(ctx context.Context, p pack.Package, opts ...packmanager
 	return nil, fmt.Errorf("not implemented manifest.manager.Unpack")
 }
 
-func (m manager) From(sub string) (packmanager.PackageManager, error) {
+func (m manager) From(sub pack.PackageFormat) (packmanager.PackageManager, error) {
 	return nil, fmt.Errorf("method not applicable to manifest manager")
 }
 
@@ -384,6 +384,6 @@ func (m manager) LocalManifestIndex(ctx context.Context) string {
 	return filepath.Join(m.LocalManifestsDir(ctx), "index.yaml")
 }
 
-func (m manager) Format() string {
-	return string(ManifestContext)
+func (m manager) Format() pack.PackageFormat {
+	return ManifestFormat
 }

--- a/manifest/manager.go
+++ b/manifest/manager.go
@@ -303,7 +303,7 @@ func (m manager) Catalog(ctx context.Context, query packmanager.CatalogQuery) ([
 			for _, version := range versions {
 				p, err := NewPackageFromManifestWithVersion(ctx, manifest, version, mopts...)
 				if err != nil {
-					log.G(ctx).Warnf("%v", err)
+					log.G(ctx).Warn(err)
 					continue
 					// TODO: Config option for fast-fail?
 					// return nil, err
@@ -314,7 +314,7 @@ func (m manager) Catalog(ctx context.Context, query packmanager.CatalogQuery) ([
 		} else {
 			more, err := NewPackageFromManifest(ctx, manifest, mopts...)
 			if err != nil {
-				log.G(ctx).Warnf("%v", err)
+				log.G(ctx).Warn(err)
 				continue
 				// TODO: Config option for fast-fail?
 				// return nil, err

--- a/manifest/manager.go
+++ b/manifest/manager.go
@@ -33,7 +33,7 @@ var useGit = false
 
 func init() {
 	// Register a new pack.Package type
-	packmanager.RegisterPackageManager(ManifestFormat, NewManifestManager())
+	packmanager.RegisterPackageManager(ManifestFormat, NewManifestManager)
 
 	// Register additional command-line flags
 	cmdfactory.RegisterFlag(
@@ -49,8 +49,8 @@ func init() {
 
 // NewManifestManager returns a `packmanager.PackageManager` which manipulates
 // Unikraft manifests.
-func NewManifestManager() packmanager.PackageManager {
-	return manager{}
+func NewManifestManager(ctx context.Context) (packmanager.PackageManager, error) {
+	return manager{}, nil
 }
 
 // update retrieves and returns a cache of the upstream manifest registry

--- a/manifest/pack.go
+++ b/manifest/pack.go
@@ -91,7 +91,7 @@ func (mp mpack) Push(ctx context.Context, opts ...pack.PushOption) error {
 }
 
 func (mp mpack) Pull(ctx context.Context, opts ...pack.PullOption) error {
-	log.G(ctx).Infof("pulling manifest package %s", mp.Name())
+	log.G(ctx).Debugf("pulling manifest package %s", mp.Name())
 
 	if mp.manifest.Provider == nil {
 		return fmt.Errorf("uninitialized manifest provider")

--- a/manifest/pack.go
+++ b/manifest/pack.go
@@ -18,9 +18,7 @@ type mpack struct {
 	version  string
 }
 
-const (
-	ManifestContext pack.ContextKey = "manifest"
-)
+const ManifestFormat pack.PackageFormat = "manifest"
 
 // NewPackageFromManifestWithVersion generates a new package based on an input
 // manifest which in itself may contain various versions and channels.  With the
@@ -129,6 +127,6 @@ func resourceCacheChecksum(manifest *Manifest) (string, string, string, error) {
 	return resource, cache, checksum, err
 }
 
-func (mp mpack) Format() string {
-	return string(ManifestContext)
+func (mp mpack) Format() pack.PackageFormat {
+	return ManifestFormat
 }

--- a/pack/package.go
+++ b/pack/package.go
@@ -6,9 +6,18 @@ package pack
 
 import (
 	"context"
+	"fmt"
 
 	"kraftkit.sh/unikraft"
 )
+
+type PackageFormat string
+
+var _ fmt.Stringer = (*PackageFormat)(nil)
+
+func (pf PackageFormat) String() string {
+	return string(pf)
+}
 
 type Package interface {
 	unikraft.Nameable
@@ -23,5 +32,5 @@ type Package interface {
 	Pull(context.Context, ...PullOption) error
 
 	// Format returns the name of the implementation.
-	Format() string
+	Format() PackageFormat
 }

--- a/packmanager/manager.go
+++ b/packmanager/manager.go
@@ -11,6 +11,13 @@ import (
 	"kraftkit.sh/unikraft/component"
 )
 
+// NewManagerConstructor represents the prototype that all implementing package
+// managers must use during their instantiation.  This standardizes their input
+// and output during "construction", particularly providing access to a
+// referencable context with which they can access (within the context of
+// KraftKit) the logging, IOStreams and Config subsystems.
+type NewManagerConstructor func(context.Context) (PackageManager, error)
+
 type PackageManager interface {
 	// Update retrieves and stores locally a cache of the upstream registry.
 	Update(context.Context) error

--- a/packmanager/manager.go
+++ b/packmanager/manager.go
@@ -37,7 +37,7 @@ type PackageManager interface {
 
 	// IsCompatible checks whether the provided source is compatible with the
 	// package manager
-	IsCompatible(context.Context, string) (PackageManager, error)
+	IsCompatible(context.Context, string) (PackageManager, bool, error)
 
 	// From is used to retrieve a sub-package manager.  For now, this is a small
 	// hack used for the umbrella.

--- a/packmanager/manager.go
+++ b/packmanager/manager.go
@@ -41,8 +41,8 @@ type PackageManager interface {
 
 	// From is used to retrieve a sub-package manager.  For now, this is a small
 	// hack used for the umbrella.
-	From(string) (PackageManager, error)
+	From(pack.PackageFormat) (PackageManager, error)
 
 	// Format returns the name of the implementation.
-	Format() string
+	Format() pack.PackageFormat
 }

--- a/packmanager/pack_options.go
+++ b/packmanager/pack_options.go
@@ -13,6 +13,7 @@ type PackOptions struct {
 	kernelLibraryIntermediateObjects bool
 	kernelLibraryObjects             bool
 	kernelSourceFiles                bool
+	kernelVersion                    string
 	output                           string
 }
 
@@ -46,6 +47,11 @@ func (popts *PackOptions) PackKernelLibraryObjects() bool {
 // PackKernelSourceFiles returns the whether to package kernel source files.
 func (popts *PackOptions) PackKernelSourceFiles() bool {
 	return popts.kernelSourceFiles
+}
+
+// KernelVersion returns the version of the kernel
+func (popts *PackOptions) KernelVersion() string {
+	return popts.kernelVersion
 }
 
 // Output returns the location of the package.
@@ -98,6 +104,13 @@ func PackKernelLibraryObjects(pack bool) PackOption {
 func PackKernelSourceFiles(pack bool) PackOption {
 	return func(popts *PackOptions) {
 		popts.kernelSourceFiles = pack
+	}
+}
+
+// PackWithKernelVersion sets the version of the Unikraft core.
+func PackWithKernelVersion(version string) PackOption {
+	return func(popts *PackOptions) {
+		popts.kernelVersion = version
 	}
 }
 

--- a/packmanager/umbrella.go
+++ b/packmanager/umbrella.go
@@ -13,17 +13,17 @@ import (
 	"kraftkit.sh/unikraft/component"
 )
 
-var packageManagers = make(map[pack.ContextKey]PackageManager)
+var packageManagers = make(map[pack.PackageFormat]PackageManager)
 
-const UmbrellaContext pack.ContextKey = "umbrella"
+const UmbrellaFormat pack.PackageFormat = "umbrella"
 
-func PackageManagers() map[pack.ContextKey]PackageManager {
+func PackageManagers() map[pack.PackageFormat]PackageManager {
 	return packageManagers
 }
 
-func RegisterPackageManager(ctxk pack.ContextKey, manager PackageManager) error {
+func RegisterPackageManager(ctxk pack.PackageFormat, manager PackageManager) error {
 	if _, ok := packageManagers[ctxk]; ok {
-		return fmt.Errorf("package manager already registered: %s", manager.Format())
+		return fmt.Errorf("package manager already registered: %s", ctxk)
 	}
 
 	packageManagers[ctxk] = manager
@@ -42,7 +42,7 @@ func NewUmbrellaManager() PackageManager {
 	return umbrella{}
 }
 
-func (u umbrella) From(sub string) (PackageManager, error) {
+func (u umbrella) From(sub pack.PackageFormat) (PackageManager, error) {
 	for _, manager := range packageManagers {
 		if manager.Format() == sub {
 			return manager, nil
@@ -146,6 +146,6 @@ func (u umbrella) IsCompatible(ctx context.Context, source string) (PackageManag
 	return nil, fmt.Errorf("cannot find compatible package manager for source: %s", source)
 }
 
-func (u umbrella) Format() string {
-	return string(UmbrellaContext)
+func (u umbrella) Format() pack.PackageFormat {
+	return UmbrellaFormat
 }

--- a/unikraft/target/target.go
+++ b/unikraft/target/target.go
@@ -10,6 +10,7 @@ import (
 
 	"kraftkit.sh/initrd"
 	"kraftkit.sh/kconfig"
+	"kraftkit.sh/pack"
 	"kraftkit.sh/unikraft"
 	"kraftkit.sh/unikraft/arch"
 	"kraftkit.sh/unikraft/component"
@@ -30,7 +31,7 @@ type Target interface {
 	Platform() plat.Platform
 
 	// Format is the desired package implementation for this target.
-	Format() string
+	Format() pack.PackageFormat
 
 	// Kernel is the path to the kernel for this target.
 	Kernel() string
@@ -59,7 +60,7 @@ type TargetConfig struct {
 	kconfig kconfig.KeyValueMap
 
 	// format is the desired packaging format.
-	format string
+	format pack.PackageFormat
 
 	// kernel is the path to the kernel for this target.
 	kernel string
@@ -108,7 +109,7 @@ func (tc TargetConfig) Initrd() *initrd.InitrdConfig {
 	return tc.initrd
 }
 
-func (tc TargetConfig) Format() string {
+func (tc TargetConfig) Format() pack.PackageFormat {
 	return tc.format
 }
 


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

This PR:

* Renames `pack.ContextKey` to `pack.PackageFormat`;
* Outputs the `pack.PackageFormat` type in `target.Target`;
* Adds additional trace- and warn-level log entries;
* Fixes a spelling mistake;
* Explicitly returns whether package manager is compatible;
* Introduces package manager constructor;
* Adds kernel version packaging option;
* Removes unnecessary printf-style string formatting; and,
* Adjusts a log level entry from info to debug