### PR TITLE
fix(packmanager): Do not error-out when initializing package manager

### DIFF
--- a/packmanager/umbrella.go
+++ b/packmanager/umbrella.go
@@ -49,7 +49,10 @@ func NewUmbrellaManager(ctx context.Context) (PackageManager, error) {
 
 		manager, err := constructor(ctx)
 		if err != nil {
-			return nil, err
+			log.G(ctx).
+				WithField("format", format).
+				Warnf("could not initialize package manager: %v", err)
+			continue
 		}
 
 		if format, ok := packageManagers[manager.Format()]; ok {


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

This PR prevents an error from occurring when the package manager cannot be initialized via its constructor.  Instead, a warning message is shown instead.  This allows, for example, the progression of applications which may not necessarily rely on a package manager to continue without erroring if there is an issue instantiating 1 or more.
