### PR TITLE
fix(cmd): properly stringify reflect.Value

### DIFF
--- a/cmd/kraft/build/build.go
+++ b/cmd/kraft/build/build.go
@@ -34,7 +34,7 @@ import (
 type Build struct {
 	Architecture string `long:"arch" short:"m" usage:"Filter the creation of the build by architecture of known targets"`
 	DotConfig    string `long:"config" short:"c" usage:"Override the path to the KConfig .config file"`
-	Fast         bool   `long:"fast" usage:"Use maximum parallization when performing the build"`
+	Fast         bool   `long:"fast" usage:"Use maximum parallelization when performing the build"`
 	Jobs         int    `long:"jobs" short:"j" usage:"Allow N jobs at once"`
 	KernelDbg    bool   `long:"dbg" usage:"Build the debuggable (symbolic) kernel image instead of the stripped image"`
 	NoCache      bool   `long:"no-cache" short:"F" usage:"Force a rebuild even if existing intermediate artifacts already exist"`
@@ -48,7 +48,7 @@ type Build struct {
 
 func New() *cobra.Command {
 	return cmdfactory.New(&Build{}, cobra.Command{
-		Short: "Configure and build Unikraft unikernels ",
+		Short: "Configure and build Unikraft unikernels",
 		Use:   "build [FLAGS] [SUBCOMMAND|DIR]",
 		Args:  cmdfactory.MaxDirArgs(1),
 		Long: heredoc.Docf(`

--- a/cmdfactory/builder.go
+++ b/cmdfactory/builder.go
@@ -141,7 +141,8 @@ func AttributeFlags(c *cobra.Command, obj any, args ...string) {
 		if err != nil {
 			defInt = 0
 		}
-		strValue := v.String()
+		// https://cs.opensource.google/go/go/+/refs/tags/go1.20.3:src/fmt/fmt_test.go;l=1046-1050
+		strValue := fmt.Sprint(v)
 
 		// Set the value from the environmental value, if known, it takes precedent
 		// over the provided value which would otherwise come from a configuration

--- a/cmdfactory/builder.go
+++ b/cmdfactory/builder.go
@@ -168,14 +168,14 @@ func AttributeFlags(c *cobra.Command, obj any, args ...string) {
 		}
 
 		switch fieldType.Type.Kind() {
-		case reflect.Int:
-			flags.IntVarP((*int)(unsafe.Pointer(v.Addr().Pointer())), name, alias, defInt, usage)
-			flags.Set(name, strValue)
-		case reflect.Int64:
+		case reflect.Int, reflect.Int64:
 			flags.IntVarP((*int)(unsafe.Pointer(v.Addr().Pointer())), name, alias, defInt, usage)
 			flags.Set(name, strValue)
 		case reflect.String:
 			flags.StringVarP((*string)(unsafe.Pointer(v.Addr().Pointer())), name, alias, defValue, usage)
+			flags.Set(name, strValue)
+		case reflect.Bool:
+			flags.BoolVarP((*bool)(unsafe.Pointer(v.Addr().Pointer())), name, alias, false, usage)
 			flags.Set(name, strValue)
 		case reflect.Slice:
 			switch fieldType.Tag.Get("split") {
@@ -189,12 +189,9 @@ func AttributeFlags(c *cobra.Command, obj any, args ...string) {
 		case reflect.Map:
 			maps[name] = v
 			flags.StringSliceP(name, alias, nil, usage)
-		case reflect.Bool:
-			flags.BoolVarP((*bool)(unsafe.Pointer(v.Addr().Pointer())), name, alias, false, usage)
-			flags.Set(name, strValue)
 		case reflect.Pointer:
 			switch fieldType.Type.Elem().Kind() {
-			case reflect.Int:
+			case reflect.Int, reflect.Int64:
 				optInt[name] = v
 				flags.IntP(name, alias, defInt, usage)
 				flags.Set(name, strValue)


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [x] Updated relevant documentation.

### Description of changes

Fixes #417

Since Go 1.5, the `fmt` package prints the _concrete value_ of `reflect.Value` by default.
This is exactly what we want in order to be able to pass those underlying values to `flags.Set`.

Also includes minor typo fixes and code reorg.

---

Demo:

```go
package main

import (
	"fmt"
	"reflect"
)

func main() {
	var myint int = 42
	var mybool bool = true
	var mystring string = "hello"

	fmt.Println(reflect.ValueOf(myint).String())
	fmt.Println(reflect.ValueOf(mybool).String())
	fmt.Println(reflect.ValueOf(mystring).String())

	fmt.Println(reflect.ValueOf(myint))
	fmt.Println(reflect.ValueOf(mybool))
	fmt.Println(reflect.ValueOf(mystring))
}
```

Output:
```
<int Value>
<bool Value>
hello
42
true
hello
```