### PR TITLE
refactor(oci)!: Rename `PushDigest` to `SaveDigest`

### DIFF
--- a/oci/handler/containerd.go
+++ b/oci/handler/containerd.go
@@ -135,8 +135,8 @@ func (handle *ContainerdHandler) ListManifests(ctx context.Context) (manifests [
 	return manifests, nil
 }
 
-// PushDigest implements DigestPusher.
-func (handle *ContainerdHandler) PushDigest(ctx context.Context, ref string, desc ocispec.Descriptor, reader io.Reader, onProgress func(float64)) (err error) {
+// SaveDigest implements DigestSaver.
+func (handle *ContainerdHandler) SaveDigest(ctx context.Context, ref string, desc ocispec.Descriptor, reader io.Reader, onProgress func(float64)) (err error) {
 	ctx, done, err := handle.lease(ctx)
 	if err != nil {
 		return err

--- a/oci/handler/directory.go
+++ b/oci/handler/directory.go
@@ -127,8 +127,8 @@ func (pt *progressWriter) Read(p []byte) (int, error) {
 	return n, err
 }
 
-// PushDigest implements DigestPusher.
-func (handle *DirectoryHandler) PushDigest(ctx context.Context, ref string, desc ocispec.Descriptor, reader io.Reader, onProgress func(float64)) error {
+// SaveDigest implements DigestSaver.
+func (handle *DirectoryHandler) SaveDigest(ctx context.Context, ref string, desc ocispec.Descriptor, reader io.Reader, onProgress func(float64)) error {
 	blobPath := handle.path
 
 	switch desc.MediaType {

--- a/oci/handler/handler.go
+++ b/oci/handler/handler.go
@@ -16,8 +16,8 @@ type DigestResolver interface {
 	DigestExists(context.Context, digest.Digest) (bool, error)
 }
 
-type DigestPusher interface {
-	PushDigest(context.Context, string, ocispec.Descriptor, io.Reader, func(float64)) error
+type DigestSaver interface {
+	SaveDigest(context.Context, string, ocispec.Descriptor, io.Reader, func(float64)) error
 }
 
 type DescriptorResolver interface {
@@ -46,7 +46,7 @@ type ImageUnpacker interface {
 
 type Handler interface {
 	DigestResolver
-	DigestPusher
+	DigestSaver
 	ManifestLister
 	ImagePusher
 	ImageResolver

--- a/oci/image.go
+++ b/oci/image.go
@@ -150,7 +150,7 @@ func (image *Image) AddBlob(ctx context.Context, blob *Blob) (ocispec.Descriptor
 		}
 	}()
 
-	if err := image.handle.PushDigest(ctx, "", blob.desc, fp, nil); err != nil {
+	if err := image.handle.SaveDigest(ctx, "", blob.desc, fp, nil); err != nil {
 		return ocispec.Descriptor{}, err
 	}
 
@@ -333,8 +333,8 @@ func (image *Image) Save(ctx context.Context, source string, onProgress func(flo
 	image.manifestDesc.ArtifactType = image.manifest.Config.MediaType
 	image.manifestDesc.Annotations = image.manifest.Annotations
 
-	// push manifest
-	if err := image.handle.PushDigest(
+	// save the manifest digest
+	if err := image.handle.SaveDigest(
 		ctx,
 		source,
 		image.manifestDesc,


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

To better reflect the action that it performs, rename the interface method `PushDigest` to `SaveDigest` since this operation does not interface with a remote registry.
