### PR TITLE
refactor(list): Make `ls` the main entrypoint

### DIFF
--- a/cmd/kraft/pkg/list/list.go
+++ b/cmd/kraft/pkg/list/list.go
@@ -36,8 +36,8 @@ type List struct {
 func New() *cobra.Command {
 	cmd, err := cmdfactory.New(&List{}, cobra.Command{
 		Short:   "List installed Unikraft component packages",
-		Use:     "list [FLAGS] [DIR]",
-		Aliases: []string{"l", "ls"},
+		Use:     "ls [FLAGS] [DIR]",
+		Aliases: []string{"l", "list"},
 		Args:    cmdfactory.MaxDirArgs(1),
 		Long: heredoc.Doc(`
 			List installed Unikraft component packages.


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

To keep things consistent with other listing methods in KraftKit, rename the default subcommand and use `list` and an alias.