### PR TITLE
fix(workflows): Adjust git commit line lengths to match `.editorconfig`

### DIFF
--- a/.github/workflows/commit-format-check.yaml
+++ b/.github/workflows/commit-format-check.yaml
@@ -20,9 +20,9 @@ jobs:
         if: always()
         uses: gsactions/commit-message-checker@v2
         with:
-          pattern: '^(?!(?:.|\n)*(?:^|\n).{72,}(?:$|\n)(?:.|\n)*)(?:.|\n)*$'
+          pattern: '^(?!(?:.|\n)*(?:^|\n).{74,}(?:$|\n)(?:.|\n)*)(?:.|\n)*$'
           flags: ''
-          error: 'The maximum line length of 72 characters is exceeded.'
+          error: 'The maximum line length of 74 characters is exceeded.'
           excludeDescription: 'true'
           excludeTitle: 'true'
           checkAllCommitMessages: 'true'
@@ -54,9 +54,9 @@ jobs:
         if: always()
         uses: gsactions/commit-message-checker@v2
         with:
-          pattern: '^(?!.{51,}).*'
+          pattern: '^(?!.{75,}).*'
           flags: ''
-          error: 'The maximum line length of 50 characters is exceeded.'
+          error: 'The maximum line length of 75 characters is exceeded.'
           excludeDescription: 'true'
           excludeTitle: 'false'
           checkAllCommitMessages: 'false'


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

The length of Git commit messages has been governed by the `.editorconfig` file in the repository since its early inception and as a result, all commit messages are of this width.  Adjust the GitHub actions workflow to match this (and previous) Git messages accordingly.