### PR TITLE
refactor(unikraft): Migrate default build directory to `.unikraft/build`

### DIFF
--- a/unikraft/app/loader.go
+++ b/unikraft/app/loader.go
@@ -25,10 +25,10 @@ import (
 	interp "github.com/compose-spec/compose-go/interpolation"
 	"github.com/pkg/errors"
 	"gopkg.in/yaml.v2"
+	"kraftkit.sh/unikraft"
 )
 
 const (
-	DefaultOutputDir  = "build"
 	DefaultConfigFile = ".config"
 )
 
@@ -46,7 +46,7 @@ func NewApplicationFromInterface(ctx context.Context, iface map[string]interface
 	app.name = name
 	app.path = popts.workdir
 
-	outdir := DefaultOutputDir
+	outdir := unikraft.BuildDir
 	if n, ok := iface["outdir"]; ok {
 		outdir, ok = n.(string)
 		if !ok {

--- a/unikraft/app/project.go
+++ b/unikraft/app/project.go
@@ -74,7 +74,7 @@ func NewProjectFromOptions(ctx context.Context, opts ...ProjectOption) (Applicat
 	var all []*application
 
 	name, _ := popts.GetProjectName()
-	outdir := DefaultOutputDir
+	outdir := unikraft.BuildDir
 
 	for i, file := range popts.kraftfiles {
 		iface := file.config

--- a/unikraft/unikraft.go
+++ b/unikraft/unikraft.go
@@ -33,5 +33,5 @@ const (
 
 	// Built-in paths
 	VendorDir = ".unikraft"
-	BuildDir  = "build"
+	BuildDir  = ".unikraft/build"
 )


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

To keep the project directory cleaner and unikraft-specific elements within a contained space, this commit migrates the default build directory from `build/` to `.unikraft/build/`.  Since the normal `build/` directory is not hidden, it also risks a collision with a user-provided directory of the same name whereas the hidden directory `.unikraft` is less likely to have a collision.
