### PR TITLE
feat(unikraft): Add component constructors

### DIFF
--- a/unikraft/core/core.go
+++ b/unikraft/core/core.go
@@ -45,6 +45,19 @@ type UnikraftConfig struct {
 	kconfig kconfig.KeyValueMap
 }
 
+// NewUnikraftFromOptions is a constructor that configures a core configuration.
+func NewUnikraftFromOptions(opts ...UnikraftOption) (Unikraft, error) {
+	uc := UnikraftConfig{}
+
+	for _, opt := range opts {
+		if err := opt(&uc); err != nil {
+			return nil, err
+		}
+	}
+
+	return &uc, nil
+}
+
 func (uc UnikraftConfig) Name() string {
 	return "unikraft"
 }

--- a/unikraft/core/options.go
+++ b/unikraft/core/options.go
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2022, Unikraft GmbH and The KraftKit Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+package core
+
+import "kraftkit.sh/kconfig"
+
+// UnikraftOption is a function that modifies a UnikraftConfig.
+type UnikraftOption func(*UnikraftConfig) error
+
+// WithName sets the name of the unikraft.
+func WithVersion(version string) UnikraftOption {
+	return func(uc *UnikraftConfig) error {
+		uc.version = version
+		return nil
+	}
+}
+
+// WithSource sets the source of the unikraft.
+func WithSource(source string) UnikraftOption {
+	return func(uc *UnikraftConfig) error {
+		uc.source = source
+		return nil
+	}
+}
+
+// WithPath sets the path of the unikraft.
+func WithPath(path string) UnikraftOption {
+	return func(uc *UnikraftConfig) error {
+		uc.path = path
+		return nil
+	}
+}
+
+// WithKConfig sets the kconfig of the unikraft.
+func WithKConfig(kconfig kconfig.KeyValueMap) UnikraftOption {
+	return func(uc *UnikraftConfig) error {
+		uc.kconfig = kconfig
+		return nil
+	}
+}

--- a/unikraft/plat/options.go
+++ b/unikraft/plat/options.go
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2022, Unikraft GmbH and The KraftKit Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+package plat
+
+import "kraftkit.sh/kconfig"
+
+// PlatformOption is a function that modifies a PlatformConfig.
+type PlatformOption func(*PlatformConfig) error
+
+// WithName sets the name of the platform.
+func WithName(name string) PlatformOption {
+	return func(pc *PlatformConfig) error {
+		pc.name = name
+		return nil
+	}
+}
+
+// WithVersion sets the version of the platform.
+func WithVersion(version string) PlatformOption {
+	return func(pc *PlatformConfig) error {
+		pc.version = version
+		return nil
+	}
+}
+
+// WithSource sets the source of the platform.
+func WithSource(source string) PlatformOption {
+	return func(pc *PlatformConfig) error {
+		pc.source = source
+		return nil
+	}
+}
+
+// WithPath sets the path of the platform.
+func WithPath(path string) PlatformOption {
+	return func(pc *PlatformConfig) error {
+		pc.path = path
+		return nil
+	}
+}
+
+// WithInternal sets the internal flag of the platform.
+func WithInternal(internal bool) PlatformOption {
+	return func(pc *PlatformConfig) error {
+		pc.internal = internal
+		return nil
+	}
+}
+
+// WithKConfig sets the kconfig of the platform.
+func WithKConfig(kconfig kconfig.KeyValueMap) PlatformOption {
+	return func(pc *PlatformConfig) error {
+		pc.kconfig = kconfig
+		return nil
+	}
+}

--- a/unikraft/plat/platform.go
+++ b/unikraft/plat/platform.go
@@ -40,6 +40,19 @@ type PlatformConfig struct {
 	kconfig kconfig.KeyValueMap
 }
 
+// NewPlatformFromOptions is a constructor that configures a platform configuration.
+func NewPlatformFromOptions(opts ...PlatformOption) (Platform, error) {
+	pc := PlatformConfig{}
+
+	for _, opt := range opts {
+		if err := opt(&pc); err != nil {
+			return nil, err
+		}
+	}
+
+	return &pc, nil
+}
+
 func (pc PlatformConfig) Name() string {
 	return pc.name
 }

