### PR TITLE
fix(paraprogress): Set the log-level in each subprocess terminal

### DIFF
--- a/tui/paraprogress/paraprogress.go
+++ b/tui/paraprogress/paraprogress.go
@@ -78,6 +78,7 @@ func NewParaProgress(ctx context.Context, processes []*Process, opts ...ParaProg
 		}
 
 		processes[i].ctx = pctx.(context.Context)
+		log.G(processes[i].ctx).Level = log.G(ctx).Level
 
 		// Update formatter when using KraftKit's TextFormatter.  The
 		// TextFormatter recognises that this is a non-standard terminal and


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

After the deepcopy introduced in d432b44 we need to additionally set the log-level appropriately.

To test this PR, try enabling debug mode during `kraft --log-level debug --log-type basic build`. Before this PR, the `make` invocations are now shown. After this PR, they are visible.