### PR TITLE
fix: Correctly handle Unikraft's KConfig tree

### DIFF
--- a/kconfig/expr.go
+++ b/kconfig/expr.go
@@ -5,7 +5,9 @@
 package kconfig
 
 import (
+	"encoding/json"
 	"fmt"
+	"strings"
 )
 
 // expr represents an arbitrary kconfig expression used in "depends on",
@@ -14,6 +16,7 @@ import (
 type expr interface {
 	String() string
 	collectDeps(map[string]bool)
+	json.Marshaler
 }
 
 type exprShell struct {
@@ -22,6 +25,15 @@ type exprShell struct {
 
 func (ex *exprShell) String() string {
 	return "$" + ex.cmd
+}
+
+func (ex *exprShell) MarshalJSON() ([]byte, error) {
+	ret := ex.String()
+	if strings.HasPrefix(ret, "\"") && strings.HasSuffix(ret, "\"") {
+		ret = ret[1 : len(ret)-1]
+	}
+	ret = strings.ReplaceAll(ret, "\"", "\\\"")
+	return []byte("\"" + ret + "\""), nil
 }
 
 func (ex *exprShell) collectDeps(deps map[string]bool) {
@@ -35,6 +47,15 @@ func (ex *exprNot) String() string {
 	return fmt.Sprintf("!(%v)", ex.ex)
 }
 
+func (ex *exprNot) MarshalJSON() ([]byte, error) {
+	ret := ex.String()
+	if strings.HasPrefix(ret, "\"") && strings.HasSuffix(ret, "\"") {
+		ret = ret[1 : len(ret)-1]
+	}
+	ret = strings.ReplaceAll(ret, "\"", "\\\"")
+	return []byte("\"" + ret + "\""), nil
+}
+
 func (ex *exprNot) collectDeps(deps map[string]bool) {
 }
 
@@ -44,6 +65,15 @@ type exprIdent struct {
 
 func (ex *exprIdent) String() string {
 	return ex.name
+}
+
+func (ex *exprIdent) MarshalJSON() ([]byte, error) {
+	ret := ex.String()
+	if strings.HasPrefix(ret, "\"") && strings.HasSuffix(ret, "\"") {
+		ret = ret[1 : len(ret)-1]
+	}
+	ret = strings.ReplaceAll(ret, "\"", "\\\"")
+	return []byte("\"" + ret + "\""), nil
 }
 
 func (ex *exprIdent) collectDeps(deps map[string]bool) {
@@ -56,6 +86,15 @@ type exprString struct {
 
 func (ex *exprString) String() string {
 	return fmt.Sprintf("%q", ex.val)
+}
+
+func (ex *exprString) MarshalJSON() ([]byte, error) {
+	ret := ex.String()
+	if strings.HasPrefix(ret, "\"") && strings.HasSuffix(ret, "\"") {
+		ret = ret[1 : len(ret)-1]
+	}
+	ret = strings.ReplaceAll(ret, "\"", "\\\"")
+	return []byte("\"" + ret + "\""), nil
 }
 
 func (ex *exprString) collectDeps(deps map[string]bool) {
@@ -106,6 +145,15 @@ func (op binOp) String() string {
 
 func (ex *exprBin) String() string {
 	return fmt.Sprintf("(%v %v %v)", ex.lex, ex.op, ex.rex)
+}
+
+func (ex *exprBin) MarshalJSON() ([]byte, error) {
+	ret := ex.String()
+	if strings.HasPrefix(ret, "\"") && strings.HasSuffix(ret, "\"") {
+		ret = ret[1 : len(ret)-1]
+	}
+	ret = strings.ReplaceAll(ret, "\"", "\\\"")
+	return []byte("\"" + ret + "\""), nil
 }
 
 func (ex *exprBin) collectDeps(deps map[string]bool) {

--- a/kconfig/kconfig.go
+++ b/kconfig/kconfig.go
@@ -205,11 +205,6 @@ func (kp *kconfigParser) parseLine() {
 		return
 	}
 
-	if kp.TryConsume("$") {
-		_ = kp.Shell()
-		return
-	}
-
 	ident := kp.Ident()
 	if kp.TryConsume("=") || kp.TryConsume(":=") {
 		// Macro definition, see:

--- a/kconfig/kconfig.go
+++ b/kconfig/kconfig.go
@@ -18,57 +18,70 @@ import (
 
 // KConfigFile represents a parsed Kconfig file (including includes).
 type KConfigFile struct {
-	Root    *KConfigMenu            // mainmenu
-	Configs map[string]*KConfigMenu // only config/menuconfig entries
+	// Root is the main menu
+	Root *KConfigMenu `json:"root,omitempty"`
+
+	// All config/menuconfig entries
+	Configs map[string]*KConfigMenu `json:"configs,omitempty"`
 }
 
-// Menu represents a single hierarchical menu or config.
+// KConfigMenu represents a single hierarchical menu or config.
 type KConfigMenu struct {
-	Kind   MenuKind       // config/menu/choice/etc
-	Type   ConfigType     // tristate/bool/string/etc
-	Name   string         // name without CONFIG_
-	Elems  []*KConfigMenu // sub-elements for menus
-	Parent *KConfigMenu   // parent menu, non-nil for everythign except for mainmenu
+	// Kind represents the structure type, e.g. config/menu/choice/etc
+	Kind MenuKind `json:"kind,omitempty"`
 
+	// Type of menu element, e.g. tristate/bool/string/etc
+	Type ConfigType `json:"type,omitempty"`
+
+	// Name without CONFIG_
+	Name string `json:"name,omitempty"`
+
+	// Sub-elements for menus
+	Children []*KConfigMenu `json:"children,omitempty"`
+
+	// Prompt is the 1-line description of the menu entry.
+	Prompt KConfigPrompt `json:"prompt,omitempty"`
+
+	// Default value of the entry.
+	Default DefaultValue `json:"default,omitempty"`
+
+	// Parent menu, non-nil for everythign except for mainmenu
+	parent      *KConfigMenu
 	kconfigFile *KConfigFile // back-link to the owning KConfig
-	prompts     []prompt
-	defaults    []defaultVal
 	dependsOn   expr
 	visibleIf   expr
 	deps        map[string]bool
 	depsOnce    sync.Once
 }
 
-type prompt struct {
-	text string
-	cond expr
+type KConfigPrompt struct {
+	Text      string `json:"text,omitempty"`
+	Condition expr   `json:"condition,omitempty"`
 }
 
-type defaultVal struct {
-	val  expr
-	cond expr
+type DefaultValue struct {
+	Value     expr `json:"value,omitempty"`
+	Condition expr `json:"condition,omitempty"`
 }
 
 type (
-	MenuKind   int
-	ConfigType int
+	MenuKind   string
+	ConfigType string
 )
 
 const (
-	_ MenuKind = iota
-	MenuConfig
-	MenuGroup
-	MenuChoice
-	MenuComment
+	MenuConfig  = MenuKind("config")
+	MenuGroup   = MenuKind("group")
+	MenuChoice  = MenuKind("choice")
+	MenuComment = MenuKind("comment")
 )
 
 const (
-	_ ConfigType = iota
-	TypeBool
-	TypeTristate
-	TypeString
-	TypeInt
-	TypeHex
+	TypeBool     = ConfigType("bool")
+	TypeTristate = ConfigType("tristate")
+	TypeString   = ConfigType("string")
+	TypeInt      = ConfigType("int")
+	TypeHex      = ConfigType("hex")
 )
 
 // DependsOn returns all transitive configs this config depends on.
@@ -97,16 +110,6 @@ func (m *KConfigMenu) DependsOn() map[string]bool {
 		}
 	})
 	return m.deps
-}
-
-func (m *KConfigMenu) Prompt() string {
-	// TODO: check prompt conditions, some prompts may be not visible. If all
-	// prompts are not visible, then then menu if effectively disabled (at least
-	// for user).
-	for _, p := range m.prompts {
-		return p.text
-	}
-	return ""
 }
 
 type kconfigParser struct {
@@ -164,7 +167,7 @@ func (kconf *KConfigFile) walk(m *KConfigMenu, dependsOn, visibleIf expr) {
 		kconf.Configs[m.Name] = m
 	}
 
-	for _, elem := range m.Elems {
+	for _, elem := range m.Children {
 		kconf.walk(elem, m.dependsOn, m.visibleIf)
 	}
 }
@@ -227,20 +230,20 @@ func (kp *kconfigParser) parseMenu(cmd string) {
 
 	case "mainmenu":
 		kp.pushCurrent(&KConfigMenu{
-			Kind:    MenuConfig,
-			prompts: []prompt{{text: kp.QuotedString()}},
+			Kind:   MenuConfig,
+			Prompt: KConfigPrompt{Text: kp.QuotedString()},
 		})
 
 	case "comment":
 		kp.newCurrent(&KConfigMenu{
-			Kind:    MenuComment,
-			prompts: []prompt{{text: kp.QuotedString()}},
+			Kind:   MenuComment,
+			Prompt: KConfigPrompt{Text: kp.QuotedString()},
 		})
 
 	case "menu":
 		kp.pushCurrent(&KConfigMenu{
-			Kind:    MenuGroup,
-			prompts: []prompt{{text: kp.QuotedString()}},
+			Kind:   MenuGroup,
+			Prompt: KConfigPrompt{Text: kp.QuotedString()},
 		})
 
 	case "if":
@@ -408,8 +411,8 @@ func (kp *kconfigParser) popCurrent() {
 	last := kp.stack[len(kp.stack)-1]
 	kp.stack = kp.stack[:len(kp.stack)-1]
 	top := kp.stack[len(kp.stack)-1]
-	last.Parent = top
-	top.Elems = append(top.Elems, last)
+	last.parent = top
+	top.Children = append(top.Children, last)
 }
 
 func (kp *kconfigParser) newCurrent(m *KConfigMenu) {
@@ -439,8 +442,8 @@ func (kp *kconfigParser) endCurrent() {
 
 	top := kp.stack[len(kp.stack)-1]
 	if top != kp.cur {
-		kp.cur.Parent = top
-		top.Elems = append(top.Elems, kp.cur)
+		kp.cur.parent = top
+		top.Children = append(top.Children, kp.cur)
 	}
 
 	kp.cur = nil
@@ -448,23 +451,23 @@ func (kp *kconfigParser) endCurrent() {
 
 func (kp *kconfigParser) tryParsePrompt() {
 	if str, ok := kp.TryQuotedString(); ok {
-		prompt := prompt{
-			text: str,
+		prompt := KConfigPrompt{
+			Text: str,
 		}
 
 		if kp.TryConsume("if") {
-			prompt.cond = kp.parseExpr()
+			prompt.Condition = kp.parseExpr()
 		}
 
-		kp.current().prompts = append(kp.current().prompts, prompt)
+		kp.current().Prompt = prompt
 	}
 }
 
 func (kp *kconfigParser) parseDefaultValue() {
-	def := defaultVal{val: kp.parseExpr()}
+	def := DefaultValue{Value: kp.parseExpr()}
 	if kp.TryConsume("if") {
-		def.cond = kp.parseExpr()
+		def.Condition = kp.parseExpr()
 	}
 
-	kp.current().defaults = append(kp.current().defaults, def)
+	kp.current().Default = def
 }

--- a/kconfig/kconfig.go
+++ b/kconfig/kconfig.go
@@ -381,7 +381,9 @@ func (kp *kconfigParser) includeSource(file string) {
 		return
 	}
 	kp.newCurrent(nil)
-	file = filepath.Join(kp.baseDir, file)
+	if file[0] != '/' {
+		file = filepath.Join(kp.baseDir, file)
+	}
 	data, err := os.ReadFile(file)
 	if err != nil {
 		kp.failf("%v", err)

--- a/kconfig/kconfig.go
+++ b/kconfig/kconfig.go
@@ -376,6 +376,10 @@ func (kp *kconfigParser) parseProperty(prop string) {
 }
 
 func (kp *kconfigParser) includeSource(file string) {
+	// ignore blank files
+	if file == "" {
+		return
+	}
 	kp.newCurrent(nil)
 	file = filepath.Join(kp.baseDir, file)
 	data, err := os.ReadFile(file)

--- a/kconfig/parser.go
+++ b/kconfig/parser.go
@@ -1,11 +1,16 @@
+// SPDX-License-Identifier: Apache-2.0
 // Copyright 2020 syzkaller project authors. All rights reserved.
-// Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+// Copyright 2022 Unikraft GmbH. All rights reserved.
+// Licensed under the Apache-2.0 License (the "License").
+// You may not use this file except in compliance with the License.
 
 package kconfig
 
 import (
+	"bufio"
 	"bytes"
 	"fmt"
+	"os/exec"
 	"strings"
 )
 
@@ -137,6 +142,86 @@ func (p *parser) MustConsume(what string) {
 	}
 }
 
+func (p *parser) interpolate(b []byte) string {
+	var vars []string
+	var v []byte
+	parsing := false
+	str := string(b)
+
+	for i := 0; i < len(b); i++ {
+		// Test if we're parsing a variable which starts with `$(` and not a shell
+		// invocation which starts with `$(shell `.
+		if i+1 <= len(b) && b[i] == '$' && b[i+1] == '(' &&
+			(i+8 <= len(b) && string(b[i+2:i+7]) != "shell") {
+			i += 2 // skip the '$('
+			parsing = true
+
+			// If we're busy accepting a variable name and come to an end `)` we can
+			// stop and save.
+		} else if parsing && b[i] == ')' {
+			parsing = false
+			vars = append(vars, string(v))
+			v = []byte{}
+		}
+
+		// Save the next character to the variable name if we're parsing.
+		if parsing {
+			v = append(v, b[i])
+		}
+	}
+
+	for _, v := range vars {
+		if v == "" {
+			continue
+		}
+
+		// Evaluate known variables found from the provided environment
+		if !strings.HasPrefix("shell", v) {
+			replace, ok := p.env[v]
+			if !ok {
+				// Try with the prefix `CONFIG_`
+				replace, ok = p.env["CONFIG_"+v]
+				if !ok {
+					continue
+				}
+			}
+
+			str = strings.ReplaceAll(str, fmt.Sprintf("$(%s)", v), replace.Value)
+		}
+	}
+
+	// Evaluate shell executions
+	if len(str) > 7 && str[0:8] == "$(shell," {
+		line := strings.TrimPrefix(str, "$(shell,")
+		line = strings.TrimSuffix(line, ")")
+
+		quoted := false
+		args := strings.FieldsFunc(line, func(r rune) bool {
+			if r == '\'' || r == '"' {
+				quoted = !quoted
+			}
+			return !quoted && r == ' '
+		})
+
+		for i := range args {
+			args[i] = strings.TrimSpace(args[i])
+			args[i] = strings.TrimPrefix(args[i], "'")
+			args[i] = strings.TrimSuffix(args[i], "'")
+		}
+
+		var buf bytes.Buffer
+		cmd := exec.Command(args[0], args[1:]...)
+		cmd.Stdout = bufio.NewWriter(&buf)
+		if err := cmd.Run(); err != nil {
+			p.failf("could not execute shell: %s", err.Error())
+			return ""
+		}
+		str = strings.TrimSpace(buf.String())
+	}
+
+	return str
+}
+
 func (p *parser) QuotedString() string {
 	var str []byte
 	quote := p.char()
@@ -168,7 +253,7 @@ func (p *parser) QuotedString() string {
 	}
 
 	p.skipSpaces()
-	return string(str)
+	return p.interpolate(str)
 }
 
 func (p *parser) TryQuotedString() (string, bool) {

--- a/kconfig/parser.go
+++ b/kconfig/parser.go
@@ -31,11 +31,6 @@ func newParser(data []byte, file string, env KeyValueMap) *parser {
 // nextLine resets the parser to the next line.
 // Automatically concatenates lines split with \ at the end.
 func (p *parser) nextLine() bool {
-	if !p.eol() {
-		p.failf("tailing data at the end of line")
-		return false
-	}
-
 	if p.err != nil || len(p.data) == 0 {
 		return false
 	}

--- a/oci/pack.go
+++ b/oci/pack.go
@@ -474,7 +474,7 @@ func (ocipack *ociPackage) Path() string {
 }
 
 // KConfigTree implements unikraft.component.Component
-func (ocipack *ociPackage) KConfigTree(...*kconfig.KeyValue) (*kconfig.KConfigFile, error) {
+func (ocipack *ociPackage) KConfigTree(context.Context, ...*kconfig.KeyValue) (*kconfig.KConfigFile, error) {
 	return nil, fmt.Errorf("not implemented: oci.ociPackage.KConfigTree")
 }
 

--- a/unikraft/arch/architecture.go
+++ b/unikraft/arch/architecture.go
@@ -78,7 +78,7 @@ func (ac ArchitectureConfig) IsUnpacked() bool {
 	return false
 }
 
-func (ac ArchitectureConfig) KConfigTree(env ...*kconfig.KeyValue) (*kconfig.KConfigFile, error) {
+func (ac ArchitectureConfig) KConfigTree(context.Context, ...*kconfig.KeyValue) (*kconfig.KConfigFile, error) {
 	// Architectures are built directly into the Unikraft core for now.
 	return nil, nil
 }

--- a/unikraft/component/component.go
+++ b/unikraft/component/component.go
@@ -27,7 +27,7 @@ type Component interface {
 
 	// KConfigTree returns the component's KConfig configuration menu tree which
 	// returns all possible options for the component
-	KConfigTree(...*kconfig.KeyValue) (*kconfig.KConfigFile, error)
+	KConfigTree(context.Context, ...*kconfig.KeyValue) (*kconfig.KConfigFile, error)
 
 	// KConfig returns the component's set of file KConfig which is known when the
 	// relevant component packages have been retrieved

--- a/unikraft/core/core.go
+++ b/unikraft/core/core.go
@@ -86,7 +86,7 @@ func (uc UnikraftConfig) IsUnpacked() bool {
 	return false
 }
 
-func (uc UnikraftConfig) KConfigTree(extra ...*kconfig.KeyValue) (*kconfig.KConfigFile, error) {
+func (uc UnikraftConfig) KConfigTree(ctx context.Context, extra ...*kconfig.KeyValue) (*kconfig.KConfigFile, error) {
 	config_uk := filepath.Join(uc.Path(), unikraft.Config_uk)
 	if _, err := os.Stat(config_uk); err != nil {
 		return nil, fmt.Errorf("could not read component Config.uk: %v", err)

--- a/unikraft/lib/library.go
+++ b/unikraft/lib/library.go
@@ -178,7 +178,7 @@ func (lc LibraryConfig) Path() string {
 	return lc.path
 }
 
-func (lc LibraryConfig) KConfigTree(env ...*kconfig.KeyValue) (*kconfig.KConfigFile, error) {
+func (lc LibraryConfig) KConfigTree(_ context.Context, env ...*kconfig.KeyValue) (*kconfig.KConfigFile, error) {
 	config_uk := filepath.Join(lc.Path(), unikraft.Config_uk)
 	if _, err := os.Stat(config_uk); err != nil {
 		return nil, fmt.Errorf("could not read component Config.uk: %v", err)
@@ -188,21 +188,9 @@ func (lc LibraryConfig) KConfigTree(env ...*kconfig.KeyValue) (*kconfig.KConfigF
 }
 
 func (lc LibraryConfig) KConfig() kconfig.KeyValueMap {
-	menu, _ := lc.KConfigTree()
-
 	values := kconfig.KeyValueMap{}
 	values.OverrideBy(lc.kconfig)
-
-	if menu == nil {
-		// Naively set the KConfig option for this library based on Unikraft
-		// convention.
-		values.Set(kconfig.Prefix+"LIB"+strings.ToUpper(lc.name), kconfig.Yes)
-
-		return values
-	}
-
-	values.Set(kconfig.Prefix+menu.Root.Name, kconfig.Yes)
-
+	values.Set(kconfig.Prefix+"LIB"+strings.ToUpper(lc.name), kconfig.Yes)
 	return values
 }
 

--- a/unikraft/plat/platform.go
+++ b/unikraft/plat/platform.go
@@ -80,7 +80,7 @@ func (pc PlatformConfig) IsUnpacked() bool {
 	return false
 }
 
-func (pc PlatformConfig) KConfigTree(env ...*kconfig.KeyValue) (*kconfig.KConfigFile, error) {
+func (pc PlatformConfig) KConfigTree(context.Context, ...*kconfig.KeyValue) (*kconfig.KConfigFile, error) {
 	// TODO: Try within the Unikraft codebase as well as via an external
 	// microlibrary.  For now, return nil as undetermined.
 	return nil, nil

--- a/unikraft/target/target.go
+++ b/unikraft/target/target.go
@@ -158,7 +158,7 @@ func (tc *TargetConfig) ConfigFilename() string {
 	return fmt.Sprintf("%s.%s", kconfig.DotConfigFileName, filepath.Base(tc.kernel))
 }
 
-func (tc *TargetConfig) KConfigTree(env ...*kconfig.KeyValue) (*kconfig.KConfigFile, error) {
+func (tc *TargetConfig) KConfigTree(_ context.Context, env ...*kconfig.KeyValue) (*kconfig.KConfigFile, error) {
 	return nil, fmt.Errorf("target does not have a Config.uk file")
 }
 

--- a/unikraft/template/template.go
+++ b/unikraft/template/template.go
@@ -72,7 +72,7 @@ func (tc TemplateConfig) Path() string {
 }
 
 // KConfigTree returns the path to the kconfig file of the template
-func (tc TemplateConfig) KConfigTree(env ...*kconfig.KeyValue) (*kconfig.KConfigFile, error) {
+func (tc TemplateConfig) KConfigTree(context.Context, ...*kconfig.KeyValue) (*kconfig.KConfigFile, error) {
 	return nil, nil
 }
 


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

This PR addresses the issue of being able to handle Unikraft's KConfig files (provided through the core repository and auxiliary microlibrary repositories).  The main outstanding issue was invoking shell commands in `include` paths.  This is now accomplished through this PR.  Necessary adjustments are made also to the Application component to correctly seed the environment that is passed to the KConfig parser.  This allows for all variables to be properly referenced.  Finally, relevant structures are updated to make them JSON-exportable, allowing the full tree to be dumped in a machine-readable fashion once parsed.

A simple program is able to return the tree and all the relevant values:

```go
import (
  "encoding/json"
  "kraftkit.sh/unikraft/app"
)

project, err :=  app.NewProjectFromOptions(ctx,
  app.WithProjectWorkdir("path/to/my/project"),
  app.WithProjectDefaultKraftfiles(),
)
// handle err

tree, err := project.KConfigTree(ctx)
// handle err

b, err := json.Marshal(tree)
// handle err

fmt.Printf(string(b))
```

GitHub-Fixes: #56 
GitHub-Supersedes: #305