### PR TITLE
feat: Native volume support

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -13,12 +13,14 @@ import (
 
 	machinev1alpha1 "kraftkit.sh/api/machine/v1alpha1"
 	networkv1alpha1 "kraftkit.sh/api/network/v1alpha1"
+	volumev1alpha1 "kraftkit.sh/api/volume/v1alpha1"
 )
 
 func init() {
 	utilruntime.Must(zip.Register(
 		machinev1alpha1.AddToScheme,
 		networkv1alpha1.AddToScheme,
+		volumev1alpha1.AddToScheme,
 	))
 
 	gob.Register(resource.Quantity{})

--- a/api/machine/v1alpha1/machine.zip.go
+++ b/api/machine/v1alpha1/machine.zip.go
@@ -12,6 +12,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 
 	networkv1alpha1 "kraftkit.sh/api/network/v1alpha1"
+	volumev1alpha1 "kraftkit.sh/api/volume/v1alpha1"
 )
 
 // MachinePort represents a network port in a single container.
@@ -79,6 +80,9 @@ type MachineSpec struct {
 
 	// Networks associated with this machine.
 	Networks []networkv1alpha1.NetworkSpec `json:"networks,omitempty"`
+
+	// Volumes associated with this machine.
+	Volumes []volumev1alpha1.Volume `json:"volumes,omitempty"`
 
 	// Resources describes the compute resources (requests and limits) required by
 	// this machine.

--- a/api/volume/v1alpha1/register.go
+++ b/api/volume/v1alpha1/register.go
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2022, Unikraft GmbH and The KraftKit Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+package v1alpha1
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"kraftkit.sh/api/volume"
+)
+
+const Version = "v1alpha1"
+
+var SchemeGroupVersion = schema.GroupVersion{
+	Group:   volume.GroupName,
+	Version: Version,
+}
+
+func AddToScheme(scheme *runtime.Scheme) error {
+	return AddToSchemeWithGV(scheme, SchemeGroupVersion)
+}
+
+func AddToSchemeWithGV(scheme *runtime.Scheme, schemeGroupVersion schema.GroupVersion) error {
+	scheme.AddKnownTypes(schemeGroupVersion,
+		&Volume{},
+		&VolumeList{},
+	)
+
+	// Add common types
+	scheme.AddKnownTypes(schemeGroupVersion,
+		&metav1.Status{},
+	)
+
+	if schemeGroupVersion == SchemeGroupVersion {
+		// Add the watch version that applies
+		metav1.AddToGroupVersion(scheme, schemeGroupVersion)
+	}
+
+	return nil
+}

