### PR TITLE
fix: Correctly pull OCI images from the registry based on platform

### DIFF
--- a/oci/pack.go
+++ b/oci/pack.go
@@ -403,6 +403,14 @@ func (ocipack *ociPackage) Pull(ctx context.Context, opts ...pack.PullOption) er
 		return err
 	}
 
+	pullArch := popts.Architecture()
+	if pullArch == "" {
+		pullArch, err = arch.HostArchitecture()
+		if err != nil {
+			return err
+		}
+	}
+
 	// If it's possible to resolve the image reference, the image has already been
 	// pulled to the local image store
 	_, err = ocipack.handle.ResolveImage(ctx, ocipack.imageRef())
@@ -413,7 +421,7 @@ func (ocipack *ociPackage) Pull(ctx context.Context, opts ...pack.PullOption) er
 	if err := ocipack.image.handle.FetchImage(
 		ctx,
 		ocipack.imageRef(),
-		popts.Platform(),
+		fmt.Sprintf("%s/%s", popts.Platform(), pullArch),
 		popts.OnProgress,
 	); err != nil {
 		return err

--- a/unikraft/arch/host.go
+++ b/unikraft/arch/host.go
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2022, Unikraft GmbH and The KraftKit Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+package arch
+
+import (
+	"fmt"
+	"runtime"
+)
+
+// HostArchitecture returns the architecture of the host or an error if
+// unsupported by Unikraft.
+func HostArchitecture() (string, error) {
+	arch := runtime.GOARCH
+	switch arch {
+	case "amd64":
+		return "x86_64", nil
+	case "arm", "arm64":
+		return arch, nil
+	default:
+		return "", fmt.Errorf("unsupported architecture: %v", arch)
+	}
+}


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

This PR fixes an issue which was introduced in #534 where the OCI pull handler was adjusted to accommodate for varying the platform.  The underlying container runtime, by misconception, uses a combination of the Unikraft platform and architecture to determine what to fetch.  Adjust this value before it is sent to the relevant handler by using a host architecture utility method when a specific architecture is not provided.