### PR TITLE
ci(deps): enable dependabot updates for GH Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,7 @@
 version: 2
+
 updates:
+
   - package-ecosystem: "gomod"
     directory: "/"
     target-branch: "staging"
@@ -45,3 +47,10 @@ updates:
       - "craciunoiuc"
     assignees:
       - "nderjung"
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: sunday
+      time: 09:00


### PR DESCRIPTION
### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [x] Updated relevant documentation.

### Description of changes

We have a few outdated GitHub Actions, such as this one (now at v4):

https://github.com/unikraft/kraftkit/blob/1b918b1dfc2862aca31e92b53ef2272c4d351ab3/.github/workflows/gochecks.yaml#L23

I think I would be beneficial for us to receive suggested updates from dependabot for these.