### PR TITLE
feat(run)!: Disable QEMU preamble and add option to show it 

### DIFF
--- a/machine/qemu/init.go
+++ b/machine/qemu/init.go
@@ -4,7 +4,13 @@
 // You may not use this file except in compliance with the License.
 package qemu
 
-import "encoding/gob"
+import (
+	"encoding/gob"
+
+	"kraftkit.sh/cmdfactory"
+)
+
+var qemuShowSgaBiosPreamble bool
 
 func init() {
 	// Register only used supported interfaces later used for serialization.  To
@@ -468,4 +474,15 @@ func init() {
 
 	// CLI configuration
 	gob.Register(QemuConfig{})
+
+	// Register additional command-line arguments
+	cmdfactory.RegisterFlag(
+		"kraft run",
+		cmdfactory.BoolVar(
+			&qemuShowSgaBiosPreamble,
+			"qemu-sgabios-preamble",
+			false,
+			"Show the QEMU SGABIOS preamble when running a unikernel",
+		),
+	)
 }


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

The preamble printed by QEMU through SGABIOS is messy and also mangles the terminal through several different control characters.

This PR adds a new run option `--qemu-sgabios-preamble` and hides all output from QEMU before the line `Booting from ROM...`.
The log files still have all the information from QEMU.