### PR TITLE
fix(run): Fix the order of runners

### DIFF
--- a/cmd/kraft/run/runner.go
+++ b/cmd/kraft/run/runner.go
@@ -32,19 +32,29 @@ type runner interface {
 // runners is the list of built-in runners which are checked sequentially for
 // capability.  The first to test positive via Runnable is used with the
 // controller.
-func runners() map[string]runner {
-	r := map[string]runner{
-		// "api":     &runnerApi{},
-		"linuxu":  &runnerLinuxu{},
-		"kernel":  &runnerKernel{},
-		"project": &runnerProject{},
+func runners() []runner {
+	r := []runner{
+		&runnerLinuxu{},
+		&runnerKernel{},
+		&runnerProject{},
 	}
 
-	for k, pm := range packmanager.PackageManagers() {
-		r[string(k)] = &runnerPackage{
+	for _, pm := range packmanager.PackageManagers() {
+		r = append(r, &runnerPackage{
 			pm: pm,
-		}
+		})
 	}
 
 	return r
+}
+
+// runnersByName is a utility method that returns a map of the available runners
+// such that their alias name can be quickly looked up.
+func runnersByName() map[string]runner {
+	runners := runners()
+	ret := make(map[string]runner, len(runners))
+	for _, runner := range runners {
+		ret[runner.String()] = runner
+	}
+	return ret
 }

--- a/manifest/manager.go
+++ b/manifest/manager.go
@@ -369,7 +369,7 @@ func (m *manifestManager) IsCompatible(ctx context.Context, source string, qopts
 		"source": source,
 	}).Trace("checking if source is compatible with the manifest manager")
 
-	if _, _, _, err := unikraft.GuessTypeNameVersion(source); err == nil {
+	if t, _, _, err := unikraft.GuessTypeNameVersion(source); err == nil && t != unikraft.ComponentTypeUnknown {
 		return m, true, nil
 	}
 


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

This PR fixes an out-of-order issue which would occassionally misdetermine what to run.  The issue is found with the use of hashmap which does not maintain order vs. a slice which does.  Necessary adjustments are made to rework the code to use a slice for the list of available runners.  The order is important because the runners based on a package manager should come last, as these can require network connectivity and would otherwise slow down the check for more lightweight runners that are local to the system.

