### PR TITLE
feat(qemu): Propagate more QEMU errors

### DIFF
--- a/machine/qemu/v1alpha1.go
+++ b/machine/qemu/v1alpha1.go
@@ -68,6 +68,14 @@ func NewMachineV1alpha1Service(ctx context.Context, opts ...any) (machinev1alpha
 
 // Create implements kraftkit.sh/api/machine/v1alpha1.MachineService.Create
 func (service *machineV1alpha1Service) Create(ctx context.Context, machine *machinev1alpha1.Machine) (*machinev1alpha1.Machine, error) {
+	if machine.Status.KernelPath == "" {
+		return machine, fmt.Errorf("empty kernel path")
+	}
+
+	if _, err := os.Stat(machine.Status.KernelPath); err != nil && os.IsNotExist(err) {
+		return machine, fmt.Errorf("supplied kernel path does not exist: %s", machine.Status.KernelPath)
+	}
+
 	if machine.ObjectMeta.UID == "" {
 		machine.ObjectMeta.UID = uuid.NewUUID()
 	}


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

This PR:
* Checks early on for the supplied kernel path and whether it is empty or an non-existent file and propagates the error;
* Saves the logs of the QEMU instance to `qemu.log` and propagates these logs if the QEMU instance failed to initialized.