### PR TITLE
fix(manifest): Better handling of Git and GitHub artifacts

### DIFF
--- a/manifest/directory.go
+++ b/manifest/directory.go
@@ -26,7 +26,7 @@ type DirectoryProvider struct {
 
 // NewDirectoryProvider attempts to parse a provided path as a Unikraft
 // "microlibirary" directory
-func NewDirectoryProvider(ctx context.Context, path string, opts ...ManifestOption) (Provider, error) {
+func NewDirectoryProvider(ctx context.Context, path, _ string, opts ...ManifestOption) (Provider, error) {
 	if f, err := os.Stat(path); err != nil || (err == nil && !f.IsDir()) {
 		return nil, fmt.Errorf("could not access directory '%s': %v", path, err)
 	}
@@ -68,7 +68,7 @@ func NewDirectoryProvider(ctx context.Context, path string, opts ...ManifestOpti
 	return &provider, nil
 }
 
-func (dp DirectoryProvider) Manifests() ([]*Manifest, error) {
+func (dp DirectoryProvider) Manifests(_ context.Context) ([]*Manifest, error) {
 	manifest := &Manifest{
 		Type:     dp.typ,
 		Name:     dp.name,

--- a/manifest/git.go
+++ b/manifest/git.go
@@ -32,7 +32,7 @@ type GitProvider struct {
 }
 
 // NewGitProvider attempts to parse a provided path as a Git repository
-func NewGitProvider(ctx context.Context, path string, opts ...ManifestOption) (Provider, error) {
+func NewGitProvider(ctx context.Context, path, _ string, opts ...ManifestOption) (Provider, error) {
 	isSSH := false
 	fullpath := path
 	if isSSHURL(path) {
@@ -183,7 +183,7 @@ func (gp GitProvider) probeVersions() []ManifestVersion {
 	return versions
 }
 
-func (gp GitProvider) Manifests() ([]*Manifest, error) {
+func (gp GitProvider) Manifests(_ context.Context) ([]*Manifest, error) {
 	base := filepath.Base(gp.repo)
 	ext := filepath.Ext(gp.repo)
 	if len(ext) > 0 {
@@ -206,6 +206,7 @@ func (gp GitProvider) Manifests() ([]*Manifest, error) {
 
 	manifest.Channels = append(manifest.Channels, gp.probeChannels()...)
 	manifest.Versions = append(manifest.Versions, gp.probeVersions()...)
+	manifest.mopts = gp.mopts
 
 	// TODO: Set the latest version
 	// if len(manifest.Versions) > 0 {

--- a/manifest/github.go
+++ b/manifest/github.go
@@ -43,6 +43,10 @@ type GitHubProvider struct {
 func NewGitHubProvider(ctx context.Context, path string, opts ...ManifestOption) (Provider, error) {
 	var branch string
 
+	if u, err := url.Parse(path); err != nil || u.Host != "github.com" {
+		return nil, fmt.Errorf("provided path does not originate from GitHub: %s", path)
+	}
+
 	repo, err := ghrepo.NewFromURL(path)
 	if err != nil {
 		return nil, err

--- a/manifest/index.go
+++ b/manifest/index.go
@@ -41,7 +41,7 @@ type ManifestIndexProvider struct {
 // a local file on disk and then a remote URL.  If either of these checks pass,
 // the Provider is instantiated since the path does indeed represent a
 // ManifestIndex.
-func NewManifestIndexProvider(ctx context.Context, path string, mopts ...ManifestOption) (Provider, error) {
+func NewManifestIndexProvider(ctx context.Context, path, _ string, mopts ...ManifestOption) (Provider, error) {
 	index, err := NewManifestIndexFromFile(path, mopts...)
 	if err == nil {
 		log.G(ctx).WithFields(logrus.Fields{
@@ -71,7 +71,7 @@ func NewManifestIndexProvider(ctx context.Context, path string, mopts ...Manifes
 	return nil, fmt.Errorf("provided path is not a manifest index: %s", path)
 }
 
-func (mip ManifestIndexProvider) Manifests() ([]*Manifest, error) {
+func (mip ManifestIndexProvider) Manifests(_ context.Context) ([]*Manifest, error) {
 	return mip.index.Manifests, nil
 }
 

--- a/manifest/manager.go
+++ b/manifest/manager.go
@@ -194,12 +194,12 @@ func (m *manifestManager) Catalog(ctx context.Context, qopts ...packmanager.Quer
 	log.G(ctx).WithFields(query.Fields()).Debug("querying manifest catalog")
 
 	if len(query.Source()) > 0 {
-		provider, err := NewProvider(ctx, query.Source(), mopts...)
+		provider, err := NewProvider(ctx, query.Source(), query.Version(), mopts...)
 		if err != nil {
 			return nil, err
 		}
 
-		manifests, err := provider.Manifests()
+		manifests, err := provider.Manifests(ctx)
 		if err != nil {
 			return nil, err
 		}
@@ -369,7 +369,9 @@ func (m *manifestManager) IsCompatible(ctx context.Context, source string, qopts
 		return m, true, nil
 	}
 
-	if _, err := NewProvider(ctx, source); err != nil {
+	query := packmanager.NewQuery(qopts...)
+
+	if _, err := NewProvider(ctx, source, query.Version()); err != nil {
 		return nil, false, fmt.Errorf("incompatible source")
 	}
 

--- a/manifest/manifest.go
+++ b/manifest/manifest.go
@@ -67,7 +67,7 @@ type ManifestProvider struct {
 // file on disk and a remote URL.  If populating a Manifest struct is possible
 // given the path, then this provider is able to return list of exactly 1
 // manifest.
-func NewManifestProvider(ctx context.Context, path string, mopts ...ManifestOption) (Provider, error) {
+func NewManifestProvider(ctx context.Context, path, _ string, mopts ...ManifestOption) (Provider, error) {
 	manifest, err := NewManifestFromFile(ctx, path, mopts...)
 	if err == nil {
 		log.G(ctx).WithFields(logrus.Fields{
@@ -93,7 +93,7 @@ func NewManifestProvider(ctx context.Context, path string, mopts ...ManifestOpti
 	return nil, fmt.Errorf("provided path is not a manifest: %s", path)
 }
 
-func (mp ManifestProvider) Manifests() ([]*Manifest, error) {
+func (mp ManifestProvider) Manifests(_ context.Context) ([]*Manifest, error) {
 	return []*Manifest{mp.manifest}, nil
 }
 
@@ -152,7 +152,7 @@ func NewManifestFromBytes(ctx context.Context, raw []byte, opts ...ManifestOptio
 	}
 
 	if providerName != "" {
-		manifest.Provider, err = NewProviderFromString(ctx, providerName, manifest.Origin, manifest, opts...)
+		manifest.Provider, err = NewProviderFromString(ctx, providerName, manifest.Origin, "", manifest, opts...)
 		if err != nil {
 			return nil, err
 		}
@@ -300,12 +300,12 @@ func findManifestsFromSource(ctx context.Context, lastSource, source string, mop
 		}
 	}
 
-	provider, err := NewProvider(ctx, source, mopts...)
+	provider, err := NewProvider(ctx, source, "", mopts...)
 	if err != nil {
 		return nil, err
 	}
 
-	newManifests, err := provider.Manifests()
+	newManifests, err := provider.Manifests(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/manifest/pack_pull_archive.go
+++ b/manifest/pack_pull_archive.go
@@ -145,7 +145,7 @@ func pullArchive(ctx context.Context, manifest *Manifest, opts ...pack.PullOptio
 		if err != nil {
 			return fmt.Errorf("could not initialize GET request to download package: %v", err)
 		} else if res.StatusCode != http.StatusOK {
-			return fmt.Errorf("received non-200 HTTP status code when attempting to download package: %v", err)
+			return fmt.Errorf("received %d HTTP status code when attempting to download package", res.StatusCode)
 		}
 
 		defer res.Body.Close()

--- a/manifest/provider.go
+++ b/manifest/provider.go
@@ -17,7 +17,7 @@ import (
 type Provider interface {
 	// Manifests returns a slice of Manifests which can be returned by this
 	// Provider
-	Manifests() ([]*Manifest, error)
+	Manifests(context.Context) ([]*Manifest, error)
 
 	// PullManifest from the provider.
 	PullManifest(context.Context, *Manifest, ...pack.PullOption) error
@@ -31,11 +31,11 @@ type Provider interface {
 // provider which does not return an error is indicator that it is supported and
 // thus the return of NewProvider a compatible interface Provider able to gather
 // information about the manifest.
-func NewProvider(ctx context.Context, path string, mopts ...ManifestOption) (Provider, error) {
+func NewProvider(ctx context.Context, path, version string, mopts ...ManifestOption) (Provider, error) {
 	log.G(ctx).WithFields(logrus.Fields{
 		"path": path,
 	}).Trace("trying manifest provider")
-	provider, err := NewManifestProvider(ctx, path, mopts...)
+	provider, err := NewManifestProvider(ctx, path, version, mopts...)
 	if err == nil {
 		log.G(ctx).WithFields(logrus.Fields{
 			"path": path,
@@ -46,7 +46,7 @@ func NewProvider(ctx context.Context, path string, mopts ...ManifestOption) (Pro
 	log.G(ctx).WithFields(logrus.Fields{
 		"path": path,
 	}).Trace("trying index provider")
-	provider, err = NewManifestIndexProvider(ctx, path, mopts...)
+	provider, err = NewManifestIndexProvider(ctx, path, version, mopts...)
 	if err == nil {
 		log.G(ctx).WithFields(logrus.Fields{
 			"path": path,
@@ -57,7 +57,7 @@ func NewProvider(ctx context.Context, path string, mopts ...ManifestOption) (Pro
 	log.G(ctx).WithFields(logrus.Fields{
 		"path": path,
 	}).Trace("trying directory provider")
-	provider, err = NewDirectoryProvider(ctx, path, mopts...)
+	provider, err = NewDirectoryProvider(ctx, path, version, mopts...)
 	if err == nil {
 		log.G(ctx).WithFields(logrus.Fields{
 			"path": path,
@@ -68,7 +68,7 @@ func NewProvider(ctx context.Context, path string, mopts ...ManifestOption) (Pro
 	log.G(ctx).WithFields(logrus.Fields{
 		"path": path,
 	}).Trace("trying github provider")
-	provider, err = NewGitHubProvider(ctx, path, mopts...)
+	provider, err = NewGitHubProvider(ctx, path, version, mopts...)
 	if err == nil {
 		log.G(ctx).WithFields(logrus.Fields{
 			"path": path,
@@ -79,7 +79,7 @@ func NewProvider(ctx context.Context, path string, mopts ...ManifestOption) (Pro
 	log.G(ctx).WithFields(logrus.Fields{
 		"path": path,
 	}).Trace("trying git provider")
-	provider, err = NewGitProvider(ctx, path, mopts...)
+	provider, err = NewGitProvider(ctx, path, version, mopts...)
 	if err == nil {
 		log.G(ctx).WithFields(logrus.Fields{
 			"path": path,
@@ -92,7 +92,7 @@ func NewProvider(ctx context.Context, path string, mopts ...ManifestOption) (Pro
 
 // NewProviderFromString returns a provider based on a giving string which
 // identifies the provider
-func NewProviderFromString(ctx context.Context, provider, path string, entity any, mopts ...ManifestOption) (Provider, error) {
+func NewProviderFromString(ctx context.Context, provider, path, version string, entity any, mopts ...ManifestOption) (Provider, error) {
 	switch provider {
 	case "index":
 		return ManifestIndexProvider{
@@ -107,11 +107,11 @@ func NewProviderFromString(ctx context.Context, provider, path string, entity an
 			manifest: entity.(*Manifest),
 		}, nil
 	case "github":
-		return NewGitHubProvider(ctx, path, mopts...)
+		return NewGitHubProvider(ctx, path, version, mopts...)
 	case "git":
-		return NewGitProvider(ctx, path, mopts...)
+		return NewGitProvider(ctx, path, version, mopts...)
 	case "directory":
-		return NewDirectoryProvider(ctx, path, mopts...)
+		return NewDirectoryProvider(ctx, path, version, mopts...)
 	}
 
 	return nil, fmt.Errorf("could not determine provider for: %s", path)


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

This PR makes necessary adjustments to the `manifest` package to better accommodate for users who wish to specify the Git SHA hash as the `version` attribute of a component.  To make this adjustment a number of changes were necessary:

- Propagating the Catalog's query of a version to each provider;
- Allowing a quick-lookup of SHA on GitHub as an archive if `--use-git` is not provided;
- Changing the "`git checkout`" mechanism to facilitate finding the hash amongst different branches.
