### PR TITLE
fix: manifest for directories

### DIFF
--- a/manifest/directory.go
+++ b/manifest/directory.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"kraftkit.sh/log"
 	"kraftkit.sh/pack"
 	"kraftkit.sh/unikraft"
 	"kraftkit.sh/unikraft/app"
@@ -122,7 +123,8 @@ func (dp DirectoryProvider) PullManifest(ctx context.Context, manifest *Manifest
 			return err
 		}
 	} else if err == nil && f.IsDir() {
-		return fmt.Errorf("local directory already exists: %s", local)
+		log.G(ctx).Warnf("local directory already exists: %s", local)
+		return nil
 	} else if err == nil && f.Mode()&os.ModeSymlink == os.ModeSymlink {
 		if err := os.Remove(local); err != nil {
 			return fmt.Errorf("could not remove symlink: %v", err)

--- a/manifest/manager.go
+++ b/manifest/manager.go
@@ -279,6 +279,10 @@ func (m manager) Catalog(ctx context.Context, query packmanager.CatalogQuery) ([
 
 		var versions []string
 		if len(query.Version) > 0 {
+			if len(manifest.Versions) == 1 && len(manifest.Versions[0].Version) == 0 {
+				log.G(ctx).Warn("manifest does not supply version")
+			}
+
 			for _, version := range manifest.Versions {
 				if version.Version == query.Version {
 					versions = append(versions, version.Version)

--- a/manifest/provider.go
+++ b/manifest/provider.go
@@ -56,6 +56,17 @@ func NewProvider(ctx context.Context, path string, mopts ...ManifestOption) (Pro
 
 	log.G(ctx).WithFields(logrus.Fields{
 		"path": path,
+	}).Trace("trying directory provider")
+	provider, err = NewDirectoryProvider(ctx, path, mopts...)
+	if err == nil {
+		log.G(ctx).WithFields(logrus.Fields{
+			"path": path,
+		}).Trace("using directory provider")
+		return provider, nil
+	}
+
+	log.G(ctx).WithFields(logrus.Fields{
+		"path": path,
 	}).Trace("trying github provider")
 	provider, err = NewGitHubProvider(ctx, path, mopts...)
 	if err == nil {
@@ -73,17 +84,6 @@ func NewProvider(ctx context.Context, path string, mopts ...ManifestOption) (Pro
 		log.G(ctx).WithFields(logrus.Fields{
 			"path": path,
 		}).Trace("using git provider")
-		return provider, nil
-	}
-
-	log.G(ctx).WithFields(logrus.Fields{
-		"path": path,
-	}).Trace("trying directory provider")
-	provider, err = NewDirectoryProvider(ctx, path, mopts...)
-	if err == nil {
-		log.G(ctx).WithFields(logrus.Fields{
-			"path": path,
-		}).Trace("using directory provider")
 		return provider, nil
 	}
 


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

This PR contains a number of fixes to the Manifest Package Manager such that it better enables using directories within the context of a Kraftfile.  A user should be able to specify a directory representing a microlibrary, e.g.:

```yaml
specification: '0.5'
name: helloworld
unikraft:
  source: ./.unikraft/unikraft
targets:
  - architecture: x86_64
    platform: kvm
libraries:
  lwip: ./.unikraft/libs/lwip
  musl: ./.unikraft/libs/musl
```