### PR TITLE
fix(kraft): Provide access to PackageManager in relevant commands

### DIFF
--- a/cmd/kraft/build/build.go
+++ b/cmd/kraft/build/build.go
@@ -68,6 +68,18 @@ func New() *cobra.Command {
 	})
 }
 
+func (*Build) Pre(cmd *cobra.Command, _ []string) error {
+	ctx := cmd.Context()
+	pm, err := packmanager.NewUmbrellaManager(ctx)
+	if err != nil {
+		return err
+	}
+
+	cmd.SetContext(packmanager.WithPackageManager(ctx, pm))
+
+	return nil
+}
+
 func (opts *Build) Run(cmd *cobra.Command, args []string) error {
 	var err error
 	var workdir string

--- a/cmd/kraft/clean/clean.go
+++ b/cmd/kraft/clean/clean.go
@@ -38,6 +38,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"kraftkit.sh/cmdfactory"
+	"kraftkit.sh/packmanager"
 	"kraftkit.sh/unikraft/app"
 )
 
@@ -60,6 +61,18 @@ func New() *cobra.Command {
 			cmdfactory.AnnotationHelpGroup: "build",
 		},
 	})
+}
+
+func (*Clean) Pre(cmd *cobra.Command, _ []string) error {
+	ctx := cmd.Context()
+	pm, err := packmanager.NewUmbrellaManager(ctx)
+	if err != nil {
+		return err
+	}
+
+	cmd.SetContext(packmanager.WithPackageManager(ctx, pm))
+
+	return nil
 }
 
 func (opts *Clean) Run(cmd *cobra.Command, args []string) error {

--- a/cmd/kraft/fetch/fetch.go
+++ b/cmd/kraft/fetch/fetch.go
@@ -11,6 +11,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"kraftkit.sh/cmdfactory"
+	"kraftkit.sh/packmanager"
 	"kraftkit.sh/unikraft/app"
 )
 
@@ -37,6 +38,18 @@ func New() *cobra.Command {
 			cmdfactory.AnnotationHelpGroup: "build",
 		},
 	})
