### PR TITLE
fix(run): Remove stop race condition

### DIFF
--- a/cmd/kraft/run/run.go
+++ b/cmd/kraft/run/run.go
@@ -381,18 +381,6 @@ func (opts *Run) Run(cmd *cobra.Command, args []string) error {
 					break loop
 				}
 			}
-
-			// Remove the instance on Ctrl+C if the --rm flag is passed
-			if opts.Remove {
-				if _, err := opts.machineController.Stop(ctx, machine); err != nil {
-					log.G(ctx).Errorf("could not stop: %v", err)
-					return
-				}
-				if _, err := opts.machineController.Delete(ctx, machine); err != nil {
-					log.G(ctx).Errorf("could not remove: %v", err)
-					return
-				}
-			}
 		}()
 	}
 
@@ -424,6 +412,17 @@ func (opts *Run) Run(cmd *cobra.Command, args []string) error {
 
 			case <-ctx.Done():
 				break loop
+			}
+		}
+
+		// Remove the instance on Ctrl+C if the --rm flag is passed
+		if opts.Remove {
+			if _, err := opts.machineController.Stop(ctx, machine); err != nil {
+				log.G(ctx).Errorf("could not stop: %v", err)
+			}
+
+			if _, err := opts.machineController.Delete(ctx, machine); err != nil {
+				log.G(ctx).Errorf("could not remove: %v", err)
 			}
 		}
 	} else {


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

The stop and remove steps were placed inside the goroutine, which caused them to be cut off early because of no syncronisation.

This moves the stop/remove pair in the sequential part as it does not need to run in parallel.

GitHub-Fixes: #632