### PR TITLE
fix(app): Create the `BuildDir` if it does not exist

### DIFF
--- a/unikraft/app/project.go
+++ b/unikraft/app/project.go
@@ -19,6 +19,7 @@ package app
 import (
 	"context"
 	"fmt"
+	"os"
 	"path/filepath"
 
 	"kraftkit.sh/kconfig"
@@ -112,6 +113,12 @@ func NewProjectFromOptions(ctx context.Context, opts ...ProjectOption) (Applicat
 		UK_NAME:   name,
 		UK_BASE:   popts.RelativePath(workdir),
 		BUILD_DIR: popts.RelativePath(outdir),
+	}
+
+	if _, err := os.Stat(uk.BUILD_DIR); err != nil && os.IsNotExist(err) {
+		if err := os.MkdirAll(uk.BUILD_DIR, 0o755); err != nil {
+			return nil, fmt.Errorf("creating build directory: %w", err)
+		}
 	}
 
 	ctx = unikraft.WithContext(ctx, uk)


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

This PR is a fix related to a recent change (50d2b33) wherein the build directory was migrated into `.unikraft/build`.  Since this directory will not exist before invoking Unikraft's build system, create it.  Without this change, invocations to Unikraft's build system fail.