### PR TITLE
ci: expire action caches

### DIFF
--- a/.github/workflows/expire-caches.yml
+++ b/.github/workflows/expire-caches.yml
@@ -1,0 +1,76 @@
+name: Expire Action Caches
+
+on:
+  push:
+    branches: [staging]
+
+jobs:
+
+  check-and-update:
+    name: Clean
+    runs-on: ubuntu-latest
+
+    permissions:
+      actions: write
+
+    steps:
+      - name: Clean up obsolete caches
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const cachePrefixes = new Map([
+              ['gochecks-Linux-go-', 0],
+              ['gounit-Linux-go-',   0],
+              ['e2e-cli-Linux-go-',  0]
+            ]);
+
+            const cacheSuffixLen = 64
+
+            await github.
+              paginate(github.rest.actions.getActionsCacheList, {
+                owner: context.repo.owner,
+                repo: context.repo.repo
+              })
+              .then(caches => {
+                for (const cache of caches) {
+                  if (cache.ref == 'refs/heads/staging') {
+                    const cachePrefix = cache.key.slice(0, -cacheSuffixLen)
+                    if (cachePrefixes.has(cachePrefix)) {
+                      const seen = cachePrefixes.get(cachePrefix)
+                      if (seen > 0) {
+                        (async () => {
+                          await github.rest.actions.deleteActionsCacheById({
+                            owner: context.repo.owner,
+                            repo: context.repo.repo,
+                            cache_id: cache.id
+                          })
+                          core.notice(`Deleted cache with key ${cache.key} for ref ${cache.ref}`)
+                        })()
+                      }
+                      cachePrefixes.set(cachePrefix, seen + 1)
+                    }
+                  } else {
+                    (async () => {
+                      await github.rest.repos.getBranch({
+                        owner: context.repo.owner,
+                        repo: context.repo.repo,
+                        branch: cache.ref
+                      })
+                      .catch(error => {
+                        if (error.status == 404) {
+                          (async () => {
+                            await github.rest.actions.deleteActionsCacheById({
+                              owner: context.repo.owner,
+                              repo: context.repo.repo,
+                              cache_id: cache.id
+                            })
+                            core.notice(`Deleted cache with key ${cache.key} for ref ${cache.ref}`)
+                          })()
+                        } else {
+                          throw error
+                        }
+                      })
+                    })()
+                  }
+                }
+              });


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [x] Updated relevant documentation.

### Description of changes

Adds an Action workflow which automatically cleans up obsolete caches on the `staging` branch, as well as on all deleted branches (e.g. merged PR branches).

Due to regular dependencies updates by dependabot, we are constantly above the 10 GB limit:
![image](https://github.com/unikraft/kraftkit/assets/3299086/2ba04327-1021-4f19-9c8b-c7d2e6c37cfa)

I already [ran the workflow once](https://github.com/unikraft/kraftkit/actions/runs/4978460458) in the repo, successfully.