### PR TITLE
fix(buildenvs): Enable TCG (emulation) in QEMU

### DIFF
--- a/buildenvs/qemu.Dockerfile
+++ b/buildenvs/qemu.Dockerfile
@@ -157,7 +157,7 @@ RUN set -ex; \
         --disable-sparse \
         --disable-spice \
         --disable-spice-protocol \
-        --disable-tcg \
+        --enable-tcg \
         --enable-tools \
         --disable-tpm \
         --disable-u2f \


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

Emulation through `tcg` was previously disabled to bring down the size of qemu. Unfortunately, this meant that running without native linux was impossible.
Enable this back to allow more people to try out kraftkit.

GitHub-Fixes: #621