+}
+
+func (*Fetch) Pre(cmd *cobra.Command, _ []string) error {
+	ctx := cmd.Context()
+	pm, err := packmanager.NewUmbrellaManager(ctx)
+	if err != nil {
+		return err
+	}
+
+	cmd.SetContext(packmanager.WithPackageManager(ctx, pm))
+
+	return nil
 }
 
 func (opts *Fetch) Run(cmd *cobra.Command, args []string) error {

--- a/cmd/kraft/kraft.go
+++ b/cmd/kraft/kraft.go
@@ -19,7 +19,6 @@ import (
 	kitversion "kraftkit.sh/internal/version"
 	"kraftkit.sh/iostreams"
 	"kraftkit.sh/log"
-	"kraftkit.sh/packmanager"
 
 	"kraftkit.sh/cmd/kraft/build"
 	"kraftkit.sh/cmd/kraft/clean"
@@ -125,13 +124,6 @@ func main() {
 	if copts.IOStreams != nil {
 		ctx = iostreams.WithIOStreams(ctx, copts.IOStreams)
 	}
-
-	pm, err := packmanager.NewUmbrellaManager(ctx)
-	if err != nil {
-		log.G(ctx).Fatal(err)
-	}
-
-	ctx = packmanager.WithPackageManager(ctx, pm)
 
 	if !config.G[config.KraftKit](ctx).NoCheckUpdates {
 		if err := kitupdate.Check(ctx); err != nil {

--- a/cmd/kraft/menu/menu.go
+++ b/cmd/kraft/menu/menu.go
@@ -12,6 +12,7 @@ import (
 
 	"kraftkit.sh/cmdfactory"
 	"kraftkit.sh/make"
+	"kraftkit.sh/packmanager"
 	"kraftkit.sh/unikraft/app"
 )
 
@@ -35,6 +36,18 @@ func New() *cobra.Command {
 			cmdfactory.AnnotationHelpGroup: "build",
 		},
 	})
+}
+
+func (*Menu) Pre(cmd *cobra.Command, _ []string) error {
+	ctx := cmd.Context()
+	pm, err := packmanager.NewUmbrellaManager(ctx)
+	if err != nil {
+		return err
+	}
+
+	cmd.SetContext(packmanager.WithPackageManager(ctx, pm))
+
+	return nil
 }
 
 func (opts *Menu) Run(cmd *cobra.Command, args []string) error {

--- a/cmd/kraft/pkg/list/list.go
+++ b/cmd/kraft/pkg/list/list.go
@@ -50,6 +50,18 @@ func New() *cobra.Command {
 	})
 }
 
+func (*List) Pre(cmd *cobra.Command, _ []string) error {
+	ctx := cmd.Context()
+	pm, err := packmanager.NewUmbrellaManager(ctx)
+	if err != nil {
+		return err
+	}
+
+	cmd.SetContext(packmanager.WithPackageManager(ctx, pm))
+
+	return nil
+}
+
 func (opts *List) Run(cmd *cobra.Command, args []string) error {
 	var err error
 

--- a/cmd/kraft/pkg/pkg.go
+++ b/cmd/kraft/pkg/pkg.go
@@ -91,10 +91,18 @@ func New() *cobra.Command {
 	return cmd
 }
 
-func (opts *Pkg) Pre(cmd *cobra.Command, args []string) error {
+func (opts *Pkg) Pre(cmd *cobra.Command, _ []string) error {
 	if (len(opts.Architecture) > 0 || len(opts.Platform) > 0) && len(opts.Target) > 0 {
 		return fmt.Errorf("the `--arch` and `--plat` options are not supported in addition to `--target`")
 	}
+
+	ctx := cmd.Context()
+	pm, err := packmanager.NewUmbrellaManager(ctx)
+	if err != nil {
+		return err
+	}
+
+	cmd.SetContext(packmanager.WithPackageManager(ctx, pm))
 
 	return nil
 }

--- a/cmd/kraft/pkg/pull/pull.go
+++ b/cmd/kraft/pkg/pull/pull.go
@@ -62,7 +62,15 @@ func New() *cobra.Command {
 	})
 }
 
-func (opts *Pull) Pre(cmd *cobra.Command, args []string) error {
+func (opts *Pull) Pre(cmd *cobra.Command, _ []string) error {
+	ctx := cmd.Context()
+	pm, err := packmanager.NewUmbrellaManager(ctx)
+	if err != nil {
+		return err
+	}
+
+	cmd.SetContext(packmanager.WithPackageManager(ctx, pm))
+
 	return cmdfactory.MutuallyExclusive(
 		"the `--with-deps` option is not supported with `--no-deps`",
 		opts.WithDeps,

--- a/cmd/kraft/pkg/source/source.go
+++ b/cmd/kraft/pkg/source/source.go
@@ -33,6 +33,18 @@ func New() *cobra.Command {
 	})
 }
 
+func (*Source) Pre(cmd *cobra.Command, _ []string) error {
+	ctx := cmd.Context()
+	pm, err := packmanager.NewUmbrellaManager(ctx)
+	if err != nil {
+		return err
+	}
+
+	cmd.SetContext(packmanager.WithPackageManager(ctx, pm))
+
+	return nil
+}
+
 func (opts *Source) Run(cmd *cobra.Command, args []string) error {
 	var err error
 	var compatible bool

--- a/cmd/kraft/pkg/unsource/unsource.go
+++ b/cmd/kraft/pkg/unsource/unsource.go
@@ -36,6 +36,18 @@ func New() *cobra.Command {
 	})
 }
 
+func (*Unsource) Pre(cmd *cobra.Command, _ []string) error {
+	ctx := cmd.Context()
+	pm, err := packmanager.NewUmbrellaManager(ctx)
+	if err != nil {
+		return err
+	}
+
+	cmd.SetContext(packmanager.WithPackageManager(ctx, pm))
+
+	return nil
+}
+
 // Run executes the unsource command
 func (opts *Unsource) Run(cmd *cobra.Command, args []string) error {
 	var err error

--- a/cmd/kraft/pkg/update/update.go
+++ b/cmd/kraft/pkg/update/update.go
@@ -38,6 +38,18 @@ func New() *cobra.Command {
 	})
 }
 
+func (*Update) Pre(cmd *cobra.Command, _ []string) error {
+	ctx := cmd.Context()
+	pm, err := packmanager.NewUmbrellaManager(ctx)
+	if err != nil {
+		return err
+	}
+
+	cmd.SetContext(packmanager.WithPackageManager(ctx, pm))
+
+	return nil
+}
+
 func (opts *Update) Run(cmd *cobra.Command, args []string) error {
 	var err error
 

--- a/cmd/kraft/prepare/prepare.go
+++ b/cmd/kraft/prepare/prepare.go
@@ -11,6 +11,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"kraftkit.sh/cmdfactory"
+	"kraftkit.sh/packmanager"
 	"kraftkit.sh/unikraft/app"
 )
 
