### PR TITLE
fix: Correctly handle platform name aliasing

### DIFF
--- a/cmd/kraft/events/events.go
+++ b/cmd/kraft/events/events.go
@@ -85,7 +85,7 @@ func (opts *Events) Run(cmd *cobra.Command, args []string) error {
 		}
 	} else {
 		var ok bool
-		platform, ok = mplatform.Platforms()[opts.platform]
+		platform, ok = mplatform.PlatformsByName()[opts.platform]
 		if !ok {
 			cancel()
 			return fmt.Errorf("unknown platform driver: %s", opts.platform)

--- a/cmd/kraft/logs/logs.go
+++ b/cmd/kraft/logs/logs.go
@@ -71,7 +71,7 @@ func (opts *Logs) Run(cmd *cobra.Command, args []string) error {
 			}
 		} else {
 			var ok bool
-			platform, ok = mplatform.Platforms()[opts.platform]
+			platform, ok = mplatform.PlatformsByName()[opts.platform]
 			if !ok {
 				return fmt.Errorf("unknown platform driver: %s", opts.platform)
 			}

--- a/cmd/kraft/ps/ps.go
+++ b/cmd/kraft/ps/ps.go
@@ -94,7 +94,7 @@ func (opts *Ps) Run(cmd *cobra.Command, args []string) error {
 			}
 		} else {
 			var ok bool
-			platform, ok = mplatform.Platforms()[opts.platform]
+			platform, ok = mplatform.PlatformsByName()[opts.platform]
 			if !ok {
 				return fmt.Errorf("unknown platform driver: %s", opts.platform)
 			}

--- a/cmd/kraft/rm/rm.go
+++ b/cmd/kraft/rm/rm.go
@@ -77,7 +77,7 @@ func (opts *Rm) Run(cmd *cobra.Command, args []string) error {
 			}
 		} else {
 			var ok bool
-			platform, ok = mplatform.Platforms()[opts.platform]
+			platform, ok = mplatform.PlatformsByName()[opts.platform]
 			if !ok {
 				return fmt.Errorf("unknown platform driver: %s", opts.platform)
 			}

--- a/cmd/kraft/run/run.go
+++ b/cmd/kraft/run/run.go
@@ -161,7 +161,7 @@ func (opts *Run) Pre(cmd *cobra.Command, _ []string) error {
 		}
 	} else {
 		var ok bool
-		opts.platform, ok = mplatform.Platforms()[plat]
+		opts.platform, ok = mplatform.PlatformsByName()[plat]
 		if !ok {
 			return fmt.Errorf("unknown platform driver: %s", opts.platform)
 		}

--- a/cmd/kraft/stop/stop.go
+++ b/cmd/kraft/stop/stop.go
@@ -80,7 +80,7 @@ func (opts *Stop) Run(cmd *cobra.Command, args []string) error {
 			}
 		} else {
 			var ok bool
-			platform, ok = mplatform.Platforms()[opts.platform]
+			platform, ok = mplatform.PlatformsByName()[opts.platform]
 			if !ok {
 				return fmt.Errorf("unknown platform driver: %s", opts.platform)
 			}

--- a/machine/platform/platform.go
+++ b/machine/platform/platform.go
@@ -19,12 +19,37 @@ func (ht Platform) String() string {
 	return string(ht)
 }
 
-// Platforms returns the list of known platforms.
-func Platforms() map[string]Platform {
+// PlatformsByName returns the list of known platforms and their name alises.
+func PlatformsByName() map[string]Platform {
 	return map[string]Platform{
-		"fc":   PlatformFirecracker,
-		"kvm":  PlatformQEMU,
-		"qemu": PlatformQEMU,
-		"xen":  PlatformXen,
+		"fc":          PlatformFirecracker,
+		"firecracker": PlatformFirecracker,
+		"kvm":         PlatformQEMU,
+		"qemu":        PlatformQEMU,
+		"xen":         PlatformXen,
 	}
+}
+
+// Platforms returns all the unique platforms.
+func Platforms() []Platform {
+	return []Platform{
+		PlatformFirecracker,
+		PlatformQEMU,
+		PlatformXen,
+	}
+}
+
+// PlatformAliases returns all the name alises for a given platform.
+func PlatformAliases() map[Platform][]string {
+	aliases := map[Platform][]string{}
+
+	for alias, plat := range PlatformsByName() {
+		if aliases[plat] == nil {
+			aliases[plat] = make([]string, 0)
+		}
+
+		aliases[plat] = append(aliases[plat], alias)
+	}
+
+	return aliases
 }

--- a/machine/platform/strategy.go
+++ b/machine/platform/strategy.go
@@ -42,8 +42,11 @@ func Strategies() map[Platform]*Strategy {
 // names.
 func DriverNames() []string {
 	ret := []string{}
-	for plat := range Strategies() {
-		ret = append(ret, plat.String())
+
+	for alias, plat := range PlatformsByName() {
+		if _, ok := Strategies()[plat]; ok {
+			ret = append(ret, alias)
+		}
 	}
 
 	return ret

--- a/unikraft/plat/transform.go
+++ b/unikraft/plat/transform.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"fmt"
 
+	mplatform "kraftkit.sh/machine/platform"
 	"kraftkit.sh/unikraft"
 )
 
@@ -22,6 +23,12 @@ func TransformFromSchema(ctx context.Context, data interface{}) (interface{}, er
 		platform.name = value
 	default:
 		return nil, fmt.Errorf("invalid type %T for platform", data)
+	}
+
+	// If the user has provided an alias for a known internal platform name,
+	// rewrite it to the correct name.
+	if alias, ok := mplatform.PlatformsByName()[platform.name]; ok {
+		platform.name = alias.String()
 	}
 
 	if uk != nil && uk.UK_BASE != "" {


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

If a user has specified a known internal-to-Unikraft platform name alias, handle the rewrite correctly across the codebase.  For example: "kvm" and "qemu" with the QEMU platform, and "fc" and "firecracker" with Firecracker.

This occurs at two levels:

* When specified within the context of a `Kraftfile`: handle during the transformation of the schema into internal structures.

* Handle at the CLI-level: when using the `--plat` flag.

To make this possible, this PR adjusts the `Platforms` method to return a slice and introduces two helper methods `PlatformsByName` and `PlatformAliases` which are used to handle the situation where a platform can have an alias.  This API adjustment is propagated across the codebase in the same commit.

