### PR TITLE
ci: fix missing go.mod hash in cache key 

### DIFF
--- a/.github/workflows/gobuild-protoc.yaml
+++ b/.github/workflows/gobuild-protoc.yaml
@@ -43,7 +43,7 @@ jobs:
           path: |
             ${{ steps.goenv.outputs.cache }}
             ${{ steps.goenv.outputs.modcache }}
-          key: ${{ github.job }}-${{ runner.os }}-go-${{ hashFiles('${{ steps.goenv.outputs.mod }}') }}
+          key: ${{ github.job }}-${{ runner.os }}-go-${{ hashFiles(steps.goenv.outputs.mod) }}
           restore-keys: |
             ${{ github.job }}-${{ runner.os }}-go-
 

--- a/.github/workflows/gobuild-qemu-devices.yaml
+++ b/.github/workflows/gobuild-qemu-devices.yaml
@@ -43,7 +43,7 @@ jobs:
           path: |
             ${{ steps.goenv.outputs.cache }}
             ${{ steps.goenv.outputs.modcache }}
-          key: ${{ github.job }}-${{ runner.os }}-go-${{ hashFiles('${{ steps.goenv.outputs.mod }}') }}
+          key: ${{ github.job }}-${{ runner.os }}-go-${{ hashFiles(steps.goenv.outputs.mod) }}
           restore-keys: |
             ${{ github.job }}-${{ runner.os }}-go-
 

--- a/.github/workflows/gochecks.yaml
+++ b/.github/workflows/gochecks.yaml
@@ -52,7 +52,7 @@ jobs:
         with:
           path: |
             ${{ github.workspace }}/third_party/libgit2/git2go/static-build/install
-          key: libgit2-${{ runner.os }}-${{ hashFiles('**/go.sum') }}
+          key: libgit2-${{ runner.os }}-${{ hashFiles(steps.goenv.outputs.mod) }}
 
       - name: Reset libgit2 pkg-config mtime
         if: steps.libgit2-cache.outputs.cache-hit == 'true'

--- a/.github/workflows/gochecks.yaml
+++ b/.github/workflows/gochecks.yaml
@@ -42,7 +42,7 @@ jobs:
           path: |
             ${{ steps.goenv.outputs.cache }}
             ${{ steps.goenv.outputs.modcache }}
-          key: ${{ github.job }}-${{ runner.os }}-go-${{ hashFiles('${{ steps.goenv.outputs.mod }}') }}
+          key: ${{ github.job }}-${{ runner.os }}-go-${{ hashFiles(steps.goenv.outputs.mod) }}
           restore-keys: |
             ${{ github.job }}-${{ runner.os }}-go-
 

--- a/.github/workflows/gotests.yaml
+++ b/.github/workflows/gotests.yaml
@@ -39,7 +39,7 @@ jobs:
           path: |
             ${{ steps.goenv.outputs.cache }}
             ${{ steps.goenv.outputs.modcache }}
-          key: ${{ github.job }}-${{ runner.os }}-go-${{ hashFiles('${{ steps.goenv.outputs.mod }}') }}
+          key: ${{ github.job }}-${{ runner.os }}-go-${{ hashFiles(steps.goenv.outputs.mod) }}
           restore-keys: |
             ${{ github.job }}-${{ runner.os }}-go-
 
@@ -92,7 +92,7 @@ jobs:
           path: |
             ${{ steps.goenv.outputs.cache }}
             ${{ steps.goenv.outputs.modcache }}
-          key: ${{ github.job }}-${{ runner.os }}-go-${{ hashFiles('${{ steps.goenv.outputs.mod }}') }}
+          key: ${{ github.job }}-${{ runner.os }}-go-${{ hashFiles(steps.goenv.outputs.mod) }}
           restore-keys: |
             ${{ github.job }}-${{ runner.os }}-go-
 

--- a/.github/workflows/gotests.yaml
+++ b/.github/workflows/gotests.yaml
@@ -49,7 +49,7 @@ jobs:
         with:
           path: |
             ${{ github.workspace }}/third_party/libgit2/git2go/static-build/install
-          key: libgit2-${{ runner.os }}-${{ hashFiles('**/go.sum') }}
+          key: libgit2-${{ runner.os }}-${{ hashFiles(steps.goenv.outputs.mod) }}
 
       - name: Reset libgit2 pkg-config mtime
         if: steps.libgit2-cache.outputs.cache-hit == 'true'
@@ -102,7 +102,7 @@ jobs:
         with:
           path: |
             ${{ github.workspace }}/third_party/libgit2/git2go/static-build/install
-          key: libgit2-${{ runner.os }}-${{ hashFiles('**/go.sum') }}
+          key: libgit2-${{ runner.os }}-${{ hashFiles(steps.goenv.outputs.mod) }}
 
       - name: Reset libgit2 pkg-config mtime
         if: steps.libgit2-cache.outputs.cache-hit == 'true'


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [x] Updated relevant documentation.

### Description of changes

It was ambitious of me to expect GitHub to expand nested expressions in #451.

![image](https://user-images.githubusercontent.com/3299086/235370068-5e71424a-147a-476a-8355-ba7277e65c47.png)
