### PR TITLE
fix(packmanager,oci): Correctly handle options

### DIFF
--- a/oci/manager_options.go
+++ b/oci/manager_options.go
@@ -35,6 +35,8 @@ func WithDetectHandler() OCIManagerOption {
 			manager.handle = func(ctx context.Context) (context.Context, handler.Handler, error) {
 				return handler.NewContainerdHandler(ctx, contAddr, namespace)
 			}
+
+			return nil
 		}
 
 		return fmt.Errorf("could not detect OCI handler")

--- a/packmanager/umbrella.go
+++ b/packmanager/umbrella.go
@@ -33,6 +33,7 @@ func RegisterPackageManager(ctxk pack.PackageFormat, constructor NewManagerConst
 	}
 
 	packageManagerConstructors[ctxk] = constructor
+	packageManagerOpts[ctxk] = opts
 
 	return nil
 }


### PR DESCRIPTION
An additional positional argument was introduced in ebe06aed9744f334a9fddb0f6d8dafe0f1bc4882 such that the package manager could be instantiated with additional options, but these options were never copied over in order to be passed to the actual constructor.

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [ ] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [ ] Tested your changes against relevant architectures and platforms;
  - [ ] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->
