### PR TITLE
feat: Converge value of HTTP `User-Agent` header

### DIFF
--- a/internal/httpclient/httpclient.go
+++ b/internal/httpclient/httpclient.go
@@ -24,7 +24,6 @@
 package httpclient
 
 import (
-	"fmt"
 	"io"
 	"net/http"
 	"os"
@@ -109,7 +108,7 @@ func NewHTTPClient(io *iostreams.IOStreams, unixSocket string, setAccept bool) (
 	}
 
 	opts = append(opts,
-		AddHeader("User-Agent", fmt.Sprintf("KraftKit CLI %s", version.Version())),
+		AddHeader("User-Agent", version.UserAgent()),
 		AddHeaderFunc("Time-Zone", func(req *http.Request) (string, error) {
 			if req.Method != "GET" && req.Method != "HEAD" {
 				if time.Local.String() != "Local" {

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -11,7 +11,7 @@ import (
 	"net/http"
 	"strings"
 
-	kitversion "kraftkit.sh/internal/version"
+	"kraftkit.sh/internal/version"
 	"kraftkit.sh/iostreams"
 
 	"github.com/MakeNowJust/heredoc"
@@ -23,7 +23,7 @@ import (
 const KraftKitLatestPath = "https://get.kraftkit.sh/latest.txt"
 
 func Check(ctx context.Context) error {
-	if kitversion.Version() == "" {
+	if version.Version() == "" {
 		return nil
 	}
 
@@ -34,7 +34,7 @@ func Check(ctx context.Context) error {
 		return err
 	}
 
-	get.Header.Set("User-Agent", "kraftkit/"+kitversion.Version())
+	get.Header.Set("User-Agent", version.Version())
 	log.G(ctx).WithFields(logrus.Fields{
 		"url":    KraftKitLatestPath,
 		"method": "GET",
@@ -60,7 +60,7 @@ func Check(ctx context.Context) error {
 		return err
 	}
 
-	currentVer, err := semver.NewVersion(strings.Split(kitversion.Version(), "-")[0])
+	currentVer, err := semver.NewVersion(strings.Split(version.Version(), "-")[0])
 	if err != nil {
 		return err
 	}

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,35 +1,8 @@
-package version
-
 // SPDX-License-Identifier: BSD-3-Clause
-//
-// Authors: Alexander Jung <alex@unikraft.io>
-//
-// Copyright (c) 2021, Unikraft GmbH.  All rights reserved.
-//
-// Redistribution and use in source and binary forms, with or without
-// modification, are permitted provided that the following conditions
-// are met:
-//
-// 1. Redistributions of source code must retain the above copyright
-//    notice, this list of conditions and the following disclaimer.
-// 2. Redistributions in binary form must reproduce the above copyright
-//    notice, this list of conditions and the following disclaimer in the
-//    documentation and/or other materials provided with the distribution.
-// 3. Neither the name of the copyright holder nor the names of its
-//    contributors may be used to endorse or promote products derived from
-//    this software without specific prior written permission.
-//
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-// POSSIBILITY OF SUCH DAMAGE.
+// Copyright (c) 2022, Unikraft GmbH and The KraftKit Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+package version
 
 import (
 	"fmt"

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -14,22 +14,22 @@ var (
 	buildTime = "No build timestamp provided"
 )
 
-// Version ...
+// Version returns KraftKit's version string.
 func Version() string {
 	return version
 }
 
-// Commit ...
+// Commit return KraftKit's HEAD Git commit SHA.
 func Commit() string {
 	return commit
 }
 
-// BuildTime ...
+// BuildTime returns the time in which the package or binary was built.
 func BuildTime() string {
 	return buildTime
 }
 
-// String ...
+// String returns all version information.
 func String() string {
 	return fmt.Sprintf("%s (%s) built %s\n",
 		version,

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -6,6 +6,7 @@ package version
 
 import (
 	"fmt"
+	"runtime"
 )
 
 var (
@@ -31,9 +32,10 @@ func BuildTime() string {
 
 // String returns all version information.
 func String() string {
-	return fmt.Sprintf("%s (%s) built %s\n",
+	return fmt.Sprintf("%s (%s) %s %s\n",
 		version,
 		commit,
+		runtime.Version(),
 		buildTime,
 	)
 }

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -13,6 +13,7 @@ var (
 	version   = "No version provided"
 	commit    = "No commit provided"
 	buildTime = "No build timestamp provided"
+	agentName = "kraftkit"
 )
 
 // Version returns KraftKit's version string.
@@ -38,4 +39,14 @@ func String() string {
 		runtime.Version(),
 		buildTime,
 	)
+}
+
+// UserAgent returns KraftKit's agent name and the version to be used when
+// making HTTP requests.
+func UserAgent() string {
+	if version != "No version provided" {
+		return fmt.Sprintf("%s/%s", agentName, version)
+	}
+
+	return agentName
 }

--- a/manifest/index.go
+++ b/manifest/index.go
@@ -147,7 +147,7 @@ func NewManifestIndexFromURL(ctx context.Context, path string, mopts ...Manifest
 		return nil, err
 	}
 
-	head.Header.Set("User-Agent", "kraftkit/"+version.Version())
+	head.Header.Set("User-Agent", version.UserAgent())
 
 	log.G(ctx).WithFields(logrus.Fields{
 		"url":    path,
@@ -168,7 +168,7 @@ func NewManifestIndexFromURL(ctx context.Context, path string, mopts ...Manifest
 		return nil, err
 	}
 
-	get.Header.Set("User-Agent", "kraftkit/"+version.Version())
+	get.Header.Set("User-Agent", version.UserAgent())
 
 	log.G(ctx).WithFields(logrus.Fields{
 		"url":    path,

--- a/manifest/manifest.go
+++ b/manifest/manifest.go
@@ -210,7 +210,7 @@ func NewManifestFromURL(ctx context.Context, path string, mopts ...ManifestOptio
 		return nil, err
 	}
 
-	head.Header.Set("User-Agent", "kraftkit/"+version.Version())
+	head.Header.Set("User-Agent", version.UserAgent())
 
 	log.G(ctx).WithFields(logrus.Fields{
 		"url":    path,
@@ -231,7 +231,7 @@ func NewManifestFromURL(ctx context.Context, path string, mopts ...ManifestOptio
 		return nil, err
 	}
 
-	get.Header.Set("User-Agent", "kraftkit/"+version.Version())
+	get.Header.Set("User-Agent", version.UserAgent())
 
 	log.G(ctx).WithFields(logrus.Fields{
 		"url":    path,


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

Amongst a few documentation updates, this PR converges the value of the HTTP `User-Agent` header into the `internal/version` package such that its value is consistent across the project.