### PR TITLE
fix: Propagation of emulation mode

### DIFF
--- a/cmd/kraft/run/run.go
+++ b/cmd/kraft/run/run.go
@@ -188,6 +188,7 @@ func (opts *Run) Run(cmd *cobra.Command, args []string) error {
 			Resources: corev1.ResourceRequirements{
 				Requests: corev1.ResourceList{},
 			},
+			Emulation: opts.DisableAccel,
 		},
 	}
 

--- a/machine/qemu/qemu_cpus.go
+++ b/machine/qemu/qemu_cpus.go
@@ -27,17 +27,15 @@ func (cpu QemuCPU) String() string {
 
 	if len(cpu.On) > 0 {
 		for _, on := range cpu.On {
-			ret.WriteString(",")
+			ret.WriteString(",+")
 			ret.WriteString(string(on))
-			ret.WriteString("=on")
 		}
 	}
 
 	if len(cpu.Off) > 0 {
 		for _, off := range cpu.Off {
-			ret.WriteString(",")
+			ret.WriteString(",-")
 			ret.WriteString(string(off))
-			ret.WriteString("=off")
 		}
 	}
 

--- a/machine/qemu/v1alpha1.go
+++ b/machine/qemu/v1alpha1.go
@@ -109,7 +109,6 @@ func (service *machineV1alpha1Service) Create(ctx context.Context, machine *mach
 
 	qopts := []QemuOption{
 		WithDaemonize(true),
-		WithEnableKVM(true),
 		WithNoGraphic(true),
 		WithPidFile(filepath.Join(machine.Status.StateDir, "machine.pid")),
 		WithNoReboot(true),
@@ -282,12 +281,13 @@ func (service *machineV1alpha1Service) Create(ctx context.Context, machine *mach
 				}),
 				WithCPU(QemuCPU{
 					CPU: QemuCPUX86Qemu64,
-					On:  QemuCPUFeatures{QemuCPUFeatureVmx},
-					Off: QemuCPUFeatures{QemuCPUFeatureSvm},
+					On:  QemuCPUFeatures{QemuCPUFeaturePdpe1gb},
+					Off: QemuCPUFeatures{QemuCPUFeatureVmx, QemuCPUFeatureSvm},
 				}),
 			)
 		} else {
 			qopts = append(qopts,
+				WithEnableKVM(true),
 				WithMachine(QemuMachine{
 					Type:         QemuMachineTypePC,
 					Accelerators: []QemuMachineAccelerator{QemuMachineAccelKVM},


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

This PR addresses using emulation mode in QEMU. First, by properly propagating the flag `-W` and secondly, by setting the correct CPU feature flags and handling of emulation in the QEMU machine provider.