### PR TITLE
refactor(cmd): rename filter function

### DIFF
--- a/cmdfactory/builder.go
+++ b/cmdfactory/builder.go
@@ -97,7 +97,7 @@ func expandRegisteredFlags(cmd *cobra.Command) {
 }
 
 // filter out registered flags from the given command's args.
-func filterRegisteredFlags(cmd *cobra.Command, args []string) (filteredArgs []string) {
+func filterOutRegisteredFlags(cmd *cobra.Command, args []string) (filteredArgs []string) {
 	for cmdline, flags := range flagOverrides {
 		if !isSameCommand(cmd, cmdline) {
 			continue
@@ -315,7 +315,7 @@ func AttributeFlags(c *cobra.Command, obj any, args ...string) error {
 	if len(args) > 0 {
 		// Some kraft commands accept flags which registration is delayed using
 		// RegisterFlag. Parsing these here would result in a failure.
-		args = filterRegisteredFlags(subC, args)
+		args = filterOutRegisteredFlags(subC, args)
 
 		if err := subC.ParseFlags(args); err != nil && !errors.Is(err, pflag.ErrHelp) {
 			return err

--- a/cmdfactory/builder_test.go
+++ b/cmdfactory/builder_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/spf13/pflag"
 )
 
-func TestFilterRegisteredFlags(t *testing.T) {
+func TestFilterOutRegisteredFlags(t *testing.T) {
 	flagOverridesOrig := copyFlagOverrides()
 	t.Cleanup(func() { flagOverrides = flagOverridesOrig })
 
@@ -44,7 +44,7 @@ func TestFilterRegisteredFlags(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
-			args := filterRegisteredFlags(cmd, tc.args)
+			args := filterOutRegisteredFlags(cmd, tc.args)
 
 			if !equalArgs(args, tc.expect) {
 				t.Errorf("Expected filtered args\n%q\ngot\n%q", tc.expect, args)


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [x] Updated relevant documentation.

### Description of changes

Rename `filterRegisteredFlags` to `filterOutRegisteredFlags`, which is more accurate.