### PR TITLE
fix(qemu): Handle parsing version commands properly

### DIFF
--- a/machine/qemu/qemu_version.go
+++ b/machine/qemu/qemu_version.go
@@ -63,5 +63,5 @@ func GetQemuVersionFromBin(ctx context.Context, bin string) (*semver.Version, er
 	// Some QEMU versions include the OS distribution that it was compiled for
 	// after the version number (surrounded by brackets).  In every case, just
 	// split the string and gather everything before the first bracket.
-	return semver.NewVersion(strings.TrimSpace(strings.Split(ret, " (")[0]))
+	return semver.NewVersion(strings.TrimSpace(strings.Split(ret, "(")[0]))
 }


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

This PR fixes an issue where the output version does not have a space between the distribution and the version resulting in malformed parsing of the version.

GitHub-Fixes: #637
