### PR TITLE
fix: Set proper group permissions for runtime directory

### DIFF
--- a/cmd/kraft/events/events.go
+++ b/cmd/kraft/events/events.go
@@ -108,7 +108,7 @@ func (opts *Events) Run(cmd *cobra.Command, args []string) error {
 
 	// Check if a pid has already been enabled
 	if _, err := os.Stat(config.G[config.KraftKit](ctx).EventsPidFile); err != nil && os.IsNotExist(err) {
-		if err := os.MkdirAll(filepath.Dir(config.G[config.KraftKit](ctx).EventsPidFile), 0o755); err != nil {
+		if err := os.MkdirAll(filepath.Dir(config.G[config.KraftKit](ctx).EventsPidFile), 0o775); err != nil {
 			cancel()
 			return err
 		}

--- a/cmd/kraft/run/run.go
+++ b/cmd/kraft/run/run.go
@@ -7,8 +7,11 @@ package run
 import (
 	"errors"
 	"fmt"
+	"io/fs"
 	"os"
+	"os/user"
 	"path/filepath"
+	"strconv"
 	"strings"
 
 	"github.com/MakeNowJust/heredoc"
@@ -305,8 +308,24 @@ func (opts *Run) Run(cmd *cobra.Command, args []string) error {
 			machine.Status.StateDir = filepath.Join(config.G[config.KraftKit](ctx).RuntimeDir, string(machine.ObjectMeta.UID))
 		}
 
-		if err := os.MkdirAll(machine.Status.StateDir, 0o775); err != nil {
+		if err := os.MkdirAll(machine.Status.StateDir, fs.ModeSetgid|0o775); err != nil {
 			return fmt.Errorf("could not make machine state dir: %w", err)
+		}
+
+		group, err := user.LookupGroup(config.G[config.KraftKit](ctx).UserGroup)
+		if err == nil {
+			gid, err := strconv.ParseInt(group.Gid, 10, 32)
+			if err != nil {
+				return fmt.Errorf("could not parse group ID for kraftkit: %w", err)
+			}
+
+			if err := os.Chown(machine.Status.StateDir, os.Getuid(), int(gid)); err != nil {
+				return fmt.Errorf("could not change group ownership of machine state dir: %w", err)
+			}
+		} else {
+			log.G(ctx).
+				WithField("error", err).
+				Warn("kraftkit group not found, falling back to current user")
 		}
 
 		var ramfs *initrd.InitrdConfig

--- a/cmd/kraft/run/run.go
+++ b/cmd/kraft/run/run.go
@@ -305,7 +305,7 @@ func (opts *Run) Run(cmd *cobra.Command, args []string) error {
 			machine.Status.StateDir = filepath.Join(config.G[config.KraftKit](ctx).RuntimeDir, string(machine.ObjectMeta.UID))
 		}
 
-		if err := os.MkdirAll(machine.Status.StateDir, 0o755); err != nil {
+		if err := os.MkdirAll(machine.Status.StateDir, 0o775); err != nil {
 			return fmt.Errorf("could not make machine state dir: %w", err)
 		}
 

--- a/cmd/kraft/run/runner_package.go
+++ b/cmd/kraft/run/runner_package.go
@@ -7,8 +7,11 @@ package run
 import (
 	"context"
 	"fmt"
+	"io/fs"
 	"os"
+	"os/user"
 	"path/filepath"
+	"strconv"
 
 	"k8s.io/apimachinery/pkg/util/uuid"
 	machineapi "kraftkit.sh/api/machine/v1alpha1"
@@ -103,8 +106,24 @@ func (runner *runnerPackage) Prepare(ctx context.Context, opts *Run, machine *ma
 	// defined state directory.
 	machine.ObjectMeta.UID = uuid.NewUUID()
 	machine.Status.StateDir = filepath.Join(config.G[config.KraftKit](ctx).RuntimeDir, string(machine.ObjectMeta.UID))
-	if err := os.MkdirAll(machine.Status.StateDir, 0o775); err != nil {
+	if err := os.MkdirAll(machine.Status.StateDir, fs.ModeSetgid|0o775); err != nil {
 		return err
+	}
+
+	group, err := user.LookupGroup(config.G[config.KraftKit](ctx).UserGroup)
+	if err == nil {
+		gid, err := strconv.ParseInt(group.Gid, 10, 32)
+		if err != nil {
+			return fmt.Errorf("could not parse group ID for kraftkit: %w", err)
+		}
+
+		if err := os.Chown(machine.Status.StateDir, os.Getuid(), int(gid)); err != nil {
+			return fmt.Errorf("could not change group ownership of machine state dir: %w", err)
+		}
+	} else {
+		log.G(ctx).
+			WithField("error", err).
+			Warn("kraftkit group not found, falling back to current user")
 	}
 
 	// Clean up the package directory if an error occurs before returning.

--- a/cmd/kraft/run/runner_package.go
+++ b/cmd/kraft/run/runner_package.go
@@ -103,7 +103,7 @@ func (runner *runnerPackage) Prepare(ctx context.Context, opts *Run, machine *ma
 	// defined state directory.
 	machine.ObjectMeta.UID = uuid.NewUUID()
 	machine.Status.StateDir = filepath.Join(config.G[config.KraftKit](ctx).RuntimeDir, string(machine.ObjectMeta.UID))
-	if err := os.MkdirAll(machine.Status.StateDir, 0o755); err != nil {
+	if err := os.MkdirAll(machine.Status.StateDir, 0o775); err != nil {
 		return err
 	}
 

--- a/config/config.go
+++ b/config/config.go
@@ -28,6 +28,7 @@ type KraftKit struct {
 	DefaultArch    string `yaml:"default_arch" env:"KRAFTKIT_DEFAULT_ARCH" usage:"The default architecture to use when invoking architecture-specific code" noattribute:"true"`
 	ContainerdAddr string `yaml:"containerd_addr,omitempty" env:"KRAFTKIT_CONTAINERD_ADDR" long:"containerd-addr" usage:"Address of containerd daemon socket" default:""`
 	EventsPidFile  string `yaml:"events_pidfile" env:"KRAFTKIT_EVENTS_PIDFILE" long:"events-pid-file" usage:"Events process ID used when running multiple unikernels" default:"/var/kraftkit/events.pid"`
+	UserGroup      string `yaml:"user_group" env:"KRAFTKIT_USER_GROUP" long:"user-group" usage:"Group to use for common files" default:"kraftkit"`
 
 	Paths struct {
 		Plugins   string `yaml:"plugins,omitempty" env:"KRAFTKIT_PATHS_PLUGINS" long:"plugins-dir" usage:"Path to KraftKit plugin directory"`

--- a/initrd/initrd.go
+++ b/initrd/initrd.go
@@ -145,7 +145,7 @@ func NewFromMapping(workdir, output string, maps ...string) (*InitrdConfig, erro
 		Files:   make(map[string]string),
 	}
 
-	f, err := os.OpenFile(output, os.O_RDWR|os.O_CREATE, 0o644)
+	f, err := os.OpenFile(output, os.O_RDWR|os.O_CREATE, 0o664)
 	if err != nil {
 		return nil, fmt.Errorf("could not open initramfs file: %w", err)
 	}

--- a/machine/firecracker/v1alpha1.go
+++ b/machine/firecracker/v1alpha1.go
@@ -7,8 +7,11 @@ package firecracker
 import (
 	"context"
 	"fmt"
+	"io/fs"
 	"os"
+	"os/user"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 
@@ -88,8 +91,24 @@ func (service *machineV1alpha1Service) Create(ctx context.Context, machine *mach
 		machine.Status.StateDir = filepath.Join(config.G[config.KraftKit](ctx).RuntimeDir, string(machine.ObjectMeta.UID))
 	}
 
-	if err := os.MkdirAll(machine.Status.StateDir, 0o775); err != nil {
+	if err := os.MkdirAll(machine.Status.StateDir, fs.ModeSetgid|0o775); err != nil {
 		return machine, err
+	}
+
+	group, err := user.LookupGroup(config.G[config.KraftKit](ctx).UserGroup)
+	if err == nil {
+		gid, err := strconv.ParseInt(group.Gid, 10, 32)
+		if err != nil {
+			return machine, fmt.Errorf("could not parse group ID for kraftkit: %w", err)
+		}
+
+		if err := os.Chown(machine.Status.StateDir, os.Getuid(), int(gid)); err != nil {
+			return machine, fmt.Errorf("could not change group ownership of machine state dir: %w", err)
+		}
+	} else {
+		log.G(ctx).
+			WithField("error", err).
+			Warn("kraftkit group not found, falling back to current user")
 	}
 
 	// Set and create the log file for this machine

--- a/machine/firecracker/v1alpha1.go
+++ b/machine/firecracker/v1alpha1.go
@@ -88,7 +88,7 @@ func (service *machineV1alpha1Service) Create(ctx context.Context, machine *mach
 		machine.Status.StateDir = filepath.Join(config.G[config.KraftKit](ctx).RuntimeDir, string(machine.ObjectMeta.UID))
 	}
 
-	if err := os.MkdirAll(machine.Status.StateDir, 0o755); err != nil {
+	if err := os.MkdirAll(machine.Status.StateDir, 0o775); err != nil {
 		return machine, err
 	}
 

--- a/machine/qemu/v1alpha1.go
+++ b/machine/qemu/v1alpha1.go
@@ -109,7 +109,7 @@ func (service *machineV1alpha1Service) Create(ctx context.Context, machine *mach
 		machine.Status.StateDir = filepath.Join(config.G[config.KraftKit](ctx).RuntimeDir, string(machine.ObjectMeta.UID))
 	}
 
-	if err := os.MkdirAll(machine.Status.StateDir, 0o755); err != nil {
+	if err := os.MkdirAll(machine.Status.StateDir, 0o775); err != nil {
 		return machine, err
 	}
 

--- a/manifest/directory.go
+++ b/manifest/directory.go
@@ -112,7 +112,7 @@ func (dp DirectoryProvider) PullManifest(ctx context.Context, manifest *Manifest
 
 	f, err := os.Lstat(local)
 	if err != nil && os.IsNotExist(err) {
-		if err := os.MkdirAll(filepath.Dir(local), 0o755); err != nil {
+		if err := os.MkdirAll(filepath.Dir(local), 0o775); err != nil {
 			return err
 		}
 	} else if err == nil && f.IsDir() {

--- a/oci/handler/directory.go
+++ b/oci/handler/directory.go
@@ -34,7 +34,7 @@ type DirectoryHandler struct {
 }
 
 func NewDirectoryHandler(path string) (*DirectoryHandler, error) {
-	if err := os.MkdirAll(path, 0o755); err != nil {
+	if err := os.MkdirAll(path, 0o775); err != nil {
 		return nil, fmt.Errorf("could not create local oci cache directory: %w", err)
 	}
 
@@ -64,7 +64,7 @@ func (handle *DirectoryHandler) ListManifests(ctx context.Context) (manifests []
 	// Create the manifest directory if it does not exist and return nil, since
 	// there's nothing to return.
 	if _, err := os.Stat(manifestsDir); err != nil && os.IsNotExist(err) {
-		if err := os.MkdirAll(manifestsDir, 0o755); err != nil {
+		if err := os.MkdirAll(manifestsDir, 0o775); err != nil {
 			return nil, fmt.Errorf("could not create local oci cache directory: %w", err)
 		}
 
@@ -157,11 +157,11 @@ func (handle *DirectoryHandler) SaveDigest(ctx context.Context, ref string, desc
 	}
 
 	// Create the parent directory if it does not exist
-	if err := os.MkdirAll(filepath.Dir(blobPath), 0o644); err != nil {
+	if err := os.MkdirAll(filepath.Dir(blobPath), 0o774); err != nil {
 		return fmt.Errorf("could not make parent directory: %w", err)
 	}
 
-	blob, err := os.OpenFile(blobPath, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0o644)
+	blob, err := os.OpenFile(blobPath, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0o664)
 	if err != nil {
 		return fmt.Errorf("could not create blob: %w", err)
 	}
@@ -298,7 +298,7 @@ func (handle *DirectoryHandler) FetchImage(ctx context.Context, fullref, platfor
 	)
 
 	// Recursively create the directory
-	if err = os.MkdirAll(manifestPath[:strings.LastIndex(manifestPath, "/")], 0o755); err != nil {
+	if err = os.MkdirAll(manifestPath[:strings.LastIndex(manifestPath, "/")], 0o775); err != nil {
 		return err
 	}
 
@@ -336,7 +336,7 @@ func (handle *DirectoryHandler) FetchImage(ctx context.Context, fullref, platfor
 	}
 
 	// Recursively create the directory
-	if err = os.MkdirAll(configPath[:strings.LastIndex(configPath, "/")], 0o755); err != nil {
+	if err = os.MkdirAll(configPath[:strings.LastIndex(configPath, "/")], 0o775); err != nil {
 		return err
 	}
 
@@ -371,7 +371,7 @@ func (handle *DirectoryHandler) FetchImage(ctx context.Context, fullref, platfor
 		)
 
 		// Recursively create the directory
-		if err = os.MkdirAll(layerPath[:strings.LastIndex(layerPath, "/")], 0o755); err != nil {
+		if err = os.MkdirAll(layerPath[:strings.LastIndex(layerPath, "/")], 0o775); err != nil {
 			return err
 		}
 
@@ -449,7 +449,7 @@ func (handle *DirectoryHandler) UnpackImage(ctx context.Context, ref string, des
 
 			// If the file is a directory, create it
 			if hdr.Typeflag == tar.TypeDir {
-				if err := os.MkdirAll(path, 0o755); err != nil {
+				if err := os.MkdirAll(path, 0o775); err != nil {
 					return err
 				}
 				continue
@@ -457,7 +457,7 @@ func (handle *DirectoryHandler) UnpackImage(ctx context.Context, ref string, des
 
 			// If the directory in the path doesn't exist, create it
 			if _, err := os.Stat(path[:strings.LastIndex(path, "/")]); os.IsNotExist(err) {
-				if err := os.MkdirAll(path[:strings.LastIndex(path, "/")], 0o755); err != nil {
+				if err := os.MkdirAll(path[:strings.LastIndex(path, "/")], 0o775); err != nil {
 					return err
 				}
 			}


### PR DESCRIPTION

<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

With the kraftkit group created, files in the runtime directory, usually set in `/var/kraftkit` can be created with group permissions. To do this, group permissions are set to be equal with the user permissions.


Depends-On: #615 