### PR TITLE
feat: Introduce `--all` flag and target selection menu in `kraft build`

### DIFF
--- a/cmd/kraft/build/build.go
+++ b/cmd/kraft/build/build.go
@@ -33,6 +33,7 @@ import (
 )
 
 type Build struct {
+	All          bool   `long:"all" usage:"Build all targets"`
 	Architecture string `long:"arch" short:"m" usage:"Filter the creation of the build by architecture of known targets"`
 	DotConfig    string `long:"config" short:"c" usage:"Override the path to the KConfig .config file"`
 	Fast         bool   `long:"fast" usage:"Use maximum parallelization when performing the build"`
@@ -390,12 +391,23 @@ func (opts *Build) Run(cmd *cobra.Command, args []string) error {
 	processes := []*paraprogress.Process{} // reset
 
 	// Filter project targets by any provided CLI options
-	selected := cli.FilterTargets(
-		opts.project.Targets(),
-		opts.Architecture,
-		opts.Platform,
-		opts.Target,
-	)
+	selected := opts.project.Targets()
+	if !opts.All {
+		selected = cli.FilterTargets(
+			selected,
+			opts.Architecture,
+			opts.Platform,
+			opts.Target,
+		)
+
+		if !config.G[config.KraftKit](ctx).NoPrompt {
+			res, err := cli.SelectTarget(selected)
+			if err != nil {
+				return err
+			}
+			selected = []target.Target{res}
+		}
+	}
 
 	if len(selected) == 0 {
 		return fmt.Errorf("no targets selected to build")

--- a/internal/cli/target.go
+++ b/internal/cli/target.go
@@ -14,7 +14,7 @@ import (
 
 // SelectTarget is a utility method used in a CLI context to prompt the user
 // for a specific application's target.
-func SelectTarget(targets target.Targets) (target.Target, error) {
+func SelectTarget(targets []target.Target) (target.Target, error) {
 	if len(targets) == 1 {
 		return targets[0], nil
 	}
@@ -49,8 +49,8 @@ func SelectTarget(targets target.Targets) (target.Target, error) {
 
 // FilterTargets returns a subset of `targets` based in input strings `arch`,
 // `plat` and/or `targ`
-func FilterTargets(targets target.Targets, arch, plat, targ string) target.Targets {
-	var selected target.Targets
+func FilterTargets(targets []target.Target, arch, plat, targ string) []target.Target {
+	var selected []target.Target
 
 	type condition func(target.Target, string, string, string) bool
 

--- a/unikraft/app/application.go
+++ b/unikraft/app/application.go
@@ -107,9 +107,6 @@ type Application interface {
 	// TargetNames return names for all targets in this Compose config
 	TargetNames() []string
 
-	// TargetByName returns the `target.Target` based on an input name
-	TargetByName(string) (target.Target, error)
-
 	// Components returns a unique list of Unikraft components which this
 	// applicatiton consists of
 	Components(context.Context) ([]component.Component, error)
@@ -552,21 +549,6 @@ func (app application) TargetNames() []string {
 	sort.Strings(names)
 
 	return names
-}
-
-// TargetByName returns the `*target.TargetConfig` based on an input name
-func (app application) TargetByName(name string) (target.Target, error) {
-	if len(name) == 0 {
-		return nil, fmt.Errorf("no target name specified in lookup")
-	}
-
-	for _, k := range app.targets {
-		if k.Name() == name {
-			return k, nil
-		}
-	}
-
-	return nil, fmt.Errorf("unknown target: %s", name)
 }
 
 // Components returns a unique list of Unikraft components which this

--- a/unikraft/app/application.go
+++ b/unikraft/app/application.go
@@ -45,7 +45,7 @@ type Application interface {
 	Libraries(ctx context.Context) (lib.Libraries, error)
 
 	// Targets returns the application's targets
-	Targets() target.Targets
+	Targets() []target.Target
 
 	// Extensions returns the application's extensions
 	Extensions() component.Extensions
@@ -123,7 +123,7 @@ type application struct {
 	template      template.TemplateConfig
 	unikraft      core.UnikraftConfig
 	libraries     lib.Libraries
-	targets       target.Targets
+	targets       []*target.TargetConfig
 	kraftfiles    []string
 	configuration kconfig.KeyValueMap
 	extensions    component.Extensions
@@ -176,8 +176,12 @@ func (app application) Libraries(ctx context.Context) (lib.Libraries, error) {
 	return libs, nil
 }
 
-func (app application) Targets() target.Targets {
-	return app.targets
+func (app application) Targets() []target.Target {
+	targets := []target.Target{}
+	for _, t := range app.targets {
+		targets = append(targets, target.Target(t))
+	}
+	return targets
 }
 
 func (app application) Extensions() component.Extensions {
@@ -204,7 +208,12 @@ func (app application) MergeTemplate(ctx context.Context, merge Application) (Ap
 		}
 	}
 
-	app.targets = merge.Targets()
+	// TODO(nderjung): This entire method and procedure needs to be re-thought to
+	// be better extensible.  For now, it is unused.  We can safely cast this:
+	app.targets = []*target.TargetConfig{}
+	for _, t := range merge.Targets() {
+		app.targets = append(app.targets, t.(*target.TargetConfig))
+	}
 
 	for id, ext := range merge.Extensions() {
 		app.extensions[id] = ext

--- a/unikraft/app/application.go
+++ b/unikraft/app/application.go
@@ -113,10 +113,6 @@ type Application interface {
 	// Components returns a unique list of Unikraft components which this
 	// applicatiton consists of
 	Components(context.Context) ([]component.Component, error)
-
-	// WithTarget is a reducer that returns the application with only the provided
-	// target.
-	WithTarget(target.Target) (Application, error)
 }
 
 type application struct {
@@ -635,10 +631,4 @@ func (app application) PrintInfo(ctx context.Context) string {
 	}
 
 	return tree.String()
-}
-
-func (app application) WithTarget(targ target.Target) (Application, error) {
-	ret := app
-	ret.targets = target.Targets{targ.(*target.TargetConfig)}
-	return ret, nil
 }

--- a/unikraft/app/application_options.go
+++ b/unikraft/app/application_options.go
@@ -134,7 +134,7 @@ func WithLibraries(libraries lib.Libraries) ApplicationOption {
 }
 
 // WithTargets sets the application's target list
-func WithTargets(targets target.Targets) ApplicationOption {
+func WithTargets(targets []*target.TargetConfig) ApplicationOption {
 	return func(ac *application) error {
 		ac.targets = targets
 		return nil

--- a/unikraft/target/target.go
+++ b/unikraft/target/target.go
@@ -77,8 +77,6 @@ type TargetConfig struct {
 	command []string
 }
 
-type Targets []*TargetConfig
-
 // NewTargetFromOptions is a constructor for TargetConfig.
 func NewTargetFromOptions(opts ...TargetOption) (Target, error) {
 	tc := TargetConfig{}


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

The previous default behavior of `kraft build` was to build all platforms and architecture target combinations.  This leads to some confusion in some cases.  Instead, provide a utility prompt menu (if allowed by the user's configuration) to select the target to construct. To resume the previous functionality, the user can use the newly introduced `--all` flag.

Necessary adjustments internally are also included. This PR also deprecates some unused methods that were discovered in this process.