### PR TITLE
fix(list): Set `NoCache` when update flag (`-u`) is set

### DIFF
--- a/cmd/kraft/pkg/list/list.go
+++ b/cmd/kraft/pkg/list/list.go
@@ -63,7 +63,9 @@ func (opts *List) Run(cmd *cobra.Command, args []string) error {
 		opts.Limit = -1
 	}
 
-	query := packmanager.CatalogQuery{}
+	query := packmanager.CatalogQuery{
+		NoCache: opts.Update,
+	}
 	if opts.ShowCore {
 		query.Types = append(query.Types, unikraft.ComponentTypeCore)
 	}


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

This PR fixes querying the catalog with the `--update|-u` flag which was unused previously.  When set, the catalog will force-updated.