### PR TITLE
fix: Downgrade group warning logs into debuging logs

### DIFF
--- a/cmd/kraft/run/run.go
+++ b/cmd/kraft/run/run.go
@@ -326,7 +326,7 @@ func (opts *Run) Run(cmd *cobra.Command, args []string) error {
 		} else {
 			log.G(ctx).
 				WithField("error", err).
-				Warn("kraftkit group not found, falling back to current user")
+				Debug("kraftkit group not found, falling back to current user")
 		}
 
 		var ramfs *initrd.InitrdConfig

--- a/cmd/kraft/run/runner_package.go
+++ b/cmd/kraft/run/runner_package.go
@@ -123,7 +123,7 @@ func (runner *runnerPackage) Prepare(ctx context.Context, opts *Run, machine *ma
 	} else {
 		log.G(ctx).
 			WithField("error", err).
-			Warn("kraftkit group not found, falling back to current user")
+			Debug("kraftkit group not found, falling back to current user")
 	}
 
 	// Clean up the package directory if an error occurs before returning.

--- a/machine/firecracker/v1alpha1.go
+++ b/machine/firecracker/v1alpha1.go
@@ -112,7 +112,7 @@ func (service *machineV1alpha1Service) Create(ctx context.Context, machine *mach
 	} else {
 		log.G(ctx).
 			WithField("error", err).
-			Warn("kraftkit group not found, falling back to current user")
+			Debug("kraftkit group not found, falling back to current user")
 	}
 
 	// Set and create the log file for this machine

--- a/machine/qemu/v1alpha1.go
+++ b/machine/qemu/v1alpha1.go
@@ -163,7 +163,7 @@ func (service *machineV1alpha1Service) Create(ctx context.Context, machine *mach
 	} else {
 		log.G(ctx).
 			WithField("error", err).
-			Warn("kraftkit group not found, falling back to current user")
+			Debug("kraftkit group not found, falling back to current user")
 	}
 
 	// Set and create the log file for this machine

--- a/oci/manager_options.go
+++ b/oci/manager_options.go
@@ -63,7 +63,7 @@ func WithDetectHandler() OCIManagerOption {
 		} else {
 			log.G(ctx).
 				WithField("error", err).
-				Warn("kraftkit group not found, falling back to current user")
+				Debug("kraftkit group not found, falling back to current user")
 		}
 
 		log.G(ctx).WithFields(logrus.Fields{

--- a/oci/pack.go
+++ b/oci/pack.go
@@ -133,7 +133,7 @@ func NewPackageFromTarget(ctx context.Context, targ target.Target, opts ...packm
 		} else {
 			log.G(ctx).
 				WithField("error", err).
-				Warn("kraftkit group not found, falling back to current user")
+				Debug("kraftkit group not found, falling back to current user")
 		}
 
 		ociDir := filepath.Join(config.G[config.KraftKit](ctx).RuntimeDir, "oci")


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [ ] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes
Downgraded warning logs into debuging logs
<!--
Please provide a detailed description of the changes made in this new PR.
-->
