### PR TITLE
feat: Platform iterator

### DIFF
--- a/cmd/kraft/stop/stop.go
+++ b/cmd/kraft/stop/stop.go
@@ -41,7 +41,7 @@ func New() *cobra.Command {
 		cmdfactory.NewEnumFlag(set.NewStringSet(mplatform.DriverNames()...).Add("auto").ToSlice(), "auto"),
 		"plat",
 		"p",
-		"Set the platform virtual machine monitor driver.",
+		"Set the platform virtual machine monitor driver.  Set to 'auto' to detect the guest's platform and 'host' to use the host platform.",
 	)
 
 	return cmd
@@ -65,29 +65,34 @@ func (opts *Stop) Run(cmd *cobra.Command, args []string) error {
 
 	ctx := cmd.Context()
 	platform := mplatform.PlatformUnknown
+	var controller machineapi.MachineService
 
-	if opts.platform == "" || opts.platform == "auto" {
-		var mode mplatform.SystemMode
-		platform, mode, err = mplatform.Detect(ctx)
-		if mode == mplatform.SystemGuest {
-			return fmt.Errorf("nested virtualization not supported")
-		} else if err != nil {
-			return err
-		}
+	if opts.All || opts.platform == "auto" {
+		controller, err = mplatform.NewMachineV1alpha1ServiceIterator(ctx)
 	} else {
-		var ok bool
-		platform, ok = mplatform.Platforms()[opts.platform]
-		if !ok {
-			return fmt.Errorf("unknown platform driver: %s", opts.platform)
+		if opts.platform == "host" {
+			var mode mplatform.SystemMode
+			platform, mode, err = mplatform.Detect(ctx)
+			if mode == mplatform.SystemGuest {
+				return fmt.Errorf("nested virtualization not supported")
+			} else if err != nil {
+				return err
+			}
+		} else {
+			var ok bool
+			platform, ok = mplatform.Platforms()[opts.platform]
+			if !ok {
+				return fmt.Errorf("unknown platform driver: %s", opts.platform)
+			}
 		}
-	}
 
-	strategy, ok := mplatform.Strategies()[platform]
-	if !ok {
-		return fmt.Errorf("unsupported platform driver: %s (contributions welcome!)", platform.String())
-	}
+		strategy, ok := mplatform.Strategies()[platform]
+		if !ok {
+			return fmt.Errorf("unsupported platform driver: %s (contributions welcome!)", platform.String())
+		}
 
-	controller, err := strategy.NewMachineV1alpha1(ctx)
+		controller, err = strategy.NewMachineV1alpha1(ctx)
+	}
 	if err != nil {
 		return err
 	}

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module kraftkit.sh
 go 1.20
 
 require (
-	api.zip v0.1.4
+	api.zip v0.1.5
 	github.com/AlecAivazis/survey/v2 v2.3.7
 	github.com/MakeNowJust/heredoc v1.0.0
 	github.com/Masterminds/semver/v3 v3.2.1

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-api.zip v0.1.4 h1:QezlTcFDaA6UYBD9ZihorU4+Znegvp7zYnmk6UOWNUE=
-api.zip v0.1.4/go.mod h1:xsEsIv4k2Olwd1GozH37SnY5jPgpExGeSz+TDQUpZNw=
+api.zip v0.1.5 h1:yepLKQk/v/DgfpIA1Q5xuvWzB+0GWp1yejoDQCjsT1s=
+api.zip v0.1.5/go.mod h1:xsEsIv4k2Olwd1GozH37SnY5jPgpExGeSz+TDQUpZNw=
 bazil.org/fuse v0.0.0-20160811212531-371fbbdaa898/go.mod h1:Xbm+BRKSBEpa4q4hTSxohYNQpsxXPbPry4JJWOB3LB8=
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=

--- a/machine/platform/iterator_v1alpha1.go
+++ b/machine/platform/iterator_v1alpha1.go
@@ -1,0 +1,187 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2022, Unikraft GmbH and The KraftKit Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+package platform
+
+import (
+	"context"
+	"fmt"
+
+	zip "api.zip"
+	"github.com/acorn-io/baaah/pkg/merr"
+
+	machinev1alpha1 "kraftkit.sh/api/machine/v1alpha1"
+)
+
+type machineV1alpha1ServiceIterator struct {
+	strategies map[Platform]machinev1alpha1.MachineService
+}
+
+// NewMachineV1alpha1ServiceIterator returns a
+// machinev1alpha1.MachineService-compatible implementation which iterates over
+// each supported host platform and calls the representing method.  This is
+// useful in circumstances where the platform is not supplied.  The first
+// platform strategy to succeed is returned in all circumstances.
+func NewMachineV1alpha1ServiceIterator(ctx context.Context) (machinev1alpha1.MachineService, error) {
+	var err error
+	iterator := machineV1alpha1ServiceIterator{
+		strategies: map[Platform]machinev1alpha1.MachineService{},
+	}
+
+	for platform, strategy := range hostSupportedStrategies() {
+		iterator.strategies[platform], err = strategy.NewMachineV1alpha1(ctx)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return &iterator, nil
+}
+
+// Create implements kraftkit.sh/api/machine/v1alpha1.MachineService
+func (iterator *machineV1alpha1ServiceIterator) Create(ctx context.Context, machine *machinev1alpha1.Machine) (*machinev1alpha1.Machine, error) {
+	var errs []error
+
+	for _, strategy := range iterator.strategies {
+		ret, err := strategy.Create(ctx, machine)
+		if err != nil {
+			errs = append(errs, err)
+			continue
+		}
+
+		return ret, nil
+	}
+
+	return machine, fmt.Errorf("all iterated platforms failed: %w", merr.NewErrors(errs...))
+}
+
+// Start implements kraftkit.sh/api/machine/v1alpha1.MachineService
+func (iterator *machineV1alpha1ServiceIterator) Start(ctx context.Context, machine *machinev1alpha1.Machine) (*machinev1alpha1.Machine, error) {
+	var errs []error
+
+	for _, strategy := range iterator.strategies {
+		ret, err := strategy.Start(ctx, machine)
+		if err != nil {
+			errs = append(errs, err)
+			continue
+		}
+
+		return ret, nil
+	}
+
+	return machine, fmt.Errorf("all iterated platforms failed: %w", merr.NewErrors(errs...))
+}
+
+// Pause implements kraftkit.sh/api/machine/v1alpha1.MachineService
+func (iterator *machineV1alpha1ServiceIterator) Pause(ctx context.Context, machine *machinev1alpha1.Machine) (*machinev1alpha1.Machine, error) {
+	var errs []error
+
+	for _, strategy := range iterator.strategies {
+		ret, err := strategy.Pause(ctx, machine)
+		if err != nil {
+			errs = append(errs, err)
+			continue
+		}
+
+		return ret, nil
+	}
+
+	return machine, fmt.Errorf("all iterated platforms failed: %w", merr.NewErrors(errs...))
+}
+
+// Stop implements kraftkit.sh/api/machine/v1alpha1.MachineService
+func (iterator *machineV1alpha1ServiceIterator) Stop(ctx context.Context, machine *machinev1alpha1.Machine) (*machinev1alpha1.Machine, error) {
+	var errs []error
+
+	for _, strategy := range iterator.strategies {
+		ret, err := strategy.Stop(ctx, machine)
+		if err != nil {
+			errs = append(errs, err)
+			continue
+		}
+
+		return ret, nil
+	}
+
+	return machine, fmt.Errorf("all iterated platforms failed: %w", merr.NewErrors(errs...))
+}
+
+// Update implements kraftkit.sh/api/machine/v1alpha1.MachineService
+func (iterator *machineV1alpha1ServiceIterator) Update(ctx context.Context, machine *machinev1alpha1.Machine) (*machinev1alpha1.Machine, error) {
+	var errs []error
+
+	for _, strategy := range iterator.strategies {
+		ret, err := strategy.Update(ctx, machine)
+		if err != nil {
+			errs = append(errs, err)
+			continue
+		}
+
+		return ret, nil
+	}
+
+	return machine, fmt.Errorf("all iterated platforms failed: %w", merr.NewErrors(errs...))
+}
+
+// Delete implements kraftkit.sh/api/machine/v1alpha1.MachineService
+func (iterator *machineV1alpha1ServiceIterator) Delete(ctx context.Context, machine *machinev1alpha1.Machine) (*machinev1alpha1.Machine, error) {
+	var errs []error
+
+	for _, strategy := range iterator.strategies {
+		ret, err := strategy.Delete(ctx, machine)
+		if err != nil {
+			errs = append(errs, err)
+			continue
+		}
+
+		return ret, nil
+	}
+
+	return machine, fmt.Errorf("all iterated platforms failed: %w", merr.NewErrors(errs...))
+}
+
+// Get implements kraftkit.sh/api/machine/v1alpha1.MachineService
+func (iterator *machineV1alpha1ServiceIterator) Get(ctx context.Context, machine *machinev1alpha1.Machine) (*machinev1alpha1.Machine, error) {
+	var errs []error
+
+	for _, strategy := range iterator.strategies {
+		ret, err := strategy.Get(ctx, machine)
+		if err != nil {
+			errs = append(errs, err)
+			continue
+		}
+
+		return ret, nil
+	}
+
+	return machine, fmt.Errorf("all iterated platforms failed: %w", merr.NewErrors(errs...))
+}
+
+// List implements kraftkit.sh/api/machine/v1alpha1.MachineService
+func (iterator *machineV1alpha1ServiceIterator) List(ctx context.Context, cached *machinev1alpha1.MachineList) (*machinev1alpha1.MachineList, error) {
+	found := []zip.Object[machinev1alpha1.MachineSpec, machinev1alpha1.MachineStatus]{}
+
+	for _, strategy := range iterator.strategies {
+		ret, err := strategy.List(ctx, &machinev1alpha1.MachineList{})
+		if err != nil {
+			continue
+		}
+
+		found = append(found, ret.Items...)
+	}
+
+	cached.Items = found
+
+	return cached, nil
+}
+
+// Watch implements kraftkit.sh/api/machine/v1alpha1.MachineService
+func (iterator *machineV1alpha1ServiceIterator) Watch(ctx context.Context, machine *machinev1alpha1.Machine) (chan *machinev1alpha1.Machine, chan error, error) {
+	panic("not implemented: kraftkit.sh/machine/platform.machineV1alpha1ServiceIterator.Watch")
+}
+
+// Logs implements kraftkit.sh/api/machine/v1alpha1.MachineService
+func (iterator *machineV1alpha1ServiceIterator) Logs(ctx context.Context, machine *machinev1alpha1.Machine) (chan string, chan error, error) {
+	panic("not implemented: kraftkit.sh/machine/platform.machineV1alpha1ServiceIterator.Logs")
+}


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

This PR introduces a platform iterator which is a useful utility method which wraps the `v1alpha1.MachineService` and iteratively calls all supported platform strategies for the given host.  This is useful when a platform is not provided such the usability of high-level commands is eased and so do not require the `--plat` flag.

The commands `kraft stop`, `kraft rm` and `kraft ps` utilize the platform iterator and are included in this PR.

A necessary bug fix found in Zip API Object Framework affects the use of the platform iterator and is included as a version bump inline.