### PR TITLE
ci: disable cache mngmt in golangci-lint action

### DIFF
--- a/.github/workflows/gochecks.yaml
+++ b/.github/workflows/gochecks.yaml
@@ -61,11 +61,13 @@ jobs:
         with:
           version: v1.52.2
           args: --disable-all --enable=gofumpt
+          skip-cache: true
 
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
           version: v1.52.2
+          skip-cache: true
 
       - name: go generate
         uses: protocol/multiple-go-modules@v1.2


### PR DESCRIPTION
### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [x] Updated relevant documentation.

### Description of changes

The Go cache is managed by the cache action at the beginning of the workflow.

Currently, we have duplicate caches because multiple workflow steps (within a single workflow) are caching the same data:

```
golangci-lint.cache-2781-a7dc2d77446f6edf7356d7b82c9431c0d650e6f2
83 MB cached 1 hour ago
```

```
gochecks-Linux-go-be104ea912ae800d5458470588f27ef037305be4bfa503909abad6a1544a3ab4
83 MB cached 1 hour ago
```