### PR TITLE
feat(export): Introduce Unikraft C-Go export package

### DIFF
--- a/unikraft/export/README.md
+++ b/unikraft/export/README.md
@@ -1,0 +1,28 @@
+# Unikraft C-Go bindings
+
+This package contains C-bindings for Unikraft to be used within the context of
+Go applications which are built on top of Unikraft.  The purpose of this package
+is twofold:
+
+1. to allow KraftKit internals to reference Unikraft internal structures during
+   the manifestation of a unikernel (either during compile-time or runtime);
+   and, 
+2. to enable developers programming in Go to directly reference Unikraft
+   internals and bypass general-purpose syscall boundaries.
+
+This package is work-in-progress, and as such the enumerated libraries exposed
+(or "exported") by this package are delivered through the `v0` suffix.  This
+serves to indicate that the exported constants, variables, methods and utilities
+offered by KraftKit representing Unikraft internals are incomplete, subject to
+change and therefore considered unstable.  Thus, usage of the exported methods
+are delivered via:
+
+```go
+import "kraftkit.sh/unikraft/export/v0"
+```
+
+Towards [the release of Unikraft v1.0
+itself](https://github.com/orgs/unikraft/projects/24/views/38), the exported
+libraries, symbols, methods and utility methods will reflect both stable APIs
+both in terms of Unikraft's internals but also with regard to how this package
+can be used.

--- a/unikraft/export/v0/ukargparse/params.go
+++ b/unikraft/export/v0/ukargparse/params.go
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2022, Unikraft GmbH and The KraftKit Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+package ukargparse
+
+import "fmt"
+
+type Param interface {
+	// The canonical name of the parameter which is understood by Unikraft.
+	Name() string
+
+	// Set the value of the parameter.
+	Set(string)
+
+	// Get the value of the parameter.
+	Value() string
+
+	// String returns the fully qualified parameter ready to be accepted by
+	// Unikraft.
+	String() string
+
+	// A method-chain mechanism for both setting and getting the Param with the
+	// newly embedded value.
+	WithValue(string) Param
+}
+
+type paramStr struct {
+	library string
+	name    string
+	value   string
+}
+
+// ParamStr instantiates a new Param based on a string value.
+func ParamStr(lib string, name string, value *string) Param {
+	param := paramStr{
+		library: lib,
+		name:    name,
+	}
+
+	if value != nil {
+		param.value = *value
+	}
+
+	return &param
+}
+
+// Name implements Param
+func (param *paramStr) Name() string {
+	return fmt.Sprintf("%s.%s", param.library, param.name)
+}
+
+// Set implements Param
+func (param *paramStr) Set(value string) {
+	param.value = value
+}
+
+// Value implements Param
+func (param *paramStr) Value() string {
+	return fmt.Sprintf("%s.%s=%s", param.library, param.name, param.value)
+}
+
+// WithValue implements Param
+func (param *paramStr) WithValue(value string) Param {
+	param.value = value
+	return param
+}
+
+// String implements Param
+func (param *paramStr) String() string {
+	return fmt.Sprintf("%s.%s=%s", param.library, param.name, param.value)
+}

--- a/unikraft/export/v0/ukargparse/parse.go
+++ b/unikraft/export/v0/ukargparse/parse.go
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2022, Unikraft GmbH and The KraftKit Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+package ukargparse
+
+import (
+	"fmt"
+	"strings"
+)
+
+type Params []Param
+
+// Parse accepts varadic length position argument args which represent Unikraft
+// command-line arguments and returns structured Params.
+func Parse(args ...string) (Params, error) {
+	params := []Param{}
+
+	for _, arg := range args {
+		libAndName := strings.SplitN(arg, ".", 1)
+		if len(libAndName) != 2 {
+			return nil, fmt.Errorf("expected param to be in the format 'libname.param=value' but got: '%s'", arg)
+		}
+
+		param := paramStr{
+			library: libAndName[0],
+			name:    libAndName[1],
+		}
+
+		if strings.Contains(arg, "=") {
+			nameAndValue := strings.SplitN(arg, "=", 1)
+			param.value = nameAndValue[1]
+		}
+
+		params = append(params, &param)
+	}
+
+	return params, nil
+}
+
+// Strings returns all parameters and their string representation which is ready
+// to be accepted by Unikraft.
+func (params Params) Strings() []string {
+	ret := make([]string, len(params))
+	for i, param := range params {
+		ret[i] = param.String()
+	}
+	return ret
+}
+
+// Contains checks whether the provided needle exists within the existing set of
+// Params.
+func (params Params) Contains(needle Param) bool {
+	for _, param := range params {
+		if param.Name() == needle.Name() {
+			return true
+		}
+	}
+
+	return false
+}


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [x] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

This package contains C-bindings for Unikraft to be used within the context of Go applications which are built on top of Unikraft.  The purpose of this package is twofold:

1. to allow KraftKit internals to reference Unikraft internal structures during the manifestation of a unikernel (either during compile-time or runtime); and,
2. to enable developers programming in Go to directly reference Unikraft internals and bypass general-purpose syscall boundaries.

This package is work-in-progress, and as such the enumerated libraries exposed (or "exported") by this package are delivered through the `v0` suffix.  This serves to indicate that the exported constants, variables, methods and utilities offered by KraftKit representing Unikraft internals are incomplete, subject to change and therefore considered unstable.  Thus, usage of the exported methods are delivered via:

```go
import "kraftkit.sh/unikraft/export/v0"
```

Towards [the release of Unikraft v1.0](https://github.com/orgs/unikraft/projects/24/views/38) itself, the exported libraries, symbols, methods and utility methods will reflect both stable APIs both in terms of Unikraft's internals but also with regard to how this package can be used.
