### PR TITLE
build: produce a statically linked kraft binary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,7 +80,7 @@ all: help
 ifeq ($(DEBUG),y)
 $(addprefix $(.PROXY), $(BIN)): GO_GCFLAGS ?= -N -l
 else
-$(addprefix $(.PROXY), $(BIN)): GO_LDFLAGS ?= -s -w
+$(addprefix $(.PROXY), $(BIN)): GO_LDFLAGS ?= -s -w -extldflags=-static
 endif
 $(addprefix $(.PROXY), $(BIN)): GO_LDFLAGS += -X "$(GOMOD)/internal/version.version=$(VERSION)"
 $(addprefix $(.PROXY), $(BIN)): GO_LDFLAGS += -X "$(GOMOD)/internal/version.commit=$(GIT_SHA)"


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [x] Updated relevant documentation.

### Description of changes

An attempt to build statically linked `kraft` binaries.

Currently, `kraft` links against:
```
        linux-vdso.so.1 (0x00007ffc0e17d000)
        libssh2.so.1 => /lib/x86_64-linux-gnu/libssh2.so.1 (0x00007f11f1c32000)
        libssl.so.3 => /lib/x86_64-linux-gnu/libssl.so.3 (0x00007f11f1b8d000)
        libcrypto.so.3 => /lib/x86_64-linux-gnu/libcrypto.so.3 (0x00007f11f173c000)
        libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007f11f1537000)
        libz.so.1 => /lib/x86_64-linux-gnu/libz.so.1 (0x00007f11f151b000)
        /lib64/ld-linux-x86-64.so.2 (0x00007f11f1c80000)
```

There is however one major caveat of doing this, so it might not be worth it:

```
$ go build \
        -tags static \
        -gcflags=all='' \
        -ldflags='-s -w -extldflags=-static -X "kraftkit.sh/internal/version.version=v0.5.1-54-g1485ca4-dirty" -X "kraftkit.sh/internal/version.commit=1485ca4" -X "kraftkit.sh/internal/version.buildTime=Wed May  3 12:02:42 CEST 2023"' \
        -o /home/acotten/git/unikraft/kraftkit/dist/kraft \
        /home/acotten/git/unikraft/kraftkit/cmd/kraft
# kraftkit.sh/cmd/kraft
/usr/bin/ld: /tmp/go-link-1213689301/000056.o: in function `pluginOpen':
/_/plugin/plugin_dlopen.go:19: warning: Using 'dlopen' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking
/usr/bin/ld: /tmp/go-link-1213689301/000059.o: in function `mygetgrouplist':
/_/os/user/getgrouplist_unix.go:15: warning: Using 'getgrouplist' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking
/usr/bin/ld: /tmp/go-link-1213689301/000058.o: in function `mygetgrgid_r':
/_/os/user/cgo_lookup_cgo.go:45: warning: Using 'getgrgid_r' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking
/usr/bin/ld: /tmp/go-link-1213689301/000058.o: in function `mygetgrnam_r':
/_/os/user/cgo_lookup_cgo.go:54: warning: Using 'getgrnam_r' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking
/usr/bin/ld: /tmp/go-link-1213689301/000058.o: in function `mygetpwnam_r':
/_/os/user/cgo_lookup_cgo.go:36: warning: Using 'getpwnam_r' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking
/usr/bin/ld: /tmp/go-link-1213689301/000058.o: in function `mygetpwuid_r':
/_/os/user/cgo_lookup_cgo.go:27: warning: Using 'getpwuid_r' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking
/usr/bin/ld: /tmp/go-link-1213689301/000053.o: in function `_cgo_cbcce81e6342_C2func_getaddrinfo':
/tmp/go-build/cgo-gcc-prolog:58: warning: Using 'getaddrinfo' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking
/usr/bin/ld: /usr/lib/gcc/x86_64-linux-gnu/12/../../../x86_64-linux-gnu/libcrypto.a(libcrypto-lib-bio_sock.o): in function `BIO_gethostbyname':
(.text+0x85): warning: Using 'gethostbyname' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking
```