### PR TITLE
fix(qemu): panic due to unchecked nil map

### DIFF
--- a/machine/qemu/v1alpha1.go
+++ b/machine/qemu/v1alpha1.go
@@ -171,6 +171,10 @@ func (service *machineV1alpha1Service) Create(ctx context.Context, machine *mach
 		machine.Status.LogFile = filepath.Join(machine.Status.StateDir, "machine.log")
 	}
 
+	if machine.Spec.Resources.Requests == nil {
+		machine.Spec.Resources.Requests = make(corev1.ResourceList, 2)
+	}
+
 	if machine.Spec.Resources.Requests.Memory().Value() == 0 {
 		quantity, err := resource.ParseQuantity("64M")
 		if err != nil {


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [ ] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

The following lines cause a panic due to assignments to a nil map:

https://github.com/unikraft/kraftkit/blob/8a562d8303c2d6483a3dc8dc6b0b2c540e430098/machine/qemu/v1alpha1.go#L181

https://github.com/unikraft/kraftkit/blob/8a562d8303c2d6483a3dc8dc6b0b2c540e430098/machine/qemu/v1alpha1.go#L191