### PR TITLE
fix(build): Negate usage doc for `--no-fast`

### DIFF
--- a/cmd/kraft/build/build.go
+++ b/cmd/kraft/build/build.go
@@ -41,7 +41,7 @@ type Build struct {
 	Kraftfile    string `long:"kraftfile" usage:"Set an alternative path of the Kraftfile"`
 	NoCache      bool   `long:"no-cache" short:"F" usage:"Force a rebuild even if existing intermediate artifacts already exist"`
 	NoConfigure  bool   `long:"no-configure" usage:"Do not run Unikraft's configure step before building"`
-	NoFast       bool   `long:"no-fast" usage:"Use maximum parallelization when performing the build"`
+	NoFast       bool   `long:"no-fast" usage:"Do not use maximum parallelization when performing the build"`
 	NoFetch      bool   `long:"no-fetch" usage:"Do not run Unikraft's fetch step before building"`
 	NoPull       bool   `long:"no-pull" usage:"Do not pull packages before invoking Unikraft's build system"`
 	NoUpdate     bool   `long:"no-update" usage:"Do not update package index before running the build"`


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

Correct the usage message for the flag `--no-fast` which was negated in itself in f951fed.  By mistake, the usage message was not updated.
