### PR TITLE
feat(qemu): Introduce version checking

### DIFF
--- a/machine/qemu/config.go
+++ b/machine/qemu/config.go
@@ -36,6 +36,7 @@ type QemuConfig struct {
 	SMP        QemuSMP           `flag:"-smp"         json:"smp,omitempty"`
 	TBSize     int               `flag:"-tb-size"     json:"tb_size,omitempty"`
 	VGA        QemuVGA           `flag:"-vga"         json:"vga,omitempty"`
+	Version    bool              `flag:"-version"     json:"-"`
 
 	// Command-line arguments for qemu-system-i386 and qemu-system-x86_64 only
 	NoHPET bool `flag:"-no-hpet" json:"no_hpet,omitempty"`

--- a/machine/qemu/qemu_cpus.go
+++ b/machine/qemu/qemu_cpus.go
@@ -21,6 +21,10 @@ type QemuCPU struct {
 }
 
 func (cpu QemuCPU) String() string {
+	if cpu.CPU == nil {
+		return ""
+	}
+
 	var ret strings.Builder
 
 	ret.WriteString(cpu.CPU.String())

--- a/machine/qemu/qemu_machine.go
+++ b/machine/qemu/qemu_machine.go
@@ -56,6 +56,9 @@ type QemuMachine struct {
 	SupressVMDesc bool                     `json:"suppress_vmdesc,omitempty"`
 	NVDIMM        bool                     `json:"nvdimm,omitempty"`
 	HMAT          bool                     `json:"hmat,omitempty"`
+
+	// Added in QEMU 8.0.0
+	Graphics bool `json:"graphics,omitempty"`
 }
 
 // String returns a QEMU command-line compatible -machine flag value
@@ -109,6 +112,11 @@ func (qm QemuMachine) String() string {
 	}
 	if qm.HMAT {
 		ret.WriteString(",hmat=on")
+	}
+
+	// Added in QEMU 8.0.0
+	if qm.HMAT {
+		ret.WriteString(",graphics=on")
 	}
 
 	return ret.String()

--- a/machine/qemu/qemu_memory.go
+++ b/machine/qemu/qemu_memory.go
@@ -28,6 +28,10 @@ const (
 )
 
 func (qm QemuMemory) String() string {
+	if qm.Size == 0 && len(qm.Unit) == 0 {
+		return ""
+	}
+
 	var ret strings.Builder
 
 	if qm.Size == 0 {

--- a/machine/qemu/qemu_rtc.go
+++ b/machine/qemu/qemu_rtc.go
@@ -40,6 +40,10 @@ type QemuRTC struct {
 }
 
 func (qr QemuRTC) String() string {
+	if qr.Base == "" {
+		return ""
+	}
+
 	var ret strings.Builder
 	ret.WriteString("base=")
 

--- a/machine/qemu/qemu_smp.go
+++ b/machine/qemu/qemu_smp.go
@@ -34,11 +34,11 @@ type QemuSMP struct {
 // [cpus=]n[,maxcpus=cpus][,cores=cores][,threads=threads][,dies=dies]
 // [,sockets=sockets]
 func (qsmp QemuSMP) String() string {
-	var ret strings.Builder
-
 	if qsmp.CPUs <= 0 {
-		qsmp.CPUs = 1
+		return ""
 	}
+
+	var ret strings.Builder
 
 	ret.WriteString("cpus=")
 	ret.WriteString(strconv.FormatUint(qsmp.CPUs, 10))

--- a/machine/qemu/qemu_version.go
+++ b/machine/qemu/qemu_version.go
@@ -16,6 +16,14 @@ import (
 	"kraftkit.sh/exec"
 )
 
+var (
+	QemuVersion4_2_0 = semver.New(4, 2, 0, "", "")
+	QemuVersion5_2_0 = semver.New(5, 2, 0, "", "")
+	QemuVersion6_2_0 = semver.New(6, 2, 0, "", "")
+	QemuVersion7_2_0 = semver.New(7, 2, 0, "", "")
+	QemuVersion8_0_0 = semver.New(8, 0, 0, "", "")
+)
+
 // GetQemuVersionFromBin is direct method of accessing the version of the
 // provided QEMU binary by executing it with the well-known flag `-version` and
 // parsing its output.

--- a/machine/qemu/qemu_version.go
+++ b/machine/qemu/qemu_version.go
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2022, Unikraft GmbH and The KraftKit Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+package qemu
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/Masterminds/semver/v3"
+
+	"kraftkit.sh/exec"
+)
+
+// GetQemuVersionFromBin is direct method of accessing the version of the
+// provided QEMU binary by executing it with the well-known flag `-version` and
+// parsing its output.
+func GetQemuVersionFromBin(ctx context.Context, bin string) (*semver.Version, error) {
+	e, err := exec.NewExecutable(bin, QemuConfig{
+		Version: true,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("could not prepare QEMU executable: %v", err)
+	}
+
+	var buf bytes.Buffer
+
+	process, err := exec.NewProcessFromExecutable(e,
+		exec.WithStdout(bufio.NewWriter(&buf)),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("could not prepare QEMU process: %v", err)
+	}
+
+	// Start and also wait for the process to be released, this ensures the
+	// program is actively being executed.
+	if err := process.StartAndWait(ctx); err != nil {
+		return nil, fmt.Errorf("could not start and wait for QEMU process: %v", err)
+	}
+
+	// Get the first line of the returned value
+	ret := strings.Split(strings.TrimSpace(buf.String()), "\n")[0]
+
+	// Check if the returned value has the magic words
+	if !strings.HasPrefix(ret, "QEMU emulator version ") {
+		return nil, fmt.Errorf("malformed return value cannot parse QEMU version")
+	}
+
+	ret = strings.TrimPrefix(ret, "QEMU emulator version ")
+
+	// Some QEMU versions include the OS distribution that it was compiled for
+	// after the version number (surrounded by brackets).  In every case, just
+	// split the string and gather everything before the first bracket.
+	return semver.NewVersion(strings.TrimSpace(strings.Split(ret, " (")[0]))
+}


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

This PR adds necessary versioning checks before the invocation of the QEMU command so as to accommodate for users who run different versions.  There are several changes that were necessary to make this PR possible:

- Adjusting several structures to return an empty string which would otherwise populate a flag during the QEMU binary executable flag serialization process;
- The introduction of a utility method `GetQemuVersionFromBin` which invokes the supplied QEMU binary and parses the returning string from the `-version` flag which determines the supplied version; and,
- Two known compatibility issues with QEMU: rejecting invocations from versions prior to 4.2.0 (which has reached EOL) and an adjustment to the SGA serial console in versions greater than 8.0.0.

