### PR TITLE
docs(README): Use `musl` in `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Simply type `exit` or Ctrl+D to quit.
 
 ## Quickstart
 
-Building a unikernel with KraftKit is designed to be simple. 
+Building a unikernel with KraftKit is designed to be simple.
 
 Add a `Kraftfile` to your project directory, which specifies the libraries needed for your unikernel:
 

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ specification: v0.5
 unikraft: stable
 
 libraries:
-  newlib: stable
+  musl: stable
 
 targets:
   - name: default

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ libraries:
 targets:
   - name: default
     architecture: x86_64
-    platform: kvm
+    platform: qemu
 ```
 
 You can also add an additional `Makefile.uk` which specifies any source files:


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [x] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

Building with Newlib results in an error:

```text
 E  /usr/bin/ld: [...]/.unikraft/build/libcontext.o: in function `ukarch_tls_area_init':
 E  [...]/.unikraft/unikraft/arch/x86/x86_64/tls.c:201: undefined reference to `ukarch_tls_tcb_init'
```

There is an issue with Newlib. Until this is fixed, there are two approaches:

i) use Musl
b) remove the libc dependency altogether

Since Musl is the default Unikraft libc, use that. Replace `newlib` with `musl` in the recommended contents for `Kraftfile`.