### PR TITLE
fix(unikraft): Do not append library prefix for all libraries

### DIFF
--- a/unikraft/lib/library.go
+++ b/unikraft/lib/library.go
@@ -190,7 +190,16 @@ func (lc LibraryConfig) KConfigTree(_ context.Context, env ...*kconfig.KeyValue)
 func (lc LibraryConfig) KConfig() kconfig.KeyValueMap {
 	values := kconfig.KeyValueMap{}
 	values.OverrideBy(lc.kconfig)
-	values.Set(kconfig.Prefix+"LIB"+strings.ToUpper(lc.name), kconfig.Yes)
+
+	// TODO(craciunoiuc): Temporary check as not all libraries follow the same
+	// naming convention. Will be replaced by the kconfig parser.
+	// See: https://github.com/unikraft/kraftkit/issue/653
+	if strings.HasPrefix(strings.ToUpper(lc.name), "LIB") {
+		values.Set(kconfig.Prefix+strings.ToUpper(lc.name), kconfig.Yes)
+	} else {
+		values.Set(kconfig.Prefix+"LIB"+strings.ToUpper(lc.name), kconfig.Yes)
+	}
+
 	return values
 }
 


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

Should eventually be replaced by #653 

Fixes the bug presented in #645, but for that example it will fail in the next step (the build), as libraries are not in the correct order. #653 will be the proper fix for this.

GitHub-Closes: #645