### PR TITLE
ci: run workflows on merge to the default branch

### DIFF
--- a/.github/workflows/gobuild-protoc.yaml
+++ b/.github/workflows/gobuild-protoc.yaml
@@ -1,6 +1,8 @@
 name: tools/protoc-gen-go-netconn
 
 on:
+  push:
+    branches: [staging]
   pull_request:
     types: [opened, synchronize, reopened]
     branches: [staging]

--- a/.github/workflows/gobuild-qemu-devices.yaml
+++ b/.github/workflows/gobuild-qemu-devices.yaml
@@ -1,6 +1,8 @@
 name: tools/go-generate-qemu-device
 
 on:
+  push:
+    branches: [staging]
   pull_request:
     types: [opened, synchronize, reopened]
     branches: [staging]

--- a/.github/workflows/gochecks.yaml
+++ b/.github/workflows/gochecks.yaml
@@ -1,6 +1,8 @@
 name: Go static checks
 
 on:
+  push:
+    branches: [staging]
   pull_request:
     types: [opened, synchronize, reopened]
     branches: [staging]

--- a/.github/workflows/gotests.yaml
+++ b/.github/workflows/gotests.yaml
@@ -1,6 +1,8 @@
 name: Tests
 
 on:
+  push:
+    branches: [staging]
   pull_request:
     types: [opened, synchronize, reopened]
     branches: [staging]


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [x] Updated relevant documentation.

### Description of changes

Aside from providing a better guarantee that merges do not break the default branch, running workflows on it makes caches [readily available to other branches](https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows#restrictions-for-accessing-a-cache), which prevents creating one cache per branch and speeds up workflow runs significantly.

Closes #442