### PR TITLE
refactor(target): Use a slash separator between plat and arch

### DIFF
--- a/unikraft/target/target.go
+++ b/unikraft/target/target.go
@@ -195,7 +195,7 @@ func KernelDbgName(target TargetConfig) (string, error) {
 // architecture combination.
 func TargetPlatArchName(target Target) string {
 	return fmt.Sprintf(
-		"%s-%s",
+		"%s/%s",
 		target.Platform().Name(),
 		target.Architecture().Name(),
 	)


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

To keep things consistent with the rest of the codebase, use a slash separator as opposed to a dash separator between the platform and architecture name combination.
