### PR TITLE
fix(kraft): Use CLI target-selection features

### DIFF
--- a/cmd/kraft/fetch/fetch.go
+++ b/cmd/kraft/fetch/fetch.go
@@ -5,19 +5,24 @@
 package fetch
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/MakeNowJust/heredoc"
 	"github.com/spf13/cobra"
 
 	"kraftkit.sh/cmdfactory"
+	"kraftkit.sh/config"
+	"kraftkit.sh/internal/cli"
 	"kraftkit.sh/packmanager"
 	"kraftkit.sh/unikraft/app"
+	"kraftkit.sh/unikraft/target"
 )
 
 type Fetch struct {
-	Architecture string `long:"arch" short:"m" usage:""`
-	Platform     string `long:"plat" short:"p" usage:""`
+	Architecture string `long:"arch" short:"m" usage:"Filter prepare based on a target's architecture"`
+	Platform     string `long:"plat" short:"p" usage:"Filter prepare based on a target's platform"`
+	Target       string `long:"target" short:"t" usage:"Filter prepare based on a specific target"`
 }
 
 func New() *cobra.Command {
@@ -77,5 +82,29 @@ func (opts *Fetch) Run(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	return project.Fetch(ctx, nil)
+	// Filter project targets by any provided CLI options
+	targets := cli.FilterTargets(
+		project.Targets(),
+		opts.Architecture,
+		opts.Platform,
+		opts.Target,
+	)
+
+	var t target.Target
+
+	switch {
+	case len(targets) == 1:
+		t = targets[0]
+
+	case config.G[config.KraftKit](ctx).NoPrompt:
+		return fmt.Errorf("could not determine which target to prepare")
+
+	default:
+		t, err = cli.SelectTarget(targets)
+		if err != nil {
+			return err
+		}
+	}
+
+	return project.Fetch(ctx, t)
 }


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

This PR adds consistent target selection to `kraft` subcommands which affect the build of a unikernel.  Before this commit, the result of running these subcommands would default to a generic (and generally unrecognised `.config` file) as opposed to the target-specific configuration file.
