### PR TITLE
build: upgrade buildenv base to Ubuntu 22.04

### DIFF
--- a/buildenvs/myself.Dockerfile
+++ b/buildenvs/myself.Dockerfile
@@ -5,19 +5,31 @@
 
 ARG GO_VERSION=1.20.2
 
-FROM golang:${GO_VERSION}-bullseye AS kraftkit-full
+FROM golang:${GO_VERSION}-bullseye AS golang
+
+FROM ubuntu:22.04 AS kraftkit-full
+
+# https://github.com/docker-library/golang/blob/5c6fa890/1.20/bullseye/Dockerfile
+ENV PATH /usr/local/go/bin:$PATH
+ENV GOLANG_VERSION ${GO_VERSION}
+COPY --from=golang /usr/local/go /usr/local/go
+ENV GOPATH /go
+ENV PATH $GOPATH/bin:$PATH
+RUN mkdir -p "$GOPATH/src" "$GOPATH/bin" && chmod -R 1777 "$GOPATH"
 
 # Install build dependencies
 RUN set -xe; \
     apt-get update; \
     apt-get install -y --no-install-recommends \
-      build-essential=12.9 \
-      cmake=3.18.4-2+deb11u1 \
-      libssh2-1-dev=1.9.0-2 \
-      libssl-dev=1.1.1n-0+deb11u4 \
-      make=4.3-4.1 \
-      pkg-config=0.29.2-1 \
-      git=1:2.30.2-1+deb11u2; \
+      ca-certificates=20211016ubuntu0.22.04.1 \
+      curl=7.81.0-1ubuntu1.10 \
+      build-essential=12.9ubuntu3 \
+      cmake=3.22.1-1ubuntu1.22.04.1 \
+      libssh2-1-dev=1.10.0-3 \
+      libssl-dev=3.0.2-0ubuntu1.9 \
+      pkg-config=0.29.2-1ubuntu3 \
+      openssh-client=1:8.9p1-3ubuntu0.1 \
+      git=1:2.34.1-1ubuntu1.9; \
     apt-get clean; \
     go install mvdan.cc/gofumpt@v0.4.0; \
     git config --global --add safe.directory /go/src/kraftkit.sh;


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [x] Updated relevant documentation.

### Description of changes


Allows producing release binaries which are dynamically linked against libssl3 instead of libssl1.1. The latter is no longer available in recent Linux distributions.

Fixes #457