### PR TITLE
refactor: Use platform iterator in `kraft logs`

### DIFF
--- a/cmd/kraft/logs/logs.go
+++ b/cmd/kraft/logs/logs.go
@@ -40,7 +40,7 @@ func New() *cobra.Command {
 		cmdfactory.NewEnumFlag(set.NewStringSet(mplatform.DriverNames()...).Add("auto").ToSlice(), "auto"),
 		"plat",
 		"p",
-		"Set the platform virtual machine monitor driver.",
+		"Set the platform virtual machine monitor driver.  Set to 'auto' to detect the guest's platform and 'host' to use the host platform.",
 	)
 
 	return cmd
@@ -56,29 +56,34 @@ func (opts *Logs) Run(cmd *cobra.Command, args []string) error {
 
 	ctx := cmd.Context()
 	platform := mplatform.PlatformUnknown
+	var controller machineapi.MachineService
 
-	if opts.platform == "" || opts.platform == "auto" {
-		var mode mplatform.SystemMode
-		platform, mode, err = mplatform.Detect(ctx)
-		if mode == mplatform.SystemGuest {
-			return fmt.Errorf("nested virtualization not supported")
-		} else if err != nil {
-			return err
-		}
+	if opts.platform == "auto" {
+		controller, err = mplatform.NewMachineV1alpha1ServiceIterator(ctx)
 	} else {
-		var ok bool
-		platform, ok = mplatform.Platforms()[opts.platform]
-		if !ok {
-			return fmt.Errorf("unknown platform driver: %s", opts.platform)
+		if opts.platform == "host" {
+			var mode mplatform.SystemMode
+			platform, mode, err = mplatform.Detect(ctx)
+			if mode == mplatform.SystemGuest {
+				return fmt.Errorf("nested virtualization not supported")
+			} else if err != nil {
+				return err
+			}
+		} else {
+			var ok bool
+			platform, ok = mplatform.Platforms()[opts.platform]
+			if !ok {
+				return fmt.Errorf("unknown platform driver: %s", opts.platform)
+			}
 		}
-	}
 
-	strategy, ok := mplatform.Strategies()[platform]
-	if !ok {
-		return fmt.Errorf("unsupported platform driver: %s (contributions welcome!)", platform.String())
-	}
+		strategy, ok := mplatform.Strategies()[platform]
+		if !ok {
+			return fmt.Errorf("unsupported platform driver: %s (contributions welcome!)", platform.String())
+		}
 
-	controller, err := strategy.NewMachineV1alpha1(ctx)
+		controller, err = strategy.NewMachineV1alpha1(ctx)
+	}
 	if err != nil {
 		return err
 	}

--- a/machine/platform/iterator_v1alpha1.go
+++ b/machine/platform/iterator_v1alpha1.go
@@ -178,10 +178,34 @@ func (iterator *machineV1alpha1ServiceIterator) List(ctx context.Context, cached
 
 // Watch implements kraftkit.sh/api/machine/v1alpha1.MachineService
 func (iterator *machineV1alpha1ServiceIterator) Watch(ctx context.Context, machine *machinev1alpha1.Machine) (chan *machinev1alpha1.Machine, chan error, error) {
-	panic("not implemented: kraftkit.sh/machine/platform.machineV1alpha1ServiceIterator.Watch")
+	var errs []error
+
+	for _, strategy := range iterator.strategies {
+		eventChan, errChan, err := strategy.Watch(ctx, machine)
+		if err != nil {
+			errs = append(errs, err)
+			continue
+		}
+
+		return eventChan, errChan, nil
+	}
+
+	return nil, nil, fmt.Errorf("all iterated platforms failed: %w", merr.NewErrors(errs...))
 }
 
 // Logs implements kraftkit.sh/api/machine/v1alpha1.MachineService
 func (iterator *machineV1alpha1ServiceIterator) Logs(ctx context.Context, machine *machinev1alpha1.Machine) (chan string, chan error, error) {
-	panic("not implemented: kraftkit.sh/machine/platform.machineV1alpha1ServiceIterator.Logs")
+	var errs []error
+
+	for _, strategy := range iterator.strategies {
+		logChan, errChan, err := strategy.Logs(ctx, machine)
+		if err != nil {
+			errs = append(errs, err)
+			continue
+		}
+
+		return logChan, errChan, nil
+	}
+
+	return nil, nil, fmt.Errorf("all iterated platforms failed: %w", merr.NewErrors(errs...))
 }


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

This PR adjusts `kraft logs` to use the recently introduced platform iterator (#550) such that specifying `--plat auto` (or omission of the `--plat` flag entirely) automatically determines the machine platform to start retrieving logs from.