### PR TITLE
fix(cli): Select targets only once

### DIFF
--- a/internal/cli/target.go
+++ b/internal/cli/target.go
@@ -95,6 +95,7 @@ func FilterTargets(targets []target.Target, arch, plat, targ string) []target.Ta
 			}
 
 			selected = append(selected, t)
+			break
 		}
 	}
 

--- a/internal/cli/target.go
+++ b/internal/cli/target.go
@@ -66,24 +66,39 @@ func FilterTargets(targets []target.Target, arch, plat, targ string) []target.Ta
 			return len(targ) == 0 && len(arch) == 0 && len(plat) == 0
 		},
 
-		// If the `targ` is supplied and the target name match
+		// If only `targ` is supplied and the target name match
 		func(t target.Target, arch, plat, targ string) bool {
-			return len(targ) > 0 && t.Name() == targ
+			return len(targ) > 0 && len(plat) == 0 && len(arch) == 0 && t.Name() == targ
 		},
 
 		// If only `arch` is supplied and the target's arch matches
 		func(t target.Target, arch, plat, targ string) bool {
-			return len(arch) > 0 && len(plat) == 0 && t.Architecture().Name() == arch
+			return len(targ) == 0 && len(plat) == 0 && len(arch) > 0 && t.Architecture().Name() == arch
 		},
 
-		// If only `plat`` is supplied and the target's platform matches
+		// If only `plat` is supplied and the target's platform matches
 		func(t target.Target, arch, plat, targ string) bool {
-			return len(plat) > 0 && len(arch) == 0 && t.Platform().Name() == plat
+			return len(targ) == 0 && len(plat) > 0 && len(arch) == 0 && t.Platform().Name() == plat
 		},
 
 		// If both `arch` and `plat` are supplied and match the target
 		func(t target.Target, arch, plat, targ string) bool {
-			return len(plat) > 0 && len(arch) > 0 && t.Architecture().Name() == arch && t.Platform().Name() == plat
+			return len(targ) == 0 && len(plat) > 0 && len(arch) > 0 && t.Platform().Name() == plat && t.Architecture().Name() == arch
+		},
+
+		// If both `arch` and `targ` are supplied and match the target
+		func(t target.Target, arch, plat, targ string) bool {
+			return len(targ) == 0 && len(targ) > 0 && len(arch) > 0 && t.Name() == targ && t.Architecture().Name() == arch
+		},
+
+		// If both `plat` and `targ` are supplied and match the target
+		func(t target.Target, arch, plat, targ string) bool {
+			return len(targ) > 0 && len(plat) > 0 && len(arch) == 0 && t.Name() == targ && t.Platform().Name() == plat
+		},
+
+		// If all arguments are supplied and match the target
+		func(t target.Target, arch, plat, targ string) bool {
+			return len(targ) > 0 && len(plat) > 0 && len(arch) > 0 && t.Name() == targ && t.Platform().Name() == plat && t.Architecture().Name() == arch
 		},
 	}
 


### PR DESCRIPTION

<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->
If the loop is not exited, there is a good chance that a target meets several conditions at the same time and is added multiple times, as described in the issue.

GitHub-Fixes: #658