### PR TITLE
ci: clean up workflow files

### DIFF
--- a/.github/workflows/actcheck.yaml
+++ b/.github/workflows/actcheck.yaml
@@ -13,15 +13,11 @@ jobs:
     name: Action Lint
     steps:
       - uses: actions/checkout@v3
-        with:
-          submodules: recursive
 
       - name: Install action linter
         run: |
-          mkdir -p ~/bin
-          curl -sL https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash | bash -s -- latest ~/bin
+          mkdir -p "$HOME"/.local/bin
+          curl -sL https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash | bash -s -- latest "$HOME"/.local/bin
 
       - name: Check that all workflows are valid
-        run: |
-          set -xe
-          find .github/workflows -type f -name '*.yaml' -print0 | xargs --null ~/bin/actionlint
+        run: actionlint -verbose

--- a/.github/workflows/e2e-cli.yaml
+++ b/.github/workflows/e2e-cli.yaml
@@ -17,6 +17,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          submodules: recursive
 
       - name: Set up Go
         uses: actions/setup-go@v4
@@ -41,7 +44,7 @@ jobs:
         run: go install github.com/onsi/ginkgo/v2/ginkgo
 
       - name: Install kraft
-        run: make kraft DOCKER= VERSION=v0.0.0-ci-e2e DISTDIR="$(go env GOPATH)"/bin
+        run: make kraft DOCKER= DISTDIR="$(go env GOPATH)"/bin
 
       - name: Run e2e tests
         env:

--- a/.github/workflows/gochecks.yaml
+++ b/.github/workflows/gochecks.yaml
@@ -12,7 +12,6 @@ on:
 jobs:
   gochecks:
     runs-on: ubuntu-latest
-    container: golang:1.20.2-bullseye
     name: All
     env:
       RUNGOGENERATE: false
@@ -39,9 +38,9 @@ jobs:
       # Temporary workaround until this pipeline uses the 'myself' buildenv
       - name: Install build dependencies
         run: |
-          apt-get update;
-          apt-get install -y --no-install-recommends \
-            cmake;
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            cmake
 
       - name: Check that go.mod is tidy
         uses: protocol/multiple-go-modules@v1.2
@@ -78,7 +77,7 @@ jobs:
             go generate ./...
             # check if go generate modified or added any files
             if ! $(git add . && git diff-index HEAD --exit-code --quiet); then
-              echo "go generated caused changes to the repository:"
+              echo "go generate caused changes to the repository:"
               git status --short
               exit 1
             fi

--- a/.github/workflows/release-stable.yaml
+++ b/.github/workflows/release-stable.yaml
@@ -27,10 +27,10 @@ jobs:
       
       - name: Install release tools
         run: |
-          echo "deb [trusted=yes] https://apt.fury.io/cli/ * *" > /etc/apt/sources.list.d/fury-cli.list;
-          apt-get update;
+          echo "deb [trusted=yes] https://apt.fury.io/cli/ * *" > /etc/apt/sources.list.d/fury-cli.list
+          apt-get update
           apt-get install -y --no-install-recommends \
-            fury-cli;
+            fury-cli
       
       - name: Generate GoReleaser configuration
         run: |


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [x] Updated relevant documentation.

### Description of changes

Minor clean up in workflow files:

- Let `make` determine the kraftkit VERSION by itself, instead of setting that value manually.
- Do not run Go checks in a container. We already use `setup-go` to pin the Go version.
- Run `actionlint` at the root of the repo without `xargs`. It knows how to find workflows.
- Remove unnecessary semi colons here and there.
- Typos.