--- a/unikraft/target/options.go
+++ b/unikraft/target/options.go
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2022, Unikraft GmbH and The KraftKit Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+package target
+
+import (
+	"kraftkit.sh/initrd"
+	"kraftkit.sh/kconfig"
+	"kraftkit.sh/pack"
+	"kraftkit.sh/unikraft/arch"
+	"kraftkit.sh/unikraft/plat"
+)
+
+// TargetOption is a function that modifies a TargetConfig.
+type TargetOption func(*TargetConfig) error
+
+// WithName sets the name of the target.
+func WithName(name string) TargetOption {
+	return func(tc *TargetConfig) error {
+		tc.name = name
+		return nil
+	}
+}
+
+// WithVersion sets the version of the target.
+func WithArchitecture(arch arch.ArchitectureConfig) TargetOption {
+	return func(tc *TargetConfig) error {
+		tc.architecture = arch
+		return nil
+	}
+}
+
+// WithPlatform sets the platform of the target.
+func WithPlatform(platform plat.PlatformConfig) TargetOption {
+	return func(tc *TargetConfig) error {
+		tc.platform = platform
+		return nil
+	}
+}
+
+// WithKConfig sets the kconfig of the target.
+func WithKConfig(kconfig kconfig.KeyValueMap) TargetOption {
+	return func(tc *TargetConfig) error {
+		tc.kconfig = kconfig
+		return nil
+	}
+}
+
+// WithFormat sets the format of the target.
+func WithFormat(format pack.PackageFormat) TargetOption {
+	return func(tc *TargetConfig) error {
+		tc.format = format
+		return nil
+	}
+}
+
+// WithKernel sets the kernel of the target.
+func WithKernel(kernel string) TargetOption {
+	return func(tc *TargetConfig) error {
+		tc.kernel = kernel
+		return nil
+	}
+}
+
+// WithKernelDbg sets the kernel debug of the target.
+func WithKernelDbg(kernelDbg string) TargetOption {
+	return func(tc *TargetConfig) error {
+		tc.kernelDbg = kernelDbg
+		return nil
+	}
+}
+
+// WithInitrd sets the initrd of the target.
+func WithInitrd(initrd *initrd.InitrdConfig) TargetOption {
+	return func(tc *TargetConfig) error {
+		tc.initrd = initrd
+		return nil
+	}
+}
+
+// WithCommand sets the command of the target.
+func WithCommand(command []string) TargetOption {
+	return func(tc *TargetConfig) error {
+		tc.command = command
+		return nil
+	}
+}

--- a/unikraft/target/target.go
+++ b/unikraft/target/target.go
@@ -79,6 +79,19 @@ type TargetConfig struct {
 
 type Targets []*TargetConfig
 
+// NewTargetFromOptions is a constructor for TargetConfig.
+func NewTargetFromOptions(opts ...TargetOption) (Target, error) {
+	tc := TargetConfig{}
+
+	for _, opt := range opts {
+		if err := opt(&tc); err != nil {
+			return nil, err
+		}
+	}
+
+	return &tc, nil
+}
+
 func (tc *TargetConfig) Name() string {
 	return tc.name
 }

--- a/unikraft/template/options.go
+++ b/unikraft/template/options.go
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2022, Unikraft GmbH and The KraftKit Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+package template
+
+// TemplateOption is a function that modifies a TemplateConfig.
+type TemplateOption func(*TemplateConfig) error
+
+// WithName sets the name of the template.
+func WithName(name string) TemplateOption {
+	return func(tc *TemplateConfig) error {
+		tc.name = name
+		return nil
+	}
+}
+
+// WithVersion sets the version of the template.
+func WithVersion(version string) TemplateOption {
+	return func(tc *TemplateConfig) error {
+		tc.version = version
+		return nil
+	}
+}
+
+// WithSource sets the source of the template.
+func WithSource(source string) TemplateOption {
+	return func(tc *TemplateConfig) error {
+		tc.source = source
+		return nil
+	}
+}

--- a/unikraft/template/template.go
+++ b/unikraft/template/template.go
@@ -1,33 +1,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
-//
-// Authors: Cezar Craciunoiu <cezar@unikraft.io>
-//
-// Copyright (c) 2022, Unikraft GmbH.  All rights reserved.
-//
-// Redistribution and use in source and binary forms, with or without
-// modification, are permitted provided that the following conditions
-// are met:
-//
-// 1. Redistributions of source code must retain the above copyright
-//    notice, this list of conditions and the following disclaimer.
-// 2. Redistributions in binary form must reproduce the above copyright
-//    notice, this list of conditions and the following disclaimer in the
-//    documentation and/or other materials provided with the distribution.
-// 3. Neither the name of the copyright holder nor the names of its
-//    contributors may be used to endorse or promote products derived from
-//    this software without specific prior written permission.
-//
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-// POSSIBILITY OF SUCH DAMAGE.
+// Copyright (c) 2022, Unikraft GmbH and The KraftKit Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
 
 // Package template implements the interface through which templates can
 // be edited and configured.

--- a/unikraft/template/template.go
+++ b/unikraft/template/template.go
@@ -60,6 +60,19 @@ type TemplateConfig struct {
 	source string
 }
 
+// NewTemplateFromOptions creates a new template configuration
+func NewTemplateFromOptions(opts ...TemplateOption) (Template, error) {
+	tc := TemplateConfig{}
+
+	for _, opt := range opts {
+		if err := opt(&tc); err != nil {
+			return nil, err
+		}
+	}
+
+	return &tc, nil
+}
+
 // Name returns the name of the template
 func (tc TemplateConfig) Name() string {
 	return tc.name


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

Some of the types inside the unikraft directory did not have functional constructors and relied on internal mechanism for instantiation. This made editing them externally impossible.

This adds constructors to all of them, similar to the existing Library ones