### PR TITLE
fix(menu): Fix hanging `kraft menu`

### DIFF
--- a/cmd/kraft/menu/menu.go
+++ b/cmd/kraft/menu/menu.go
@@ -13,7 +13,9 @@ import (
 
 	"kraftkit.sh/cmdfactory"
 	"kraftkit.sh/config"
+	"kraftkit.sh/exec"
 	"kraftkit.sh/internal/cli"
+	"kraftkit.sh/iostreams"
 	"kraftkit.sh/make"
 	"kraftkit.sh/packmanager"
 	"kraftkit.sh/unikraft/app"
@@ -123,5 +125,9 @@ func (opts *Menu) Run(cmd *cobra.Command, args []string) error {
 		ctx,
 		t,
 		make.WithTarget("menuconfig"),
+		make.WithExecOptions(
+			exec.WithStdout(iostreams.G(ctx).Out),
+			exec.WithStdin(iostreams.G(ctx).In),
+		),
 	)
 }


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

This commit fixes an issue where the Unikraft menuconfig system would not open and the command `kraft menu` would hang.  This issue was introduced in ba4153ba when the default functionality of the `exec` package removed IOStreams as the command's std{in,out,err}.  This change is still valid, the implementing method should decide what these values are and in this PR, we do this with the invocation of the menuconfig.

