### PR TITLE
fix: target kconfig

### DIFF
--- a/cmd/kraft/build/build.go
+++ b/cmd/kraft/build/build.go
@@ -114,7 +114,7 @@ func (opts *Build) Run(cmd *cobra.Command, args []string) error {
 		// name of the project and the target/plat string (which is variable in
 		// length).
 		for _, targ := range project.Targets() {
-			if newLen := len(targ.Name()) + len(targ.ArchPlatString()) + 15; newLen > nameWidth {
+			if newLen := len(targ.Name()) + len(target.TargetPlatArchName(targ)) + 15; newLen > nameWidth {
 				nameWidth = newLen
 			}
 		}
@@ -381,7 +381,7 @@ func (opts *Build) Run(cmd *cobra.Command, args []string) error {
 		targ := targ
 		if !opts.NoConfigure {
 			processes = append(processes, paraprogress.NewProcess(
-				fmt.Sprintf("configuring %s (%s)", targ.Name(), targ.ArchPlatString()),
+				fmt.Sprintf("configuring %s (%s)", targ.Name(), target.TargetPlatArchName(targ)),
 				func(ctx context.Context, w func(progress float64)) error {
 					return project.Configure(
 						ctx,
@@ -401,7 +401,7 @@ func (opts *Build) Run(cmd *cobra.Command, args []string) error {
 
 		if !opts.NoPrepare {
 			processes = append(processes, paraprogress.NewProcess(
-				fmt.Sprintf("preparing %s (%s)", targ.Name(), targ.ArchPlatString()),
+				fmt.Sprintf("preparing %s (%s)", targ.Name(), target.TargetPlatArchName(targ)),
 				func(ctx context.Context, w func(progress float64)) error {
 					return project.Prepare(
 						ctx,
@@ -420,7 +420,7 @@ func (opts *Build) Run(cmd *cobra.Command, args []string) error {
 		}
 
 		processes = append(processes, paraprogress.NewProcess(
-			fmt.Sprintf("building %s (%s)", targ.Name(), targ.ArchPlatString()),
+			fmt.Sprintf("building %s (%s)", targ.Name(), target.TargetPlatArchName(targ)),
 			func(ctx context.Context, w func(progress float64)) error {
 				return project.Build(
 					ctx,

--- a/cmd/kraft/build/build.go
+++ b/cmd/kraft/build/build.go
@@ -124,7 +124,7 @@ func (opts *Build) Run(cmd *cobra.Command, args []string) error {
 	var processes []*paraprogress.Process
 	var searches []*processtree.ProcessTreeItem
 
-	_, err = project.Components()
+	_, err = project.Components(ctx)
 	if err != nil && project.Template().Name() != "" {
 		var packages []pack.Package
 		search := processtree.NewProcessTreeItem(
@@ -229,7 +229,7 @@ func (opts *Build) Run(cmd *cobra.Command, args []string) error {
 	}
 
 	// Overwrite template with user options
-	components, err := project.Components()
+	components, err := project.Components(ctx)
 	if err != nil {
 		return err
 	}

--- a/cmd/kraft/pkg/pull/pull.go
+++ b/cmd/kraft/pkg/pull/pull.go
@@ -116,7 +116,7 @@ func (opts *Pull) Run(cmd *cobra.Command, args []string) error {
 			return err
 		}
 
-		if _, err = project.Components(); err != nil {
+		if _, err = project.Components(ctx); err != nil {
 			// Pull the template from the package manager
 			var packages []pack.Package
 			search := processtree.NewProcessTreeItem(
@@ -213,7 +213,7 @@ func (opts *Pull) Run(cmd *cobra.Command, args []string) error {
 		}
 
 		// List the components
-		components, err := project.Components()
+		components, err := project.Components(ctx)
 		if err != nil {
 			return err
 		}

--- a/cmd/kraft/run/run.go
+++ b/cmd/kraft/run/run.go
@@ -197,7 +197,7 @@ func (opts *Run) Run(cmd *cobra.Command, args []string) error {
 
 		// c). use a defined working directory as a Unikraft project
 	} else if len(workdir) > 0 {
-		target := opts.Target
+		targetName := opts.Target
 		project, err := app.NewProjectFromOptions(
 			ctx,
 			app.WithProjectWorkdir(workdir),
@@ -208,12 +208,12 @@ func (opts *Run) Run(cmd *cobra.Command, args []string) error {
 		}
 
 		if len(project.TargetNames()) == 1 {
-			target = project.TargetNames()[0]
-			if len(opts.Target) > 0 && opts.Target != target {
+			targetName = project.TargetNames()[0]
+			if len(opts.Target) > 0 && opts.Target != targetName {
 				return fmt.Errorf("unknown target: %s", opts.Target)
 			}
 
-		} else if target == "" && len(project.Targets()) > 1 {
+		} else if targetName == "" && len(project.Targets()) > 1 {
 			if config.G[config.KraftKit](ctx).NoPrompt {
 				return fmt.Errorf("with 'no prompt' enabled please select a target")
 			}
@@ -226,23 +226,23 @@ func (opts *Run) Run(cmd *cobra.Command, args []string) error {
 				return err
 			}
 
-			target = selectedTarget
+			targetName = selectedTarget
 
-		} else if target != "" && utils.Contains(project.TargetNames(), target) {
-			return fmt.Errorf("unknown target: %s", target)
+		} else if targetName != "" && utils.Contains(project.TargetNames(), targetName) {
+			return fmt.Errorf("unknown target: %s", targetName)
 		}
 
-		t, err := project.TargetByName(target)
+		t, err := project.TargetByName(targetName)
 		if err != nil {
 			return err
 		}
 
 		// Validate selection of target
 		if len(opts.Architecture) > 0 && (opts.Architecture != t.Architecture().Name()) {
-			return fmt.Errorf("selected target (%s) does not match specified architecture (%s)", t.ArchPlatString(), opts.Architecture)
+			return fmt.Errorf("selected target (%s) does not match specified architecture (%s)", target.TargetPlatArchName(t), opts.Architecture)
 		}
 		if len(opts.Platform) > 0 && (opts.Platform != t.Platform().Name()) {
-			return fmt.Errorf("selected target (%s) does not match specified platform (%s)", t.ArchPlatString(), opts.Platform)
+			return fmt.Errorf("selected target (%s) does not match specified platform (%s)", target.TargetPlatArchName(t), opts.Platform)
 		}
 
 		name := t.Name()
@@ -385,7 +385,7 @@ func (opts *Run) Run(cmd *cobra.Command, args []string) error {
 func selectionTargets(tgts target.Targets) []string {
 	tgtStrings := make([]string, 0, len(tgts))
 	for _, tgt := range tgts {
-		tgtStrings = append(tgtStrings, fmt.Sprintf("%s (%s)", tgt.Name(), tgt.ArchPlatString()))
+		tgtStrings = append(tgtStrings, fmt.Sprintf("%s (%s)", tgt.Name(), target.TargetPlatArchName(tgt)))
 	}
 
 	sort.Strings(tgtStrings)

--- a/kconfig/config.go
+++ b/kconfig/config.go
@@ -194,6 +194,37 @@ type KeyValue struct {
 	comments []string
 }
 
+// NewKeyValue returns a populated KeyValue by parsing the input line
+func NewKeyValue(line string) (string, *KeyValue) {
+	line = strings.TrimSpace(line)
+
+	// Skip blank lines
+	if line == "" {
+		return "", nil
+	}
+
+	// Skip commented-out lines
+	if strings.HasPrefix(line, "#") {
+		return "", nil
+	}
+
+	tokens := strings.SplitN(line, "=", 2)
+	if len(tokens) <= 1 {
+		return "", nil
+	}
+
+	k := tokens[0]
+	v := strings.Join(tokens[1:], "=")
+	if strings.HasPrefix(v, "\"") && strings.HasSuffix(v, "\"") {
+		v = strings.TrimSuffix(v[1:], "\"")
+	}
+
+	return k, &KeyValue{
+		Key:   k,
+		Value: v,
+	}
+}
+
 const (
 	Yes    = "y"
 	Mod    = "m"

--- a/kconfig/config.go
+++ b/kconfig/config.go
@@ -82,6 +82,34 @@ func (kvm KeyValueMap) OverrideBy(other KeyValueMap) KeyValueMap {
 	return kvm
 }
 
+// NewKConfigValuesFromFile build a KConfigValues from a provided file path
+func NewKeyValueMapFromFile(file string) (KeyValueMap, error) {
+	f, err := os.Open(file)
+	if err != nil {
+		return nil, fmt.Errorf("could not open file: %v", err)
+	}
+
+	defer f.Close()
+
+	ret := KeyValueMap{}
+
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		k, v := NewKeyValue(scanner.Text())
+		if v == nil {
+			continue
+		}
+
+		ret[k] = v
+	}
+
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+
+	return ret, nil
+}
+
 // Slice returns the map as a slice
 func (kvm KeyValueMap) Slice() []*KeyValue {
 	var slice []*KeyValue

--- a/kconfig/config.go
+++ b/kconfig/config.go
@@ -140,6 +140,21 @@ func (kvm KeyValueMap) RemoveEmpty() KeyValueMap {
 	return kvm
 }
 
+// Get returns a KeyValue based on a key and a boolean result value if the
+// entries was resolvable.
+func (kvm KeyValueMap) Get(key string) (*KeyValue, bool) {
+	if val, ok := kvm[key]; ok {
+		return val, true
+	}
+
+	// Attempt with a `CONFIG_` prefix
+	if val, ok := kvm[fmt.Sprintf("%s%s", Prefix, key)]; ok {
+		return val, true
+	}
+
+	return nil, false
+}
+
 // String returns the serialized string representing a .config file
 func (kvm KeyValueMap) String() string {
 	var ret strings.Builder

--- a/kconfig/config.go
+++ b/kconfig/config.go
@@ -225,6 +225,11 @@ func NewKeyValue(line string) (string, *KeyValue) {
 	}
 }
 
+// String implements fmt.Stringer
+func (kv KeyValue) String() string {
+	return fmt.Sprintf("%s=%s", kv.Key, kv.Value)
+}
+
 const (
 	Yes    = "y"
 	Mod    = "m"

--- a/kconfig/config.go
+++ b/kconfig/config.go
@@ -111,13 +111,18 @@ func (kvm KeyValueMap) Unset(key string) KeyValueMap {
 // Resolve update a KConfig for keys without value (`key`, but not `key=`)
 func (kvm KeyValueMap) Resolve(lookupFn func(string) (string, bool)) KeyValueMap {
 	for k, v := range kvm {
-		if v == nil {
-			if value, ok := lookupFn(k); ok {
-				kvm[k] = &KeyValue{
-					Key:   k,
-					Value: value,
-				}
-			}
+		if v != nil {
+			continue
+		}
+
+		value, ok := lookupFn(k)
+		if !ok {
+			continue
+		}
+
+		kvm[k] = &KeyValue{
+			Key:   k,
+			Value: value,
 		}
 	}
 

--- a/unikraft/app/application.go
+++ b/unikraft/app/application.go
@@ -33,7 +33,7 @@ type Application interface {
 	WorkingDir() string
 
 	// Unikraft returns the application's unikraft configuration
-	Unikraft() core.Unikraft
+	Unikraft(context.Context) core.Unikraft
 
 	// OutDir returns the path to the application's output directory
 	OutDir() string
@@ -112,7 +112,7 @@ type Application interface {
 
 	// Components returns a unique list of Unikraft components which this
 	// applicatiton consists of
-	Components() ([]component.Component, error)
+	Components(context.Context) ([]component.Component, error)
 
 	// WithTarget is a reducer that returns the application with only the provided
 	// target.
@@ -164,12 +164,12 @@ func (app application) Template() template.Template {
 	return app.template
 }
 
-func (app application) Unikraft() core.Unikraft {
+func (app application) Unikraft(ctx context.Context) core.Unikraft {
 	return app.unikraft
 }
 
 func (app application) Libraries(ctx context.Context) (lib.Libraries, error) {
-	uklibs, err := app.unikraft.Libraries(ctx)
+	uklibs, err := app.Unikraft(ctx).Libraries(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -224,7 +224,7 @@ func (app application) MergeTemplate(ctx context.Context, merge Application) (Ap
 	}
 
 	// Need to first merge the app configuration over the template
-	uk := merge.Unikraft()
+	uk := merge.Unikraft(ctx)
 	uk.KConfig().OverrideBy(app.unikraft.KConfig())
 	app.unikraft = uk.(core.UnikraftConfig)
 
@@ -564,9 +564,9 @@ func (app application) TargetByName(name string) (target.Target, error) {
 
 // Components returns a unique list of Unikraft components which this
 // applicatiton consists of
-func (app application) Components() ([]component.Component, error) {
+func (app application) Components(ctx context.Context) ([]component.Component, error) {
 	components := []component.Component{
-		app.unikraft,
+		app.Unikraft(ctx),
 	}
 
 	if app.template.Name() != "" {

--- a/unikraft/app/application.go
+++ b/unikraft/app/application.go
@@ -241,11 +241,14 @@ func (app application) KConfigTree(env ...*kconfig.KeyValue) (*kconfig.KConfigFi
 }
 
 func (app application) KConfig() kconfig.KeyValueMap {
-	all := kconfig.KeyValueMap{}
-	all.OverrideBy(app.unikraft.KConfig())
+	if app.configuration == nil {
+		app.configuration = kconfig.KeyValueMap{}
+	}
+
+	all := app.configuration.OverrideBy(app.unikraft.KConfig())
 
 	for _, library := range app.libraries {
-		all.OverrideBy(library.KConfig())
+		all = all.OverrideBy(library.KConfig())
 	}
 
 	return all

--- a/unikraft/app/application.go
+++ b/unikraft/app/application.go
@@ -642,6 +642,6 @@ func (app application) PrintInfo(ctx context.Context) string {
 
 func (app application) WithTarget(targ target.Target) (Application, error) {
 	ret := app
-	ret.targets = target.Targets{targ.(target.TargetConfig)}
+	ret.targets = target.Targets{targ.(*target.TargetConfig)}
 	return ret, nil
 }

--- a/unikraft/app/merge.go
+++ b/unikraft/app/merge.go
@@ -72,7 +72,7 @@ func mergeLibraries(base, override lib.Libraries) (lib.Libraries, error) {
 	return base, err
 }
 
-func mergeTargets(base, override []target.TargetConfig) ([]target.TargetConfig, error) {
+func mergeTargets(base, override []*target.TargetConfig) ([]*target.TargetConfig, error) {
 	err := mergo.Merge(&base, &override, mergo.WithOverride)
 	return base, err
 }

--- a/unikraft/app/project.go
+++ b/unikraft/app/project.go
@@ -21,6 +21,8 @@ import (
 	"fmt"
 	"path/filepath"
 
+	"kraftkit.sh/kconfig"
+	"kraftkit.sh/log"
 	"kraftkit.sh/schema"
 	"kraftkit.sh/unikraft"
 )
@@ -141,6 +143,19 @@ func NewProjectFromOptions(ctx context.Context, opts ...ProjectOption) (Applicat
 
 	for _, library := range app.libraries {
 		popts.kconfig.OverrideBy(library.KConfig())
+	}
+
+	// Post-process each target by parsing any available .config file
+	for _, target := range app.targets {
+		kvmap, err := kconfig.NewKeyValueMapFromFile(
+			filepath.Join(popts.workdir, target.ConfigFilename()),
+		)
+		if err != nil {
+			log.G(ctx).Warnf("could not read target config file: %v", err)
+			continue
+		}
+
+		target.KConfig().OverrideBy(kvmap)
 	}
 
 	project, err := NewApplicationFromOptions(

--- a/unikraft/app/project_options.go
+++ b/unikraft/app/project_options.go
@@ -23,10 +23,8 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/compose-spec/compose-go/dotenv"
 	interp "github.com/compose-spec/compose-go/interpolation"
 	"github.com/compose-spec/compose-go/template"
-	"github.com/pkg/errors"
 
 	"kraftkit.sh/kconfig"
 )
@@ -51,7 +49,6 @@ type ProjectOptions struct {
 	workdir           string
 	kraftfiles        []kraftfile
 	kconfig           kconfig.KeyValueMap
-	dotConfigFile     string
 	skipValidation    bool
 	skipInterpolation bool
 	skipNormalization bool
@@ -221,99 +218,6 @@ func WithProjectConfig(config []string) ProjectOption {
 func WithProjectKraftfile(file string) ProjectOption {
 	return func(popts *ProjectOptions) error {
 		popts.AddKraftfile(file)
-		return nil
-	}
-}
-
-// WithProjectDotConfigFile set an alternate config file
-func WithProjectDotConfigFile(file string) ProjectOption {
-	return func(popts *ProjectOptions) error {
-		popts.dotConfigFile = file
-		return nil
-	}
-}
-
-func withProjectDotConfig(popts *ProjectOptions) error {
-	if popts.dotConfigFile == "" {
-		wd, err := popts.Workdir()
-		if err != nil {
-			return err
-		}
-
-		popts.dotConfigFile = filepath.Join(wd, kconfig.DotConfigFileName)
-	}
-
-	dotConfigFile := popts.dotConfigFile
-
-	abs, err := filepath.Abs(dotConfigFile)
-	if err != nil {
-		return err
-	}
-
-	dotConfigFile = abs
-
-	s, err := os.Stat(dotConfigFile)
-	if os.IsNotExist(err) {
-		if popts.dotConfigFile != "" {
-			return errors.Errorf("couldn't find config file: %s", popts.dotConfigFile)
-		}
-		return nil
-	}
-
-	if err != nil {
-		return err
-	}
-
-	if s.IsDir() {
-		if popts.dotConfigFile == "" {
-			return nil
-		}
-		return errors.Errorf("%s is a directory", dotConfigFile)
-	}
-
-	file, err := os.Open(dotConfigFile)
-	if err != nil {
-		return err
-	}
-
-	defer file.Close()
-
-	config := kconfig.KeyValueMap{}
-
-	notInConfigSet := make(map[string]interface{})
-	env, err := dotenv.ParseWithLookup(file, func(k string) (string, bool) {
-		v, ok := os.LookupEnv(k)
-		if !ok {
-			config.Unset(k)
-			return "", true
-		}
-
-		return v, true
-	})
-	if err != nil {
-		return err
-	}
-
-	for k, v := range env {
-		if _, ok := notInConfigSet[k]; ok {
-			continue
-		}
-
-		config.Set(k, v)
-	}
-
-	popts.kconfig = config
-
-	return nil
-}
-
-// WithProjectDotConfig imports configuration variables from .config file
-func WithProjectDotConfig(enforce bool) ProjectOption {
-	return func(popts *ProjectOptions) error {
-		if err := withProjectDotConfig(popts); err != nil && enforce {
-			return err
-		}
-
 		return nil
 	}
 }

--- a/unikraft/target/target.go
+++ b/unikraft/target/target.go
@@ -21,10 +21,6 @@ import (
 type Target interface {
 	component.Component
 
-	// ArchPlatString returns the canonical name for platform architecture string
-	// combination
-	ArchPlatString() string
-
 	// Architecture is the component architecture for this target.
 	Architecture() arch.Architecture
 
@@ -153,10 +149,6 @@ func (tc *TargetConfig) KConfigTree(env ...*kconfig.KeyValue) (*kconfig.KConfigF
 	return nil, fmt.Errorf("target does not have a Config.uk file")
 }
 
-func (tc *TargetConfig) ArchPlatString() string {
-	return tc.platform.Name() + "-" + tc.architecture.Name()
-}
-
 func (tc *TargetConfig) PrintInfo(ctx context.Context) string {
 	return "not implemented: unikraft.plat.TargetConfig.PrintInfo"
 }
@@ -186,4 +178,14 @@ func KernelDbgName(target TargetConfig) (string, error) {
 	}
 
 	return fmt.Sprintf("%s.dbg", name), nil
+}
+
+// TargetPlatArchName returns the canonical name for the platform and
+// architecture combination.
+func TargetPlatArchName(target Target) string {
+	return fmt.Sprintf(
+		"%s-%s",
+		target.Platform().Name(),
+		target.Architecture().Name(),
+	)
 }

--- a/unikraft/target/target.go
+++ b/unikraft/target/target.go
@@ -75,78 +75,79 @@ type TargetConfig struct {
 	command []string
 }
 
-type Targets []TargetConfig
+type Targets []*TargetConfig
 
-func (tc TargetConfig) Name() string {
+func (tc *TargetConfig) Name() string {
 	return tc.name
 }
 
-func (tc TargetConfig) Source() string {
+func (tc *TargetConfig) Source() string {
 	return ""
 }
 
-func (tc TargetConfig) Version() string {
+func (tc *TargetConfig) Version() string {
 	return ""
 }
 
-func (tc TargetConfig) Architecture() arch.Architecture {
+func (tc *TargetConfig) Architecture() arch.Architecture {
 	return tc.architecture
 }
 
-func (tc TargetConfig) Platform() plat.Platform {
+func (tc *TargetConfig) Platform() plat.Platform {
 	return tc.platform
 }
 
-func (tc TargetConfig) Kernel() string {
+func (tc *TargetConfig) Kernel() string {
 	return tc.kernel
 }
 
-func (tc TargetConfig) KernelDbg() string {
+func (tc *TargetConfig) KernelDbg() string {
 	return tc.kernelDbg
 }
 
-func (tc TargetConfig) Initrd() *initrd.InitrdConfig {
+func (tc *TargetConfig) Initrd() *initrd.InitrdConfig {
 	return tc.initrd
 }
 
-func (tc TargetConfig) Format() pack.PackageFormat {
+func (tc *TargetConfig) Format() pack.PackageFormat {
 	return tc.format
 }
 
-func (tc TargetConfig) Type() unikraft.ComponentType {
+func (tc *TargetConfig) Type() unikraft.ComponentType {
 	return unikraft.ComponentTypeUnknown
 }
 
-func (tc TargetConfig) Path() string {
+func (tc *TargetConfig) Path() string {
 	return ""
 }
 
-func (tc TargetConfig) Command() []string {
+func (tc *TargetConfig) Command() []string {
 	return tc.command
 }
 
-func (tc TargetConfig) IsUnpacked() bool {
+func (tc *TargetConfig) IsUnpacked() bool {
 	return false
 }
 
-func (tc TargetConfig) KConfig() kconfig.KeyValueMap {
-	values := kconfig.KeyValueMap{}
-	values.OverrideBy(tc.kconfig)
-	values.OverrideBy(tc.architecture.KConfig())
-	values.OverrideBy(tc.platform.KConfig())
+func (tc *TargetConfig) KConfig() kconfig.KeyValueMap {
+	if tc.kconfig == nil {
+		tc.kconfig = kconfig.KeyValueMap{}
+		tc.kconfig.OverrideBy(tc.architecture.KConfig())
+		tc.kconfig.OverrideBy(tc.platform.KConfig())
+	}
 
-	return values
+	return tc.kconfig
 }
 
-func (tc TargetConfig) KConfigTree(env ...*kconfig.KeyValue) (*kconfig.KConfigFile, error) {
+func (tc *TargetConfig) KConfigTree(env ...*kconfig.KeyValue) (*kconfig.KConfigFile, error) {
 	return nil, fmt.Errorf("target does not have a Config.uk file")
 }
 
-func (tc TargetConfig) ArchPlatString() string {
+func (tc *TargetConfig) ArchPlatString() string {
 	return tc.platform.Name() + "-" + tc.architecture.Name()
 }
 
-func (tc TargetConfig) PrintInfo(ctx context.Context) string {
+func (tc *TargetConfig) PrintInfo(ctx context.Context) string {
 	return "not implemented: unikraft.plat.TargetConfig.PrintInfo"
 }
 

--- a/unikraft/target/target.go
+++ b/unikraft/target/target.go
@@ -7,6 +7,7 @@ package target
 import (
 	"context"
 	"fmt"
+	"path/filepath"
 
 	"kraftkit.sh/initrd"
 	"kraftkit.sh/kconfig"
@@ -44,6 +45,11 @@ type Target interface {
 
 	// Command is the command-line arguments set for this target.
 	Command() []string
+
+	// ConfigFilename returns the target-specific `.config` file which contains
+	// all the porclained KConfig key values which is formatted
+	// `.config.<TARGET-NAME>`
+	ConfigFilename() string
 }
 
 type TargetConfig struct {
@@ -137,6 +143,10 @@ func (tc *TargetConfig) KConfig() kconfig.KeyValueMap {
 	}
 
 	return tc.kconfig
+}
+
+func (tc *TargetConfig) ConfigFilename() string {
+	return fmt.Sprintf("%s.%s", kconfig.DotConfigFileName, filepath.Base(tc.kernel))
 }
 
 func (tc *TargetConfig) KConfigTree(env ...*kconfig.KeyValue) (*kconfig.KConfigFile, error) {


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

This PR:

- Refactors the `Resolve` `KeyValueMap` method;
- Adds `Get` method to `KeyValueMap`;
- Adds `NewKeyValue` constructor for `KeyValue`;
- Implements `fmt.Stringer` for `KeyValue`;
- Adds `NewKeyValueMapFromFile`;
- Passes `target.Target` as a pointer to fix `OverrideBy`;
- Adds target method `ConfigFilename`;
- Deprecates application `KConfigFile`;
- Passes context to all component methods;
- Correctly handles setting application KConfig;
- Handles instantiating each target with correct KConfig; and,
- Removes `ArchPlatString` in favor of `TargetPlatArchName`.