### PR TITLE
fix: Handle user emulation via QEMU

### DIFF
--- a/cmd/kraft/run/run.go
+++ b/cmd/kraft/run/run.go
@@ -159,10 +159,11 @@ func (opts *Run) Pre(cmd *cobra.Command, _ []string) error {
 	if plat == "" || plat == "auto" {
 		var mode mplatform.SystemMode
 		opts.platform, mode, err = mplatform.Detect(ctx)
-		if mode == mplatform.SystemGuest && !opts.DisableAccel {
-			return fmt.Errorf("nested virtualization not supported")
-		} else if err != nil {
+		if err != nil {
 			return err
+		} else if mode == mplatform.SystemGuest {
+			log.G(ctx).Warn("using hardware emulation")
+			opts.DisableAccel = true
 		}
 	} else {
 		var ok bool


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

This PR fixes an issue where a user may not necessarily have an actual acceleration technology, only QEMU, which is the default install functionality of KraftKit itself. In this scenario, adjust the various checks that then simply force the user into emulation mode.

GitHub-Fixes: #592 