### PR TITLE
fix(run): Fix issues related to project runner

### DIFF
--- a/cmd/kraft/run/run.go
+++ b/cmd/kraft/run/run.go
@@ -150,6 +150,16 @@ func (opts *Run) Pre(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 
+	if !set.NewStringSet("kernel", "project").Contains(opts.RunAs) {
+		// Set use of the global package manager.
+		pm, err := packmanager.NewUmbrellaManager(ctx)
+		if err != nil {
+			return err
+		}
+
+		cmd.SetContext(packmanager.WithPackageManager(ctx, pm))
+	}
+
 	if opts.RunAs != "" {
 		runners := runners()
 		if _, ok = runners[opts.RunAs]; !ok {
@@ -162,16 +172,6 @@ func (opts *Run) Pre(cmd *cobra.Command, _ []string) error {
 
 			return fmt.Errorf("unknown runner: %s (choice of %v)", opts.RunAs, choices)
 		}
-	}
-
-	if opts.RunAs != "kernel" {
-		// Set use of the global package manager.
-		pm, err := packmanager.NewUmbrellaManager(ctx)
-		if err != nil {
-			return err
-		}
-
-		cmd.SetContext(packmanager.WithPackageManager(ctx, pm))
 	}
 
 	return nil


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

This PR fixes two issues related to using the project runner in `kraft run`:

* Firstly, a new check occurs whether the runner-type has been pre-emptively set to "project" or "kernel".  These runners do not require access to the package manager which would otherwise be instantiated, slowing down the instantiation process via `kraft run`. In the future, it may make sense to simply embbed the user of the package manager in the relevant runner.
* Secondly, correctly set application arguments in project runner which stems from misparsing the cmdline arguments provided within `kraft run` as well as not setting them in the machine specification.
