### PR TITLE
ci(e2e): fix missing build time kraft version

### DIFF
--- a/.github/workflows/e2e-cli.yaml
+++ b/.github/workflows/e2e-cli.yaml
@@ -41,9 +41,9 @@ jobs:
         run: go install github.com/onsi/ginkgo/v2/ginkgo
 
       - name: Install kraft
-        env:
-          DOCKER: ''
-        run: make kraft DISTDIR="$(go env GOPATH)"/bin
+        run: make kraft DOCKER= VERSION=v0.0.0-ci-e2e DISTDIR="$(go env GOPATH)"/bin
 
       - name: Run e2e tests
+        env:
+          KRAFTKIT_NO_CHECK_UPDATES: true
         run: ginkgo -v -p -randomize-all ./test/e2e/cli/


### PR DESCRIPTION
### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [x] Updated relevant documentation.

### Description of changes

The [fetch depth](https://github.com/actions/checkout/blob/f095bcc56b7c2baf48f3ac70d6d6782f4f553222/action.yml#L56-L57) is too shallow for `git describe --tags` to be able to return anything, so we set the `VERSION` variable manually.

This could be something to pay attention to in release workflows in general. We are [already addressing it](https://github.com/unikraft/kraftkit/blob/8fb2ec33764509657df1ceb1c8a8856b06865e83/.github/workflows/release-stable.yaml#L19-L20), but I think the current regex is still a good safeguard against small regressions.

GitHub-Fixes: #411