### PR TITLE
fix(cmdfactory): panic while filtering empty flag values

### DIFF
--- a/cmdfactory/builder.go
+++ b/cmdfactory/builder.go
@@ -115,8 +115,8 @@ func filterOutRegisteredFlags(cmd *cobra.Command, args []string) (filteredArgs [
 			args = args[1:]
 
 			switch {
-			// not a flag
-			case arg[0] != '-' || len(arg) == 1:
+			// not a flag ("", <val>, -)
+			case len(arg) == 0 || arg[0] != '-' || len(arg) == 1:
 				filteredArgs = append(filteredArgs, arg)
 
 			// long flag

--- a/cmdfactory/builder_test.go
+++ b/cmdfactory/builder_test.go
@@ -40,6 +40,12 @@ func TestFilterOutRegisteredFlags(t *testing.T) {
 			args:   []string{"--subcmd1-override1", "val1", "--subcmd1-override2=val2", "--y", "yval", "--z=zval"},
 			expect: []string{"--y", "yval", "--z=zval"},
 		},
+		{
+			// unikraft/kraftkit#552
+			desc:   "args contain flags with empty values",
+			args:   []string{"--subcmd1-override1", "", "--subcmd1-override2=", "-v", "-w", "", "-x=", "--y", "", "--z="},
+			expect: []string{"-v", "-w", "", "-x=", "--y", "", "--z="},
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [x] Updated relevant documentation.

### Description of changes

Passing a flag with an explicitly empty value in the format `--myflag ""` causes `cmdfactory.filterOutRegisteredFlags()` to panic with:

```
panic: runtime error: index out of range [0] with length 0 [recovered]
        panic: runtime error: index out of range [0] with length 0
```

The first commit includes just the reproduction via a test case.
The second one includes the fix.