### PR TITLE
test(e2e): pretty-print ExitError on cmd failure

### DIFF
--- a/test/e2e/cli/version_test.go
+++ b/test/e2e/cli/version_test.go
@@ -6,8 +6,6 @@
 package cli_test
 
 import (
-	"os/exec"
-
 	. "github.com/onsi/ginkgo/v2" //nolint:stylecheck
 	. "github.com/onsi/gomega"    //nolint:stylecheck
 
@@ -16,7 +14,7 @@ import (
 )
 
 var _ = Describe("kraft version", func() {
-	var cmd *exec.Cmd
+	var cmd *fcmd.Cmd
 
 	var stdout *fcmd.IOStream
 	var stderr *fcmd.IOStream
@@ -68,10 +66,7 @@ var _ = Describe("kraft version", func() {
 		It("should print an error and exit", func() {
 			err := cmd.Run()
 			Expect(err).To(HaveOccurred())
-			Expect(err).To(BeAssignableToTypeOf((*exec.ExitError)(nil)))
-
-			eErr := err.(*exec.ExitError)
-			Expect(eErr.ProcessState.ExitCode()).To(Equal(1))
+			Expect(err).To(MatchError("exit status 1"))
 
 			Expect(stderr.String()).To(BeEmpty())
 			Expect(stdout).To(MatchRegexp(`^unknown command "some-arg" for "kraft version"\n$`))


### PR DESCRIPTION

<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [x] Updated relevant documentation.

### Description of changes

Wraps `*exec.ExitError` in a type that implements `GomegaStringer`, so that these errors can be pretty-printed (in this particular case: dump stderr).

GitHub-Fixes: #415

Example:

```
kraft version when invoked with the --help flag [It] should print the command's help
/home/acotten/git/unikraft/kraftkit/test/e2e/cli/version_test.go:54

  [FAILED] Unexpected error:
      <*cmd.ExitError | 0xc00034a0c0>:
      exit status 2
      panic: invalid argument "<bool Value>" for "--fast" flag: strconv.ParseBool: parsing "<bool Value>": invalid syntax

          goroutine 1 [running]:
          kraftkit.sh/cmd/kraft/build.New()
                /home/acotten/git/unikraft/kraftkit/cmd/kraft/build/build.go:71 +0x20d
          main.New()
                /home/acotten/git/unikraft/kraftkit/cmd/kraft/kraft.go:69 +0x28a
          main.main()
                /home/acotten/git/unikraft/kraftkit/cmd/kraft/kraft.go:101 +0x2b

  occurred
```