### PR TITLE
fix(github-action): Re-use project instantiation and target selection

### DIFF
--- a/tools/github-action/build.go
+++ b/tools/github-action/build.go
@@ -15,33 +15,13 @@ import (
 	"kraftkit.sh/log"
 	"kraftkit.sh/make"
 	"kraftkit.sh/unikraft/app"
-	"kraftkit.sh/unikraft/target"
 )
 
 func (opts *GithubAction) build(ctx context.Context) error {
-	// Filter project targets by any provided input arguments
-	targets := target.Filter(
-		opts.project.Targets(),
-		opts.Arch,
-		opts.Plat,
-		opts.Target,
-	)
-
-	if len(targets) != 1 {
-		// TODO(nderjung): We should support building multiple targets in the
-		// future, but for now we disable this ability.  This is largely to do with
-		// package management afterwards which does not yet support multi-target
-		// artifacts.  Once this is supported, we can enable multiple target-builds
-		// (and packaging).  Moreover, since it is possible to also execute the
-		// unikernel after a successful build via this action, multiple targets
-		// would also fail at this step.
-		return fmt.Errorf("cannot build more than one target using action")
-	}
-
 	if err := opts.project.Configure(
 		ctx,
-		targets[0], // Target-specific options
-		nil,        // No extra configuration options
+		opts.target, // Target-specific options
+		nil,         // No extra configuration options
 		make.WithSilent(true),
 		make.WithExecOptions(
 			exec.WithStdin(iostreams.G(ctx).In),
@@ -54,7 +34,7 @@ func (opts *GithubAction) build(ctx context.Context) error {
 
 	return opts.project.Build(
 		ctx,
-		targets[0], // Target-specific options
+		opts.target, // Target-specific options
 		app.WithBuildMakeOptions(
 			make.WithMaxJobs(true),
 			make.WithExecOptions(


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

Parts of this code was copied verbatim instead of adapted, resulting in duplicate code within the action.  This PR simply removes elements (instantiation of a project and selection of a target) such that this values are computed only once.  Additionally, in some cases, the value were miscalculated (such as when a custom Kraftfile is specified as a string).

