### PR TITLE
ci: determine cache locations from 'go env'

### DIFF
--- a/.github/workflows/gobuild-protoc.yaml
+++ b/.github/workflows/gobuild-protoc.yaml
@@ -25,13 +25,23 @@ jobs:
           go-version: 1.20.2
           cache: false
 
+      - name: Set Go variables
+        id: goenv
+        run: |
+          cd tools/protoc-gen-go-netconn
+          {
+            echo "cache=$(go env GOCACHE)"
+            echo "modcache=$(go env GOMODCACHE)"
+            echo "mod=$(go env GOMOD)"
+          } >>"$GITHUB_OUTPUT"
+
       - name: Go caches
         uses: actions/cache@v3
         with:
           path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: ${{ github.job }}-${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+            ${{ steps.goenv.outputs.cache }}
+            ${{ steps.goenv.outputs.modcache }}
+          key: ${{ github.job }}-${{ runner.os }}-go-${{ hashFiles('${{ steps.goenv.outputs.mod }}') }}
           restore-keys: |
             ${{ github.job }}-${{ runner.os }}-go-
 

--- a/.github/workflows/gobuild-qemu-devices.yaml
+++ b/.github/workflows/gobuild-qemu-devices.yaml
@@ -25,13 +25,23 @@ jobs:
           go-version: 1.20.2
           cache: false
 
+      - name: Set Go variables
+        id: goenv
+        run: |
+          cd tools/go-generate-qemu-devices
+          {
+            echo "cache=$(go env GOCACHE)"
+            echo "modcache=$(go env GOMODCACHE)"
+            echo "mod=$(go env GOMOD)"
+          } >>"$GITHUB_OUTPUT"
+
       - name: Go caches
         uses: actions/cache@v3
         with:
           path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: ${{ github.job }}-${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+            ${{ steps.goenv.outputs.cache }}
+            ${{ steps.goenv.outputs.modcache }}
+          key: ${{ github.job }}-${{ runner.os }}-go-${{ hashFiles('${{ steps.goenv.outputs.mod }}') }}
           restore-keys: |
             ${{ github.job }}-${{ runner.os }}-go-
 

--- a/.github/workflows/gochecks.yaml
+++ b/.github/workflows/gochecks.yaml
@@ -25,13 +25,22 @@ jobs:
           go-version: 1.20.2
           cache: false
 
+      - name: Set Go variables
+        id: goenv
+        run: |
+          {
+            echo "cache=$(go env GOCACHE)"
+            echo "modcache=$(go env GOMODCACHE)"
+            echo "mod=$(go env GOMOD)"
+          } >>"$GITHUB_OUTPUT"
+
       - name: Go caches
         uses: actions/cache@v3
         with:
           path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: ${{ github.job }}-${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+            ${{ steps.goenv.outputs.cache }}
+            ${{ steps.goenv.outputs.modcache }}
+          key: ${{ github.job }}-${{ runner.os }}-go-${{ hashFiles('${{ steps.goenv.outputs.mod }}') }}
           restore-keys: |
             ${{ github.job }}-${{ runner.os }}-go-
 

--- a/.github/workflows/gotests.yaml
+++ b/.github/workflows/gotests.yaml
@@ -22,13 +22,22 @@ jobs:
           go-version: 1.20.2
           cache: false
 
+      - name: Set Go variables
+        id: goenv
+        run: |
+          {
+            echo "cache=$(go env GOCACHE)"
+            echo "modcache=$(go env GOMODCACHE)"
+            echo "mod=$(go env GOMOD)"
+          } >>"$GITHUB_OUTPUT"
+
       - name: Go caches
         uses: actions/cache@v3
         with:
           path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: ${{ github.job }}-${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+            ${{ steps.goenv.outputs.cache }}
+            ${{ steps.goenv.outputs.modcache }}
+          key: ${{ github.job }}-${{ runner.os }}-go-${{ hashFiles('${{ steps.goenv.outputs.mod }}') }}
           restore-keys: |
             ${{ github.job }}-${{ runner.os }}-go-
 
@@ -66,13 +75,22 @@ jobs:
           go-version: 1.20.2
           cache: false
 
+      - name: Set Go variables
+        id: goenv
+        run: |
+          {
+            echo "cache=$(go env GOCACHE)"
+            echo "modcache=$(go env GOMODCACHE)"
+            echo "mod=$(go env GOMOD)"
+          } >>"$GITHUB_OUTPUT"
+
       - name: Go caches
         uses: actions/cache@v3
         with:
           path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: ${{ github.job }}-${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+            ${{ steps.goenv.outputs.cache }}
+            ${{ steps.goenv.outputs.modcache }}
+          key: ${{ github.job }}-${{ runner.os }}-go-${{ hashFiles('${{ steps.goenv.outputs.mod }}') }}
           restore-keys: |
             ${{ github.job }}-${{ runner.os }}-go-
 


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [x] Updated relevant documentation.

### Description of changes

Instead of guessing where the Go caches are, we can ask `go env` directly, and avoid future breakages if the paths change.

I stole that idea from the `setup-go` action.