### PR TITLE
fix(run): Set pull platform for linuxu runner

### DIFF
--- a/cmd/kraft/run/runner_linuxu.go
+++ b/cmd/kraft/run/runner_linuxu.go
@@ -143,6 +143,7 @@ func (runner *runnerLinuxu) Prepare(ctx context.Context, opts *Run, machine *mac
 			func(ctx context.Context, w func(progress float64)) error {
 				popts := []pack.PullOption{
 					pack.WithPullWorkdir(dir),
+					pack.WithPullPlatform(opts.platform.String()),
 				}
 				if log.LoggerTypeFromString(config.G[config.KraftKit](ctx).Log.Type) == log.FANCY {
 					popts = append(popts, pack.WithPullProgressFunc(w))


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

This PR fixes an issue where we must set the platform of the ELF loader to pull for, which is based on the identified platform (either automatically or via the use of the `--plat` flag).