### PR TITLE
fix(cmd): unknown flag due to children traversal

### DIFF
--- a/cmdfactory/builder.go
+++ b/cmdfactory/builder.go
@@ -234,8 +234,12 @@ func AttributeFlags(c *cobra.Command, obj any, args ...string) error {
 	}
 
 	// If any arguments are passed, parse them immediately
+	subC, args, err := c.Find(args)
+	if err != nil {
+		return err
+	}
 	if len(args) > 0 {
-		if err := c.ParseFlags(args); err != nil && !errors.Is(err, pflag.ErrHelp) {
+		if err := subC.ParseFlags(args); err != nil && !errors.Is(err, pflag.ErrHelp) {
 			return err
 		}
 	}

--- a/internal/cli/options.go
+++ b/internal/cli/options.go
@@ -129,7 +129,7 @@ func WithDefaultConfigManager(cmd *cobra.Command) CliOption {
 		}
 
 		// Attribute all configuration flags and command-line argument values
-		if err := cmdfactory.AttributeFlags(cmd, cfgm.Config, os.Args...); err != nil {
+		if err := cmdfactory.AttributeFlags(cmd, cfgm.Config, os.Args[1:]...); err != nil {
 			return err
 		}
 


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [x] Updated relevant documentation.

### Description of changes

Parsing all the flags at the top-level (`kraft` command) results in "unknown flags" errors thrown by `spf13/pflag`, because the parsing traverses the flags of all children commands, ignoring the command hierarchy.

To work around this issue, we adopt the [same approach](https://github.com/spf13/cobra/blob/v1.7.0/command.go#L1039-L1044) as `spf13/cobra`, and intelligently identify the actual (sub-)command and its associated flags before performing the parsing.

### How I tested the changes

- `kraft build --arch=x86_64` now runs without throwing "unknown flag".
- `--log-type` is propagated to sub-commands.
- ` --config-dir` is propagated to sub-commands.