### PR TITLE
feat: Native ELFLoader support

### DIFF
--- a/api/machine/v1alpha1/machine.zip.go
+++ b/api/machine/v1alpha1/machine.zip.go
@@ -118,6 +118,9 @@ type MachineStatus struct {
 	// The fully-qualified path to the kernel image of the machine instance.
 	KernelPath string `json:"kernelPath,omitempty"`
 
+	// The fully-qualified path to the initramfs file of the machine instance.
+	InitrdPath string `json:"initrdPath,omitempty"`
+
 	// ExitCode is the ...
 	ExitCode int `json:"exitCode,omitempty"`
 

--- a/cmd/kraft/run/run.go
+++ b/cmd/kraft/run/run.go
@@ -115,6 +115,7 @@ type runner interface {
 // controller.
 func runners() []runner {
 	return []runner{
+		&runnerLinuxu{},
 		&runnerKernel{},
 		&runnerProject{},
 		&runnerPackage{},

--- a/cmd/kraft/run/runner_kernel.go
+++ b/cmd/kraft/run/runner_kernel.go
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2022, Unikraft GmbH and The KraftKit Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+package run
+
+import (
+	"context"
+	"debug/elf"
+	"fmt"
+	"path/filepath"
+
+	machineapi "kraftkit.sh/api/machine/v1alpha1"
+	"kraftkit.sh/unikraft"
+)
+
+// runnerKernel is a simple runner used for instantiating a prebuilt Unikraft
+// unikernel which is used in the most verbose usecase.  E.g.:
+//
+//	$ kraft run path/to/kernel_qemu-x86_64
+type runnerKernel struct {
+	kernelPath string
+	args       []string
+}
+
+// String implements Runner.
+func (runner *runnerKernel) String() string {
+	return "kernel"
+}
+
+// Runnable implements Runner.
+func (runner *runnerKernel) Runnable(ctx context.Context, opts *Run, args ...string) (bool, error) {
+	if len(args) == 0 {
+		return false, fmt.Errorf("no arguments supplied")
+	}
+
+	var err error
+	runner.kernelPath, err = filepath.Abs(args[0])
+	if err != nil {
+		return false, err
+	}
+
+	runner.args = args[1:]
+	return unikraft.IsFileUnikraftUnikernel(runner.kernelPath)
+}
+
+// Prepare implements Runner.
+func (runner *runnerKernel) Prepare(ctx context.Context, opts *Run, machine *machineapi.Machine, args ...string) error {
+	filename := filepath.Base(runner.kernelPath)
+	machine.Spec.Platform = opts.platform.String()
+	machine.Spec.Kernel = "kernel://" + filename
+	machine.Status.KernelPath = runner.kernelPath
+
+	// We need to know the architecture pre-emptively, see if we can
+	// "intelligently" guess this by inspecting the ELF binary if the -m|--arch
+	// has not been provided.
+	if opts.Architecture == "" {
+		fe, err := elf.Open(runner.kernelPath)
+		if err != nil {
+			return err
+		}
+
+		defer fe.Close()
+
+		switch fe.Machine {
+		case elf.EM_X86_64, elf.EM_386:
+			machine.Spec.Architecture = "x86_64"
+		case elf.EM_ARM:
+			machine.Spec.Architecture = "arm"
+		case elf.EM_AARCH64:
+			machine.Spec.Architecture = "arm64"
+		default:
+			return fmt.Errorf("unsupported kernel architecture: %v", fe.Machine.String())
+		}
+	} else {
+		machine.Spec.Architecture = opts.Architecture
+	}
+
+	if len(opts.InitRd) > 0 {
+		machine.Status.InitrdPath = opts.InitRd
+	}
+
+	return nil
+}

--- a/cmd/kraft/run/runner_linuxu.go
+++ b/cmd/kraft/run/runner_linuxu.go
@@ -1,0 +1,185 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2022, Unikraft GmbH and The KraftKit Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+package run
+
+import (
+	"context"
+	"debug/elf"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	machineapi "kraftkit.sh/api/machine/v1alpha1"
+	"kraftkit.sh/config"
+	"kraftkit.sh/log"
+	"kraftkit.sh/pack"
+	"kraftkit.sh/tui/paraprogress"
+	"kraftkit.sh/unikraft/elfloader"
+)
+
+// https://github.com/file/file/blob/FILE5_44/src/readelf.h#L543
+const DF_1_PIE elf.DynFlag = 0x08000000 //nolint:stylecheck
+
+// runnerLinuxu is a runner that allows for the instantiation of a Linux
+// Userspace binary in "binary compatibility"-mode which in turn utilizes the
+// Unikraft ELFLoader application to enable its runtime.  The binary (and
+// desired root filesystem) are mounted to this application to enable its
+// runtime.  E.g.:
+//
+//	$ kraft run path/to/bin
+type runnerLinuxu struct {
+	exePath string
+	args    []string
+}
+
+// String implements Runner.
+func (runner *runnerLinuxu) String() string {
+	return "linuxu"
+}
+
+// Runnable implements Runner.
+func (runner *runnerLinuxu) Runnable(ctx context.Context, opts *Run, args ...string) (bool, error) {
+	if len(args) == 0 {
+		return false, fmt.Errorf("no arguments supplied")
+	}
+
+	runner.exePath = args[0]
+	runner.args = args[1:]
+
+	fs, err := os.Stat(runner.exePath)
+	if err != nil {
+		return false, err
+	} else if fs.IsDir() {
+		return false, fmt.Errorf("first positional argument is a directory: %s", runner.exePath)
+	}
+
+	fi, err := os.Open(runner.exePath)
+	if err != nil {
+		return false, fmt.Errorf("opening file %s: %w", runner.exePath, err)
+	}
+
+	defer fi.Close()
+
+	ef, err := elf.NewFile(fi)
+	if err != nil {
+		return false, fmt.Errorf("reading ELF file %s: %w", runner.exePath, err)
+	}
+
+	// Both static and dynamic PIEs have this type.
+	if ef.Type != elf.ET_DYN {
+		return false, fmt.Errorf("ELF file is shared object")
+	}
+
+	// Based on file(1) and elf.(*File).DynString.
+	// https://github.com/file/file/blob/FILE5_44/src/readelf.c#L1141-L1147
+	// https://cs.opensource.google/go/go/+/refs/tags/go1.20.4:src/debug/elf/file.go;l=1602-1643
+	ds := ef.SectionByType(elf.SHT_DYNAMIC)
+	if ds == nil {
+		return false, fmt.Errorf("ELF file has type %s but no dynamic section", ef.Type)
+	}
+
+	d, err := ds.Data()
+	if err != nil {
+		return false, fmt.Errorf("reading ELF section %s of type %s", ds.Name, ds.Type)
+	}
+
+	for len(d) > 0 {
+		var t elf.DynTag
+		var v uint64
+		switch ef.Class {
+		case elf.ELFCLASS32:
+			t = elf.DynTag(ef.ByteOrder.Uint32(d[0:4]))
+			v = uint64(ef.ByteOrder.Uint32(d[4:8]))
+			d = d[8:]
+		case elf.ELFCLASS64:
+			t = elf.DynTag(ef.ByteOrder.Uint64(d[0:8]))
+			v = ef.ByteOrder.Uint64(d[8:16])
+			d = d[16:]
+		}
+		if t == elf.DT_FLAGS_1 && elf.DynFlag(v)&DF_1_PIE != 0 {
+			return true, nil
+		}
+	}
+
+	// Fallback
+	// This logic originates from Debian's hardening-check devscript.
+	// https://salsa.debian.org/debian/devscripts/-/blob/v2.23.3/scripts/hardening-check.pl?ref_type=tags#L293-303
+	for _, p := range ef.Progs {
+		if p.Type == elf.PT_PHDR {
+			return true, nil
+		}
+	}
+
+	return false, fmt.Errorf("file is not ELF executable")
+}
+
+// Prepare implements Runner.
+func (runner *runnerLinuxu) Prepare(ctx context.Context, opts *Run, machine *machineapi.Machine, args ...string) error {
+	loader, err := elfloader.NewELFLoaderFromPrebuilt(ctx, runner.exePath)
+	if err != nil {
+		return err
+	}
+
+	// Create a temporary directory where the image can be stored
+	dir, err := os.MkdirTemp("", "")
+	if err != nil {
+		return err
+	}
+
+	// TODO(nderjung): For now, there is no proper support for using the --initrd
+	// flag since we set Linux userspace application as the initramfs.  In the
+	// future when we have better volume/filesystem support, we can re-think its
+	// use here.
+	if len(opts.InitRd) > 0 {
+		log.G(ctx).Warnf("ignoring --initrd in favour of Linux userspace binary")
+	}
+
+	paramodel, err := paraprogress.NewParaProgress(
+		ctx,
+		[]*paraprogress.Process{paraprogress.NewProcess(
+			fmt.Sprintf("pulling %s", loader.Name()),
+			func(ctx context.Context, w func(progress float64)) error {
+				popts := []pack.PullOption{
+					pack.WithPullWorkdir(dir),
+				}
+				if log.LoggerTypeFromString(config.G[config.KraftKit](ctx).Log.Type) == log.FANCY {
+					popts = append(popts, pack.WithPullProgressFunc(w))
+				}
+
+				return loader.Pull(
+					ctx,
+					popts...,
+				)
+			},
+		)},
+		paraprogress.IsParallel(false),
+		paraprogress.WithRenderer(
+			log.LoggerTypeFromString(config.G[config.KraftKit](ctx).Log.Type) != log.FANCY,
+		),
+		paraprogress.WithFailFast(true),
+	)
+	if err != nil {
+		return err
+	}
+
+	if err := paramodel.Start(); err != nil {
+		return err
+	}
+
+	machine.Spec.Architecture = loader.Architecture().Name()
+	machine.Spec.Platform = loader.Platform().Name()
+	machine.Spec.Kernel = fmt.Sprintf("elfloader://%s:%s", loader.Name(), loader.Version())
+	machine.Spec.ApplicationArgs = append([]string{filepath.Base(runner.exePath)}, runner.args...)
+	machine.Status.InitrdPath = runner.exePath
+
+	// Use the symbolic debuggable kernel image?
+	if opts.WithKernelDbg {
+		machine.Status.KernelPath = loader.KernelDbg()
+	} else {
+		machine.Status.KernelPath = loader.Kernel()
+	}
+
+	return nil
+}

--- a/cmd/kraft/run/runner_package.go
+++ b/cmd/kraft/run/runner_package.go
@@ -34,6 +34,10 @@ type runnerPackage struct {
 
 // String implements Runner.
 func (runner *runnerPackage) String() string {
+	if runner.pm != nil {
+		return runner.pm.Format().String()
+	}
+
 	return "package"
 }
 
@@ -46,7 +50,11 @@ func (runner *runnerPackage) Runnable(ctx context.Context, opts *Run, args ...st
 	runner.packName = args[0]
 	runner.args = args[1:]
 
-	pm, compatible, err := packmanager.G(ctx).IsCompatible(ctx, runner.packName)
+	if runner.pm == nil {
+		runner.pm = packmanager.G(ctx)
+	}
+
+	pm, compatible, err := runner.pm.IsCompatible(ctx, runner.packName)
 	if err == nil && compatible {
 		runner.pm = pm
 		return true, nil

--- a/cmd/kraft/run/runner_package.go
+++ b/cmd/kraft/run/runner_package.go
@@ -1,0 +1,152 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2022, Unikraft GmbH and The KraftKit Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+package run
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	machineapi "kraftkit.sh/api/machine/v1alpha1"
+	"kraftkit.sh/config"
+	"kraftkit.sh/log"
+	"kraftkit.sh/pack"
+	"kraftkit.sh/packmanager"
+	"kraftkit.sh/tui/paraprogress"
+	"kraftkit.sh/unikraft"
+	"kraftkit.sh/unikraft/target"
+)
+
+// runnerPackage is a runner for a package defined through a respective
+// compatible package manager.  Utilizing the PackageManger interface,
+// determination of whether the provided positional argument represents a
+// package.  Typically this is used in the OCI usecase where a compatible image
+// is referenced which contains a pre-built Unikraft unikernel.  E.g.:
+//
+//	$ kraft run unikraft.org/helloworld:latest
+type runnerPackage struct {
+	packName string
+	args     []string
+	pm       packmanager.PackageManager
+}
+
+// String implements Runner.
+func (runner *runnerPackage) String() string {
+	return "package"
+}
+
+// Runnable implements Runner.
+func (runner *runnerPackage) Runnable(ctx context.Context, opts *Run, args ...string) (bool, error) {
+	if len(args) == 0 {
+		return false, fmt.Errorf("no arguments supplied")
+	}
+
+	runner.packName = args[0]
+	runner.args = args[1:]
+
+	pm, compatible, err := packmanager.G(ctx).IsCompatible(ctx, runner.packName)
+	if err == nil && compatible {
+		runner.pm = pm
+		return true, nil
+	} else if err != nil {
+		return false, err
+	}
+
+	return false, nil
+}
+
+// Prepare implements Runner.
+func (runner *runnerPackage) Prepare(ctx context.Context, opts *Run, machine *machineapi.Machine, args ...string) error {
+	// First try the local cache of the catalog
+	packs, err := runner.pm.Catalog(ctx,
+		packmanager.WithTypes(unikraft.ComponentTypeApp),
+		packmanager.WithName(runner.packName),
+		packmanager.WithCache(true),
+	)
+	if err != nil {
+		return err
+	}
+
+	if len(packs) > 1 {
+		return fmt.Errorf("could not determine what to run, too many options")
+	} else if len(packs) == 0 {
+		// Second, try accessing the remote catalog
+		packs, err = runner.pm.Catalog(ctx,
+			packmanager.WithTypes(unikraft.ComponentTypeApp),
+			packmanager.WithName(runner.packName),
+			packmanager.WithCache(false),
+		)
+		if err != nil {
+			return err
+		}
+
+		if len(packs) > 1 {
+			return fmt.Errorf("could not determine what to run, too many options")
+		} else if len(packs) == 0 {
+			return fmt.Errorf("not found: %s", runner.packName)
+		}
+	}
+
+	// Create a temporary directory where the image can be stored
+	dir, err := os.MkdirTemp("", "")
+	if err != nil {
+		return err
+	}
+
+	paramodel, err := paraprogress.NewParaProgress(
+		ctx,
+		[]*paraprogress.Process{paraprogress.NewProcess(
+			fmt.Sprintf("pulling %s", runner.packName),
+			func(ctx context.Context, w func(progress float64)) error {
+				return packs[0].Pull(
+					ctx,
+					pack.WithPullProgressFunc(w),
+					pack.WithPullWorkdir(dir),
+				)
+			},
+		)},
+		paraprogress.IsParallel(false),
+		paraprogress.WithRenderer(
+			log.LoggerTypeFromString(config.G[config.KraftKit](ctx).Log.Type) != log.FANCY,
+		),
+		paraprogress.WithFailFast(true),
+	)
+	if err != nil {
+		return err
+	}
+
+	if err := paramodel.Start(); err != nil {
+		return err
+	}
+
+	// Crucially, the catalog should return an interface that also implements
+	// target.Target.  This demonstrates that the implementing package can
+	// resolve application kernels.
+	targ, ok := packs[0].(target.Target)
+	if !ok {
+		return fmt.Errorf("package does not convert to target")
+	}
+
+	machine.Spec.Architecture = targ.Architecture().Name()
+	machine.Spec.Platform = targ.Platform().Name()
+	machine.Spec.Kernel = fmt.Sprintf("%s://%s", runner.pm.Format(), runner.packName)
+	machine.Spec.ApplicationArgs = runner.args
+
+	// Set the path to the initramfs if present.
+	if opts.InitRd == "" && targ.Initrd() != nil {
+		machine.Status.InitrdPath = targ.Initrd().Output
+	} else if len(opts.InitRd) > 0 {
+		machine.Status.InitrdPath = opts.InitRd
+	}
+
+	// Use the symbolic debuggable kernel image?
+	if opts.WithKernelDbg {
+		machine.Status.KernelPath = targ.KernelDbg()
+	} else {
+		machine.Status.KernelPath = targ.Kernel()
+	}
+
+	return nil
+}

--- a/cmd/kraft/run/runner_project.go
+++ b/cmd/kraft/run/runner_project.go
@@ -1,0 +1,118 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2022, Unikraft GmbH and The KraftKit Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+package run
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	machineapi "kraftkit.sh/api/machine/v1alpha1"
+	"kraftkit.sh/config"
+	"kraftkit.sh/internal/cli"
+	"kraftkit.sh/unikraft/app"
+	"kraftkit.sh/unikraft/target"
+)
+
+// runnerProject is the runner for a path to a project which either uses the
+// only provided target (single) or one specified via the -t|--target flag
+// (multiple), e.g.:
+//
+//	$ kraft run                            // single target in cwd.
+//	$ kraft run path/to/project            // single target at path.
+//	$ kraft run -t target                  // multiple targets in cwd.
+//	$ kraft run -t target path/to/project  // multiple targets at path.
+type runnerProject struct {
+	workdir string
+	args    []string
+}
+
+// String implements Runner.
+func (runner *runnerProject) String() string {
+	return "project"
+}
+
+// Runnable implements Runner.
+func (runner *runnerProject) Runnable(ctx context.Context, opts *Run, args ...string) (bool, error) {
+	var err error
+
+	if len(args) == 0 {
+		runner.workdir, err = os.Getwd()
+		if err != nil {
+			return false, err
+		}
+	} else {
+		runner.workdir = args[0]
+		runner.args = args[1:]
+	}
+
+	if !app.IsWorkdirInitialized(runner.workdir) {
+		return false, fmt.Errorf("path is not project: %s", runner.workdir)
+	}
+
+	return true, nil
+}
+
+// Prepare implements Runner.
+func (runner *runnerProject) Prepare(ctx context.Context, opts *Run, machine *machineapi.Machine, args ...string) error {
+	project, err := app.NewProjectFromOptions(
+		ctx,
+		app.WithProjectWorkdir(runner.workdir),
+		app.WithProjectDefaultKraftfiles(),
+	)
+	if err != nil {
+		return fmt.Errorf("could not instantiate project directory %s: %v", runner.workdir, err)
+	}
+
+	// Filter project targets by any provided CLI options
+	targets := cli.FilterTargets(
+		project.Targets(),
+		opts.Architecture,
+		opts.platform.String(),
+		opts.Target,
+	)
+
+	var t target.Target
+
+	switch {
+	case len(targets) == 0:
+		return fmt.Errorf("could not detect any project targets based on plat=\"%s\" arch=\"%s\"", opts.platform.String(), opts.Architecture)
+
+	case len(targets) == 1:
+		t = targets[0]
+
+	case config.G[config.KraftKit](ctx).NoPrompt && len(targets) > 1:
+		return fmt.Errorf("could not determine what to run based on provided CLI arguments")
+
+	default:
+		t, err = cli.SelectTarget(targets)
+		if err != nil {
+			return fmt.Errorf("could not select target: %v", err)
+		}
+	}
+
+	// Provide a meaningful name
+	targetName := t.Name()
+	if targetName == project.Name() || targetName == "" {
+		targetName = t.Platform().Name() + "-" + t.Architecture().Name()
+	}
+
+	machine.Spec.Kernel = "project://" + project.Name() + ":" + targetName
+	machine.Spec.Architecture = t.Architecture().Name()
+	machine.Spec.Platform = t.Platform().Name()
+
+	// Use the symbolic debuggable kernel image?
+	if opts.WithKernelDbg {
+		machine.Status.KernelPath = t.KernelDbg()
+	} else {
+		machine.Status.KernelPath = t.Kernel()
+	}
+
+	if len(opts.InitRd) > 0 {
+		machine.Status.InitrdPath = opts.InitRd
+	}
+
+	return nil
+}

--- a/cmd/kraft/run/utils.go
+++ b/cmd/kraft/run/utils.go
@@ -1,0 +1,147 @@
+package run
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/containerd/nerdctl/pkg/strutil"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/uuid"
+	machineapi "kraftkit.sh/api/machine/v1alpha1"
+	networkapi "kraftkit.sh/api/network/v1alpha1"
+	"kraftkit.sh/log"
+	machinename "kraftkit.sh/machine/name"
+)
+
+// Are we publishing ports? E.g. -p/--ports=127.0.0.1:80:8080/tcp ...
+func (opts *Run) parsePorts(_ context.Context, machine *machineapi.Machine) error {
+	if len(opts.Ports) == 0 {
+		return nil
+	}
+
+	opts.Ports = strutil.DedupeStrSlice(opts.Ports)
+	for _, port := range opts.Ports {
+		parsed, err := machineapi.ParsePort(port)
+		if err != nil {
+			return err
+		}
+		machine.Spec.Ports = append(machine.Spec.Ports, parsed...)
+	}
+
+	return nil
+}
+
+// Was a network specified? E.g. --network=bridge:kraft0
+func (opts *Run) parseNetworks(ctx context.Context, machine *machineapi.Machine) error {
+	if opts.Network == "" {
+		return nil
+	}
+
+	// Try to discover the user-provided network.
+	found, err := opts.networkController.Get(ctx, &networkapi.Network{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: opts.networkName,
+		},
+	})
+	if err != nil {
+		return err
+	}
+
+	// Generate the UID pre-emptively so that we can uniquely reference the
+	// network interface which will allow us to clean it up later. Additionally,
+	// it's OK if the IP or MAC address are empty, the network controller will
+	// populate values if they are unset and will populate with new values
+	// following the returning from the Update operation.
+	newIface := networkapi.NetworkInterfaceTemplateSpec{
+		ObjectMeta: metav1.ObjectMeta{
+			UID: uuid.NewUUID(),
+		},
+		Spec: networkapi.NetworkInterfaceSpec{
+			IP:         opts.IP,
+			MacAddress: opts.MacAddress,
+		},
+	}
+
+	// Update the list of interfaces
+	if found.Spec.Interfaces == nil {
+		found.Spec.Interfaces = []networkapi.NetworkInterfaceTemplateSpec{}
+	}
+	found.Spec.Interfaces = append(found.Spec.Interfaces, newIface)
+
+	// Update the network with the new interface.
+	found, err = opts.networkController.Update(ctx, found)
+	if err != nil {
+		return err
+	}
+
+	// Only use the single new interface.
+	for _, iface := range found.Spec.Interfaces {
+		if iface.UID == newIface.UID {
+			newIface = iface
+			break
+		}
+	}
+
+	// Set the interface on the machine.
+	found.Spec.Interfaces = []networkapi.NetworkInterfaceTemplateSpec{newIface}
+	machine.Spec.Networks = []networkapi.NetworkSpec{found.Spec}
+
+	// Set up a clean up method to remove the interface if the machine exits and
+	// we are requesting to remove the machine.
+	if opts.Remove && !opts.Detach {
+		defer func() {
+			// Get the latest version of the network.
+			found, err := opts.networkController.Get(ctx, &networkapi.Network{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: opts.networkName,
+				},
+			})
+			if err != nil {
+				log.G(ctx).Errorf("could not get network information for %s: %v", opts.networkName, err)
+				return
+			}
+
+			// Remove the new network interface
+			for i, iface := range found.Spec.Interfaces {
+				if iface.UID == newIface.UID {
+					ret := make([]networkapi.NetworkInterfaceTemplateSpec, 0)
+					ret = append(ret, found.Spec.Interfaces[:i]...)
+					found.Spec.Interfaces = append(ret, found.Spec.Interfaces[i+1:]...)
+					break
+				}
+			}
+
+			if _, err = opts.networkController.Update(ctx, found); err != nil {
+				log.G(ctx).Errorf("could not update network %s: %v", opts.networkName, err)
+				return
+			}
+		}()
+	}
+
+	return nil
+}
+
+// assignName determines the machine instance's name either from a provided
+// argument or randomly generates one.
+func (opts *Run) assignName(ctx context.Context, machine *machineapi.Machine) error {
+	if opts.Name == "" {
+		machine.ObjectMeta.Name = machinename.NewRandomMachineName(0)
+		return nil
+	}
+
+	// Check if this name has been previously used
+	machines, err := opts.machineController.List(ctx, &machineapi.MachineList{})
+	if err != nil {
+		return err
+	}
+
+	for _, found := range machines.Items {
+		if opts.Name == found.Name {
+			return fmt.Errorf("machine instance name already in use: %s", opts.Name)
+		}
+	}
+
+	machine.ObjectMeta.Name = opts.Name
+
+	return nil
+}

--- a/machine/qemu/v1alpha1.go
+++ b/machine/qemu/v1alpha1.go
@@ -163,9 +163,9 @@ func (service *machineV1alpha1Service) Create(ctx context.Context, machine *mach
 	}
 
 	// TODO: Parse Rootfs types
-	if len(machine.Spec.Rootfs) > 0 {
+	if len(machine.Status.InitrdPath) > 0 {
 		qopts = append(qopts,
-			WithInitRd(machine.Spec.Rootfs),
+			WithInitRd(machine.Status.InitrdPath),
 		)
 	}
 

--- a/machine/qemu/v1alpha1.go
+++ b/machine/qemu/v1alpha1.go
@@ -82,12 +82,16 @@ func (service *machineV1alpha1Service) Create(ctx context.Context, machine *mach
 	machine.Status.State = machinev1alpha1.MachineStateUnknown
 
 	if len(machine.Status.StateDir) == 0 {
-		machine.Status.StateDir = config.G[config.KraftKit](ctx).RuntimeDir
+		machine.Status.StateDir = filepath.Join(config.G[config.KraftKit](ctx).RuntimeDir, string(machine.ObjectMeta.UID))
+	}
+
+	if err := os.MkdirAll(machine.Status.StateDir, 0o755); err != nil {
+		return machine, err
 	}
 
 	// Set and create the log file for this machine
 	if len(machine.Status.LogFile) == 0 {
-		machine.Status.LogFile = filepath.Join(machine.Status.StateDir, string(machine.ObjectMeta.UID)+".log")
+		machine.Status.LogFile = filepath.Join(machine.Status.StateDir, "machine.log")
 	}
 
 	if machine.Spec.Resources.Requests.Memory().Value() == 0 {
@@ -114,7 +118,7 @@ func (service *machineV1alpha1Service) Create(ctx context.Context, machine *mach
 		WithDaemonize(true),
 		WithEnableKVM(true),
 		WithNoGraphic(true),
-		WithPidFile(filepath.Join(machine.Status.StateDir, string(machine.ObjectMeta.UID)+".pid")),
+		WithPidFile(filepath.Join(machine.Status.StateDir, "machine.pid")),
 		WithNoReboot(true),
 		WithNoStart(true),
 		WithName(string(machine.ObjectMeta.UID)),
@@ -128,14 +132,14 @@ func (service *machineV1alpha1Service) Create(ctx context.Context, machine *mach
 		// Create a QMP connection solely for manipulating the machine
 		WithQMP(QemuHostCharDevUnix{
 			SocketDir: machine.Status.StateDir,
-			Name:      string(machine.ObjectMeta.UID) + "_control",
+			Name:      "qemu_control",
 			NoWait:    true,
 			Server:    true,
 		}),
 		// Create a QMP connection solely for listening to events
 		WithQMP(QemuHostCharDevUnix{
 			SocketDir: machine.Status.StateDir,
-			Name:      string(machine.ObjectMeta.UID) + "_events",
+			Name:      "qemu_events",
 			NoWait:    true,
 			Server:    true,
 		}),
@@ -145,7 +149,7 @@ func (service *machineV1alpha1Service) Create(ctx context.Context, machine *mach
 		}),
 		WithMonitor(QemuHostCharDevUnix{
 			SocketDir: machine.Status.StateDir,
-			Name:      string(machine.ObjectMeta.UID) + "_mon",
+			Name:      "qemu_mon",
 			NoWait:    true,
 			Server:    true,
 		}),

--- a/manifest/init.go
+++ b/manifest/init.go
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2022, Unikraft GmbH and The KraftKit Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+package manifest
+
+import (
+	"kraftkit.sh/cmdfactory"
+	"kraftkit.sh/packmanager"
+	// "kraftkit.sh/packmanager"
+)
+
+// useGit is a local variable used within the context of the manifest package
+// and is dynamically injected as a CLI option.
+var useGit = false
+
+// FIXME(antoineco): avoid init, initialize things where needed
+func init() {
+	// Register a new pack.Package type
+	_ = packmanager.RegisterPackageManager(ManifestFormat, NewManifestManager)
+
+	// Register additional command-line flags
+	cmdfactory.RegisterFlag(
+		"kraft pkg pull",
+		cmdfactory.BoolVarP(
+			&useGit,
+			"git", "g",
+			false,
+			"Use Git when pulling sources",
+		),
+	)
+}

--- a/manifest/manager.go
+++ b/manifest/manager.go
@@ -162,6 +162,11 @@ func (m *manifestManager) Update(ctx context.Context) error {
 	return localIndex.WriteToFile(m.LocalManifestIndex(ctx))
 }
 
+func (m *manifestManager) SetSources(_ context.Context, sources ...string) error {
+	m.manifests = sources
+	return nil
+}
+
 func (m *manifestManager) AddSource(ctx context.Context, source string) error {
 	if m.manifests == nil {
 		m.manifests = make([]string, 0)

--- a/manifest/manager.go
+++ b/manifest/manager.go
@@ -16,7 +16,6 @@ import (
 	"github.com/gobwas/glob"
 	"github.com/sirupsen/logrus"
 
-	"kraftkit.sh/cmdfactory"
 	"kraftkit.sh/config"
 	"kraftkit.sh/log"
 	"kraftkit.sh/pack"
@@ -27,27 +26,6 @@ import (
 
 type manifestManager struct {
 	manifests []string
-}
-
-// useGit is a local variable used within the context of the manifest package
-// and is dynamically injected as a CLI option.
-var useGit = false
-
-// FIXME(antoineco): avoid init, initialize things where needed
-func init() {
-	// Register a new pack.Package type
-	_ = packmanager.RegisterPackageManager(ManifestFormat, NewManifestManager)
-
-	// Register additional command-line flags
-	cmdfactory.RegisterFlag(
-		"kraft pkg pull",
-		cmdfactory.BoolVarP(
-			&useGit,
-			"git", "g",
-			false,
-			"Use Git when pulling sources",
-		),
-	)
 }
 
 // NewManifestManager returns a `packmanager.PackageManager` which manipulates

--- a/manifest/manager.go
+++ b/manifest/manager.go
@@ -64,11 +64,11 @@ func NewManifestManager(ctx context.Context, opts ...any) (packmanager.PackageMa
 		}
 	}
 
-	return manager, nil
+	return &manager, nil
 }
 
 // update retrieves and returns a cache of the upstream manifest registry
-func (m manifestManager) update(ctx context.Context) (*ManifestIndex, error) {
+func (m *manifestManager) update(ctx context.Context) (*ManifestIndex, error) {
 	if len(config.G[config.KraftKit](ctx).Unikraft.Manifests) == 0 {
 		return nil, fmt.Errorf("no manifests specified in config")
 	}
@@ -107,7 +107,7 @@ func (m manifestManager) update(ctx context.Context) (*ManifestIndex, error) {
 	return localIndex, nil
 }
 
-func (m manifestManager) Update(ctx context.Context) error {
+func (m *manifestManager) Update(ctx context.Context) error {
 	// Create parent directories if not present
 	if err := os.MkdirAll(filepath.Dir(m.LocalManifestIndex(ctx)), 0o771); err != nil {
 		return err
@@ -153,7 +153,7 @@ func (m manifestManager) Update(ctx context.Context) error {
 	return localIndex.WriteToFile(m.LocalManifestIndex(ctx))
 }
 
-func (m manifestManager) AddSource(ctx context.Context, source string) error {
+func (m *manifestManager) AddSource(ctx context.Context, source string) error {
 	for _, manifest := range config.G[config.KraftKit](ctx).Unikraft.Manifests {
 		if source == manifest {
 			log.G(ctx).Warnf("manifest already saved: %s", source)
@@ -169,7 +169,7 @@ func (m manifestManager) AddSource(ctx context.Context, source string) error {
 	return config.M[config.KraftKit](ctx).Write(true)
 }
 
-func (m manifestManager) RemoveSource(ctx context.Context, source string) error {
+func (m *manifestManager) RemoveSource(ctx context.Context, source string) error {
 	manifests := []string{}
 
 	for _, manifest := range config.G[config.KraftKit](ctx).Unikraft.Manifests {
@@ -183,19 +183,19 @@ func (m manifestManager) RemoveSource(ctx context.Context, source string) error 
 	return config.M[config.KraftKit](ctx).Write(false)
 }
 
-func (m manifestManager) Pack(ctx context.Context, c component.Component, opts ...packmanager.PackOption) ([]pack.Package, error) {
+func (m *manifestManager) Pack(ctx context.Context, c component.Component, opts ...packmanager.PackOption) ([]pack.Package, error) {
 	return nil, fmt.Errorf("not implemented manifest.manager.Pack")
 }
 
-func (m manifestManager) Unpack(ctx context.Context, p pack.Package, opts ...packmanager.UnpackOption) ([]component.Component, error) {
+func (m *manifestManager) Unpack(ctx context.Context, p pack.Package, opts ...packmanager.UnpackOption) ([]component.Component, error) {
 	return nil, fmt.Errorf("not implemented manifest.manager.Unpack")
 }
 
-func (m manifestManager) From(sub pack.PackageFormat) (packmanager.PackageManager, error) {
+func (m *manifestManager) From(sub pack.PackageFormat) (packmanager.PackageManager, error) {
 	return nil, fmt.Errorf("method not applicable to manifest manager")
 }
 
-func (m manifestManager) Catalog(ctx context.Context, qopts ...packmanager.QueryOption) ([]pack.Package, error) {
+func (m *manifestManager) Catalog(ctx context.Context, qopts ...packmanager.QueryOption) ([]pack.Package, error) {
 	var err error
 	var index *ManifestIndex
 	var allManifests []*Manifest
@@ -375,7 +375,7 @@ func (m manifestManager) Catalog(ctx context.Context, qopts ...packmanager.Query
 	return packages, nil
 }
 
-func (m manifestManager) IsCompatible(ctx context.Context, source string, qopts ...packmanager.QueryOption) (packmanager.PackageManager, bool, error) {
+func (m *manifestManager) IsCompatible(ctx context.Context, source string, qopts ...packmanager.QueryOption) (packmanager.PackageManager, bool, error) {
 	log.G(ctx).WithFields(logrus.Fields{
 		"source": source,
 	}).Debug("checking if source is compatible with the manifest manager")
@@ -392,7 +392,7 @@ func (m manifestManager) IsCompatible(ctx context.Context, source string, qopts 
 }
 
 // LocalManifestDir returns the user configured path to all the manifests
-func (m manifestManager) LocalManifestsDir(ctx context.Context) string {
+func (m *manifestManager) LocalManifestsDir(ctx context.Context) string {
 	if len(config.G[config.KraftKit](ctx).Paths.Manifests) > 0 {
 		return config.G[config.KraftKit](ctx).Paths.Manifests
 	}
@@ -401,10 +401,10 @@ func (m manifestManager) LocalManifestsDir(ctx context.Context) string {
 }
 
 // LocalManifestIndex returns the user configured path to the manifest index
-func (m manifestManager) LocalManifestIndex(ctx context.Context) string {
+func (m *manifestManager) LocalManifestIndex(ctx context.Context) string {
 	return filepath.Join(m.LocalManifestsDir(ctx), "index.yaml")
 }
 
-func (m manifestManager) Format() pack.PackageFormat {
+func (m *manifestManager) Format() pack.PackageFormat {
 	return ManifestFormat
 }

--- a/oci/init.go
+++ b/oci/init.go
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2022, Unikraft GmbH and The KraftKit Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+package oci
+
+import (
+	"kraftkit.sh/cmdfactory"
+	"kraftkit.sh/packmanager"
+)
+
+// FIXME(antoineco): avoid init, initialize things where needed
+func init() {
+	// Register a new pkg.Package type
+	_ = packmanager.RegisterPackageManager(
+		OCIFormat,
+		NewOCIManager,
+		WithDefaultAuth(),
+		WithDefaultRegistries(),
+		WithDetectHandler(),
+	)
+
+	// Register additional command-line flags
+	cmdfactory.RegisterFlag(
+		"kraft pkg",
+		cmdfactory.StringVar(
+			&flagTag,
+			"oci-tag",
+			"",
+			"Set the OCI image tag.",
+		),
+	)
+	cmdfactory.RegisterFlag(
+		"kraft pkg",
+		cmdfactory.BoolVar(
+			&flagUseMediaTypes,
+			"oci-use-media-types",
+			false,
+			"Use media types as opposed to well-known paths (experimental).",
+		),
+	)
+}

--- a/oci/manager.go
+++ b/oci/manager.go
@@ -292,6 +292,12 @@ func (manager *ociManager) Catalog(ctx context.Context, qopts ...packmanager.Que
 	return packs, nil
 }
 
+// SetSources implements packmanager.PackageManager
+func (manager *ociManager) SetSources(_ context.Context, sources ...string) error {
+	manager.registries = sources
+	return nil
+}
+
 // AddSource implements packmanager.PackageManager
 func (manager *ociManager) AddSource(ctx context.Context, source string) error {
 	if manager.registries == nil {

--- a/oci/manager.go
+++ b/oci/manager.go
@@ -62,12 +62,12 @@ func NewOCIManager(ctx context.Context, opts ...any) (packmanager.PackageManager
 }
 
 // Update implements packmanager.PackageManager
-func (manager ociManager) Update(ctx context.Context) error {
+func (manager *ociManager) Update(ctx context.Context) error {
 	return nil
 }
 
 // Pack implements packmanager.PackageManager
-func (manager ociManager) Pack(ctx context.Context, entity component.Component, opts ...packmanager.PackOption) ([]pack.Package, error) {
+func (manager *ociManager) Pack(ctx context.Context, entity component.Component, opts ...packmanager.PackOption) ([]pack.Package, error) {
 	targ, ok := entity.(target.Target)
 	if !ok {
 		return nil, fmt.Errorf("entity is not Unikraft target")
@@ -82,13 +82,13 @@ func (manager ociManager) Pack(ctx context.Context, entity component.Component, 
 }
 
 // Unpack implements packmanager.PackageManager
-func (manager ociManager) Unpack(ctx context.Context, entity pack.Package, opts ...packmanager.UnpackOption) ([]component.Component, error) {
+func (manager *ociManager) Unpack(ctx context.Context, entity pack.Package, opts ...packmanager.UnpackOption) ([]component.Component, error) {
 	return nil, fmt.Errorf("not implemented: oci.manager.Unpack")
 }
 
 // registry is a wrapper method for authenticating and listing OCI repositories
 // from a provided domain representing a registry.
-func (manager ociManager) registry(ctx context.Context, domain string) (*regtool.Registry, error) {
+func (manager *ociManager) registry(ctx context.Context, domain string) (*regtool.Registry, error) {
 	var err error
 	var auth regtypes.AuthConfig
 
@@ -120,7 +120,7 @@ func (manager ociManager) registry(ctx context.Context, domain string) (*regtool
 }
 
 // Catalog implements packmanager.PackageManager
-func (manager ociManager) Catalog(ctx context.Context, qopts ...packmanager.QueryOption) ([]pack.Package, error) {
+func (manager *ociManager) Catalog(ctx context.Context, qopts ...packmanager.QueryOption) ([]pack.Package, error) {
 	var packs []pack.Package
 	query := packmanager.NewQuery(qopts...)
 	qname := query.Name()
@@ -295,7 +295,7 @@ func (manager ociManager) Catalog(ctx context.Context, qopts ...packmanager.Quer
 }
 
 // AddSource implements packmanager.PackageManager
-func (manager ociManager) AddSource(ctx context.Context, source string) error {
+func (manager *ociManager) AddSource(ctx context.Context, source string) error {
 	for _, manifest := range config.G[config.KraftKit](ctx).Unikraft.Manifests {
 		if source == manifest {
 			log.G(ctx).Warnf("manifest already saved: %s", source)
@@ -312,7 +312,7 @@ func (manager ociManager) AddSource(ctx context.Context, source string) error {
 }
 
 // RemoveSource implements packmanager.PackageManager
-func (manager ociManager) RemoveSource(ctx context.Context, source string) error {
+func (manager *ociManager) RemoveSource(ctx context.Context, source string) error {
 	manifests := []string{}
 
 	for _, manifest := range config.G[config.KraftKit](ctx).Unikraft.Manifests {
@@ -327,7 +327,7 @@ func (manager ociManager) RemoveSource(ctx context.Context, source string) error
 }
 
 // IsCompatible implements packmanager.PackageManager
-func (manager ociManager) IsCompatible(ctx context.Context, source string, qopts ...packmanager.QueryOption) (packmanager.PackageManager, bool, error) {
+func (manager *ociManager) IsCompatible(ctx context.Context, source string, qopts ...packmanager.QueryOption) (packmanager.PackageManager, bool, error) {
 	log.G(ctx).
 		WithField("source", source).
 		Debug("checking if source is an oci unikernel")
@@ -416,11 +416,11 @@ func (manager ociManager) IsCompatible(ctx context.Context, source string, qopts
 }
 
 // From implements packmanager.PackageManager
-func (manager ociManager) From(pack.PackageFormat) (packmanager.PackageManager, error) {
+func (manager *ociManager) From(pack.PackageFormat) (packmanager.PackageManager, error) {
 	return nil, fmt.Errorf("not possible: oci.manager.From")
 }
 
 // Format implements packmanager.PackageManager
-func (manager ociManager) Format() pack.PackageFormat {
+func (manager *ociManager) Format() pack.PackageFormat {
 	return OCIFormat
 }

--- a/oci/manager.go
+++ b/oci/manager.go
@@ -58,13 +58,6 @@ func NewOCIManager(ctx context.Context, opts ...any) (packmanager.PackageManager
 		return nil, fmt.Errorf("cannot instantiate OCI Manager without handler")
 	}
 
-	// Populate the internal list of manifests with locally saved manifests
-	for _, registry := range config.G[config.KraftKit](ctx).Unikraft.Manifests {
-		if _, compatible, _ := manager.IsCompatible(ctx, registry); compatible {
-			manager.registries = append(manager.registries, registry)
-		}
-	}
-
 	return &manager, nil
 }
 

--- a/oci/oci.go
+++ b/oci/oci.go
@@ -4,11 +4,6 @@
 // You may not use this file except in compliance with the License.
 package oci
 
-import (
-	"kraftkit.sh/cmdfactory"
-	"kraftkit.sh/packmanager"
-)
-
 var (
 	flagTag           string
 	flagUseMediaTypes bool
@@ -18,35 +13,3 @@ const (
 	DefaultRegistry  = "unikraft.org"
 	DefaultNamespace = "default"
 )
-
-// FIXME(antoineco): avoid init, initialize things where needed
-func init() {
-	// Register a new pkg.Package type
-	_ = packmanager.RegisterPackageManager(
-		OCIFormat,
-		NewOCIManager,
-		WithDefaultAuth(),
-		WithDefaultRegistries(),
-		WithDetectHandler(),
-	)
-
-	// Register additional command-line flags
-	cmdfactory.RegisterFlag(
-		"kraft pkg",
-		cmdfactory.StringVar(
-			&flagTag,
-			"oci-tag",
-			"",
-			"Set the OCI image tag.",
-		),
-	)
-	cmdfactory.RegisterFlag(
-		"kraft pkg",
-		cmdfactory.BoolVar(
-			&flagUseMediaTypes,
-			"oci-use-media-types",
-			false,
-			"Use media types as opposed to well-known paths (experimental).",
-		),
-	)
-}

--- a/oci/pack.go
+++ b/oci/pack.go
@@ -379,7 +379,7 @@ func (ocipack *ociPackage) imageRef() string {
 
 // Metadata implements pack.Package
 func (ocipack *ociPackage) Metadata() any {
-	return nil
+	return ocipack.image.manifest
 }
 
 // Push implements pack.Package

--- a/packmanager/manager.go
+++ b/packmanager/manager.go
@@ -36,6 +36,9 @@ type PackageManager interface {
 	// Catalog returns all packages known to the manager via given query
 	Catalog(context.Context, ...QueryOption) ([]pack.Package, error)
 
+	// Set the list of sources for the package manager
+	SetSources(context.Context, ...string) error
+
 	// Add a source to the package manager
 	AddSource(context.Context, string) error
 

--- a/packmanager/umbrella.go
+++ b/packmanager/umbrella.go
@@ -97,6 +97,17 @@ func (u umbrella) Update(ctx context.Context) error {
 	return nil
 }
 
+func (u umbrella) SetSources(ctx context.Context, sources ...string) error {
+	for _, manager := range packageManagers {
+		err := manager.SetSources(ctx, sources...)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
 func (u umbrella) AddSource(ctx context.Context, source string) error {
 	for _, manager := range packageManagers {
 		log.G(ctx).WithFields(logrus.Fields{

--- a/unikraft/component/component.go
+++ b/unikraft/component/component.go
@@ -109,7 +109,7 @@ func parseStringProp(entry string) map[string]interface{} {
 			component["version"] = v
 		}
 
-	} else if u, err := url.Parse("https://" + entry); err == nil && u.Host != "" {
+	} else if u, err := url.Parse(entry); err == nil && u.Host != "" {
 		component["source"] = entry
 
 		if v := urlHasVersion(u); len(v) > 0 {

--- a/unikraft/elfloader/elfloader.go
+++ b/unikraft/elfloader/elfloader.go
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2022, Unikraft GmbH and The KraftKit Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+package elfloader
+
+import (
+	"kraftkit.sh/pack"
+	"kraftkit.sh/packmanager"
+	"kraftkit.sh/unikraft"
+)
+
+type ELFLoader struct {
+	registry packmanager.PackageManager
+	kernel   string
+	pack     pack.Package
+}
+
+var _ unikraft.Nameable = (*ELFLoader)(nil)
+
+// Type implements kraftkit.sh/unikraft.Nameable
+func (ocipack *ELFLoader) Type() unikraft.ComponentType {
+	return unikraft.ComponentTypeApp
+}
+
+// Name implements kraftkit.sh/unikraft.Nameable
+func (ocipack *ELFLoader) Name() string {
+	return ocipack.pack.Name()
+}
+
+// Version implements kraftkit.sh/unikraft.Nameable
+func (ocipack *ELFLoader) Version() string {
+	return ocipack.pack.Version()
+}

--- a/unikraft/elfloader/elfloader_pack.go
+++ b/unikraft/elfloader/elfloader_pack.go
@@ -38,6 +38,17 @@ func NewELFLoaderFromPrebuilt(ctx context.Context, linuxu string, pbopts ...ELFL
 		}
 	}
 
+	if defaultPrebuilt != "" {
+		// Return early if the user provided a custom elfloader unikernel
+		// application.
+		if ok, _ := unikraft.IsFileUnikraftUnikernel(defaultPrebuilt); ok {
+			elfloader.kernel = defaultPrebuilt
+			return &elfloader, nil
+		}
+	} else {
+		defaultPrebuilt = DefaultPrebuilt
+	}
+
 	var err error
 	elfloader.registry = packmanager.G(ctx)
 	if elfloader.registry == nil {

--- a/unikraft/elfloader/elfloader_pack.go
+++ b/unikraft/elfloader/elfloader_pack.go
@@ -1,0 +1,147 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2022, Unikraft GmbH and The KraftKit Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+package elfloader
+
+import (
+	"context"
+	"fmt"
+
+	"kraftkit.sh/initrd"
+	"kraftkit.sh/oci"
+	"kraftkit.sh/pack"
+	"kraftkit.sh/packmanager"
+	"kraftkit.sh/unikraft"
+	"kraftkit.sh/unikraft/arch"
+	"kraftkit.sh/unikraft/plat"
+	"kraftkit.sh/unikraft/target"
+)
+
+var _ pack.Package = (*ELFLoader)(nil)
+
+const (
+	PrebuiltRegistry = "loaders.unikraft.org"
+	DefaultPrebuilt  = "loaders.unikraft.org/default:latest"
+)
+
+// ELFLoaderPrebuiltOption ...
+type ELFLoaderPrebuiltOption func(*ELFLoader) error
+
+// NewELFLoaderFromPrebuilt ...
+func NewELFLoaderFromPrebuilt(ctx context.Context, linuxu string, pbopts ...ELFLoaderPrebuiltOption) (*ELFLoader, error) {
+	elfloader := ELFLoader{}
+
+	for _, opt := range pbopts {
+		if err := opt(&elfloader); err != nil {
+			return nil, err
+		}
+	}
+
+	var err error
+	elfloader.registry = packmanager.G(ctx)
+	if elfloader.registry == nil {
+		elfloader.registry, err = oci.NewOCIManager(ctx,
+			oci.WithDetectHandler(),
+		)
+	} else {
+		elfloader.registry, err = elfloader.registry.From(oci.OCIFormat)
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	if err := elfloader.registry.SetSources(ctx, PrebuiltRegistry); err != nil {
+		return nil, err
+	}
+
+	// First try locally
+	results, err := elfloader.registry.Catalog(ctx,
+		packmanager.WithName(defaultPrebuilt),
+		packmanager.WithTypes(unikraft.ComponentTypeApp),
+		packmanager.WithCache(true),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(results) == 0 {
+		results, err = elfloader.registry.Catalog(ctx,
+			packmanager.WithName(defaultPrebuilt),
+			packmanager.WithTypes(unikraft.ComponentTypeApp),
+			packmanager.WithCache(false),
+		)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if len(results) == 0 {
+		return nil, fmt.Errorf("could not find elfloader")
+	} else if len(results) > 1 {
+		options := make([]string, len(results))
+		for i, result := range results {
+			options[i] = result.Name()
+		}
+		return nil, fmt.Errorf("too many options: %v", options)
+	}
+
+	elfloader.pack = results[0]
+
+	return &elfloader, nil
+}
+
+// Metadata implements kraftkit.sh/pack.Package
+func (elfloader *ELFLoader) Metadata() any {
+	return elfloader.pack.Metadata()
+}
+
+// Push implements kraftkit.sh/pack.Package
+func (elfloader *ELFLoader) Push(ctx context.Context, opts ...pack.PushOption) error {
+	panic("not implemented: kraftkit.sh/unikraft/elfloader.ELFLoader.Push")
+}
+
+// Pull implements kraftkit.sh/pack.Package
+func (elfloader *ELFLoader) Pull(ctx context.Context, opts ...pack.PullOption) error {
+	return elfloader.pack.Pull(ctx, opts...)
+}
+
+// Format implements kraftkit.sh/unikraft.component.Component
+func (elfloader *ELFLoader) Format() pack.PackageFormat {
+	return elfloader.pack.Format()
+}
+
+// Architecture implements kraftkit.sh/unikraft.target.Target
+func (elfloader *ELFLoader) Architecture() arch.Architecture {
+	return elfloader.pack.(target.Target).Architecture()
+}
+
+// Platform implements kraftkit.sh/unikraft.target.Target
+func (elfloader *ELFLoader) Platform() plat.Platform {
+	return elfloader.pack.(target.Target).Platform()
+}
+
+// Kernel implements kraftkit.sh/unikraft.target.Target
+func (elfloader *ELFLoader) Kernel() string {
+	return elfloader.pack.(target.Target).Kernel()
+}
+
+// KernelDbg implements kraftkit.sh/unikraft.target.Target
+func (elfloader *ELFLoader) KernelDbg() string {
+	return elfloader.pack.(target.Target).KernelDbg()
+}
+
+// Initrd implements kraftkit.sh/unikraft.target.Target
+func (elfloader *ELFLoader) Initrd() *initrd.InitrdConfig {
+	return elfloader.pack.(target.Target).Initrd()
+}
+
+// Command implements kraftkit.sh/unikraft.target.Target
+func (elfloader *ELFLoader) Command() []string {
+	return elfloader.pack.(target.Target).Command()
+}
+
+// ConfigFilename implements kraftkit.sh/unikraft.target.Target
+func (elfloader *ELFLoader) ConfigFilename() string {
+	return elfloader.pack.(target.Target).ConfigFilename()
+}

--- a/unikraft/elfloader/init.go
+++ b/unikraft/elfloader/init.go
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2022, Unikraft GmbH and The KraftKit Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+package elfloader
+
+import "kraftkit.sh/cmdfactory"
+
+var defaultPrebuilt string
+
+func init() {
+	// Register additional command-line arguments
+	cmdfactory.RegisterFlag(
+		"kraft run",
+		cmdfactory.StringVar(
+			&defaultPrebuilt,
+			"elfloader",
+			defaultPrebuilt,
+			"Set the path to an alternative ELF loader unikernel.",
+		),
+	)
+}

--- a/unikraft/utils.go
+++ b/unikraft/utils.go
@@ -1,0 +1,48 @@
+package unikraft
+
+import (
+	"debug/elf"
+	"fmt"
+	"os"
+
+	"kraftkit.sh/internal/set"
+)
+
+// IsFileUnikraftUnikernel is a utility method that determines whether the
+// provided input file is a Unikraft unikernel.  The file is checked with a
+// number of known facts about the kernel image built with Unikraft.
+func IsFileUnikraftUnikernel(path string) (bool, error) {
+	fs, err := os.Stat(path)
+	if err != nil {
+		return false, err
+	} else if fs.IsDir() {
+		return false, fmt.Errorf("first positional argument is a directory: %v", path)
+	}
+
+	// Sanity check whether the provided file is an ELF kernel with
+	// Unikraft-centric properties.  This check might not always work, especially
+	// if the version changes and the sections change name.
+	//
+	// TODO(nderjung): This check should be replaced with a more stable mechanism
+	// that detects whether a bootflag is set. See[0].
+	// [0]: https://github.com/unikraft/unikraft/pull/
+	fe, err := elf.Open(path)
+	if err != nil {
+		return false, err
+	}
+
+	defer fe.Close()
+
+	knownUnikraftSections := set.NewStringSet(
+		".uk_inittab",
+		".uk_ctortab",
+		".uk_thread_inittab",
+	)
+	for _, symbol := range fe.Sections {
+		if knownUnikraftSections.Contains(symbol.Name) {
+			return true, nil
+		}
+	}
+
+	return false, fmt.Errorf("provided file is not a Unikraft unikernel")
+}

--- a/unikraft/utils.go
+++ b/unikraft/utils.go
@@ -39,7 +39,7 @@ func IsFileUnikraftUnikernel(path string) (bool, error) {
 		".uk_thread_inittab",
 	)
 	for _, symbol := range fe.Sections {
-		if knownUnikraftSections.Contains(symbol.Name) {
+		if knownUnikraftSections.ContainsExactly(symbol.Name) {
 			return true, nil
 		}
 	}


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

This PR introduces native [ELFLoader](https://github.com/unikraft/app-elfloader) support into KraftKit which in turn enables running arbitrary statically linked Linux Userspace binaries via the `kraft run` subcommand.

To accomplish this, a number of changes were necessary which are incorporated in this PR:

- The OCI PackageManager was reworked slightly to accommodate for use of ephemeral registries so as to fetch sources from the new ELFLoader registry which is held at `loaders.unikraft.org`;
- Accommodation for the initram filesystem in the Machine Interface was adjusted in the status so that the interpration of the Linux Userspace binary can be delivered to the ELFLoader unikernel application;
- The `kraft run` subcommand was adjusted to accommodate for both determining and preparing the Machine Interface for instantiation based on different input positional arguments. By consequence, four entrypoints are now are possible:
  
| Runner | Purpose |
|-|-|
| `linuxu` | Determination of a Linux Userspace binary and actualization of the ELFLoader unikernel application (new) |
| `kernel` | Determination of a Unikraft kernel and instantiation of the unikernel (existing) |
| `project` | Determination of the positional argument (or therelackof and thus the current working directory) representing a project directory, one which contains a `kraft.yaml`/`Kraftfile` such that the user simply can run `kraft run` to instantiate their current unikernel (existing) |
| `package` | Determination of the positional argument representing a package such that the user can retrieve and instantiate a unikernel via the compatible package manager |

At a high-level, the user simply needs to provide a positional argument of a Linux userspace application to realise the functionality provided in this PR, for example:

```bash
git clone https://github.com/unikraft/app-elfloader.git;
cd app-elfloader/examples/helloworld;
make;
kraft run helloworld_static;
```