### PR TITLE
fix(clean): Pass config to clean to avoid errors

### DIFF
--- a/cmd/kraft/clean/clean.go
+++ b/cmd/kraft/clean/clean.go
@@ -38,11 +38,16 @@ import (
 	"github.com/spf13/cobra"
 
 	"kraftkit.sh/cmdfactory"
+	"kraftkit.sh/internal/cli"
 	"kraftkit.sh/packmanager"
 	"kraftkit.sh/unikraft/app"
 )
 
-type Clean struct{}
+type Clean struct {
+	Architecture string `long:"arch" short:"m" usage:"Filter prepare based on a target's architecture"`
+	Platform     string `long:"plat" short:"p" usage:"Filter prepare based on a target's platform"`
+	Target       string `long:"target" short:"t" usage:"Filter prepare based on a specific target"`
+}
 
 func New() *cobra.Command {
 	cmd, err := cmdfactory.New(&Clean{}, cobra.Command{
@@ -105,5 +110,18 @@ func (opts *Clean) Run(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	return project.Clean(ctx, nil)
+	// Filter project targets by any provided CLI options
+	targets := cli.FilterTargets(
+		project.Targets(),
+		opts.Architecture,
+		opts.Platform,
+		opts.Target,
+	)
+
+	t, err := cli.SelectTarget(targets)
+	if err != nil {
+		return err
+	}
+
+	return project.Clean(ctx, t)
 }

--- a/internal/cli/target.go
+++ b/internal/cli/target.go
@@ -15,6 +15,10 @@ import (
 // SelectTarget is a utility method used in a CLI context to prompt the user
 // for a specific application's target.
 func SelectTarget(targets target.Targets) (target.Target, error) {
+	if len(targets) == 1 {
+		return targets[0], nil
+	}
+
 	names := make([]string, 0, len(targets))
 	for _, t := range targets {
 		names = append(names, fmt.Sprintf(


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [ ] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [ ] Tested your changes against relevant architectures and platforms;
  - [ ] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

Cleaning a project also requires specifying the config to clean by.
The fix follows the model of other `make` invocations and passes a
target to the `invocation`.
As such, this also introduces three new, optional, arguments to it.

Closes: #564