### PR TITLE
fix(run): Instantiate the umbrella if `--as` is not set

### DIFF
--- a/cmd/kraft/run/run.go
+++ b/cmd/kraft/run/run.go
@@ -150,7 +150,7 @@ func (opts *Run) Pre(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 
-	if !set.NewStringSet("kernel", "project").Contains(opts.RunAs) {
+	if opts.RunAs == "" || !set.NewStringSet("kernel", "project").Contains(opts.RunAs) {
 		// Set use of the global package manager.
 		pm, err := packmanager.NewUmbrellaManager(ctx)
 		if err != nil {


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

This PR fixes an issue where all package managers managed through the umbrella package manager were not instantiated when `--as` is unset. In this scenario, we want to attempt to try all runners.  This if-statement would not enter because of the specific check for NOT containing "kernel" and "project".