### PR TITLE
feat(app): Allow instantiating kraftfiles from byte slices.

### DIFF
--- a/unikraft/app/project_options.go
+++ b/unikraft/app/project_options.go
@@ -151,6 +151,16 @@ func (popts *ProjectOptions) AddKraftfile(file string) error {
 	return nil
 }
 
+// AddKraftfileFromBytes adds and extracts the file contents from a given byte slice
+// and attaches it to the ProjectOptions.
+func (popts *ProjectOptions) AddKraftfileFromBytes(content []byte) error {
+	popts.kraftfile = &Kraftfile{
+		content: content,
+	}
+
+	return nil
+}
+
 type ProjectOption func(*ProjectOptions) error
 
 // NewProjectOptions creates ProjectOptions
@@ -215,6 +225,13 @@ func WithProjectConfig(config []string) ProjectOption {
 func WithProjectKraftfile(file string) ProjectOption {
 	return func(popts *ProjectOptions) error {
 		return popts.AddKraftfile(file)
+	}
+}
+
+// WithProjectKraftfile adds a kraft file to the project
+func WithProjectKraftfileFromBytes(content []byte) ProjectOption {
+	return func(popts *ProjectOptions) error {
+		return popts.AddKraftfileFromBytes(content)
 	}
 }
 


### PR DESCRIPTION
### Prerequisite checklist
  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

When working with BuildKit, the LLB plugin doesn't have a direct access to the client-local filesystem.

BuildKit provides files on a request-response basis and the interface is a slice of bytes.

Allow instantiating kraftfiles from raw byte slices to decouple the process from trying to directly
interface with the filesystem.
