### PR TITLE
fix(rm): Remove entire QEMU machine state directory

### DIFF
--- a/machine/qemu/v1alpha1.go
+++ b/machine/qemu/v1alpha1.go
@@ -817,7 +817,10 @@ func (service *machineV1alpha1Service) Delete(ctx context.Context, machine *mach
 
 	var errs merr.Errors
 
-	errs = append(errs, os.Remove(machine.Status.LogFile))
+	err := os.RemoveAll(machine.Status.StateDir)
+	if err != nil {
+		errs = append(errs, fmt.Errorf("error deleting QEMU's state directory %s: %w", machine.Status.StateDir, err))
+	}
 
 	// Do not throw errors (likely these resources do not exist at this point)
 	// when trying to remove ephemeral files that are controlled by the QEMU


### PR DESCRIPTION
### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

This changes the Delete logic for QEMU and removes the entire state directory in one go. 

GitHub-Fixes: #633 
