### PR TITLE
fix(cmd): filter out registered flags before parse

### DIFF
--- a/cmdfactory/builder_test.go
+++ b/cmdfactory/builder_test.go
@@ -1,0 +1,105 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2022 Acorn Labs, Inc; All rights reserved.
+// Copyright 2022 Unikraft GmbH; All rights reserved.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+package cmdfactory
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+func TestFilterRegisteredFlags(t *testing.T) {
+	flagOverridesOrig := copyFlagOverrides()
+	t.Cleanup(func() { flagOverrides = flagOverridesOrig })
+
+	flagOverrides = map[string][]*pflag.Flag{
+		"kraft cmd1":         makeLongFlags("cmd1-override1", "cmd1-override2"),
+		"kraft cmd2":         makeLongFlags("cmd2-override1", "cmd2-override2"),
+		"kraft cmd1 subcmd1": makeLongFlags("subcmd1-override1", "subcmd1-override2"),
+		"kraft cmd1 subcmd2": makeLongFlags("subcmd2-override1", "subcmd2-override2"),
+	}
+
+	cmd := makeCommand("kraft", "cmd1", "subcmd1")
+
+	testCases := []struct {
+		desc   string
+		args   []string
+		expect []string
+	}{
+		{
+			desc:   "args do not contain registered flags",
+			args:   []string{"-v", "-w", "wval", "-x=xval", "--y", "yval", "--z=zval"},
+			expect: []string{"-v", "-w", "wval", "-x=xval", "--y", "yval", "--z=zval"},
+		},
+		{
+			desc:   "args contain registered flags in long format",
+			args:   []string{"--subcmd1-override1", "val1", "--subcmd1-override2=val2", "--y", "yval", "--z=zval"},
+			expect: []string{"--y", "yval", "--z=zval"},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			args := filterRegisteredFlags(cmd, tc.args)
+
+			if !equalArgs(args, tc.expect) {
+				t.Errorf("Expected filtered args\n%q\ngot\n%q", tc.expect, args)
+			}
+		})
+	}
+}
+
+func equalArgs(got, expect []string) bool {
+	if len(got) != len(expect) {
+		return false
+	}
+
+	for i := 0; i < len(got); i++ {
+		if got[i] != expect[i] {
+			return false
+		}
+	}
+
+	return true
+}
+
+// makeCommand produces a command with the given hierarchy of subcommands, and
+// returns the deepest command.
+func makeCommand(hierarchy ...string) *cobra.Command {
+	var lastRoot *cobra.Command
+
+	for _, cmdName := range hierarchy {
+		newRoot := &cobra.Command{Use: cmdName + " [-F file | -D dir]... [-f format] something"}
+		if lastRoot != nil {
+			lastRoot.AddCommand(newRoot)
+		}
+		lastRoot = newRoot
+	}
+
+	return lastRoot
+}
+
+// makeLongFlags returns string flags with the given names.
+func makeLongFlags(names ...string) []*pflag.Flag {
+	flags := make([]*pflag.Flag, 0, len(names))
+
+	for _, n := range names {
+		var strVal string
+		flags = append(flags, StringVar(&strVal, n, "default", "a test flag"))
+	}
+
+	return flags
+}
+
+// copyFlagOverrides returns a copy of the global flagOverrides slice.
+func copyFlagOverrides() map[string][]*pflag.Flag {
+	flagOverridesCpy := make(map[string][]*pflag.Flag, len(flagOverrides))
+	for cmdline, flags := range flagOverrides {
+		flagOverridesCpy[cmdline] = flags
+	}
+	return flagOverridesCpy
+}


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [x] Updated relevant documentation.

### Description of changes

Some kraft commands accept flags which registration is delayed using `cmdfactory.RegisterFlag`. Parsing these here results in an expected failure. `kraft pkg --oci-tag` is one example of such flag.

Flags are parsed a second time by `spf13/cobra` inside `cmdfactory.Main`, so if a flag is really not supported, the error will still be reported eventually.

### How it was tested

- `kraft pkg --arch x86_64 --oci-tag test:test` now succeeds
- `kraft pkg --arch x86_64 --oci-tag test:test --foo bar` does not