### PR TITLE
fix(manifest): Remove duplicate pull argument

### DIFF
--- a/manifest/git.go
+++ b/manifest/git.go
@@ -17,6 +17,7 @@ import (
 	gitssh "github.com/go-git/go-git/v5/plumbing/transport/ssh"
 	giturl "github.com/kubescape/go-git-url"
 
+	"kraftkit.sh/config"
 	"kraftkit.sh/log"
 	"kraftkit.sh/pack"
 	"kraftkit.sh/unikraft"
@@ -215,7 +216,7 @@ func (gp *GitProvider) Manifests() ([]*Manifest, error) {
 }
 
 func (gp *GitProvider) PullManifest(ctx context.Context, manifest *Manifest, popts ...pack.PullOption) error {
-	if useGit {
+	if config.G[config.KraftKit](ctx).GitProtocol != "git" {
 		return pullGit(ctx, manifest, popts...)
 	}
 

--- a/manifest/github.go
+++ b/manifest/github.go
@@ -19,6 +19,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"golang.org/x/oauth2"
 
+	"kraftkit.sh/config"
 	"kraftkit.sh/internal/ghrepo"
 	"kraftkit.sh/log"
 	"kraftkit.sh/pack"
@@ -126,7 +127,7 @@ func (ghp GitHubProvider) Manifests() ([]*Manifest, error) {
 }
 
 func (ghp GitHubProvider) PullManifest(ctx context.Context, manifest *Manifest, popts ...pack.PullOption) error {
-	if useGit {
+	if config.G[config.KraftKit](ctx).GitProtocol == "git" {
 		return pullGit(ctx, manifest, popts...)
 	}
 

--- a/manifest/init.go
+++ b/manifest/init.go
@@ -5,28 +5,11 @@
 package manifest
 
 import (
-	"kraftkit.sh/cmdfactory"
 	"kraftkit.sh/packmanager"
-	// "kraftkit.sh/packmanager"
 )
-
-// useGit is a local variable used within the context of the manifest package
-// and is dynamically injected as a CLI option.
-var useGit = false
 
 // FIXME(antoineco): avoid init, initialize things where needed
 func init() {
 	// Register a new pack.Package type
 	_ = packmanager.RegisterPackageManager(ManifestFormat, NewManifestManager)
-
-	// Register additional command-line flags
-	cmdfactory.RegisterFlag(
-		"kraft pkg pull",
-		cmdfactory.BoolVarP(
-			&useGit,
-			"git", "g",
-			false,
-			"Use Git when pulling sources",
-		),
-	)
 }


### PR DESCRIPTION


<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

The argument to use git was duplicated by the `--git-protocol` argument and is now removed in favor of that. To use git the remaining one needs to be called like `--git-protocol git`.

The argument was also removed because it caused `cmdfactory` to behave wrongly and waaas also confusing.