--- a/api/volume/v1alpha1/volume.zip.go
+++ b/api/volume/v1alpha1/volume.zip.go
@@ -1,0 +1,154 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2022, Unikraft GmbH and The KraftKit Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file expect in compliance with the License.
+package v1alpha1
+
+import (
+	"context"
+
+	zip "api.zip"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type (
+	// Volume is the mutable API object that represents a volume.
+	Volume = zip.Object[VolumeSpec, VolumeStatus]
+
+	// VolumeList is the mutable API object that represents a list of volumes.
+	VolumeList = zip.ObjectList[VolumeSpec, VolumeStatus]
+)
+
+// VolumeSpec contains the desired behavior of the volume.
+type VolumeSpec struct {
+	// Driver is the name of the implementing strategy.  Volume drivers let you
+	// store volumes on remote hosts or cloud providers, to encrypt the contents
+	// of volumes, or to add other functionality.
+	Driver string `json:"driver,omitempty"`
+
+	// The source of the mount.  For named volumes, this is the name of the
+	// volume.  For anonymous volumes, this field is omitted.
+	Source string `json:"source,omitempty"`
+
+	// The destination takes as its value the path where the file or directory is
+	// mounted in the machine.
+	Destination string `json:"destination,omitempty"`
+
+	// File permission mode (Linux only).
+	Mode string `json:"mode,omitempty"`
+
+	// Mark whether the volume is readonly.
+	ReadOnly bool `json:"readOnly,omitempty"`
+}
+
+// VolumeTemplateSpec describes the data a volume should have when created
+// from a template.
+type VolumeTemplateSpec struct {
+	// Metadata of the components used or created from this template.
+	metav1.ObjectMeta `json:"metadata,omitempty"`
+
+	// Spec defines the behavior of the volume.
+	Spec VolumeSpec `json:"spec,omitempty"`
+}
+
+// VolumeState indicates the state of the volume.
+type VolumeState string
+
+const (
+	// used for PersistentVolumeClaims that are not yet bound
+	VolumeStatePending = VolumeState("Pending")
+	// used for PersistentVolumeClaims that are bound
+	VolumeStateBound = VolumeState("Bound")
+	// used for PersistentVolumeClaims that lost their underlying
+	// PersistentVolume. The claim was bound to a PersistentVolume and this
+	// volume does not exist any longer and all data on it was lost.
+	VolumeStateLost = VolumeState("Lost")
+)
+
+// String implements fmt.Stringer
+func (vs VolumeState) String() string {
+	return string(vs)
+}
+
+// VolumeStatus contains the complete status of the volume.
+type VolumeStatus struct {
+	// State is the current state of the volume.
+	State VolumeState `json:"state"`
+
+	// DriverConfig is driver-specific attributes which are populated by the
+	// underlying volume implementation.
+	DriverConfig interface{} `json:"driverConfig,omitempty"`
+}
+
+// VolumeService is the interface of available methods which can be performed
+// by an implementing network driver.
+type VolumeService interface {
+	Create(context.Context, *Volume) (*Volume, error)
+	Delete(context.Context, *Volume) (*Volume, error)
+	Get(context.Context, *Volume) (*Volume, error)
+	List(context.Context, *VolumeList) (*VolumeList, error)
+}
+
+// VolumeServiceHandler provides a Zip API Object Framework service for the
+// volume.
+type VolumeServiceHandler struct {
+	create zip.MethodStrategy[*Volume, *Volume]
+	delete zip.MethodStrategy[*Volume, *Volume]
+	get    zip.MethodStrategy[*Volume, *Volume]
+	list   zip.MethodStrategy[*VolumeList, *VolumeList]
+}
+
+// Create implements VolumeService
+func (client *VolumeServiceHandler) Create(ctx context.Context, req *Volume) (*Volume, error) {
+	return client.create.Do(ctx, req)
+}
+
+// Delete implements VolumeService
+func (client *VolumeServiceHandler) Delete(ctx context.Context, req *Volume) (*Volume, error) {
+	return client.delete.Do(ctx, req)
+}
+
+// Get implements VolumeService
+func (client *VolumeServiceHandler) Get(ctx context.Context, req *Volume) (*Volume, error) {
+	return client.get.Do(ctx, req)
+}
+
+// List implements VolumeService
+func (client *VolumeServiceHandler) List(ctx context.Context, req *VolumeList) (*VolumeList, error) {
+	return client.list.Do(ctx, req)
+}
+
+// NewVolumeServiceHandler returns a service based on an inline API
+// client which essentially wraps the specific call, enabling pre- and post-
+// call hooks.  This is useful for wrapping the command with decorators, for
+// example, a cache, error handlers, etc.  Simultaneously, it enables access to
+// the service via inline code without having to make invocations to an external
+// handler.
+func NewVolumeServiceHandler(ctx context.Context, impl VolumeService, opts ...zip.ClientOption) (VolumeService, error) {
+	create, err := zip.NewMethodClient(ctx, impl.Create, opts...)
+	if err != nil {
+		return nil, err
+	}
+
+	delete, err := zip.NewMethodClient(ctx, impl.Delete, opts...)
+	if err != nil {
+		return nil, err
+	}
+
+	get, err := zip.NewMethodClient(ctx, impl.Get, opts...)
+	if err != nil {
+		return nil, err
+	}
+
+	list, err := zip.NewMethodClient(ctx, impl.List, opts...)
+	if err != nil {
+		return nil, err
+	}
+
+	return &VolumeServiceHandler{
+		create,
+		delete,
+		get,
+		list,
+	}, nil
+}

--- a/api/volume/volume.go
+++ b/api/volume/volume.go
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2022, Unikraft GmbH and The KraftKit Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+package volume
+
+// GroupName is the name of the API group.
+var GroupName = "volume.unikraft.io"

--- a/cmd/kraft/run/run.go
+++ b/cmd/kraft/run/run.go
@@ -63,46 +63,44 @@ func New() *cobra.Command {
 		Use:     "run [FLAGS] PROJECT|PACKAGE|BINARY -- [APP ARGS]",
 		Aliases: []string{"r"},
 		Long: heredoc.Doc(`
-			Launch a unikernel`),
-		Example: heredoc.Docf(`
+			Run a unikernel virtual machine`),
+		Example: heredoc.Doc(`
 			Run a built target in the current working directory project:
-			%[1]s%[1]s%[1]s
 			$ kraft run
-			%[1]s%[1]s%[1]s
 
-			Run a selected target from multiple in project at the provided
-			working directory:
-			%[1]s%[1]s%[1]s
+			Run a specific target from a multi-target project at the provided project directory:
 			$ kraft run -t TARGET path/to/project
-			%[1]s%[1]s%[1]s
 
 			Run a specific kernel binary:
-			%[1]s%[1]s%[1]s
 			$ kraft run --arch x86_64 --plat qemu path/to/kernel-x86_64-qemu
-			%[1]s%[1]s%[1]s
 
-			Run an OCI-compatible unikernel, mapping port 8080 on the host
-			to port 80 in the unikernel:
-			%[1]s%[1]s%[1]s
+			Run an OCI-compatible unikernel, mapping port 8080 on the host to port 80 in the unikernel:
 			$ kraft run -p 8080:80 unikraft.org/nginx:latest
-			%[1]s%[1]s%[1]s
 
-			Run a Linux userspace binary in POSIX-/binary- compatibility mode:
-			%[1]s%[1]s%[1]s
-			$ kraft run path/to/helloworld
-			%[1]s%[1]s%[1]s
+			Attach the unikernel to an existing network kraft0 backed by the bridge driver:
+			$ kraft run --network bridge:kraft0
 
-			Supply an initramfs file to the unikernel that is instantiated based on 
-			the current project working directory:
-			$ kraft run --initrd ./initramfs.cpio .
+			Run a Linux userspace binary in POSIX-/binary-compatibility mode:
+			$ kraft run a.out
 
-			Supply a path which is dynamically serialized into an initramfs CPIO
-			archive:
-			$ kraft run -i ./path/to/rootfs .
+			Supply an initramfs CPIO archive file to the unikernel for its rootfs:
+			$ kraft run --initrd ./initramfs.cpio
 
-			Specify a specific path inside the initramfs, /root, mapped to the host:
-			$ kraft run -i ./path/to/rootfs:/root .
-			`, "`"),
+			Supply a path which is dynamically serialized into an initramfs CPIO archive:
+			$ kraft run --initrd ./path/to/rootfs
+
+			Specify a specific path which is dynamically serialized into initramfs and map it to /dir in the unikernel:
+			$ kraft run --initrd ./path/to/dir:/dir
+
+			Mount a bi-directional path from on the host to the unikernel mapped to /dir:
+			$ kraft run -v ./path/to/dir:/dir
+
+			Supply a read-only root file system at / via initramfs CPIO archive and mount a bi-directional volume at /dir:
+			$ kraft run --initrd ./initramfs.cpio:/ --volume ./path/to/dir:/dir
+
+			Customize the default content directory of the official Unikraft NGINX OCI-compatible unikernel and map port 8080 to localhost:
+			$ kraft run -v ./path/to/html:/nginx/html -p 8080:80 unikraft.org/nginx:latest
+			`),
 		Annotations: map[string]string{
 			cmdfactory.AnnotationHelpGroup: "run",
 		},

--- a/cmd/kraft/run/run.go
+++ b/cmd/kraft/run/run.go
@@ -47,6 +47,7 @@ type Run struct {
 	Remove        bool     `long:"rm" usage:"Automatically remove the unikernel when it shutsdown"`
 	RunAs         string   `long:"as" usage:"Force a specific runner"`
 	Target        string   `long:"target" short:"t" usage:"Explicitly use the defined project target"`
+	Volumes       []string `long:"volume" short:"v" usage:"Bind a volume to the instance"`
 	WithKernelDbg bool     `long:"symbolic" usage:"Use the debuggable (symbolic) unikernel"`
 
 	platform          mplatform.Platform
@@ -276,6 +277,10 @@ func (opts *Run) Run(cmd *cobra.Command, args []string) error {
 	}
 
 	if err := opts.parseNetworks(ctx, machine); err != nil {
+		return err
+	}
+
+	if err := opts.parseVolumes(ctx, machine); err != nil {
 		return err
 	}
 

--- a/machine/qemu/config.go
+++ b/machine/qemu/config.go
@@ -15,6 +15,7 @@ type QemuConfig struct {
 	Devices    []QemuDevice      `flag:"-device"      json:"device,omitempty"`
 	Display    QemuDisplay       `flag:"-display"     json:"display,omitempty"`
 	EnableKVM  bool              `flag:"-enable-kvm"  json:"enable_kvm,omitempty"`
+	FsDevs     []QemuFsDev       `flag:"-fsdev"       json:"fsdev,omitempty"`
 	InitRd     string            `flag:"-initrd"      json:"initrd,omitempty"`
 	Kernel     string            `flag:"-kernel"      json:"kernel,omitempty"`
 	Machine    QemuMachine       `flag:"-machine"     json:"machine,omitempty"`
@@ -111,6 +112,18 @@ func WithDisplay(display QemuDisplay) QemuOption {
 func WithEnableKVM(enableKVM bool) QemuOption {
 	return func(qc *QemuConfig) error {
 		qc.EnableKVM = enableKVM
+		return nil
+	}
+}
+
+func WithFsDevice(fsdev QemuFsDev) QemuOption {
+	return func(qc *QemuConfig) error {
+		if qc.FsDevs == nil {
+			qc.FsDevs = make([]QemuFsDev, 0)
+		}
+
+		qc.FsDevs = append(qc.FsDevs, fsdev)
+
 		return nil
 	}
 }

--- a/machine/qemu/init.go
+++ b/machine/qemu/init.go
@@ -388,7 +388,7 @@ func init() {
 	// gob.Register(QemuDeviceVhostUserScsiPciNonTransitional{})
 	// gob.Register(QemuDeviceVhostUserScsiPciTransitional{})
 	// gob.Register(QemuDeviceVirtio9pDevice{})
-	// gob.Register(QemuDeviceVirtio9pPci{})
+	gob.Register(QemuDeviceVirtio9pPci{})
 	// gob.Register(QemuDeviceVirtio9pPciNonTransitional{})
 	// gob.Register(QemuDeviceVirtio9pPciTransitional{})
 	// gob.Register(QemuDeviceVirtioBlkDevice{})
@@ -459,6 +459,12 @@ func init() {
 	// gob.Register(QemuNetDevVde{})
 	// gob.Register(QemuNetDevVhostUser{})
 	// gob.Register(QemuNetDevVhostVdpa{})
+
+	// Filesystem Devices
+	gob.Register(QemuFsDevLocal{})
+	// gob.Register(QemuFsDevProxy{})
+	// gob.Register(QemuFsDevSynth{})
+	gob.Register(QemuFsDevLocalSecurityModelPassthrough)
 
 	// CLI configuration
 	gob.Register(QemuConfig{})

--- a/machine/qemu/qemu_fsdev.go
+++ b/machine/qemu/qemu_fsdev.go
@@ -1,0 +1,248 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2022, Unikraft GmbH and The KraftKit Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+package qemu
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+type QemuFsDev interface {
+	fmt.Stringer
+}
+
+type QemuFsDevType string
+
+const (
+	QemuFsDevTypeLocal = QemuFsDevType("local")
+	QemuFsDevTypeProxy = QemuFsDevType("proxy")
+	QemuFsDevTypeSynth = QemuFsDevType("synth")
+)
+
+type QemuFsDevLocalSecurityModel string
+
+const (
+	QemuFsDevLocalSecurityModelMappedFile  = QemuFsDevLocalSecurityModel("mapped-file")
+	QemuFsDevLocalSecurityModelMappedXattr = QemuFsDevLocalSecurityModel("mapped-xattr")
+	QemuFsDevLocalSecurityModelNone        = QemuFsDevLocalSecurityModel("none")
+	QemuFsDevLocalSecurityModelPassthrough = QemuFsDevLocalSecurityModel("passthrough")
+)
+
+type QemuFsDevLocal struct {
+	Id            string                      `json:"id,omitempty"`
+	Path          string                      `json:"path,omitempty"`
+	SecurityModel QemuFsDevLocalSecurityModel `json:"security_model,omitempty"`
+	Writeout      string                      `json:"writeout,omitempty"`
+	Readonly      bool                        `json:"readonly,omitempty"`
+	Fmode         string                      `json:"fmode,omitempty"`
+	Dmode         string                      `json:"dmode,omitempty"`
+	Throttling    struct {
+		// length of the bps-read-max burst period, in seconds
+		BpsReadMaxLength int `json:"bps-read-max-length,omitempty"`
+		// total bytes read burst
+		BpsReadMax int `json:"bps-read-max,omitempty"`
+		// limit read bytes per second
+		BpsRead int `json:"bps-read,omitempty"`
+		// length of the bps-total-max burst period, in seconds
+		BpsTotalMaxLength int `json:"bps-total-max-length,omitempty"`
+		// total bytes burst
+		BpsTotalMax int `json:"bps-total-max,omitempty"`
+		// limit total bytes per second
+		BpsTotal int `json:"bps-total,omitempty"`
+		// length of the bps-write-max burst period, in seconds
+		BpsWriteMaxLength int `json:"bps-write-max-length,omitempty"`
+		// total bytes write burst
+		BpsWriteMax int `json:"bps-write-max,omitempty"`
+		// limit write bytes per second
+		BpsWrite int `json:"bps-write,omitempty"`
+		// length of the iops-read-max burst period, in seconds
+		IopsReadMaxLength int `json:"iops-read-max-length,omitempty"`
+		// I/O operations read burst
+		IopsReadMax int `json:"iops-read-max,omitempty"`
+		// limit read operations per second
+		IopsRead int `json:"iops-read,omitempty"`
+		// when limiting by iops max size of an I/O in bytes
+		IopsSize int `json:"iops-size,omitempty"`
+		// length of the iops-total-max burst period, in seconds
+		IopsTotalMaxLength int `json:"iops-total-max-length,omitempty"`
+		// I/O operations burst
+		IopsTotalMax int `json:"iops-total-max,omitempty"`
+		// limit total I/O operations per second
+		IopsTotal int `json:"iops-total,omitempty"`
+		// length of the iops-write-max burst period, in seconds
+		IopsWriteMaxLength int `json:"iops-write-max-length,omitempty"`
+		// I/O operations write burst
+		IopsWriteMax int `json:"iops-write-max,omitempty"`
+		// limit write operations per second
+		IopsWrite int `json:"iops-write,omitempty"`
+	} `json:"throttling,omitempty"`
+}
+
+// String returns a QEMU command-line compatible fsdev string with the format:
+// local,id=id,path=path,security_model=mapped-xattr|mapped-file|passthrough|none
+// [,writeout=immediate][,readonly][,fmode=fmode][,dmode=dmode]
+// [[,throttling.bps-total=b]|[[,throttling.bps-read=r][,throttling.bps-write=w]]]
+// [[,throttling.iops-total=i]|[[,throttling.iops-read=r][,throttling.iops-write=w]]]
+// [[,throttling.bps-total-max=bm]|[[,throttling.bps-read-max=rm][,throttling.bps-write-max=wm]]]
+// [[,throttling.iops-total-max=im]|[[,throttling.iops-read-max=irm][,throttling.iops-write-max=iwm]]]
+// [[,throttling.iops-size=is]]
+func (fd QemuFsDevLocal) String() string {
+	var ret strings.Builder
+
+	ret.WriteString(string(QemuFsDevTypeLocal))
+	ret.WriteString(",id=")
+	ret.WriteString(fd.Id)
+	ret.WriteString(",path=")
+	ret.WriteString(fd.Path)
+	ret.WriteString(",security_model=")
+	ret.WriteString(string(fd.SecurityModel))
+
+	if len(fd.Writeout) > 0 {
+		ret.WriteString(",writeout=")
+		ret.WriteString(fd.Writeout)
+	}
+	if fd.Readonly {
+		ret.WriteString(",readonly")
+	}
+	if len(fd.Fmode) > 0 {
+		ret.WriteString(",fmode=")
+		ret.WriteString(fd.Fmode)
+	}
+	if len(fd.Dmode) > 0 {
+		ret.WriteString(",dmode=")
+		ret.WriteString(fd.Dmode)
+	}
+	if fd.Throttling.BpsReadMaxLength > 0 {
+		ret.WriteString(",throttling.bps-read-max-length=")
+		ret.WriteString(strconv.Itoa(fd.Throttling.BpsReadMaxLength))
+	}
+	if fd.Throttling.BpsReadMax > 0 {
+		ret.WriteString(",throttling.bps-read-max=")
+		ret.WriteString(strconv.Itoa(fd.Throttling.BpsReadMax))
+	}
+	if fd.Throttling.BpsRead > 0 {
+		ret.WriteString(",throttling.bps-read=")
+		ret.WriteString(strconv.Itoa(fd.Throttling.BpsRead))
+	}
+	if fd.Throttling.BpsTotalMaxLength > 0 {
+		ret.WriteString(",throttling.bps-total-max-length=")
+		ret.WriteString(strconv.Itoa(fd.Throttling.BpsTotalMaxLength))
+	}
+	if fd.Throttling.BpsTotalMax > 0 {
+		ret.WriteString(",throttling.bps-total-max=")
+		ret.WriteString(strconv.Itoa(fd.Throttling.BpsTotalMax))
+	}
+	if fd.Throttling.BpsTotal > 0 {
+		ret.WriteString(",throttling.bps-total=")
+		ret.WriteString(strconv.Itoa(fd.Throttling.BpsTotal))
+	}
+	if fd.Throttling.BpsWriteMaxLength > 0 {
+		ret.WriteString(",throttling.bps-write-max-length=")
+		ret.WriteString(strconv.Itoa(fd.Throttling.BpsWriteMaxLength))
+	}
+	if fd.Throttling.BpsWriteMax > 0 {
+		ret.WriteString(",throttling.bps-write-max=")
+		ret.WriteString(strconv.Itoa(fd.Throttling.BpsWriteMax))
+	}
+	if fd.Throttling.BpsWrite > 0 {
+		ret.WriteString(",throttling.bps-write=")
+		ret.WriteString(strconv.Itoa(fd.Throttling.BpsWrite))
+	}
+	if fd.Throttling.IopsReadMaxLength > 0 {
+		ret.WriteString(",throttling.iops-read-max-length=")
+		ret.WriteString(strconv.Itoa(fd.Throttling.IopsReadMaxLength))
+	}
+	if fd.Throttling.IopsReadMax > 0 {
+		ret.WriteString(",throttling.iops-read-max=")
+		ret.WriteString(strconv.Itoa(fd.Throttling.IopsReadMax))
+	}
+	if fd.Throttling.IopsRead > 0 {
+		ret.WriteString(",throttling.iops-read=")
+		ret.WriteString(strconv.Itoa(fd.Throttling.IopsRead))
+	}
+	if fd.Throttling.IopsSize > 0 {
+		ret.WriteString(",throttling.iops-size=")
+		ret.WriteString(strconv.Itoa(fd.Throttling.IopsSize))
+	}
+	if fd.Throttling.IopsTotalMaxLength > 0 {
+		ret.WriteString(",throttling.iops-total-max-length=")
+		ret.WriteString(strconv.Itoa(fd.Throttling.IopsTotalMaxLength))
+	}
+	if fd.Throttling.IopsTotalMax > 0 {
+		ret.WriteString(",throttling.iops-total-max=")
+		ret.WriteString(strconv.Itoa(fd.Throttling.IopsTotalMax))
+	}
+	if fd.Throttling.IopsTotal > 0 {
+		ret.WriteString(",throttling.iops-total=")
+		ret.WriteString(strconv.Itoa(fd.Throttling.IopsTotal))
+	}
+	if fd.Throttling.IopsWriteMaxLength > 0 {
+		ret.WriteString(",throttling.iops-write-max-length=")
+		ret.WriteString(strconv.Itoa(fd.Throttling.IopsWriteMaxLength))
+	}
+	if fd.Throttling.IopsWriteMax > 0 {
+		ret.WriteString(",throttling.iops-write-max=")
+		ret.WriteString(strconv.Itoa(fd.Throttling.IopsWriteMax))
+	}
+	if fd.Throttling.IopsWrite > 0 {
+		ret.WriteString(",throttling.iops-write=")
+		ret.WriteString(strconv.Itoa(fd.Throttling.IopsWrite))
+	}
+
+	return ret.String()
+}
+
+type QemuFsDevProxy struct {
+	Id       string `json:"id,omitempty"`
+	Socket   string `json:"socket,omitempty"`
+	SockFd   int    `json:"sock_fd,omitempty"`
+	Writeout string `json:"writeout,omitempty"`
+	Readonly bool   `json:"readonly,omitempty"`
+}
+
+// String returns a QEMU command-line compatible fsdev string with the format:
+// proxy,id=id,socket=socket[,writeout=immediate][,readonly]
+// proxy,id=id,sock_fd=sock_fd[,writeout=immediate][,readonly]
+func (fd QemuFsDevProxy) String() string {
+	var ret strings.Builder
+
+	ret.WriteString(string(QemuFsDevTypeSynth))
+	ret.WriteString(",id=")
+	ret.WriteString(fd.Id)
+
+	if len(fd.Socket) > 0 {
+		ret.WriteString(",socket=")
+		ret.WriteString(fd.Socket)
+	} else if fd.SockFd > 0 {
+		ret.WriteString(",sock_fd=")
+		ret.WriteString(strconv.Itoa(fd.SockFd))
+	}
+	if len(fd.Writeout) > 0 {
+		ret.WriteString(",writeout=")
+		ret.WriteString(fd.Writeout)
+	}
+	if fd.Readonly {
+		ret.WriteString(",readonly")
+	}
+
+	return ret.String()
+}
+
+type QemuFsDevSynth struct {
+	Id string `json:"id,omitempty"`
+}
+
+// String returns a QEMU command-line compatible fsdev string with the format:
+// synth,id=id
+func (fd QemuFsDevSynth) String() string {
+	var ret strings.Builder
+
+	ret.WriteString(string(QemuFsDevTypeSynth))
+	ret.WriteString(",id=")
+	ret.WriteString(fd.Id)
+
+	return ret.String()
+}

--- a/machine/volume/9pfs/v1alpha1.go
+++ b/machine/volume/9pfs/v1alpha1.go
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2022, Unikraft GmbH and The KraftKit Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+package ninepfs
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"k8s.io/apimachinery/pkg/util/uuid"
+
+	volumev1alpha1 "kraftkit.sh/api/volume/v1alpha1"
+)
+
+type v1alpha1Volume struct{}
+
+func NewVolumeServiceV1alpha1(ctx context.Context, opts ...any) (volumev1alpha1.VolumeService, error) {
+	return &v1alpha1Volume{}, nil
+}
+
+// Create implements kraftkit.sh/api/volume/v1alpha1.Create
+func (*v1alpha1Volume) Create(ctx context.Context, volume *volumev1alpha1.Volume) (*volumev1alpha1.Volume, error) {
+	if len(volume.Spec.Driver) == 0 {
+		volume.Spec.Driver = "9pfs"
+	} else if volume.Spec.Driver != "9pfs" {
+		return volume, fmt.Errorf("cannot use 9pfs driver when driver set to %s", volume.Spec.Driver)
+	}
+
+	if len(volume.Spec.Source) == 0 {
+		return volume, fmt.Errorf("cannot use 9pfs volume without host path")
+	}
+
+	if _, err := os.Stat(volume.Spec.Source); err != nil {
+		return volume, fmt.Errorf("cannot stat host path volume: %w", err)
+	}
+
+	if volume.ObjectMeta.UID == "" {
+		volume.ObjectMeta.UID = uuid.NewUUID()
+	}
+
+	volume.Status.State = volumev1alpha1.VolumeStateBound
+
+	return volume, nil
+}
+
+// Delete implements kraftkit.sh/api/volume/v1alpha1.Delete
+func (*v1alpha1Volume) Delete(_ context.Context, _ *volumev1alpha1.Volume) (*volumev1alpha1.Volume, error) {
+	return nil, nil
+}
+
+// Get implements kraftkit.sh/api/volume/v1alpha1.Get
+func (*v1alpha1Volume) Get(_ context.Context, volume *volumev1alpha1.Volume) (*volumev1alpha1.Volume, error) {
+	return volume, nil
+}
+
+// List implements kraftkit.sh/api/volume/v1alpha1.List
+func (*v1alpha1Volume) List(_ context.Context, volumes *volumev1alpha1.VolumeList) (*volumev1alpha1.VolumeList, error) {
+	return volumes, nil
+}
+
+// Watch implements kraftkit.sh/api/volume/v1alpha1.Watch
+func (*v1alpha1Volume) Watch(context.Context, *volumev1alpha1.Volume) (chan *volumev1alpha1.Volume, chan error, error) {
+	panic("not implemented: kraftkit.sh/machine/volume/9pfs.v1alpha1Volume.Watch")
+}

--- a/machine/volume/register_linux.go
+++ b/machine/volume/register_linux.go
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2022, Unikraft GmbH and The KraftKit Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+package volume
+
+import (
+	"context"
+	"path/filepath"
+
+	zip "api.zip"
+
+	volumev1alpha1 "kraftkit.sh/api/volume/v1alpha1"
+	"kraftkit.sh/config"
+	"kraftkit.sh/kconfig"
+	"kraftkit.sh/machine/store"
+	ninepfs "kraftkit.sh/machine/volume/9pfs"
+)
+
+// hostSupportedStrategies returns the map of known supported drivers for the
+// given host.
+func hostSupportedStrategies() map[string]*Strategy {
+	return map[string]*Strategy{
+		"9pfs": {
+			IsCompatible: func(source string, _ kconfig.KeyValueMap) (bool, error) {
+				// TODO(nderjung): For now, it is OK to return true because this is the
+				// only supported driver.  In the future, we should a). check if the
+				// provided source is a readable directory and b). check if the supplied
+				// KConfig of the machine indicates that 9pfs is indeed part of the
+				// build configuration.
+				return true, nil
+			},
+			NewVolumeV1alpha1: func(ctx context.Context, opts ...any) (volumev1alpha1.VolumeService, error) {
+				service, err := ninepfs.NewVolumeServiceV1alpha1(ctx, opts...)
+				if err != nil {
+					return nil, err
+				}
+
+				embeddedStore, err := store.NewEmbeddedStore[volumev1alpha1.VolumeSpec, volumev1alpha1.VolumeStatus](
+					filepath.Join(
+						config.G[config.KraftKit](ctx).RuntimeDir,
+						"volumev1alpha1",
+					),
+				)
+				if err != nil {
+					return nil, err
+				}
+
+				return volumev1alpha1.NewVolumeServiceHandler(
+					ctx,
+					service,
+					zip.WithStore[volumev1alpha1.VolumeSpec, volumev1alpha1.VolumeStatus](embeddedStore, zip.StoreRehydrationSpecNil),
+				)
+			},
+		},
+	}
+}

--- a/machine/volume/strategy.go
+++ b/machine/volume/strategy.go
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2022, Unikraft GmbH and The KraftKit Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+package volume
+
+import (
+	"context"
+
+	volumev1alpha1 "kraftkit.sh/api/volume/v1alpha1"
+	"kraftkit.sh/kconfig"
+)
+
+// NewStrategyConstructor is a prototype for the instantiation function of a
+// platform driver implementation.
+type NewStrategyConstructor[T any] func(context.Context, ...any) (T, error)
+
+// strategies contains the map of registered strategies, whether provided as
+// part from builtins and are host specific, or those that have been registered
+// dynamically at runtime.
+var strategies = make(map[string]*Strategy)
+
+// Strategy represents canonical reference of a machine driver and their
+// platform.
+type Strategy struct {
+	IsCompatible      func(string, kconfig.KeyValueMap) (bool, error)
+	NewVolumeV1alpha1 NewStrategyConstructor[volumev1alpha1.VolumeService]
+}
+
+// Strategies returns the list of registered platform implementations.
+func Strategies() map[string]*Strategy {
+	base := hostSupportedStrategies()
+	for name, driverInfo := range strategies {
+		base[name] = driverInfo
+	}
+
+	return base
+}
+
+// DriverNames returns the list of registered platform driver implementation
+// names.
+func DriverNames() []string {
+	ret := []string{}
+	for plat := range Strategies() {
+		ret = append(ret, plat)
+	}
+
+	return ret
+}

--- a/unikraft/export/v0/ukargparse/params.go
+++ b/unikraft/export/v0/ukargparse/params.go
@@ -11,10 +11,10 @@ type Param interface {
 	Name() string
 
 	// Set the value of the parameter.
-	Set(string)
+	Set(any)
 
 	// Get the value of the parameter.
-	Value() string
+	Value() any
 
 	// String returns the fully qualified parameter ready to be accepted by
 	// Unikraft.
@@ -22,7 +22,7 @@ type Param interface {
 
 	// A method-chain mechanism for both setting and getting the Param with the
 	// newly embedded value.
-	WithValue(string) Param
+	WithValue(any) Param
 }
 
 type paramStr struct {
@@ -32,14 +32,19 @@ type paramStr struct {
 }
 
 // ParamStr instantiates a new Param based on a string value.
-func ParamStr(lib string, name string, value *string) Param {
+func ParamStr(lib string, name string, value any) Param {
 	param := paramStr{
 		library: lib,
 		name:    name,
 	}
 
-	if value != nil {
-		param.value = *value
+	v, ok := value.(*string)
+	if !ok {
+		return &param
+	}
+
+	if v != nil {
+		param.value = *v
 	}
 
 	return &param
@@ -51,18 +56,22 @@ func (param *paramStr) Name() string {
 }
 
 // Set implements Param
-func (param *paramStr) Set(value string) {
-	param.value = value
+func (param *paramStr) Set(value any) {
+	v, ok := value.(string)
+	if !ok {
+		return
+	}
+	param.value = v
 }
 
 // Value implements Param
-func (param *paramStr) Value() string {
-	return fmt.Sprintf("%s.%s=%s", param.library, param.name, param.value)
+func (param *paramStr) Value() any {
+	return param.value
 }
 
 // WithValue implements Param
-func (param *paramStr) WithValue(value string) Param {
-	param.value = value
+func (param *paramStr) WithValue(value any) Param {
+	param.Set(value)
 	return param
 }
 

--- a/unikraft/export/v0/ukargparse/params_strmap.go
+++ b/unikraft/export/v0/ukargparse/params_strmap.go
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2022, Unikraft GmbH and The KraftKit Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+package ukargparse
+
+import (
+	"fmt"
+	"strings"
+)
+
+type paramStrMap struct {
+	library string
+	name    string
+	values  map[string]string
+}
+
+// ParamStr instantiates a new Param based on a string value.
+func ParamStrMap(lib string, name string, values any) Param {
+	return &paramStrMap{
+		library: lib,
+		name:    name,
+		values:  values.(map[string]string),
+	}
+}
+
+// Name implements Param
+func (param *paramStrMap) Name() string {
+	return fmt.Sprintf("%s.%s", param.library, param.name)
+}
+
+// Set implements Param
+func (param *paramStrMap) Set(value any) {
+	v, ok := value.(map[string]string)
+	if !ok {
+		return
+	}
+	param.values = v
+}
+
+// Value implements Param
+func (param *paramStrMap) Value() any {
+	return param.values
+}
+
+// WithValue implements Param
+func (param *paramStrMap) WithValue(value any) Param {
+	param.Set(value)
+	return param
+}
+
+// String implements Param
+func (param *paramStrMap) String() string {
+	var ret strings.Builder
+	ret.WriteString(param.library)
+	ret.WriteString(".")
+	ret.WriteString(param.name)
+	ret.WriteString("[")
+
+	for k, v := range param.values {
+		ret.WriteString(k)
+		ret.WriteString("=")
+		ret.WriteString(v)
+	}
+
+	ret.WriteString("]")
+
+	return ret.String()
+}

--- a/unikraft/export/v0/ukargparse/params_strslice.go
+++ b/unikraft/export/v0/ukargparse/params_strslice.go
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2022, Unikraft GmbH and The KraftKit Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+package ukargparse
+
+import (
+	"fmt"
+	"strings"
+)
+
+type ParamStrSlice struct {
+	library string
+	name    string
+	values  []string
+}
+
+// NewParamStrSlice instantiates a new Param based on a slice of strings.
+func NewParamStrSlice(lib string, name string, values any) Param {
+	param := &ParamStrSlice{
+		library: lib,
+		name:    name,
+	}
+
+	if strs, ok := values.([]string); ok {
+		param.values = strs
+	}
+
+	return param
+}
+
+// Name implements Param
+func (param *ParamStrSlice) Name() string {
+	return fmt.Sprintf("%s.%s", param.library, param.name)
+}
+
+// Set implements Param
+func (param *ParamStrSlice) Set(value any) {
+	v, ok := value.([]string)
+	if !ok {
+		return
+	}
+
+	param.values = v
+}
+
+// Value implements Param
+func (param *ParamStrSlice) Value() any {
+	return param.values
+}
+
+// WithValue implements Param
+func (param *ParamStrSlice) WithValue(value any) Param {
+	param.Set(value)
+	return param
+}
+
+// String implements Param
+func (param *ParamStrSlice) String() string {
+	var ret strings.Builder
+	ret.WriteString(param.library)
+	ret.WriteString(".")
+	ret.WriteString(param.name)
+	ret.WriteString("=[")
+
+	for _, v := range param.values {
+		ret.WriteString("\"")
+		ret.WriteString(v)
+		ret.WriteString("\"")
+	}
+
+	ret.WriteString("]")
+
+	return ret.String()
+}

--- a/unikraft/export/v0/vfscore/library.go
+++ b/unikraft/export/v0/vfscore/library.go
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2022, Unikraft GmbH and The KraftKit Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+package vfscore
+
+const LibraryName = "vfscore"

--- a/unikraft/export/v0/vfscore/params.go
+++ b/unikraft/export/v0/vfscore/params.go
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2022, Unikraft GmbH and The KraftKit Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+package vfscore
+
+import (
+	"strings"
+
+	"kraftkit.sh/unikraft/export/v0/ukargparse"
+)
+
+var ParamVfsFstab = ukargparse.NewParamStrSlice("vfs", "fstab", nil)
+
+// ExportedParams returns the parameters available by this exported library.
+func ExportedParams() []ukargparse.Param {
+	return []ukargparse.Param{
+		ParamVfsFstab,
+	}
+}
+
+// FstabEntry is a vfscore mount entry.
+type FstabEntry struct {
+	sourceDevice string
+	mountTarget  string
+	fsDriver     string
+	flags        string
+	options      string
+}
+
+// NewFstabEntry generates a structure that is representative of one of
+// Unikraft's vfscore automounts.
+func NewFstabEntry(sourceDevice, mountTarget, fsDriver, flags, options string) FstabEntry {
+	return FstabEntry{
+		sourceDevice,
+		mountTarget,
+		fsDriver,
+		flags,
+		options,
+	}
+}
+
+// String implements fmt.Stringer and returns a valid vfs.automount-formatted
+// entry.
+func (entry FstabEntry) String() string {
+	return strings.Join([]string{
+		entry.sourceDevice,
+		entry.mountTarget,
+		entry.fsDriver,
+		entry.flags,
+		entry.options,
+	}, ":")
+}


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

This PR introduces native volume support into KraftKit which ultimately allows users to bind devices to the unikernel in a simple and expressive manner. At a high-level, this allows users to specify devices they would like to mount to a unikernel in `kraft run` with the introduction of a new flag `-v|--volume`.

Practically, the implementation is built around the same API definitions that are used to express both a machine instance but also the networking setup.

QEMU is the only machine driver implementation to recognise and act on the updated machine specification that describes a volume.  Additionally, the only driver implementation for volumes is 9pfs, which is a lightweight passthrough mechanism for mounting a source path on the host in a bidirectional manner.  The utility of this is that a user can make adjustments on their host and have those immediately reflected within the instance.

GitHub-Depends: #545 