### PR TITLE
feat(pkg): Enable packaging of application arguments

### DIFF
--- a/cmd/kraft/pkg/pkg.go
+++ b/cmd/kraft/pkg/pkg.go
@@ -10,6 +10,7 @@ import (
 	"os"
 
 	"github.com/MakeNowJust/heredoc"
+	"github.com/mattn/go-shellwords"
 	"github.com/spf13/cobra"
 
 	"kraftkit.sh/config"
@@ -31,6 +32,7 @@ import (
 
 type Pkg struct {
 	Architecture string   `local:"true" long:"arch" short:"m" usage:"Filter the creation of the package by architecture of known targets"`
+	Args         string   `local:"true" long:"args" short:"a" usage:"Pass arguments that will be part of the running kernel's command line"`
 	Dbg          bool     `local:"true" long:"dbg" usage:"Package the debuggable (symbolic) kernel image instead of the stripped image"`
 	Force        bool     `local:"true" long:"force-format" usage:"Force the use of a packaging handler format"`
 	Format       string   `local:"true" long:"as" short:"M" usage:"Force the packaging despite possible conflicts" default:"auto"`
@@ -183,6 +185,11 @@ func (opts *Pkg) Run(cmd *cobra.Command, args []string) error {
 				name += " (" + format.String() + ")"
 			}
 
+			cmdShellArgs, err := shellwords.Parse(opts.Args)
+			if err != nil {
+				return err
+			}
+
 			tree = append(tree, processtree.NewProcessTreeItem(
 				name,
 				targ.Architecture().Name()+"/"+targ.Platform().Name(),
@@ -199,6 +206,7 @@ func (opts *Pkg) Run(cmd *cobra.Command, args []string) error {
 					}
 
 					popts := []packmanager.PackOption{
+						packmanager.PackArgs(cmdShellArgs...),
 						packmanager.PackKConfig(opts.WithKConfig),
 						packmanager.PackOutput(opts.Output),
 						packmanager.PackInitrd(opts.Initrd),

--- a/oci/pack.go
+++ b/oci/pack.go
@@ -56,6 +56,11 @@ var (
 func NewPackageFromTarget(ctx context.Context, targ target.Target, opts ...packmanager.PackOption) (pack.Package, error) {
 	var err error
 
+	popts := &packmanager.PackOptions{}
+	for _, opt := range opts {
+		opt(popts)
+	}
+
 	// Initialize the ociPackage by copying over target.Target attributes
 	ocipack := ociPackage{
 		arch:    targ.Architecture(),
@@ -63,6 +68,7 @@ func NewPackageFromTarget(ctx context.Context, targ target.Target, opts ...packm
 		kconfig: targ.KConfig(),
 		kernel:  targ.Kernel(),
 		initrd:  targ.Initrd(),
+		command: popts.Args(),
 	}
 
 	if flagTag != "" {
@@ -86,11 +92,6 @@ func NewPackageFromTarget(ctx context.Context, targ target.Target, opts ...packm
 	}
 	if err != nil {
 		return nil, err
-	}
-
-	popts := &packmanager.PackOptions{}
-	for _, opt := range opts {
-		opt(popts)
 	}
 
 	if contAddr := config.G[config.KraftKit](ctx).ContainerdAddr; len(contAddr) > 0 {

--- a/packmanager/pack_options.go
+++ b/packmanager/pack_options.go
@@ -8,6 +8,7 @@ package packmanager
 // component.
 type PackOptions struct {
 	appSourceFiles                   bool
+	args                             []string
 	initrd                           string
 	kconfig                          bool
 	kernelLibraryIntermediateObjects bool
@@ -21,6 +22,11 @@ type PackOptions struct {
 // packaged.
 func (popts *PackOptions) PackAppSourceFiles() bool {
 	return popts.appSourceFiles
+}
+
+// Args returns the arguments to pass to the kernel.
+func (popts *PackOptions) Args() []string {
+	return popts.args
 }
 
 // Initrd returns the path of the initrd file that should be packaged.
@@ -66,6 +72,13 @@ type PackOption func(*PackOptions)
 func PackAppSourceFiles(pack bool) PackOption {
 	return func(popts *PackOptions) {
 		popts.appSourceFiles = pack
+	}
+}
+
+// PackArgs sets the arguments to be passed to the application.
+func PackArgs(args ...string) PackOption {
+	return func(popts *PackOptions) {
+		popts.args = args
 	}
 }
 


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

This commit adds the possibility to pass arguments `--args "-lash"` when packaging as oci

Closes: #469