### PR TITLE
fix(packmanager): Filter oci images based on type

### DIFF
--- a/oci/manager.go
+++ b/oci/manager.go
@@ -123,6 +123,7 @@ func (manager *ociManager) Catalog(ctx context.Context, qopts ...packmanager.Que
 	query := packmanager.NewQuery(qopts...)
 	qname := query.Name()
 	qversion := query.Version()
+	qtypes := query.Types()
 
 	// Adjust for the version being suffixed in a prototypical OCI reference
 	// format
@@ -292,7 +293,24 @@ func (manager *ociManager) Catalog(ctx context.Context, qopts ...packmanager.Que
 		packs = append(packs, pack)
 	}
 
-	return packs, nil
+	var filtered []pack.Package
+	for _, pack := range packs {
+		if len(qtypes) > 0 {
+			found := false
+			for _, t := range qtypes {
+				if pack.Type() == t {
+					found = true
+					break
+				}
+			}
+			if !found {
+				continue
+			}
+		}
+		filtered = append(filtered, pack)
+	}
+
+	return filtered, nil
 }
 
 // SetSources implements packmanager.PackageManager


### PR DESCRIPTION
The oci images were not filtered based on the types in the query, which would for instace cause <app> oci images to show up when querying for libraries.

<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [ ] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [ ] Tested your changes against relevant architectures and platforms;
  - [ ] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->
