### PR TITLE
feat!: Replace dynamic OCI arguments with generic options

### DIFF
--- a/cmd/kraft/pkg/pkg.go
+++ b/cmd/kraft/pkg/pkg.go
@@ -65,7 +65,7 @@ func New() *cobra.Command {
 		`, "`"),
 		Example: heredoc.Doc(`
 			# Package a project as an OCI archive and embed the target's KConfig.
-			$ kraft pkg --as oci --oci-tag unikraft.org/nginx:latest --with-kconfig`),
+			$ kraft pkg --as oci --name unikraft.org/nginx:latest --with-kconfig`),
 		Annotations: map[string]string{
 			cmdfactory.AnnotationHelpGroup: "pkg",
 		},
@@ -201,9 +201,10 @@ func (opts *Pkg) Run(cmd *cobra.Command, args []string) error {
 
 					popts := []packmanager.PackOption{
 						packmanager.PackArgs(cmdShellArgs...),
-						packmanager.PackKConfig(opts.WithKConfig),
-						packmanager.PackOutput(opts.Output),
 						packmanager.PackInitrd(opts.Initrd),
+						packmanager.PackKConfig(opts.WithKConfig),
+						packmanager.PackName(opts.Name),
+						packmanager.PackOutput(opts.Output),
 					}
 
 					if ukversion, ok := targ.KConfig().Get(unikraft.UK_FULLVERSION); ok {

--- a/oci/init.go
+++ b/oci/init.go
@@ -5,7 +5,6 @@
 package oci
 
 import (
-	"kraftkit.sh/cmdfactory"
 	"kraftkit.sh/packmanager"
 )
 
@@ -18,25 +17,5 @@ func init() {
 		WithDefaultAuth(),
 		WithDefaultRegistries(),
 		WithDetectHandler(),
-	)
-
-	// Register additional command-line flags
-	cmdfactory.RegisterFlag(
-		"kraft pkg",
-		cmdfactory.StringVar(
-			&flagTag,
-			"oci-tag",
-			"",
-			"Set the OCI image tag.",
-		),
-	)
-	cmdfactory.RegisterFlag(
-		"kraft pkg",
-		cmdfactory.BoolVar(
-			&flagUseMediaTypes,
-			"oci-use-media-types",
-			false,
-			"Use media types as opposed to well-known paths (experimental).",
-		),
 	)
 }

--- a/oci/oci.go
+++ b/oci/oci.go
@@ -4,11 +4,6 @@
 // You may not use this file except in compliance with the License.
 package oci
 
-var (
-	flagTag           string
-	flagUseMediaTypes bool
-)
-
 const (
 	DefaultRegistry  = "unikraft.org"
 	DefaultNamespace = "default"

--- a/packmanager/pack_options.go
+++ b/packmanager/pack_options.go
@@ -15,6 +15,7 @@ type PackOptions struct {
 	kernelLibraryObjects             bool
 	kernelSourceFiles                bool
 	kernelVersion                    string
+	name                             string
 	output                           string
 }
 
@@ -58,6 +59,11 @@ func (popts *PackOptions) PackKernelSourceFiles() bool {
 // KernelVersion returns the version of the kernel
 func (popts *PackOptions) KernelVersion() string {
 	return popts.kernelVersion
+}
+
+// Name returns the name of the package.
+func (popts *PackOptions) Name() string {
+	return popts.name
 }
 
 // Output returns the location of the package.
@@ -124,6 +130,13 @@ func PackKernelSourceFiles(pack bool) PackOption {
 func PackWithKernelVersion(version string) PackOption {
 	return func(popts *PackOptions) {
 		popts.kernelVersion = version
+	}
+}
+
+// PackName sets the name of the package.
+func PackName(name string) PackOption {
+	return func(popts *PackOptions) {
+		popts.name = name
 	}
 }
 


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

The flags were also registered wrongly with the latest changes, which lead to errors.
As now at least a package manager is always available, the options can become 'permanent'.
