### PR TITLE
feat(manifest): Check if the provided source is a component "Nameable"

### DIFF
--- a/manifest/manager.go
+++ b/manifest/manager.go
@@ -363,6 +363,11 @@ func (m manager) IsCompatible(ctx context.Context, source string) (packmanager.P
 	log.G(ctx).WithFields(logrus.Fields{
 		"source": source,
 	}).Debug("checking if source is compatible with the manifest manager")
+
+	if _, _, _, err := unikraft.GuessTypeNameVersion(source); err == nil {
+		return m, true, nil
+	}
+
 	if _, err := NewProvider(ctx, source); err != nil {
 		return nil, false, fmt.Errorf("incompatible source")
 	}


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

This PR adds a preemptive check to `IsCompatible` such that if a provided source is in the form `<TYPE>/<NAME>:<VERSION>` (which is a Unikraft-centric "`Nameable`" representation) to allow it to pass with respect to the manifest package manager.