### PR TITLE
fix(manifest): Improve manifest Catalog caching

### DIFF
--- a/manifest/git.go
+++ b/manifest/git.go
@@ -96,12 +96,12 @@ func NewGitProvider(ctx context.Context, path string, opts ...ManifestOption) (P
 		return nil, fmt.Errorf("could not list remote git repository: %v", err)
 	}
 
-	return provider, nil
+	return &provider, nil
 }
 
 // probeChannels is an internal method which matches Git branches for the
 // repository and uses this as a ManifestChannel
-func (gp GitProvider) probeChannels() []ManifestChannel {
+func (gp *GitProvider) probeChannels() []ManifestChannel {
 	var channels []ManifestChannel
 
 	// This is unikraft-centric ettiquette where there exists two branches:
@@ -150,7 +150,7 @@ func (gp GitProvider) probeChannels() []ManifestChannel {
 
 // probeVersions is an internal method which matches Git tags for the repository
 // and uses this as a ManifestVersion
-func (gp GitProvider) probeVersions() []ManifestVersion {
+func (gp *GitProvider) probeVersions() []ManifestVersion {
 	var versions []ManifestVersion
 
 	for _, ref := range gp.refs {
@@ -183,7 +183,7 @@ func (gp GitProvider) probeVersions() []ManifestVersion {
 	return versions
 }
 
-func (gp GitProvider) Manifests() ([]*Manifest, error) {
+func (gp *GitProvider) Manifests() ([]*Manifest, error) {
 	base := filepath.Base(gp.repo)
 	ext := filepath.Ext(gp.repo)
 	if len(ext) > 0 {
@@ -214,7 +214,7 @@ func (gp GitProvider) Manifests() ([]*Manifest, error) {
 	return []*Manifest{manifest}, nil
 }
 
-func (gp GitProvider) PullManifest(ctx context.Context, manifest *Manifest, popts ...pack.PullOption) error {
+func (gp *GitProvider) PullManifest(ctx context.Context, manifest *Manifest, popts ...pack.PullOption) error {
 	if useGit {
 		return pullGit(ctx, manifest, popts...)
 	}
@@ -229,7 +229,7 @@ func (gp GitProvider) PullManifest(ctx context.Context, manifest *Manifest, popt
 	return nil
 }
 
-func (gp GitProvider) String() string {
+func (gp *GitProvider) String() string {
 	return "git"
 }
 

--- a/manifest/index.go
+++ b/manifest/index.go
@@ -47,7 +47,7 @@ func NewManifestIndexProvider(ctx context.Context, path string, mopts ...Manifes
 		log.G(ctx).WithFields(logrus.Fields{
 			"path": path,
 		}).Trace("retrieved index")
-		return ManifestIndexProvider{
+		return &ManifestIndexProvider{
 			path:  path,
 			index: index,
 			mopts: mopts,
@@ -60,7 +60,7 @@ func NewManifestIndexProvider(ctx context.Context, path string, mopts ...Manifes
 		log.G(ctx).WithFields(logrus.Fields{
 			"path": path,
 		}).Trace("retrieved index")
-		return ManifestIndexProvider{
+		return &ManifestIndexProvider{
 			path:  path,
 			index: index,
 			mopts: mopts,
@@ -71,15 +71,15 @@ func NewManifestIndexProvider(ctx context.Context, path string, mopts ...Manifes
 	return nil, fmt.Errorf("provided path is not a manifest index: %s", path)
 }
 
-func (mip ManifestIndexProvider) Manifests() ([]*Manifest, error) {
+func (mip *ManifestIndexProvider) Manifests() ([]*Manifest, error) {
 	return mip.index.Manifests, nil
 }
 
-func (mip ManifestIndexProvider) PullManifest(ctx context.Context, manifest *Manifest, opts ...pack.PullOption) error {
+func (mip *ManifestIndexProvider) PullManifest(ctx context.Context, manifest *Manifest, opts ...pack.PullOption) error {
 	return fmt.Errorf("not implemented: manifest.ManifestIndexProvider.PullManifest")
 }
 
-func (mip ManifestIndexProvider) String() string {
+func (mip *ManifestIndexProvider) String() string {
 	return "index"
 }
 

--- a/manifest/manager.go
+++ b/manifest/manager.go
@@ -226,8 +226,6 @@ func (m *manifestManager) Catalog(ctx context.Context, qopts ...packmanager.Quer
 		allManifests = append(allManifests, manifests...)
 	}
 
-	log.G(ctx).Debugf("found %d manifests in catalog", len(allManifests))
-
 	var packages []pack.Package
 	var g glob.Glob
 	types := query.Types()
@@ -360,6 +358,8 @@ func (m *manifestManager) Catalog(ctx context.Context, qopts ...packmanager.Quer
 		// the shorter string comes first
 		return len(iRunes) < len(jRunes)
 	})
+
+	log.G(ctx).Tracef("found %d/%d matching manifests in catalog", len(packages), len(allManifests))
 
 	return packages, nil
 }

--- a/manifest/manager.go
+++ b/manifest/manager.go
@@ -317,7 +317,7 @@ func (m *manifestManager) Catalog(ctx context.Context, qopts ...packmanager.Quer
 		} else {
 			more, err := NewPackageFromManifest(manifest, mopts...)
 			if err != nil {
-				log.G(ctx).Debug(err)
+				log.G(ctx).Trace(err)
 				continue
 				// TODO: Config option for fast-fail?
 				// return nil, err

--- a/manifest/manager.go
+++ b/manifest/manager.go
@@ -25,7 +25,8 @@ import (
 )
 
 type manifestManager struct {
-	manifests []string
+	manifests  []string
+	indexCache *ManifestIndex
 }
 
 // NewManifestManager returns a `packmanager.PackageManager` which manipulates
@@ -60,7 +61,7 @@ func (m *manifestManager) update(ctx context.Context) (*ManifestIndex, error) {
 		return nil, fmt.Errorf("no manifests specified in config")
 	}
 
-	localIndex := &ManifestIndex{
+	index := &ManifestIndex{
 		LastUpdated: time.Now(),
 	}
 
@@ -87,21 +88,26 @@ func (m *manifestManager) update(ctx context.Context) (*ManifestIndex, error) {
 			log.G(ctx).Warnf("%s", err)
 		}
 
-		localIndex.Origin = manipath
-		localIndex.Manifests = append(localIndex.Manifests, manifests...)
+		index.Origin = manipath
+		index.Manifests = append(index.Manifests, manifests...)
 	}
 
-	return localIndex, nil
+	return index, nil
 }
 
 func (m *manifestManager) Update(ctx context.Context) error {
-	// Create parent directories if not present
-	if err := os.MkdirAll(filepath.Dir(m.LocalManifestIndex(ctx)), 0o771); err != nil {
+	index, err := m.update(ctx)
+	if err != nil {
 		return err
 	}
 
-	localIndex, err := m.update(ctx)
-	if err != nil {
+	m.indexCache = new(ManifestIndex)
+	*m.indexCache = *index
+
+	manifests := make([]*Manifest, len(index.Manifests))
+
+	// Create parent directories if not present
+	if err := os.MkdirAll(filepath.Dir(m.LocalManifestIndex(ctx)), 0o771); err != nil {
 		return err
 	}
 
@@ -109,7 +115,7 @@ func (m *manifestManager) Update(ctx context.Context) error {
 	// TODO: Merge manifests of same name and type?
 
 	// Create a file for each manifest
-	for i, manifest := range localIndex.Manifests {
+	for i, manifest := range index.Manifests {
 		filename := manifest.Name + ".yaml"
 
 		if manifest.Type != unikraft.ComponentTypeCore {
@@ -123,21 +129,23 @@ func (m *manifestManager) Update(ctx context.Context) error {
 
 		log.G(ctx).WithFields(logrus.Fields{
 			"path": fileloc,
-		}).Debugf("saving manifest")
+		}).Tracef("saving manifest")
 
 		if err := manifest.WriteToFile(fileloc); err != nil {
 			log.G(ctx).Errorf("could not save manifest: %s", err)
 		}
 
 		// Replace manifest with relative path
-		localIndex.Manifests[i] = &Manifest{
+		manifests[i] = &Manifest{
 			Name:     manifest.Name,
 			Type:     manifest.Type,
 			Manifest: "./" + filename,
 		}
 	}
 
-	return localIndex.WriteToFile(m.LocalManifestIndex(ctx))
+	index.Manifests = manifests
+
+	return index.WriteToFile(m.LocalManifestIndex(ctx))
 }
 
 func (m *manifestManager) SetSources(_ context.Context, sources ...string) error {
@@ -182,8 +190,7 @@ func (m *manifestManager) From(sub pack.PackageFormat) (packmanager.PackageManag
 
 func (m *manifestManager) Catalog(ctx context.Context, qopts ...packmanager.QueryOption) ([]pack.Package, error) {
 	var err error
-	var index *ManifestIndex
-	var allManifests []*Manifest
+	var manifests []*Manifest
 
 	query := packmanager.NewQuery(qopts...)
 	mopts := []ManifestOption{
@@ -199,31 +206,36 @@ func (m *manifestManager) Catalog(ctx context.Context, qopts ...packmanager.Quer
 			return nil, err
 		}
 
-		manifests, err := provider.Manifests()
+		manifests, err = provider.Manifests()
 		if err != nil {
 			return nil, err
 		}
-
-		allManifests = append(allManifests, manifests...)
 	} else if !query.UseCache() {
-		index, err = m.update(ctx)
-		if err != nil {
-			return nil, err
+		// If Catalog is executed in multiple successive calls, which occurs when
+		// searching for multiple packages sequentially, check if the cacheIndex has
+		// been set.  Even if UseCache set has been set, it means that at least once
+		// call to Catalog has properly updated the index.
+		if m.indexCache == nil {
+			indexCache, err := m.update(ctx)
+			if err != nil {
+				return nil, err
+			}
+
+			m.indexCache = &ManifestIndex{}
+			*m.indexCache = *indexCache
 		}
 
-		allManifests = append(allManifests, index.Manifests...)
+		manifests = m.indexCache.Manifests
 	} else {
-		index, err = NewManifestIndexFromFile(m.LocalManifestIndex(ctx))
+		m.indexCache, err = NewManifestIndexFromFile(m.LocalManifestIndex(ctx))
 		if err != nil {
 			return nil, err
 		}
 
-		manifests, err := FindManifestsFromSource(ctx, index.Origin, mopts...)
+		manifests, err = FindManifestsFromSource(ctx, m.indexCache.Origin, mopts...)
 		if err != nil {
 			return nil, err
 		}
-
-		allManifests = append(allManifests, manifests...)
 	}
 
 	var packages []pack.Package
@@ -250,7 +262,7 @@ func (m *manifestManager) Catalog(ctx context.Context, qopts ...packmanager.Quer
 
 	g = glob.MustCompile(name)
 
-	for _, manifest := range allManifests {
+	for _, manifest := range manifests {
 		if len(types) > 0 {
 			found := false
 			for _, t := range types {
@@ -359,7 +371,7 @@ func (m *manifestManager) Catalog(ctx context.Context, qopts ...packmanager.Quer
 		return len(iRunes) < len(jRunes)
 	})
 
-	log.G(ctx).Tracef("found %d/%d matching manifests in catalog", len(packages), len(allManifests))
+	log.G(ctx).Tracef("found %d/%d matching manifests in catalog", len(packages), len(manifests))
 
 	return packages, nil
 }

--- a/manifest/manifest.go
+++ b/manifest/manifest.go
@@ -73,7 +73,7 @@ func NewManifestProvider(ctx context.Context, path string, mopts ...ManifestOpti
 		log.G(ctx).WithFields(logrus.Fields{
 			"path": path,
 		}).Trace("retrieved manifest")
-		return ManifestProvider{
+		return &ManifestProvider{
 			path:     path,
 			manifest: manifest,
 		}, nil
@@ -84,7 +84,7 @@ func NewManifestProvider(ctx context.Context, path string, mopts ...ManifestOpti
 		log.G(ctx).WithFields(logrus.Fields{
 			"path": path,
 		}).Trace("retrieved manifest")
-		return ManifestProvider{
+		return &ManifestProvider{
 			path:     path,
 			manifest: manifest,
 		}, nil
@@ -93,17 +93,17 @@ func NewManifestProvider(ctx context.Context, path string, mopts ...ManifestOpti
 	return nil, fmt.Errorf("provided path is not a manifest: %s", path)
 }
 
-func (mp ManifestProvider) Manifests() ([]*Manifest, error) {
+func (mp *ManifestProvider) Manifests() ([]*Manifest, error) {
 	return []*Manifest{mp.manifest}, nil
 }
 
-func (mp ManifestProvider) PullManifest(ctx context.Context, manifest *Manifest, opts ...pack.PullOption) error {
+func (mp *ManifestProvider) PullManifest(ctx context.Context, manifest *Manifest, opts ...pack.PullOption) error {
 	manifest.mopts = mp.manifest.mopts
 
 	return pullArchive(ctx, manifest, opts...)
 }
 
-func (mp ManifestProvider) String() string {
+func (mp *ManifestProvider) String() string {
 	return "manifest"
 }
 

--- a/manifest/pack.go
+++ b/manifest/pack.go
@@ -85,7 +85,9 @@ func (mp mpack) Push(ctx context.Context, opts ...pack.PushOption) error {
 }
 
 func (mp mpack) Pull(ctx context.Context, opts ...pack.PullOption) error {
-	log.G(ctx).Debugf("pulling manifest package %s", mp.Name())
+	log.G(ctx).
+		WithField("package", unikraft.TypeNameVersion(mp)).
+		Debugf("pulling manifest")
 
 	if mp.manifest.Provider == nil {
 		return fmt.Errorf("uninitialized manifest provider")

--- a/manifest/provider.go
+++ b/manifest/provider.go
@@ -102,7 +102,7 @@ func NewProviderFromString(ctx context.Context, provider, path string, entity an
 			ctx:   ctx,
 		}, nil
 	case "manifest":
-		return ManifestProvider{
+		return &ManifestProvider{
 			path:     path,
 			manifest: entity.(*Manifest),
 		}, nil

--- a/manifest/provider.go
+++ b/manifest/provider.go
@@ -95,7 +95,7 @@ func NewProvider(ctx context.Context, path string, mopts ...ManifestOption) (Pro
 func NewProviderFromString(ctx context.Context, provider, path string, entity any, mopts ...ManifestOption) (Provider, error) {
 	switch provider {
 	case "index":
-		return ManifestIndexProvider{
+		return &ManifestIndexProvider{
 			path:  path,
 			index: entity.(*ManifestIndex),
 			mopts: mopts,


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

This PR improves in-memory caching when using the `Catalog` method.  Often, the `Catalog` method is called sequentially (for example, when finding individual components, such as alibraries, as part of a build).  In the manifest package manager implementation, the call to `Catalog` would repeatedly hit the remote manifest index and subsequentially download all latest manifests.  For larger projects that have many libraries, this is quite an expensive operation since multiple look-ups and downloads occur.  In this PR, fix this by using a temprorary in-memory index that can be referenced.  It is populated the first time when either `Update` or `Catalog` are called.