@@ -34,6 +35,18 @@ func New() *cobra.Command {
 			cmdfactory.AnnotationHelpGroup: "build",
 		},
 	})
+}
+
+func (*Prepare) Pre(cmd *cobra.Command, _ []string) error {
+	ctx := cmd.Context()
+	pm, err := packmanager.NewUmbrellaManager(ctx)
+	if err != nil {
+		return err
+	}
+
+	cmd.SetContext(packmanager.WithPackageManager(ctx, pm))
+
+	return nil
 }
 
 func (opts *Prepare) Run(cmd *cobra.Command, args []string) error {

--- a/cmd/kraft/properclean/properclean.go
+++ b/cmd/kraft/properclean/properclean.go
@@ -38,6 +38,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"kraftkit.sh/cmdfactory"
+	"kraftkit.sh/packmanager"
 	"kraftkit.sh/unikraft/app"
 )
 
@@ -63,6 +64,18 @@ func New() *cobra.Command {
 	})
 
 	return cmd
+}
+
+func (*ProperClean) Pre(cmd *cobra.Command, _ []string) error {
+	ctx := cmd.Context()
+	pm, err := packmanager.NewUmbrellaManager(ctx)
+	if err != nil {
+		return err
+	}
+
+	cmd.SetContext(packmanager.WithPackageManager(ctx, pm))
+
+	return nil
 }
 
 func (opts *ProperClean) Run(cmd *cobra.Command, args []string) error {

--- a/cmd/kraft/run/run.go
+++ b/cmd/kraft/run/run.go
@@ -78,8 +78,17 @@ func New() *cobra.Command {
 	return cmd
 }
 
-func (opts *Run) Pre(cmd *cobra.Command, args []string) error {
+func (opts *Run) Pre(cmd *cobra.Command, _ []string) error {
 	opts.Hypervisor = cmd.Flag("hypervisor").Value.String()
+
+	ctx := cmd.Context()
+	pm, err := packmanager.NewUmbrellaManager(ctx)
+	if err != nil {
+		return err
+	}
+
+	cmd.SetContext(packmanager.WithPackageManager(ctx, pm))
+
 	return nil
 }
 

--- a/cmd/kraft/set/set.go
+++ b/cmd/kraft/set/set.go
@@ -40,6 +40,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"kraftkit.sh/cmdfactory"
+	"kraftkit.sh/packmanager"
 	"kraftkit.sh/unikraft/app"
 )
 
@@ -65,6 +66,18 @@ func New() *cobra.Command {
 			cmdfactory.AnnotationHelpGroup: "build",
 		},
 	})
+}
+
+func (*Set) Pre(cmd *cobra.Command, _ []string) error {
+	ctx := cmd.Context()
+	pm, err := packmanager.NewUmbrellaManager(ctx)
+	if err != nil {
+		return err
+	}
+
+	cmd.SetContext(packmanager.WithPackageManager(ctx, pm))
+
+	return nil
 }
 
 func (opts *Set) Run(cmd *cobra.Command, args []string) error {

--- a/cmd/kraft/unset/unset.go
+++ b/cmd/kraft/unset/unset.go
@@ -39,6 +39,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"kraftkit.sh/cmdfactory"
+	"kraftkit.sh/packmanager"
 	"kraftkit.sh/unikraft/app"
 )
 
@@ -64,6 +65,18 @@ func New() *cobra.Command {
 			cmdfactory.AnnotationHelpGroup: "build",
 		},
 	})
+}
+
+func (*Unset) Pre(cmd *cobra.Command, _ []string) error {
+	ctx := cmd.Context()
+	pm, err := packmanager.NewUmbrellaManager(ctx)
+	if err != nil {
+		return err
+	}
+
+	cmd.SetContext(packmanager.WithPackageManager(ctx, pm))
+
+	return nil
 }
 
 func (opts *Unset) Run(cmd *cobra.Command, args []string) error {


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

This PR migrates the instantiation of the umbrella package manager to subcommands which require access.  This focus prevents commands which would otherwise not use the package manager from calling additional initializers.

GitHub-Fixes: #366
