### PR TITLE
fix(ps): Show missing information (IPs and plat/arch)

### DIFF
--- a/cmd/kraft/ps/ps.go
+++ b/cmd/kraft/ps/ps.go
@@ -169,9 +169,10 @@ func (opts *Ps) Run(cmd *cobra.Command, args []string) error {
 	table.AddField("MEM", cs.Bold)
 	if opts.Long {
 		table.AddField("PORTS", cs.Bold)
+		table.AddField("IP", cs.Bold)
 		table.AddField("ARCH", cs.Bold)
-		table.AddField("PLAT", cs.Bold)
 	}
+	table.AddField("PLAT", cs.Bold)
 	table.EndRow()
 
 	for _, item := range items {
@@ -186,8 +187,11 @@ func (opts *Ps) Run(cmd *cobra.Command, args []string) error {
 		table.AddField(item.mem, nil)
 		if opts.Long {
 			table.AddField(item.ports, nil)
+			table.AddField(strings.Join(item.ips, ","), nil)
 			table.AddField(item.arch, nil)
 			table.AddField(item.plat, nil)
+		} else {
+			table.AddField(fmt.Sprintf("%s/%s", item.plat, item.arch), nil)
 		}
 		table.EndRow()
 	}


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

This commit fixes an issue where the list of IPs from the machine was gathered but never shown and to always show the plat/arch combination regarldess of whether `--long` is provided.
