### PR TITLE
fix: Retrieve authenticated manifest packages 

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "libgit2/git2go"]
-	path = third_party/github.com/libgit2/git2go/v31
+	path = third_party/libgit2/git2go
 	url = https://github.com/libgit2/git2go.git

--- a/Makefile
+++ b/Makefile
@@ -101,7 +101,7 @@ buildenv-%:
 .PHONY: devenv
 devenv: DOCKER_RUN_EXTRA ?= -it --name $(REPO)-devenv
 devenv: WITH_KVM         ?= n
-devenv: $(VENDORDIR)/github.com/libgit2/git2go/v31/vendor/libgit2
+devenv: $(VENDORDIR)/libgit2/git2go/vendor/libgit2
 devenv: ## Start the development environment container.
 ifeq ($(WITH_KVM),y)
 	$(Q)$(call DOCKER_RUN,--device /dev/kvm $(DOCKER_RUN_EXTRA),myself-full,bash)
@@ -139,16 +139,16 @@ properclean: ## Completely clean the repository's build artifacts.
 	$(DOCKER) rmi $(IMAGE)
 
 .PHONY: git2go
-git2go: $(VENDORDIR)/github.com/libgit2/git2go/v31/static-build/install/lib/pkgconfig/libgit2.pc
+git2go: $(VENDORDIR)/libgit2/git2go/static-build/install/lib/pkgconfig/libgit2.pc
 
-$(VENDORDIR)/github.com/libgit2/git2go/v31/static-build/install/lib/pkgconfig/libgit2.pc: $(VENDORDIR)/github.com/libgit2/git2go/v31/vendor/libgit2
-	$(MAKE) -C $(VENDORDIR)/github.com/libgit2/git2go/v31 install-static
+$(VENDORDIR)/libgit2/git2go/static-build/install/lib/pkgconfig/libgit2.pc: $(VENDORDIR)/libgit2/git2go/vendor/libgit2
+	$(MAKE) -C $(VENDORDIR)/libgit2/git2go install-static
 
-$(VENDORDIR)/github.com/libgit2/git2go/v31/vendor/libgit2: $(VENDORDIR)/github.com/libgit2/git2go
-	$(GIT) -C $(VENDORDIR)/github.com/libgit2/git2go/v31 submodule update --init --recursive
+$(VENDORDIR)/libgit2/git2go/vendor/libgit2: $(VENDORDIR)/libgit2/git2go
+	$(GIT) -C $(VENDORDIR)/libgit2/git2go submodule update --init --recursive
 
-$(VENDORDIR)/github.com/libgit2/git2go:
-	$(GIT) clone --branch v31.7.9 --recurse-submodules https://github.com/libgit2/git2go.git $@/v31
+$(VENDORDIR)/libgit2/git2go:
+	$(GIT) clone --branch v31.7.9 --recurse-submodules https://github.com/libgit2/git2go.git $@
 
 .PHONY: help
 help: ## Show this help menu and exit.

--- a/buildenvs/myself.Dockerfile
+++ b/buildenvs/myself.Dockerfile
@@ -13,6 +13,8 @@ RUN set -xe; \
     apt-get install -y --no-install-recommends \
       build-essential=12.9 \
       cmake=3.18.4-2+deb11u1 \
+      libssh2-1-dev=1.9.0-2 \
+      libssl-dev=1.1.1n-0+deb11u4 \
       make=4.3-4.1 \
       pkg-config=0.29.2-1 \
       git=1:2.30.2-1+deb11u2; \

--- a/go.mod
+++ b/go.mod
@@ -62,7 +62,7 @@ require (
 	sigs.k8s.io/kustomize/kyaml v0.14.1
 )
 
