### PR TITLE
fix(run): Fix miscellaneous `kraft run` issues

### DIFF
--- a/cmd/kraft/run/run.go
+++ b/cmd/kraft/run/run.go
@@ -188,14 +188,6 @@ func (opts *Run) Pre(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 
-	// Set use of the global package manager.
-	pm, err := packmanager.NewUmbrellaManager(ctx)
-	if err != nil {
-		return err
-	}
-
-	cmd.SetContext(packmanager.WithPackageManager(ctx, pm))
-
 	if opts.RunAs != "" {
 		runners := runners()
 		if _, ok = runners[opts.RunAs]; !ok {
@@ -208,6 +200,16 @@ func (opts *Run) Pre(cmd *cobra.Command, _ []string) error {
 
 			return fmt.Errorf("unknown runner: %s (choice of %v)", opts.RunAs, choices)
 		}
+	}
+
+	if opts.RunAs != "kernel" {
+		// Set use of the global package manager.
+		pm, err := packmanager.NewUmbrellaManager(ctx)
+		if err != nil {
+			return err
+		}
+
+		cmd.SetContext(packmanager.WithPackageManager(ctx, pm))
 	}
 
 	return nil

--- a/cmd/kraft/run/run.go
+++ b/cmd/kraft/run/run.go
@@ -5,7 +5,6 @@
 package run
 
 import (
-	"context"
 	"fmt"
 	"strings"
 
@@ -91,43 +90,6 @@ func New() *cobra.Command {
 	)
 
 	return cmd
-}
-
-// runner is an interface for defining different mechanisms to execute the
-// provided unikernel.  Standardizing first the check, Runnable, to determine
-// whether the provided input is capable of executing, and Prepare, actually
-// performing the preparation of the Machine specification for the controller.
-type runner interface {
-	// String implements fmt.Stringer and returns the name of the implementing
-	// runner.
-	fmt.Stringer
-
-	// Runnable checks whether the provided configuration is runnable.
-	Runnable(context.Context, *Run, ...string) (bool, error)
-
-	// Prepare the provided configuration into a machine specification ready for
-	// execution by the controller.
-	Prepare(context.Context, *Run, *machineapi.Machine, ...string) error
-}
-
-// runners is the list of built-in runners which are checked sequentially for
-// capability.  The first to test positive via Runnable is used with the
-// controller.
-func runners() map[string]runner {
-	r := map[string]runner{
-		"linuxu":  &runnerLinuxu{},
-		"kernel":  &runnerKernel{},
-		"project": &runnerProject{},
-		"package": &runnerPackage{},
-	}
-
-	for k, pm := range packmanager.PackageManagers() {
-		r[string(k)] = &runnerPackage{
-			pm: pm,
-		}
-	}
-
-	return r
 }
 
 func (opts *Run) Pre(cmd *cobra.Command, _ []string) error {

--- a/cmd/kraft/run/runner.go
+++ b/cmd/kraft/run/runner.go
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2022, Unikraft GmbH and The KraftKit Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+package run
+
+import (
+	"context"
+	"fmt"
+
+	machineapi "kraftkit.sh/api/machine/v1alpha1"
+	"kraftkit.sh/packmanager"
+)
+
+// runner is an interface for defining different mechanisms to execute the
+// provided unikernel.  Standardizing first the check, Runnable, to determine
+// whether the provided input is capable of executing, and Prepare, actually
+// performing the preparation of the Machine specification for the controller.
+type runner interface {
+	// String implements fmt.Stringer and returns the name of the implementing
+	// runner.
+	fmt.Stringer
+
+	// Runnable checks whether the provided configuration is runnable.
+	Runnable(context.Context, *Run, ...string) (bool, error)
+
+	// Prepare the provided configuration into a machine specification ready for
+	// execution by the controller.
+	Prepare(context.Context, *Run, *machineapi.Machine, ...string) error
+}
+
+// runners is the list of built-in runners which are checked sequentially for
+// capability.  The first to test positive via Runnable is used with the
+// controller.
+func runners() map[string]runner {
+	r := map[string]runner{
+		// "api":     &runnerApi{},
+		"linuxu":  &runnerLinuxu{},
+		"kernel":  &runnerKernel{},
+		"project": &runnerProject{},
+	}
+
+	for k, pm := range packmanager.PackageManagers() {
+		r[string(k)] = &runnerPackage{
+			pm: pm,
+		}
+	}
+
+	return r
+}

--- a/cmd/kraft/run/runner_kernel.go
+++ b/cmd/kraft/run/runner_kernel.go
@@ -50,6 +50,7 @@ func (runner *runnerKernel) Prepare(ctx context.Context, opts *Run, machine *mac
 	machine.Spec.Platform = opts.platform.String()
 	machine.Spec.Kernel = "kernel://" + filename
 	machine.Status.KernelPath = runner.kernelPath
+	machine.Spec.ApplicationArgs = runner.args
 
 	// We need to know the architecture pre-emptively, see if we can
 	// "intelligently" guess this by inspecting the ELF binary if the -m|--arch


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

This PR adjusts the `kraft run` command in several ways which improve its usability:
* Correctly propagate the application arguments when using the kernel runner;
* Fix an issue where the network was pre-emptively removed before the invocation of the unikernel.  This is because the `defer` clean up was migrated into the network parser.  Of course, at the end of this function it is invoked.  Instead, it should be part of the main method that handles the creation and start of the unikernel such that in this lifecycle it is handled correctly;
* Optimize the execution flow by reading the `--as` flag early: when it is set to "kernel", we can skip the instantiating
of the umbrella package manager which would otherwise invoke needless cycles on a service that is not used.  Instead, only call this on runners that rely on this necessary KraftKit subsystem;
* Move the `runner` interface to its own file to keep the `run.go` code base simpler.