### PR TITLE
fix(plat): Handle KVM VMM target names

### DIFF
--- a/unikraft/plat/platform.go
+++ b/unikraft/plat/platform.go
@@ -7,7 +7,6 @@ package plat
 import (
 	"context"
 	"os"
-	"strings"
 
 	"kraftkit.sh/kconfig"
 	"kraftkit.sh/unikraft"
@@ -92,15 +91,15 @@ func (pc PlatformConfig) KConfig() kconfig.KeyValueMap {
 	values.OverrideBy(pc.kconfig)
 
 	// The following are built-in assumptions given the naming conventions used
-	// within the Unikraft core.  Ultimately, this should be discovered by probing
-	// the core or the external microlibrary.
-
-	var plat strings.Builder
-	plat.WriteString(kconfig.Prefix)
-	plat.WriteString("PLAT_")
-	plat.WriteString(strings.ToUpper(pc.Name()))
-
-	values.Set(plat.String(), kconfig.Yes)
+	// within the Unikraft core.
+	switch pc.Name() {
+	case "fc", "firecracker":
+		values.Set("CONFIG_PLAT_KVM", kconfig.Yes)
+		values.Set("CONFIG_KVM_VMM_FIRECRACKER", kconfig.Yes)
+	case "kvm", "qemu":
+		values.Set("CONFIG_PLAT_KVM", kconfig.Yes)
+		values.Set("CONFIG_KVM_VMM_QEMU", kconfig.Yes)
+	}
 
 	return values
 }


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->


Following the merge of https://github.com/unikraft/unikraft/pull/760 and the release of Unikraft v0.13.0 (Atlas) comes the introduction of KVM VMM targets.  This has the effect of modifying the resulting kernel binary name with the VMM of choice. This commit allows for specifying this target and correctly handling setting the correct internal KConfig options.

For now this fix does not handle backwards compatibility pre-v0.13.0. An immediate fix is to simply change the target name from `kvm` to `qemu` in relevant `kraft.yaml` files.