### PR TITLE
refactor: Downgrade specific log entries

### DIFF
--- a/manifest/manager.go
+++ b/manifest/manager.go
@@ -330,7 +330,7 @@ func (m manifestManager) Catalog(ctx context.Context, qopts ...packmanager.Query
 		} else {
 			more, err := NewPackageFromManifest(manifest, mopts...)
 			if err != nil {
-				log.G(ctx).Warn(err)
+				log.G(ctx).Debug(err)
 				continue
 				// TODO: Config option for fast-fail?
 				// return nil, err

--- a/oci/manager_options.go
+++ b/oci/manager_options.go
@@ -30,7 +30,7 @@ func WithDetectHandler() OCIManagerOption {
 			log.G(ctx).WithFields(logrus.Fields{
 				"addr":      contAddr,
 				"namespace": namespace,
-			}).Debug("using containerd handler")
+			}).Trace("using containerd handler")
 
 			manager.handle = func(ctx context.Context) (context.Context, handler.Handler, error) {
 				return handler.NewContainerdHandler(ctx, contAddr, namespace)
@@ -57,7 +57,7 @@ func WithContainerd(ctx context.Context, addr, namespace string) OCIManagerOptio
 		log.G(ctx).WithFields(logrus.Fields{
 			"addr":      addr,
 			"namespace": namespace,
-		}).Debug("using containerd handler")
+		}).Trace("using containerd handler")
 
 		manager.handle = func(ctx context.Context) (context.Context, handler.Handler, error) {
 			return handler.NewContainerdHandler(ctx, addr, namespace)

--- a/packmanager/umbrella.go
+++ b/packmanager/umbrella.go
@@ -59,7 +59,7 @@ func NewUmbrellaManager(ctx context.Context) (PackageManager, error) {
 		if err != nil {
 			log.G(ctx).
 				WithField("format", format).
-				Warnf("could not initialize package manager: %v", err)
+				Debugf("could not initialize package manager: %v", err)
 			continue
 		}
 


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

This commit downgrades three specific log entries:
* The first is is a warning that occurs when a package manager cannot be instantiated.  This is the most visible message and does not apply to users who are not using containerd or the package management features of KraftKit.  The warning always appears and is now reduced to a debug message;
* The next are messages are a conversion from debug to trace of determination of containerd as the OCI handler, this is more informational and less useful for debugging; and,
* The last is a warning which always occurs because there are specific repositories in the Unikraft OSS project that do not yet have fully populated contents (and therefore cannot be parsed by KraftKit).  Downgrade this log entry to a debug level such that it is still detectable by maintainers.
