### PR TITLE
ci(lint): output warnings to both GitHub and stdout

### DIFF
--- a/.github/workflows/gochecks.yaml
+++ b/.github/workflows/gochecks.yaml
@@ -62,14 +62,15 @@ jobs:
         if: success() || failure()  # run this step even if the previous one failed
         uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.52.2
-          args: --disable-all --enable=gofumpt
+          version: v1.53.3
+          args: --disable-all --enable=gofumpt --out-format=colored-line-number
           skip-cache: true
 
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.52.2
+          version: v1.53.3
+          args: --out-format=colored-line-number
           skip-cache: true
 
       - name: go generate


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [x] Updated relevant documentation.

### Description of changes

By default, the golangci-lint Action outputs its findings via the GitHub API only. This is both useful and confusing. On one hand, warnings appear directly in the "Files changed" web view, in the context of the actual issue. On the other hand, warnings [aren't highlighted in the output of the Action run](https://github.com/unikraft/kraftkit/actions/runs/5290159754/jobs/9573966868).

![image](https://github.com/unikraft/kraftkit/assets/3299086/e02f87e5-b77a-4b24-b518-0c8fab5f5b87)

We can now have the best of both worlds since https://github.com/golangci/golangci-lint-action/pull/769:

![image](https://github.com/unikraft/kraftkit/assets/3299086/19ee90e5-0f9f-41a3-a78e-263b01c8f51a)
