### PR TITLE
fix: flag attribution to struct fields of composite type

### DIFF
--- a/cmdfactory/builder_test.go
+++ b/cmdfactory/builder_test.go
@@ -6,11 +6,105 @@
 package cmdfactory
 
 import (
+	"os"
 	"testing"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
+
+func TestAttributeFlags_StructFields(t *testing.T) {
+	attributeFlags := func(t *testing.T, obj any, args ...string) {
+		t.Helper()
+
+		rootCmd, subCmds := []string{"kraft"}, []string{"cmd1", "subcmd1"}
+		cmd := makeCommand(append(rootCmd, subCmds...)...)
+
+		allArgs := append(args, subCmds...)
+		os.Args = append([]string{os.Args[1]}, allArgs...)
+
+		// AttributeFlags also populates cmd's private flag fields.
+		if err := AttributeFlags(cmd, obj, allArgs...); err != nil {
+			t.Fatal("Failed to associate flags with struct fields:", err)
+		}
+
+		// Execute command to invoke cmd.RunE. This executes all middlewares injected
+		// by bind(), which role is to assign parsed flag values to struct fields.
+		if _, err := executeC(cmd); err != nil {
+			t.Fatal("Failed to execute command:", err)
+		}
+	}
+
+	type TestObj struct {
+		String string            `long:"string" usage:"String arg"`
+		Int    int               `long:"int" usage:"Integer arg"`
+		Bool   bool              `long:"bool" usage:"Boolean arg"`
+		Slice  []string          `long:"slice" usage:"Slice arg"`
+		Map    map[string]string `long:"map" usage:"Map arg"`
+		Nested struct {
+			String string            `long:"n-string" usage:"Nested string arg"`
+			Int    int               `long:"n-int" usage:"Nested integer arg"`
+			Bool   bool              `long:"n-bool" usage:"Nested boolean arg"`
+			Slice  []string          `long:"n-slice" usage:"Nested slice arg"`
+			Map    map[string]string `long:"n-map" usage:"Nested map arg"`
+		}
+	}
+
+	t.Run("String fields", func(t *testing.T) {
+		obj := &TestObj{}
+		attributeFlags(t, obj, "--string=val", "--n-string=n-val")
+		if expect, got := "val", obj.String; expect != got {
+			t.Errorf("Unexpected value for string struct field after flags attribution. Expected %q, got %q", expect, got)
+		}
+		if expect, got := "n-val", obj.Nested.String; expect != got {
+			t.Errorf("Unexpected value for nested string struct field after flags attribution. Expected %q, got %q", expect, got)
+		}
+	})
+
+	t.Run("Integer fields", func(t *testing.T) {
+		obj := &TestObj{}
+		attributeFlags(t, obj, "--int=1", "--n-int=2")
+		if expect, got := 1, obj.Int; expect != got {
+			t.Errorf("Unexpected value for int struct field after flags attribution. Expected %d, got %d", expect, got)
+		}
+		if expect, got := 2, obj.Nested.Int; expect != got {
+			t.Errorf("Unexpected value for nested int struct field after flags attribution. Expected %d, got %d", expect, got)
+		}
+	})
+
+	t.Run("Boolean fields", func(t *testing.T) {
+		obj := &TestObj{}
+		attributeFlags(t, obj, "--bool=true", "--n-bool=true")
+		if expect, got := true, obj.Bool; expect != got {
+			t.Errorf("Unexpected value for bool struct field after flags attribution. Expected %t, got %t", expect, got)
+		}
+		if expect, got := true, obj.Nested.Bool; expect != got {
+			t.Errorf("Unexpected value for nested bool struct field after flags attribution. Expected %t, got %t", expect, got)
+		}
+	})
+
+	t.Run("Slice fields", func(t *testing.T) {
+		obj := &TestObj{}
+		attributeFlags(t, obj, "--slice=val1", "--slice=val2", "--n-slice=val1,val2")
+		if expect, got := []string{"val1", "val2"}, obj.Slice; !equalSlices(got, expect) {
+			t.Errorf("Unexpected value for slice struct field after flags attribution. Expected %v, got %v", expect, got)
+		}
+		if expect, got := []string{"val1", "val2"}, obj.Nested.Slice; !equalSlices(got, expect) {
+			t.Errorf("Unexpected value for nested slice struct field after flags attribution. Expected %v, got %v", expect, got)
+		}
+	})
+
+	t.Run("Map fields", func(t *testing.T) {
+		obj := &TestObj{}
+		attributeFlags(t, obj, "--map=key=val", "--n-map=key=val")
+		if expect, got := map[string]string{"key": "val"}, obj.Map; !equalMaps(got, expect) {
+			t.Errorf("Unexpected value for map struct field after flags attribution. Expected %v, got %v", expect, got)
+		}
+		if expect, got := map[string]string{"key": "val"}, obj.Nested.Map; !equalMaps(got, expect) {
+			t.Errorf("Unexpected value for nested map struct field after flags attribution. Expected %v, got %v", expect, got)
+		}
+	})
+}
 
 func TestFilterOutRegisteredFlags(t *testing.T) {
 	flagOverridesOrig := copyFlagOverrides()
@@ -52,25 +146,11 @@ func TestFilterOutRegisteredFlags(t *testing.T) {
 		t.Run(tc.desc, func(t *testing.T) {
 			args := filterOutRegisteredFlags(cmd, tc.args)
 
-			if !equalArgs(args, tc.expect) {
+			if !equalSlices(args, tc.expect) {
 				t.Errorf("Expected filtered args\n%q\ngot\n%q", tc.expect, args)
 			}
 		})
 	}
-}
-
-func equalArgs(got, expect []string) bool {
-	if len(got) != len(expect) {
-		return false
-	}
-
-	for i := 0; i < len(got); i++ {
-		if got[i] != expect[i] {
-			return false
-		}
-	}
-
-	return true
 }
 
 // makeCommand produces a command with the given hierarchy of subcommands, and
@@ -79,7 +159,10 @@ func makeCommand(hierarchy ...string) *cobra.Command {
 	var lastRoot *cobra.Command
 
 	for _, cmdName := range hierarchy {
-		newRoot := &cobra.Command{Use: cmdName + " [-F file | -D dir]... [-f format] something"}
+		newRoot := &cobra.Command{
+			Use:  cmdName + " [-F file | -D dir]... [-f format] something",
+			RunE: func(*cobra.Command, []string) error { return nil },
+		}
 		if lastRoot != nil {
 			lastRoot.AddCommand(newRoot)
 		}
@@ -108,4 +191,32 @@ func copyFlagOverrides() map[string][]*pflag.Flag {
 		flagOverridesCpy[cmdline] = flags
 	}
 	return flagOverridesCpy
+}
+
+func equalSlices(got, expect []string) bool {
+	if len(got) != len(expect) {
+		return false
+	}
+
+	for i := 0; i < len(got); i++ {
+		if got[i] != expect[i] {
+			return false
+		}
+	}
+
+	return true
+}
+
+func equalMaps(got, expect map[string]string) bool {
+	if len(got) != len(expect) {
+		return false
+	}
+
+	for k, gv := range got {
+		if ev, ok := expect[k]; !ok || ev != gv {
+			return false
+		}
+	}
+
+	return true
 }

--- a/internal/cli/options.go
+++ b/internal/cli/options.go
@@ -129,7 +129,11 @@ func WithDefaultConfigManager(cmd *cobra.Command) CliOption {
 		}
 
 		// Attribute all configuration flags and command-line argument values
-		if err := cmdfactory.AttributeFlags(cmd, cfgm.Config, os.Args[1:]...); err != nil {
+		cmd, args, err := cmd.Find(os.Args[1:])
+		if err != nil {
+			return err
+		}
+		if err := cmdfactory.AttributeFlags(cmd, cfgm.Config, args...); err != nil {
 			return err
 		}
 


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [x] Updated relevant documentation.

### Description of changes

Copied from https://github.com/unikraft/kraftkit/issues/537#issuecomment-1608264469:

`cmdfactory` calls `AttributeFlags` with the **root** command (and all args + flags). The `RunE` function, overridden by `bind()`, is therefore assigned to the **root** command.

However, the root command itself is never executed by cobra, only whichever _sub_ command was selected by the use, so `bind()` has absolutely no effect. Its result is never called.

This PR ensures that `AttributeFlags` is called with the subcommand invoked by the user, instead of the root command.

GitHub-Fixes #537