### PR TITLE
refactor(cmd): use internal set package

### DIFF
--- a/cmdfactory/builder.go
+++ b/cmdfactory/builder.go
@@ -19,6 +19,8 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
+
+	"kraftkit.sh/internal/set"
 )
 
 var (
@@ -103,9 +105,9 @@ func filterOutRegisteredFlags(cmd *cobra.Command, args []string) (filteredArgs [
 			continue
 		}
 
-		registeredFlagsNames := make(map[string]struct{}, len(flags))
+		registeredFlagsNames := set.NewStringSet()
 		for _, flag := range flags {
-			registeredFlagsNames[flag.Name] = struct{}{}
+			registeredFlagsNames.Add(flag.Name)
 		}
 
 		for len(args) > 0 {
@@ -122,7 +124,7 @@ func filterOutRegisteredFlags(cmd *cobra.Command, args []string) (filteredArgs [
 				subs := strings.SplitN(arg, "=", 2)
 
 				flagName := strings.TrimPrefix(subs[0], "--")
-				if _, isRegistered := registeredFlagsNames[flagName]; isRegistered {
+				if registeredFlagsNames.Contains(flagName) {
 					if len(subs) == 1 {
 						args = args[1:]
 					}
@@ -136,7 +138,7 @@ func filterOutRegisteredFlags(cmd *cobra.Command, args []string) (filteredArgs [
 				subs := strings.SplitN(arg, "=", 2)
 
 				flagName := strings.TrimPrefix(subs[0], "-")
-				if _, isRegistered := registeredFlagsNames[flagName]; isRegistered {
+				if registeredFlagsNames.Contains(flagName) {
 					if len(subs) == 1 {
 						args = args[1:]
 					}


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [x] Updated relevant documentation.

### Description of changes

Use the internal `set` package instead of having another implementation of a string set. I realized after the fact that we had a package for that.