### PR TITLE
feat(build): Handle pull authentication and introduce `--no-pull`

### DIFF
--- a/cmd/kraft/build/build.go
+++ b/cmd/kraft/build/build.go
@@ -41,16 +41,11 @@ type Build struct {
 	NoConfigure  bool   `long:"no-configure" usage:"Do not run Unikraft's configure step before building"`
 	NoFetch      bool   `long:"no-fetch" usage:"Do not run Unikraft's fetch step before building"`
 	NoPrepare    bool   `long:"no-prepare" usage:"Do not run Unikraft's prepare step before building"`
+	NoPull       bool   `long:"no-pull" usage:"Do not pull packages before invoking Unikraft's build system"`
 	Platform     string `long:"plat" short:"p" usage:"Filter the creation of the build by platform of known targets"`
 	SaveBuildLog string `long:"build-log" usage:"Use the specified file to save the output from the build"`
 	Target       string `long:"target" short:"t" usage:"Build a particular known target"`
 }
-
-// The longest word is "configuring" (which is 11 characters long), plus
-// additional space characters (2 characters), brackets (2 characters) the
-// name of the project and the target/plat string (which is variable in
-// length).
-const maxExtraCharacters = 15
 
 func New() *cobra.Command {
 	cmd, err := cmdfactory.New(&Build{}, cobra.Command{
@@ -92,65 +87,14 @@ func (*Build) Pre(cmd *cobra.Command, _ []string) error {
 	return nil
 }
 
-func (opts *Build) Run(cmd *cobra.Command, args []string) error {
-	var err error
-	var workdir string
-
-	if (len(opts.Architecture) > 0 || len(opts.Platform) > 0) && len(opts.Target) > 0 {
-		return fmt.Errorf("the `--arch` and `--plat` options are not supported in addition to `--target`")
-	}
-
-	if len(args) == 0 {
-		workdir, err = os.Getwd()
-		if err != nil {
-			return err
-		}
-	} else {
-		workdir = args[0]
-	}
-
-	ctx := cmd.Context()
-
-	// Initialize at least the configuration options for a project
-	project, err := app.NewProjectFromOptions(
-		ctx,
-		app.WithProjectWorkdir(workdir),
-		app.WithProjectDefaultKraftfiles(),
-	)
-	if err != nil {
-		return err
-	}
-
-	if !app.IsWorkdirInitialized(workdir) {
-		return fmt.Errorf("cannot build uninitialized project! start with: ukbuild init")
-	}
-
-	parallel := !config.G[config.KraftKit](ctx).NoParallel
-	norender := log.LoggerTypeFromString(config.G[config.KraftKit](ctx).Log.Type) != log.FANCY
-	nameWidth := -1
-
-	// Calculate the width of the longest process name so that we can align the
-	// two independent processtrees if we are using "render" mode (aka the fancy
-	// mode is enabled).
-	if !norender {
-		comps, err := project.Components(ctx)
-		if err != nil {
-			return err
-		}
-		for _, component := range comps {
-			if newLen := len(unikraft.TypeNameVersion(component)) + maxExtraCharacters; newLen > nameWidth {
-				nameWidth = newLen
-			}
-		}
-	}
-
+func (opts *Build) pull(ctx context.Context, project app.Application, workdir string, norender bool, nameWidth int) error {
 	var missingPacks []pack.Package
 	var processes []*paraprogress.Process
 	var searches []*processtree.ProcessTreeItem
+	parallel := !config.G[config.KraftKit](ctx).NoParallel
 	auths := config.G[config.KraftKit](ctx).Auth
 
-	_, err = project.Components(ctx)
-	if err != nil && project.Template().Name() != "" {
+	if _, err := project.Components(ctx); err != nil && project.Template().Name() != "" {
 		var packages []pack.Package
 		search := processtree.NewProcessTreeItem(
 			fmt.Sprintf("finding %s",
@@ -353,7 +297,67 @@ func (opts *Build) Run(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	processes = []*paraprogress.Process{} // reset
+	return nil
+}
+
+func (opts *Build) Run(cmd *cobra.Command, args []string) error {
+	var err error
+	var workdir string
+
+	if (len(opts.Architecture) > 0 || len(opts.Platform) > 0) && len(opts.Target) > 0 {
+		return fmt.Errorf("the `--arch` and `--plat` options are not supported in addition to `--target`")
+	}
+
+	if len(args) == 0 {
+		workdir, err = os.Getwd()
+		if err != nil {
+			return err
+		}
+	} else {
+		workdir = args[0]
+	}
+
+	ctx := cmd.Context()
+
+	// Initialize at least the configuration options for a project
+	project, err := app.NewProjectFromOptions(
+		ctx,
+		app.WithProjectWorkdir(workdir),
+		app.WithProjectDefaultKraftfiles(),
+	)
+	if err != nil {
+		return err
+	}
+
+	if !app.IsWorkdirInitialized(workdir) {
+		return fmt.Errorf("cannot build uninitialized project")
+	}
+
+	norender := log.LoggerTypeFromString(config.G[config.KraftKit](ctx).Log.Type) != log.FANCY
+	nameWidth := -1
+
+	// Calculate the width of the longest process name so that we can align the
+	// two independent processtrees if we are using "render" mode (aka the fancy
+	// mode is enabled).
+	if !norender {
+		// The longest word is "configuring" (which is 11 characters long), plus
+		// additional space characters (2 characters), brackets (2 characters) the
+		// name of the project and the target/plat string (which is variable in
+		// length).
+		for _, targ := range project.Targets() {
+			if newLen := len(targ.Name()) + len(target.TargetPlatArchName(targ)) + 15; newLen > nameWidth {
+				nameWidth = newLen
+			}
+		}
+	}
+
+	if !opts.NoPull {
+		if err := opts.pull(ctx, project, workdir, norender, nameWidth); err != nil {
+			return err
+		}
+	}
+
+	processes := []*paraprogress.Process{} // reset
 
 	// Filter project targets by any provided CLI options
 	selected := cli.FilterTargets(

--- a/cmd/kraft/build/build.go
+++ b/cmd/kraft/build/build.go
@@ -147,6 +147,7 @@ func (opts *Build) Run(cmd *cobra.Command, args []string) error {
 	var missingPacks []pack.Package
 	var processes []*paraprogress.Process
 	var searches []*processtree.ProcessTreeItem
+	auths := config.G[config.KraftKit](ctx).Auth
 
 	_, err = project.Components(ctx)
 	if err != nil && project.Template().Name() != "" {
@@ -161,6 +162,7 @@ func (opts *Build) Run(cmd *cobra.Command, args []string) error {
 					packmanager.WithTypes(unikraft.ComponentTypeApp),
 					packmanager.WithVersion(project.Template().Version()),
 					packmanager.WithCache(!opts.NoCache),
+					packmanager.WithAuthConfig(config.G[config.KraftKit](ctx).Auth),
 				)
 				if err != nil {
 					return err
@@ -259,6 +261,7 @@ func (opts *Build) Run(cmd *cobra.Command, args []string) error {
 	}
 	for _, component := range components {
 		component := component // loop closure
+		auths := auths
 
 		searches = append(searches, processtree.NewProcessTreeItem(
 			fmt.Sprintf("finding %s",
@@ -271,6 +274,7 @@ func (opts *Build) Run(cmd *cobra.Command, args []string) error {
 					packmanager.WithVersion(component.Version()),
 					packmanager.WithSource(component.Source()),
 					packmanager.WithCache(!opts.NoCache),
+					packmanager.WithAuthConfig(auths),
 				)
 				if err != nil {
 					return err
@@ -314,6 +318,7 @@ func (opts *Build) Run(cmd *cobra.Command, args []string) error {
 	if len(missingPacks) > 0 {
 		for _, p := range missingPacks {
 			p := p // loop closure
+			auths := auths
 			processes = append(processes, paraprogress.NewProcess(
 				fmt.Sprintf("pulling %s",
 					unikraft.TypeNameVersion(p),
@@ -325,6 +330,7 @@ func (opts *Build) Run(cmd *cobra.Command, args []string) error {
 						pack.WithPullWorkdir(workdir),
 						// pack.WithPullChecksum(!opts.NoChecksum),
 						pack.WithPullCache(!opts.NoCache),
+						pack.WithPullAuthConfig(auths),
 					)
 				},
 			))

--- a/pack/pull_options.go
+++ b/pack/pull_options.go
@@ -12,7 +12,7 @@ import (
 // PullOptions contains the list of options which can be set for pulling a
 // package.
 type PullOptions struct {
-	auths             map[string]*config.AuthConfig
+	auths             map[string]config.AuthConfig
 	architectures     []string
 	platforms         []string
 	version           string
@@ -26,7 +26,7 @@ type PullOptions struct {
 // domain was not found.
 func (ppo *PullOptions) Auths(domain string) *config.AuthConfig {
 	if auth, ok := ppo.auths[domain]; ok {
-		return auth
+		return &auth
 	}
 
 	return nil
@@ -81,13 +81,16 @@ func NewPullOptions(opts ...PullOption) (*PullOptions, error) {
 
 // WithPullAuthConfig sets the authentication config to use when pulling the
 // package.
-func WithPullAuthConfig(auth *config.AuthConfig) PullOption {
+func WithPullAuthConfig(auth map[string]config.AuthConfig) PullOption {
 	return func(opts *PullOptions) error {
 		if opts.auths == nil {
-			opts.auths = make(map[string]*config.AuthConfig, 1)
+			opts.auths = map[string]config.AuthConfig{}
 		}
 
-		opts.auths[auth.Endpoint] = auth
+		for k, v := range auth {
+			opts.auths[k] = v
+		}
+
 		return nil
 	}
 }


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

This PR introduces two adjustments to the `kraft build` command:
- The proper propagation of authentication such that invoking `kraft build` on remote private repositories is possible; and,
- The introduction of a `--no-pull` flag that disable pulling of remote sources before a build.  This short-cuts most of the "intelligence" from the `kraft build` command and is useful in circumstances where the relevant packages have been fully retrieved and the user wishes to simply run the underlying Unikraft build system.