### PR TITLE
refactor(build)!: Remove the preparation step

### DIFF
--- a/cmd/kraft/build/build.go
+++ b/cmd/kraft/build/build.go
@@ -43,7 +43,6 @@ type Build struct {
 	NoConfigure  bool   `long:"no-configure" usage:"Do not run Unikraft's configure step before building"`
 	NoFast       bool   `long:"no-fast" usage:"Use maximum parallelization when performing the build"`
 	NoFetch      bool   `long:"no-fetch" usage:"Do not run Unikraft's fetch step before building"`
-	NoPrepare    bool   `long:"no-prepare" usage:"Do not run Unikraft's prepare step before building"`
 	NoPull       bool   `long:"no-pull" usage:"Do not pull packages before invoking Unikraft's build system"`
 	NoUpdate     bool   `long:"no-update" usage:"Do not update package index before running the build"`
 	Platform     string `long:"plat" short:"p" usage:"Filter the creation of the build by platform of known targets"`
@@ -456,26 +455,6 @@ func (opts *Build) Run(cmd *cobra.Command, args []string) error {
 							exec.WithStdout(log.G(ctx).Writer()),
 							exec.WithStderr(log.G(ctx).WriterLevel(logrus.ErrorLevel)),
 						),
-					)
-				},
-			))
-		}
-
-		if !opts.NoPrepare {
-			processes = append(processes, paraprogress.NewProcess(
-				fmt.Sprintf("preparing %s (%s)", targ.Name(), target.TargetPlatArchName(targ)),
-				func(ctx context.Context, w func(progress float64)) error {
-					return opts.project.Prepare(
-						ctx,
-						targ, // Target-specific options
-						append(
-							mopts,
-							make.WithProgressFunc(w),
-							make.WithExecOptions(
-								exec.WithStdout(log.G(ctx).Writer()),
-								exec.WithStderr(log.G(ctx).WriterLevel(logrus.ErrorLevel)),
-							),
-						)...,
 					)
 				},
 			))


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

This commit totally removes the preparation step before the build (and also removes the `--no-prepare` flag).  This is a redundant step as it is technically accomplished through Unikraft's core build system and is a spill-over from the earlier pykraft implementation which required a separation between these steps.  It is no longer necessary.