-replace github.com/libgit2/git2go/v31 v31.7.9 => ./third_party/github.com/libgit2/git2go/v31
+replace github.com/libgit2/git2go/v31 v31.7.9 => ./third_party/libgit2/git2go
 
 require (
 	github.com/AdaLogics/go-fuzz-headers v0.0.0-20230106234847-43070de90fa1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -30,6 +30,7 @@ require (
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510
 	github.com/henvic/httpretty v0.1.0
 	github.com/imdario/mergo v0.3.15
+	github.com/kubescape/go-git-url v0.0.24
 	github.com/libgit2/git2go/v31 v31.7.9
 	github.com/mattn/go-colorable v0.1.13
 	github.com/mattn/go-isatty v0.0.18
@@ -150,6 +151,7 @@ require (
 	github.com/tklauser/go-sysconf v0.3.11 // indirect
 	github.com/tklauser/numcpus v0.6.0 // indirect
 	github.com/vbatts/tar-split v0.11.2 // indirect
+	github.com/whilp/git-urls v1.0.0 // indirect
 	github.com/xanzy/ssh-agent v0.3.3 // indirect
 	github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb // indirect
 	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect
@@ -168,4 +170,5 @@ require (
 	google.golang.org/protobuf v1.29.1 // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect
 	k8s.io/kube-openapi v0.0.0-20230109183929-3758b55a6596 // indirect
+	k8s.io/utils v0.0.0-20221108210102-8e77b1f39fe2 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -294,6 +294,8 @@ github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
 github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
+github.com/kubescape/go-git-url v0.0.24 h1:+Ryb+bA+6Kx8dBHR7nnoK7ZFvtfWkwI4exYhkhBDZUQ=
+github.com/kubescape/go-git-url v0.0.24/go.mod h1:IbVT7Wsxlghsa+YxI5KOx4k9VQJaa3z0kTaQz5D3nKM=
 github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
 github.com/lucasb-eyer/go-colorful v1.2.0 h1:1nnpGOrhyZZuNyfu1QjKiUICQ74+3FNCN69Aj6K7nkY=
 github.com/lucasb-eyer/go-colorful v1.2.0/go.mod h1:R4dSotOR9KMtayYi1e77YzuveK+i7ruzyGqttikkLy0=
@@ -466,6 +468,8 @@ github.com/vbatts/tar-split v0.11.2 h1:Via6XqJr0hceW4wff3QRzD5gAk/tatMw/4ZA7cTlI
 github.com/vbatts/tar-split v0.11.2/go.mod h1:vV3ZuO2yWSVsz+pfFzDG/upWH1JhjOiEaWq6kXyQ3VI=
 github.com/vishvananda/netlink v1.1.0/go.mod h1:cTgwzPIzzgDAYoQrMm0EdrjRUBkTqKYppBueQtXaqoE=
 github.com/vishvananda/netns v0.0.0-20191106174202-0a2b9b5464df/go.mod h1:JP3t17pCcGlemwknint6hfoeCVQrEMVwxRLRjXpq+BU=
+github.com/whilp/git-urls v1.0.0 h1:95f6UMWN5FKW71ECsXRUd3FVYiXdrE7aX4NZKcPmIjU=
+github.com/whilp/git-urls v1.0.0/go.mod h1:J16SAmobsqc3Qcy98brfl5f5+e0clUvg1krgwk/qCfE=
 github.com/xanzy/ssh-agent v0.3.3 h1:+/15pJfg/RsTxqYcX6fHqOXZwwMP+2VyYWJeWM2qQFM=
 github.com/xanzy/ssh-agent v0.3.3/go.mod h1:6dzNDKs0J9rVPHPhaGCukekBHKqfl+L3KghI1Bc68Uw=
 github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=
@@ -690,6 +694,8 @@ honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWh
 honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 k8s.io/kube-openapi v0.0.0-20230109183929-3758b55a6596 h1:8cNCQs+WqqnSpZ7y0LMQPKD+RZUHU17VqLPMW3qxnxc=
 k8s.io/kube-openapi v0.0.0-20230109183929-3758b55a6596/go.mod h1:/BYxry62FuDzmI+i9B+X2pqfySRmSOW2ARmj5Zbqhj0=
+k8s.io/utils v0.0.0-20221108210102-8e77b1f39fe2 h1:GfD9OzL11kvZN5iArC6oTS7RTj7oJOIfnislxYlqTj8=
+k8s.io/utils v0.0.0-20221108210102-8e77b1f39fe2/go.mod h1:OLgZIPagt7ERELqWJFomSt595RzquPNLL48iOWgYOg0=
 oras.land/oras-go/v2 v2.0.2 h1:3aSQdJ7EUC0ft2e9PjJB9Jzastz5ojPA4LzZ3Q4YbUc=
 oras.land/oras-go/v2 v2.0.2/go.mod h1:PWnWc/Kyyg7wUTUsDHshrsJkzuxXzreeMd6NrfdnFSo=
 sigs.k8s.io/kustomize/kyaml v0.14.1 h1:c8iibius7l24G2wVAGZn/Va2wNys03GXLjYVIcFVxKA=

--- a/manifest/git.go
+++ b/manifest/git.go
@@ -148,6 +148,8 @@ func (gp GitProvider) probeChannels() ([]ManifestChannel, error) {
 				channels[i] = channel
 			}
 		}
+	} else if len(gp.branch) > 0 && len(channels) == 1 {
+		channels[0].Default = true
 	}
 
 	return channels, nil

--- a/manifest/git.go
+++ b/manifest/git.go
@@ -251,7 +251,12 @@ func (gp GitProvider) PullManifest(ctx context.Context, manifest *Manifest, popt
 		return pullGit(ctx, manifest, popts...)
 	}
 
-	return pullArchive(ctx, manifest, popts...)
+	if err := pullArchive(ctx, manifest, popts...); err != nil {
+		log.G(ctx).Trace(err)
+		return pullGit(ctx, manifest, popts...)
+	}
+
+	return nil
 }
 
 func (gp GitProvider) String() string {

--- a/manifest/github.go
+++ b/manifest/github.go
@@ -141,12 +141,17 @@ func (ghp GitHubProvider) Manifests() ([]*Manifest, error) {
 	return []*Manifest{manifest}, nil
 }
 
-func (ghp GitHubProvider) PullManifest(ctx context.Context, manifest *Manifest, opts ...pack.PullOption) error {
+func (ghp GitHubProvider) PullManifest(ctx context.Context, manifest *Manifest, popts ...pack.PullOption) error {
 	if useGit {
-		return pullGit(ctx, manifest, opts...)
+		return pullGit(ctx, manifest, popts...)
 	}
 
-	return pullArchive(ctx, manifest, opts...)
+	if err := pullArchive(ctx, manifest, popts...); err != nil {
+		log.G(ctx).Trace(err)
+		return pullGit(ctx, manifest, popts...)
+	}
+
+	return nil
 }
 
 func (ghp GitHubProvider) String() string {

--- a/manifest/github.go
+++ b/manifest/github.go
@@ -42,15 +42,6 @@ type GitHubProvider struct {
 // format.
 func NewGitHubProvider(ctx context.Context, path string, mopts ...ManifestOption) (Provider, error) {
 	var branch string
-	if strings.Contains(path, "@") {
-		split := strings.Split(path, "@")
-		if len(split) != 2 {
-			return nil, fmt.Errorf("malformed github repository URI: %s", path)
-		}
-
-		path = split[0]
-		branch = split[1]
-	}
 
 	repo, err := ghrepo.NewFromURL(path)
 	if err != nil {
@@ -271,16 +262,6 @@ func gitProviderFromGitHub(ctx context.Context, repo string, mopts ...ManifestOp
 
 	// Here's the "hack"
 	manifest := manifests[0]
-
-	// If the repo string originally contains @-notation, remove it
-	if strings.Contains(repo, "@") {
-		split := strings.Split(repo, "@")
-		if len(split) != 2 {
-			return nil, fmt.Errorf("malformed github repository URI: %s", repo)
-		}
-
-		repo = split[0]
-	}
 
 	ghr, err := ghrepo.NewFromURL(repo)
 	if err != nil {

--- a/manifest/manifest.go
+++ b/manifest/manifest.go
@@ -426,5 +426,9 @@ func (m Manifest) DefaultChannel() (*ManifestChannel, error) {
 // Auths returns the map of provided authentication configuration passed as an
 // option to the Manifest
 func (m Manifest) Auths() map[string]config.AuthConfig {
+	if m.auths == nil {
+		m.auths = make(map[string]config.AuthConfig)
+	}
+
 	return m.auths
 }

--- a/unikraft/component/component.go
+++ b/unikraft/component/component.go
@@ -7,6 +7,8 @@ package component
 import (
 	"context"
 	"fmt"
+	"net/url"
+	"os"
 
 	"kraftkit.sh/kconfig"
 	"kraftkit.sh/unikraft"
@@ -38,4 +40,85 @@ type Component interface {
 // representation of the component with its name and version
 func NameAndVersion(component Component) string {
 	return fmt.Sprintf("%s:%s", component.Name(), component.Version())
+}
+
+// TranslateFromSchema is an intermediate method used to convert well-known
+// attributes from the Kraftfile schema into a standardized map.  This method is
+// primarily used by other components internally which follow a similar format
+// of specifying a version, source and list of KConfig options.
+func TranslateFromSchema(props interface{}) (map[string]interface{}, error) {
+	component := make(map[string]interface{})
+
+	switch entry := props.(type) {
+	case string:
+		for k, v := range parseStringProp(entry) {
+			component[k] = v
+		}
+
+	case map[string]interface{}:
+		for key, prop := range entry {
+			switch key {
+			case "version":
+				component["version"] = prop.(string)
+
+			case "source":
+				for k, v := range parseStringProp(prop.(string)) {
+					component[k] = v
+				}
+
+			case "kconfig":
+				switch tprop := prop.(type) {
+				case map[string]interface{}:
+					component["kconfig"] = kconfig.NewKeyValueMapFromMap(tprop)
+				case []interface{}:
+					component["kconfig"] = kconfig.NewKeyValueMapFromSlice(tprop...)
+				}
+			}
+		}
+	}
+
+	return component, nil
+}
+
+func urlHasVersion(u *url.URL) string {
+	if len(u.RawQuery) > 0 {
+		// Pre-emptively determine the version by parsing the URL's query parameters
+		for _, k := range []string{
+			"branch",
+			"tag",
+			"version",
+		} {
+			if v := u.Query().Get(k); len(v) > 0 {
+				return v
+			}
+		}
+	}
+
+	return ""
+}
+
+func parseStringProp(entry string) map[string]interface{} {
+	component := make(map[string]interface{})
+
+	if f, err := os.Stat(entry); err == nil && f.IsDir() {
+		component["source"] = entry
+	} else if u, err := url.Parse(entry); err == nil && u.Host != "" {
+		component["source"] = entry
+
+		if v := urlHasVersion(u); len(v) > 0 {
+			component["version"] = v
+		}
+
+	} else if u, err := url.Parse("https://" + entry); err == nil && u.Host != "" {
+		component["source"] = entry
+
+		if v := urlHasVersion(u); len(v) > 0 {
+			component["version"] = v
+		}
+
+	} else {
+		component["version"] = entry
+	}
+
+	return component
 }

--- a/unikraft/core/transform.go
+++ b/unikraft/core/transform.go
@@ -6,12 +6,10 @@ package core
 
 import (
 	"context"
-	"net/url"
-	"os"
-	"strings"
 
 	"kraftkit.sh/kconfig"
 	"kraftkit.sh/unikraft"
+	"kraftkit.sh/unikraft/component"
 )
 
 // TransformFromSchema parses an input schema and returns an instantiated
@@ -28,49 +26,21 @@ func TransformFromSchema(ctx context.Context, props interface{}) (interface{}, e
 		)
 	}
 
-	switch entry := props.(type) {
-	case string:
-		if strings.Contains(entry, "@") {
-			split := strings.Split(entry, "@")
-			if len(split) == 2 {
-				core.source = split[0]
-				core.version = split[1]
-			}
-		} else if f, err := os.Stat(entry); err == nil && f.IsDir() {
-			core.source = entry
-		} else if u, err := url.Parse(entry); err == nil && u.Scheme != "" && u.Host != "" {
-			core.source = u.Path
-		} else {
-			core.version = entry
-		}
+	c, err := component.TranslateFromSchema(props)
+	if err != nil {
+		return nil, err
+	}
 
-	case map[string]interface{}:
-		for key, prop := range entry {
-			switch key {
-			case "version":
-				core.version = prop.(string)
+	if source, ok := c["source"]; ok {
+		core.source = source.(string)
+	}
 
-			case "source":
-				prop := prop.(string)
-				if strings.Contains(prop, "@") {
-					split := strings.Split(prop, "@")
-					if len(split) == 2 {
-						core.version = split[1]
-						prop = split[0]
-					}
-				}
+	if version, ok := c["version"]; ok {
+		core.version = version.(string)
+	}
 
-				core.source = prop
-
-			case "kconfig":
-				switch tprop := prop.(type) {
-				case map[string]interface{}:
-					core.kconfig = kconfig.NewKeyValueMapFromMap(tprop)
-				case []interface{}:
-					core.kconfig = kconfig.NewKeyValueMapFromSlice(tprop...)
-				}
-			}
-		}
+	if kconf, ok := c["kconfig"]; ok {
+		core.kconfig = kconf.(kconfig.KeyValueMap)
 	}
 
 	return core, nil


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

This PR adds relevant functionality towards retrieving components from remote sources which require authentication.  It is possible to use HTTP Basic and Bearer to access archives from GitHub as well as Git over SSH.

To test this PR, set the source of the unikraft core (or library) to a private Git repository:

```yaml
---
specification: '0.5'
name: helloworld
unikraft:
  source: ssh://github.com/username/unikraft.git
targets:
  - architecture: x86_64
    platform: kvm
```

Then in a terminal:

```
eval `ssh-agent` # Initialize a new SSH agent socket
ssh-add path/to/ssh_key # Add a private key to the agent
cd path/to/app 
kraft pkg pull # Pull the private components over SSH
```

To test with GitHub authorization header, login to GitHub with a personal access token:

```
kraft login -u $USERNAME -t $TOKEN github.com
```

Then the path can then just be a normal HTTPS schema, e.g.:

```yaml
---
specification: '0.5'
name: helloworld
unikraft:
  source: https://github.com/username/unikraft.git
targets:
  - architecture: x86_64
    platform: kvm
```

GitHub-Closes: #402