### PR TITLE
fix(cmd): properly check for help flag in args

### DIFF
--- a/cmdfactory/help.go
+++ b/cmdfactory/help.go
@@ -14,6 +14,7 @@ import (
 	"kraftkit.sh/iostreams"
 	"kraftkit.sh/log"
 
+	"kraftkit.sh/internal/set"
 	"kraftkit.sh/internal/text"
 )
 
@@ -118,7 +119,7 @@ func fullname(cmd *cobra.Command) string {
 }
 
 func rootHelpFunc(cmd *cobra.Command, args []string) {
-	if isRootCmd(cmd.Parent()) && len(args) >= 2 && args[1] != "--help" && args[1] != "-h" {
+	if isRootCmd(cmd.Parent()) && len(args) >= 2 && !set.NewStringSet(args...).ContainsAnyOf("--help", "-h") {
 		nestedSuggestFunc(cmd, args[1])
 		hasFailed = true
 		return

--- a/test/e2e/cli/version_test.go
+++ b/test/e2e/cli/version_test.go
@@ -43,10 +43,7 @@ var _ = Describe("kraft version", func() {
 
 	When("invoked with the --help flag", func() {
 		BeforeEach(func() {
-			// FIXME(antoineco): Sub-commands of the root command handle help flags
-			// improperly when top-level flags exist in the arguments.
-			// Ref. unikraft/kraftkit#430
-			cmd.Args = []string{cmd.Args[0], cmd.Args[len(cmd.Args)-1], "--help"}
+			cmd.Args = append(cmd.Args, "--help")
 		})
 
 		It("should print the command's help", func() {


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [x] Updated relevant documentation.

### Description of changes

Fixes #430

Checks whether the arguments contain a help flag, regardless of this position in the arguments list.

This officially concludes the list of things I wanted to tackle as a follow-up to the initial e2e tests 🙂