### PR TITLE
fix(unikraft): Better handling of schema transformations

### DIFF
--- a/cmd/kraft/build/build.go
+++ b/cmd/kraft/build/build.go
@@ -204,6 +204,14 @@ func (opts *Build) pull(ctx context.Context, project app.Application, workdir st
 		return err
 	}
 	for _, component := range components {
+		// Skip "finding" the component if path is the same as the source (which
+		// means that the source code is already available as it is a directory on
+		// disk.  In this scenario, the developer is likely hacking the particular
+		// microlibrary/component.
+		if component.Path() == component.Source() {
+			continue
+		}
+
 		component := component // loop closure
 		auths := auths
 

--- a/unikraft/component/component.go
+++ b/unikraft/component/component.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"net/url"
 	"os"
+	"strconv"
 
 	"kraftkit.sh/kconfig"
 	"kraftkit.sh/unikraft"
@@ -59,7 +60,14 @@ func TranslateFromSchema(props interface{}) (map[string]interface{}, error) {
 		for key, prop := range entry {
 			switch key {
 			case "version":
-				component["version"] = prop.(string)
+				switch tprop := prop.(type) {
+				case string:
+					component["version"] = tprop
+				case int:
+					component["version"] = strconv.Itoa(tprop)
+				default:
+					component["version"] = fmt.Sprint(prop)
+				}
 
 			case "source":
 				for k, v := range parseStringProp(prop.(string)) {

--- a/unikraft/core/transform.go
+++ b/unikraft/core/transform.go
@@ -6,10 +6,12 @@ package core
 
 import (
 	"context"
+	"os"
 
 	"kraftkit.sh/kconfig"
 	"kraftkit.sh/unikraft"
 	"kraftkit.sh/unikraft/component"
+	"kraftkit.sh/utils"
 )
 
 // TransformFromSchema parses an input schema and returns an instantiated
@@ -33,6 +35,19 @@ func TransformFromSchema(ctx context.Context, props interface{}) (interface{}, e
 
 	if source, ok := c["source"]; ok {
 		core.source = source.(string)
+
+		// If the provided source is a directory on the host, set the "path" to this
+		// value.  The "path" is the location on disk where the microlibrary will
+		// eventually saved by the relevant package manager.  For completeness, use
+		// absolute paths for both the path and the source.
+		if f, err := os.Stat(core.source); err == nil && f.IsDir() {
+			if uk != nil && uk.UK_BASE != "" {
+				core.path = utils.RelativePath(uk.UK_BASE, core.source)
+				core.source = core.path
+			} else {
+				core.path = core.source
+			}
+		}
 	}
 
 	if version, ok := c["version"]; ok {

--- a/unikraft/lib/transform.go
+++ b/unikraft/lib/transform.go
@@ -7,10 +7,12 @@ package lib
 import (
 	"context"
 	"fmt"
+	"os"
 
 	"kraftkit.sh/kconfig"
 	"kraftkit.sh/unikraft"
 	"kraftkit.sh/unikraft/component"
+	"kraftkit.sh/utils"
 )
 
 // TransformFromSchema parses an input schema and returns an instantiated
@@ -38,6 +40,19 @@ func TransformFromSchema(ctx context.Context, name string, props interface{}) (L
 
 	if source, ok := c["source"]; ok {
 		lib.source = source.(string)
+
+		// If the provided source is a directory on the host, set the "path" to this
+		// value.  The "path" is the location on disk where the microlibrary will
+		// eventually saved by the relevant package manager.  For completeness, use
+		// absolute paths for both the path and the source.
+		if f, err := os.Stat(lib.source); err == nil && f.IsDir() {
+			if uk != nil && uk.UK_BASE != "" {
+				lib.path = utils.RelativePath(uk.UK_BASE, lib.source)
+				lib.source = lib.path
+			} else {
+				lib.path = lib.source
+			}
+		}
 	}
 
 	if version, ok := c["version"]; ok {


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

This PR fixes a number of issues related to parsing the schema and the values of attributes related to the `version`.  Particularly:

* Fixes additional types which can be set within the Kraftfile's specification.
* Fixes an issue where a directory can be specified as the source.  This is useful in circumstances where the user is directly manipulating the library's source code or it is not a public/upstream microlibrary/component.  Setting the path will correctly resolve the manifest's `DirectoryProvider`. 

This PR can be tested by specifying a source and version transformations.  For example, setting a path on disk of a microlibrary or a commit version that only contains numerical value.