### PR TITLE
fix(oci): Fix misuse of well-known path for initramfs file

### DIFF
--- a/oci/pack.go
+++ b/oci/pack.go
@@ -173,7 +173,7 @@ func NewPackageFromTarget(ctx context.Context, targ target.Target, opts ...packm
 			ocispec.MediaTypeImageLayer,
 			popts.Initrd(),
 			WellKnownInitrdPath,
-			WithLayerAnnotation(AnnotationKernelPath, WellKnownKernelPath),
+			WithLayerAnnotation(AnnotationKernelInitrdPath, WellKnownInitrdPath),
 		)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

The well-known constant representing the kernel was used instead of the initramfs.  This PR fixes this misuse. Packages built via OCI with initramfs need to be re-packaged as there will be two kernel listings in the layer manifest.