### PR TITLE
feat(build): Allow specifying non-standard location for `Kraftfile`

### DIFF
--- a/cmd/kraft/clean/clean.go
+++ b/cmd/kraft/clean/clean.go
@@ -45,6 +45,7 @@ import (
 
 type Clean struct {
 	Architecture string `long:"arch" short:"m" usage:"Filter prepare based on a target's architecture"`
+	Kraftfile    string `long:"kraftfile" usage:"Set an alternative path of the Kraftfile"`
 	Platform     string `long:"plat" short:"p" usage:"Filter prepare based on a target's platform"`
 	Target       string `long:"target" short:"t" usage:"Filter prepare based on a specific target"`
 }
@@ -100,12 +101,18 @@ func (opts *Clean) Run(cmd *cobra.Command, args []string) error {
 		workdir = args[0]
 	}
 
-	// Initialize at least the configuration options for a project
-	project, err := app.NewProjectFromOptions(
-		ctx,
+	popts := []app.ProjectOption{
 		app.WithProjectWorkdir(workdir),
-		app.WithProjectDefaultKraftfiles(),
-	)
+	}
+
+	if len(opts.Kraftfile) > 0 {
+		popts = append(popts, app.WithProjectKraftfile(opts.Kraftfile))
+	} else {
+		popts = append(popts, app.WithProjectDefaultKraftfiles())
+	}
+
+	// Initialize at least the configuration options for a project
+	project, err := app.NewProjectFromOptions(ctx, popts...)
 	if err != nil {
 		return err
 	}

--- a/cmd/kraft/fetch/fetch.go
+++ b/cmd/kraft/fetch/fetch.go
@@ -21,6 +21,7 @@ import (
 
 type Fetch struct {
 	Architecture string `long:"arch" short:"m" usage:"Filter prepare based on a target's architecture"`
+	Kraftfile    string `long:"kraftfile" usage:"Set an alternative path of the Kraftfile"`
 	Platform     string `long:"plat" short:"p" usage:"Filter prepare based on a target's platform"`
 	Target       string `long:"target" short:"t" usage:"Filter prepare based on a specific target"`
 }
@@ -77,12 +78,18 @@ func (opts *Fetch) Run(cmd *cobra.Command, args []string) error {
 		workdir = args[0]
 	}
 
-	// Initialize at least the configuration options for a project
-	project, err := app.NewProjectFromOptions(
-		ctx,
+	popts := []app.ProjectOption{
 		app.WithProjectWorkdir(workdir),
-		app.WithProjectDefaultKraftfiles(),
-	)
+	}
+
+	if len(opts.Kraftfile) > 0 {
+		popts = append(popts, app.WithProjectKraftfile(opts.Kraftfile))
+	} else {
+		popts = append(popts, app.WithProjectDefaultKraftfiles())
+	}
+
+	// Initialize at least the configuration options for a project
+	project, err := app.NewProjectFromOptions(ctx, popts...)
 	if err != nil {
 		return err
 	}

--- a/cmd/kraft/menu/menu.go
+++ b/cmd/kraft/menu/menu.go
@@ -22,6 +22,7 @@ import (
 
 type Menu struct {
 	Architecture string `long:"arch" short:"m" usage:"Filter prepare based on a target's architecture"`
+	Kraftfile    string `long:"kraftfile" usage:"Set an alternative path of the Kraftfile"`
 	Platform     string `long:"plat" short:"p" usage:"Filter prepare based on a target's platform"`
 	Target       string `long:"target" short:"t" usage:"Filter prepare based on a specific target"`
 }
@@ -78,12 +79,18 @@ func (opts *Menu) Run(cmd *cobra.Command, args []string) error {
 		workdir = args[0]
 	}
 
-	// Initialize at least the configuration options for a project
-	project, err := app.NewProjectFromOptions(
-		ctx,
+	popts := []app.ProjectOption{
 		app.WithProjectWorkdir(workdir),
-		app.WithProjectDefaultKraftfiles(),
-	)
+	}
+
+	if len(opts.Kraftfile) > 0 {
+		popts = append(popts, app.WithProjectKraftfile(opts.Kraftfile))
+	} else {
+		popts = append(popts, app.WithProjectDefaultKraftfiles())
+	}
+
+	// Initialize at least the configuration options for a project
+	project, err := app.NewProjectFromOptions(ctx, popts...)
 	if err != nil {
 		return err
 	}

--- a/cmd/kraft/pkg/list/list.go
+++ b/cmd/kraft/pkg/list/list.go
@@ -23,6 +23,7 @@ import (
 )
 
 type List struct {
+	Kraftfile string `long:"kraftfile" usage:"Set an alternative path of the Kraftfile"`
 	Limit     int    `long:"limit" short:"l" usage:"Set the maximum number of results" default:"50"`
 	NoLimit   bool   `long:"no-limit" usage:"Do not limit the number of items to print"`
 	ShowApps  bool   `long:"apps" short:"" usage:"Show applications"`
@@ -102,11 +103,17 @@ func (opts *List) Run(cmd *cobra.Command, args []string) error {
 
 	// List pacakges part of a project
 	if len(workdir) > 0 {
-		project, err := app.NewProjectFromOptions(
-			ctx,
+		popts := []app.ProjectOption{
 			app.WithProjectWorkdir(workdir),
-			app.WithProjectDefaultKraftfiles(),
-		)
+		}
+
+		if len(opts.Kraftfile) > 0 {
+			popts = append(popts, app.WithProjectKraftfile(opts.Kraftfile))
+		} else {
+			popts = append(popts, app.WithProjectDefaultKraftfiles())
+		}
+
+		project, err := app.NewProjectFromOptions(ctx, popts...)
 		if err != nil {
 			return err
 		}

--- a/cmd/kraft/pkg/pkg.go
+++ b/cmd/kraft/pkg/pkg.go
@@ -39,6 +39,7 @@ type Pkg struct {
 	Format       string `local:"true" long:"as" short:"M" usage:"Force the packaging despite possible conflicts" default:"auto"`
 	Initrd       string `local:"true" long:"initrd" short:"i" usage:"Path to init ramdisk to bundle within the package (passing a path will automatically generate a CPIO image)"`
 	Kernel       string `local:"true" long:"kernel" short:"k" usage:"Override the path to the unikernel image"`
+	Kraftfile    string `long:"kraftfile" usage:"Set an alternative path of the Kraftfile"`
 	Name         string `local:"true" long:"name" short:"n" usage:"Specify the name of the package"`
 	Output       string `local:"true" long:"output" short:"o" usage:"Save the package at the following output"`
 	Platform     string `local:"true" long:"plat" short:"p" usage:"Filter the creation of the package by platform of known targets"`
@@ -114,12 +115,18 @@ func (opts *Pkg) Run(cmd *cobra.Command, args []string) error {
 
 	ctx := cmd.Context()
 
-	// Interpret the project directory
-	project, err := app.NewProjectFromOptions(
-		ctx,
+	popts := []app.ProjectOption{
 		app.WithProjectWorkdir(workdir),
-		app.WithProjectDefaultKraftfiles(),
-	)
+	}
+
+	if len(opts.Kraftfile) > 0 {
+		popts = append(popts, app.WithProjectKraftfile(opts.Kraftfile))
+	} else {
+		popts = append(popts, app.WithProjectDefaultKraftfiles())
+	}
+
+	// Interpret the project directory
+	project, err := app.NewProjectFromOptions(ctx, popts...)
 	if err != nil {
 		return err
 	}

--- a/cmd/kraft/pkg/push/push.go
+++ b/cmd/kraft/pkg/push/push.go
@@ -23,7 +23,8 @@ import (
 )
 
 type Push struct {
-	Format string `local:"true" long:"as" short:"M" usage:"Force the packaging despite possible conflicts" default:"auto"`
+	Format    string `local:"true" long:"as" short:"M" usage:"Force the packaging despite possible conflicts" default:"auto"`
+	Kraftfile string `long:"kraftfile" usage:"Set an alternative path of the Kraftfile"`
 }
 
 func New() *cobra.Command {
@@ -85,12 +86,18 @@ func (opts *Push) Run(cmd *cobra.Command, args []string) error {
 	norender := log.LoggerTypeFromString(config.G[config.KraftKit](ctx).Log.Type) != log.FANCY
 	ref := ""
 	if workdir != "" {
-		// Read the kraft yaml specification and get the target name
-		project, err := app.NewProjectFromOptions(
-			ctx,
+		popts := []app.ProjectOption{
 			app.WithProjectWorkdir(workdir),
-			app.WithProjectDefaultKraftfiles(),
-		)
+		}
+
+		if len(opts.Kraftfile) > 0 {
+			popts = append(popts, app.WithProjectKraftfile(opts.Kraftfile))
+		} else {
+			popts = append(popts, app.WithProjectDefaultKraftfiles())
+		}
+
+		// Read the kraft yaml specification and get the target name
+		project, err := app.NewProjectFromOptions(ctx, popts...)
 		if err != nil {
 			return err
 		}

--- a/cmd/kraft/prepare/prepare.go
+++ b/cmd/kraft/prepare/prepare.go
@@ -21,6 +21,7 @@ import (
 
 type Prepare struct {
 	Architecture string `long:"arch" short:"m" usage:"Filter prepare based on a target's architecture"`
+	Kraftfile    string `long:"kraftfile" usage:"Set an alternative path of the Kraftfile"`
 	Platform     string `long:"plat" short:"p" usage:"Filter prepare based on a target's platform"`
 	Target       string `long:"target" short:"t" usage:"Filter prepare based on a specific target"`
 }
@@ -77,12 +78,18 @@ func (opts *Prepare) Run(cmd *cobra.Command, args []string) error {
 		workdir = args[0]
 	}
 
-	// Initialize at least the configuration options for a project
-	project, err := app.NewProjectFromOptions(
-		ctx,
+	popts := []app.ProjectOption{
 		app.WithProjectWorkdir(workdir),
-		app.WithProjectDefaultKraftfiles(),
-	)
+	}
+
+	if len(opts.Kraftfile) > 0 {
+		popts = append(popts, app.WithProjectKraftfile(opts.Kraftfile))
+	} else {
+		popts = append(popts, app.WithProjectDefaultKraftfiles())
+	}
+
+	// Initialize at least the configuration options for a project
+	project, err := app.NewProjectFromOptions(ctx, popts...)
 	if err != nil {
 		return err
 	}

--- a/cmd/kraft/properclean/properclean.go
+++ b/cmd/kraft/properclean/properclean.go
@@ -42,7 +42,9 @@ import (
 	"kraftkit.sh/unikraft/app"
 )
 
-type ProperClean struct{}
+type ProperClean struct {
+	Kraftfile string `long:"kraftfile" usage:"Set an alternative path of the Kraftfile"`
+}
 
 func New() *cobra.Command {
 	cmd, err := cmdfactory.New(&ProperClean{}, cobra.Command{
@@ -96,12 +98,18 @@ func (opts *ProperClean) Run(cmd *cobra.Command, args []string) error {
 		workdir = args[0]
 	}
 
-	// Initialize at least the configuration options for a project
-	project, err := app.NewProjectFromOptions(
-		ctx,
+	popts := []app.ProjectOption{
 		app.WithProjectWorkdir(workdir),
-		app.WithProjectDefaultKraftfiles(),
-	)
+	}
+
+	if len(opts.Kraftfile) > 0 {
+		popts = append(popts, app.WithProjectKraftfile(opts.Kraftfile))
+	} else {
+		popts = append(popts, app.WithProjectDefaultKraftfiles())
+	}
+
+	// Initialize at least the configuration options for a project
+	project, err := app.NewProjectFromOptions(ctx, popts...)
 	if err != nil {
 		return err
 	}

--- a/cmd/kraft/run/run.go
+++ b/cmd/kraft/run/run.go
@@ -33,6 +33,7 @@ type Run struct {
 	InitRd        string   `long:"initrd" usage:"Use the specified initrd"`
 	IP            string   `long:"ip" usage:"Assign the provided IP address"`
 	KernelArgs    []string `long:"kernel-arg" short:"a" usage:"Set additional kernel arguments"`
+	Kraftfile     string   `long:"kraftfile" usage:"Set an alternative path of the Kraftfile"`
 	MacAddress    string   `long:"mac" usage:"Assign the provided MAC address"`
 	Memory        string   `long:"memory" short:"M" usage:"Assign MB memory to the unikernel" default:"64M"`
 	Name          string   `long:"name" short:"n" usage:"Name of the instance"`

--- a/cmd/kraft/run/runner_project.go
+++ b/cmd/kraft/run/runner_project.go
@@ -63,11 +63,17 @@ func (runner *runnerProject) Runnable(ctx context.Context, opts *Run, args ...st
 
 // Prepare implements Runner.
 func (runner *runnerProject) Prepare(ctx context.Context, opts *Run, machine *machineapi.Machine, args ...string) error {
-	project, err := app.NewProjectFromOptions(
-		ctx,
+	popts := []app.ProjectOption{
 		app.WithProjectWorkdir(runner.workdir),
-		app.WithProjectDefaultKraftfiles(),
-	)
+	}
+
+	if len(opts.Kraftfile) > 0 {
+		popts = append(popts, app.WithProjectKraftfile(opts.Kraftfile))
+	} else {
+		popts = append(popts, app.WithProjectDefaultKraftfiles())
+	}
+
+	project, err := app.NewProjectFromOptions(ctx, popts...)
 	if err != nil {
 		return fmt.Errorf("could not instantiate project directory %s: %v", runner.workdir, err)
 	}

--- a/cmd/kraft/set/set.go
+++ b/cmd/kraft/set/set.go
@@ -45,7 +45,8 @@ import (
 )
 
 type Set struct {
-	Workdir string `long:"workdir" short:"w" usage:"Work on a unikernel at a path"`
+	Kraftfile string `long:"kraftfile" usage:"Set an alternative path of the Kraftfile"`
+	Workdir   string `long:"workdir" short:"w" usage:"Work on a unikernel at a path"`
 }
 
 func New() *cobra.Command {
@@ -126,13 +127,19 @@ func (opts *Set) Run(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("dotconfig file does not exist: %s", dotconfig)
 	}
 
-	// Initialize at least the configuration options for a project
-	project, err := app.NewProjectFromOptions(
-		ctx,
+	popts := []app.ProjectOption{
 		app.WithProjectWorkdir(workdir),
-		app.WithProjectDefaultKraftfiles(),
 		app.WithProjectConfig(confOpts),
-	)
+	}
+
+	if len(opts.Kraftfile) > 0 {
+		popts = append(popts, app.WithProjectKraftfile(opts.Kraftfile))
+	} else {
+		popts = append(popts, app.WithProjectDefaultKraftfiles())
+	}
+
+	// Initialize at least the configuration options for a project
+	project, err := app.NewProjectFromOptions(ctx, popts...)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION


<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

This PR introduces a new flag `--kraftfile` which allows the user to specify a non-standard location for the `Kraftfile`.