### PR TITLE
feat:  Add information about container build environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,19 @@ curl --proto '=https' --tlsv1.2 -sSf https://get.kraftkit.sh | sh
 
 Alternatively, you can download the binaries from the [releases pages](https://github.com/unikraft/kraftkit/releases).
 
+### Container build environment
+
+KraftKit ships a container build environment which you can use instead of installing any dependencies directly on your host.
+It includes the `kraft` binary as well as all the additional tools and libraries for building Unikraft unikernels.
+Simply attach a working directory on your host as a mount path volume mapped to `/workspace`, e.g.:
+
+```shell
+docker run -it --rm -v $(pwd):/workspace --entrypoint bash kraftkit.sh/base:latest
+```
+
+The above command will drop you into a container shell.
+Simply type `exit` or Ctrl+D to quit.
+
 ## Quickstart
 
 Building a unikernel with KraftKit is designed to be simple. 

--- a/buildenvs/base.Dockerfile
+++ b/buildenvs/base.Dockerfile
@@ -111,4 +111,6 @@ RUN set -xe; \
     rm -Rf /var/lib/apt/lists/*; \
     kraft --log-type basic --log-level debug pkg update;
 
+WORKDIR /workspace
+
 ENTRYPOINT [ "kraft" ]


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

This PR sets the base build environment's `WORKDIR` to `/workspace` such that it is the default location when entering in on a shell. Usage is then provided in the frontmatter's `README.md` file.