### PR TITLE
feat!: Implement OCI Index manipulation

### DIFF
--- a/cmd/kraft/pkg/pkg.go
+++ b/cmd/kraft/pkg/pkg.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/MakeNowJust/heredoc"
 	"github.com/mattn/go-shellwords"
@@ -23,6 +24,8 @@ import (
 	"kraftkit.sh/packmanager"
 	"kraftkit.sh/tui/processtree"
 	"kraftkit.sh/unikraft/app"
+	"kraftkit.sh/unikraft/component"
+	"kraftkit.sh/unikraft/target"
 
 	"kraftkit.sh/cmd/kraft/pkg/list"
 	"kraftkit.sh/cmd/kraft/pkg/pull"
@@ -33,19 +36,19 @@ import (
 )
 
 type Pkg struct {
-	Architecture string `local:"true" long:"arch" short:"m" usage:"Filter the creation of the package by architecture of known targets"`
-	Args         string `local:"true" long:"args" short:"a" usage:"Pass arguments that will be part of the running kernel's command line"`
-	Dbg          bool   `local:"true" long:"dbg" usage:"Package the debuggable (symbolic) kernel image instead of the stripped image"`
-	Force        bool   `local:"true" long:"force-format" usage:"Force the use of a packaging handler format"`
-	Format       string `local:"true" long:"as" short:"M" usage:"Force the packaging despite possible conflicts" default:"auto"`
-	Initrd       string `local:"true" long:"initrd" short:"i" usage:"Path to init ramdisk to bundle within the package (passing a path will automatically generate a CPIO image)"`
-	Kernel       string `local:"true" long:"kernel" short:"k" usage:"Override the path to the unikernel image"`
-	Kraftfile    string `long:"kraftfile" usage:"Set an alternative path of the Kraftfile"`
-	Name         string `local:"true" long:"name" short:"n" usage:"Specify the name of the package"`
-	Output       string `local:"true" long:"output" short:"o" usage:"Save the package at the following output"`
-	Platform     string `local:"true" long:"plat" short:"p" usage:"Filter the creation of the package by platform of known targets"`
-	Target       string `local:"true" long:"target" short:"t" usage:"Package a particular known target"`
-	WithKConfig  bool   `local:"true" long:"with-kconfig" usage:"Include the target .config"`
+	Architecture string   `local:"true" long:"arch" short:"m" usage:"Filter the creation of the package by architecture of known targets"`
+	Args         string   `local:"true" long:"args" short:"a" usage:"Pass arguments that will be part of the running kernel's command line"`
+	Dbg          bool     `local:"true" long:"dbg" usage:"Package the debuggable (symbolic) kernel image instead of the stripped image"`
+	Force        bool     `local:"true" long:"force-format" usage:"Force the use of a packaging handler format"`
+	Format       string   `local:"true" long:"as" short:"M" usage:"Force the packaging despite possible conflicts" default:"auto"`
+	Initrd       string   `local:"true" long:"initrd" short:"i" usage:"Path to init ramdisk to bundle within the package (passing a path will automatically generate a CPIO image)"`
+	Kernel       string   `local:"true" long:"kernel" short:"k" usage:"Override the path to the unikernel image"`
+	Kraftfile    string   `long:"kraftfile" usage:"Set an alternative path of the Kraftfile"`
+	Name         string   `local:"true" long:"name" short:"n" usage:"Specify the name of the package"`
+	Output       string   `local:"true" long:"output" short:"o" usage:"Save the package at the following output"`
+	Platform     string   `local:"true" long:"plat" short:"p" usage:"Filter the creation of the package by platform of known targets"`
+	Targets      []string `local:"true" long:"target" short:"t" usage:"Package a particular known target"`
+	WithKConfig  bool     `local:"true" long:"with-kconfig" usage:"Include the target .config"`
 }
 
 func New() *cobra.Command {
@@ -66,7 +69,17 @@ func New() *cobra.Command {
 		`, "`"),
 		Example: heredoc.Doc(`
 			# Package a project as an OCI archive and embed the target's KConfig.
-			$ kraft pkg --as oci --name unikraft.org/nginx:latest --with-kconfig`),
+			$ kraft pkg --as oci --name unikraft.org/nginx:latest --with-kconfig
+
+			# Package a project with a given target name
+			$ kraft pkg --as oci --name unikraft.org/nginx:latest --target my_target
+
+			# Package a project with a given platform and architecture
+			$ kraft pkg --as oci --name unikraft.org/nginx:latest --plat qemu --arch x86_64
+
+			# Package a project with multiple targets
+			$ kraft pkg --as oci --name unikraft.org/nginx:latest --target my_target --target my_other_target
+		`),
 		Annotations: map[string]string{
 			cmdfactory.AnnotationHelpGroup: "pkg",
 		},
@@ -86,7 +99,7 @@ func New() *cobra.Command {
 }
 
 func (opts *Pkg) Pre(cmd *cobra.Command, _ []string) error {
-	if (len(opts.Architecture) > 0 || len(opts.Platform) > 0) && len(opts.Target) > 0 {
+	if (len(opts.Architecture) > 0 || len(opts.Platform) > 0) && len(opts.Targets) > 0 {
 		return fmt.Errorf("the `--arch` and `--plat` options are not supported in addition to `--target`")
 	}
 
@@ -100,6 +113,22 @@ func (opts *Pkg) Pre(cmd *cobra.Command, _ []string) error {
 	opts.Platform = platform.PlatformByName(opts.Platform).String()
 
 	return nil
+}
+
+func matchOption(targets []string, option string) bool {
+	for _, target := range targets {
+		name := target
+		if strings.Contains(target, "/") {
+			name = string(platform.PlatformByName(strings.Split(target, "/")[0])) +
+				"/" +
+				strings.Split(target, "/")[1]
+		}
+		if name == option {
+			return true
+		}
+	}
+
+	return false
 }
 
 func (opts *Pkg) Run(cmd *cobra.Command, args []string) error {
@@ -134,11 +163,13 @@ func (opts *Pkg) Run(cmd *cobra.Command, args []string) error {
 	}
 
 	var tree []*processtree.ProcessTreeItem
+	var targets []target.Target
+	var packageOpts []packmanager.PackOption
 
 	parallel := !config.G[config.KraftKit](ctx).NoParallel
 	norender := log.LoggerTypeFromString(config.G[config.KraftKit](ctx).Log.Type) != log.FANCY
 
-	// Generate a package for every matching requested target
+	// Generate a package with all matching requested targets
 	for _, targ := range project.Targets() {
 		// See: https://github.com/golang/go/wiki/CommonMistakes#using-reference-to-loop-iterator-variable
 		targ := targ
@@ -146,13 +177,17 @@ func (opts *Pkg) Run(cmd *cobra.Command, args []string) error {
 		switch true {
 		case
 			// If no arguments are supplied
-			len(opts.Target) == 0 &&
+			len(opts.Targets) == 0 &&
 				len(opts.Architecture) == 0 &&
 				len(opts.Platform) == 0,
 
 			// If the --target flag is supplied and the target name match
-			len(opts.Target) > 0 &&
-				targ.Name() == opts.Target,
+			len(opts.Targets) > 0 &&
+				matchOption(opts.Targets, targ.Name()),
+
+			// If the --target flag is supplied and the target is a plat/arch combo
+			len(opts.Targets) > 0 &&
+				matchOption(opts.Targets, target.TargetPlatArchName(targ)),
 
 			// If only the --arch flag is supplied and the target's arch matches
 			len(opts.Architecture) > 0 &&
@@ -170,68 +205,67 @@ func (opts *Pkg) Run(cmd *cobra.Command, args []string) error {
 				targ.Architecture().Name() == opts.Architecture &&
 				targ.Platform().Name() == opts.Platform:
 
-			var format pack.PackageFormat
-			name := "packaging " + targ.Name()
-			if opts.Format != "auto" {
-				format = pack.PackageFormat(opts.Format)
-			} else if targ.Format().String() != "" {
-				format = targ.Format()
-			}
-			if format.String() != "auto" {
-				name += " (" + format.String() + ")"
-			}
-
 			cmdShellArgs, err := shellwords.Parse(opts.Args)
 			if err != nil {
 				return err
 			}
 
-			tree = append(tree, processtree.NewProcessTreeItem(
-				name,
-				targ.Architecture().Name()+"/"+targ.Platform().Name(),
-				func(ctx context.Context) error {
-					var err error
-					pm := packmanager.G(ctx)
+			packageOpts = append(packageOpts,
+				packmanager.PackArgs(cmdShellArgs...),
+				packmanager.PackInitrd(opts.Initrd),
+				packmanager.PackKConfig(opts.WithKConfig),
+				packmanager.PackName(opts.Name),
+				packmanager.PackOutput(opts.Output),
+			)
 
-					// Switch the package manager the desired format for this target
-					if format != "auto" {
-						pm, err = pm.From(format)
-						if err != nil {
-							return err
-						}
-					}
+			if ukversion, ok := targ.KConfig().Get(unikraft.UK_FULLVERSION); ok {
+				packageOpts = append(packageOpts,
+					packmanager.PackWithKernelVersion(ukversion.Value),
+				)
+			}
 
-					popts := []packmanager.PackOption{
-						packmanager.PackArgs(cmdShellArgs...),
-						packmanager.PackInitrd(opts.Initrd),
-						packmanager.PackKConfig(opts.WithKConfig),
-						packmanager.PackName(opts.Name),
-						packmanager.PackOutput(opts.Output),
-					}
-
-					if ukversion, ok := targ.KConfig().Get(unikraft.UK_FULLVERSION); ok {
-						popts = append(popts,
-							packmanager.PackWithKernelVersion(ukversion.Value),
-						)
-					}
-
-					if _, err := pm.Pack(ctx, targ, popts...); err != nil {
-						return err
-					}
-
-					return nil
-				},
-			))
+			targets = append(targets, targ)
 
 		default:
 			continue
 		}
 	}
 
+	var components []component.Component
+	var targetNames string
+
+	// Convert targets from []target.Target to []component.Component
+	for _, targ := range targets {
+		components = append(components, targ)
+		targetNames += targ.Name() + " "
+	}
+
+	tree = append(tree, processtree.NewProcessTreeItem(
+		opts.Output,
+		targetNames,
+		func(ctx context.Context) error {
+			pm := packmanager.G(ctx)
+
+			// Switch the package manager the desired format for this target
+			if opts.Format != "auto" {
+				pm, err = pm.From(pack.PackageFormat(opts.Format))
+				if err != nil {
+					return err
+				}
+			}
+
+			if _, err := pm.Pack(ctx, components, packageOpts...); err != nil {
+				return err
+			}
+
+			return nil
+		},
+	))
+
 	if len(tree) == 0 {
 		switch true {
-		case len(opts.Target) > 0:
-			return fmt.Errorf("no matching targets found for: %s", opts.Target)
+		case len(opts.Targets) > 0:
+			return fmt.Errorf("no matching targets found for: %s", opts.Targets)
 		case len(opts.Architecture) > 0 && len(opts.Platform) == 0:
 			return fmt.Errorf("no matching targets found for architecture: %s", opts.Architecture)
 		case len(opts.Architecture) == 0 && len(opts.Platform) > 0:

--- a/cmd/kraft/pkg/pull/pull.go
+++ b/cmd/kraft/pkg/pull/pull.go
@@ -256,6 +256,8 @@ func (opts *Pull) Run(cmd *cobra.Command, args []string) error {
 					packmanager.WithSource(c.Source()),
 					packmanager.WithTypes(c.Type()),
 					packmanager.WithCache(opts.ForceCache),
+					packmanager.WithArchitecture(opts.Architecture),
+					packmanager.WithPlatform(opts.Platform),
 				},
 			})
 		}
@@ -263,7 +265,10 @@ func (opts *Pull) Run(cmd *cobra.Command, args []string) error {
 		// Is this a list (space delimetered) of packages to pull?
 	} else if len(args) > 0 {
 		for _, arg := range args {
-			pm, compatible, err := pm.IsCompatible(ctx, arg)
+			pm, compatible, err := pm.IsCompatible(ctx, arg,
+				packmanager.WithArchitecture(opts.Architecture),
+				packmanager.WithPlatform(opts.Platform),
+			)
 			if err != nil || !compatible {
 				continue
 			}
@@ -273,6 +278,8 @@ func (opts *Pull) Run(cmd *cobra.Command, args []string) error {
 				query: []packmanager.QueryOption{
 					packmanager.WithCache(opts.ForceCache),
 					packmanager.WithName(arg),
+					packmanager.WithArchitecture(opts.Architecture),
+					packmanager.WithPlatform(opts.Platform),
 				},
 			})
 		}

--- a/cmd/kraft/pkg/push/push.go
+++ b/cmd/kraft/pkg/push/push.go
@@ -125,6 +125,7 @@ func (opts *Push) Run(cmd *cobra.Command, args []string) error {
 	if pm, compatible, err := pmananger.IsCompatible(ctx, ref); err == nil && compatible {
 		packages, err := pm.Catalog(ctx,
 			packmanager.WithCache(true),
+			packmanager.WithAllTargets(true),
 			packmanager.WithName(ref),
 		)
 		if err != nil {
@@ -138,7 +139,6 @@ func (opts *Push) Run(cmd *cobra.Command, args []string) error {
 		}
 
 		// Call push if it exists
-		// TODO push if it doesn't exist too
 		proc := paraprogress.NewProcess(
 			fmt.Sprintf("pushing %s",
 				ref,

--- a/cmd/kraft/run/runner_package.go
+++ b/cmd/kraft/run/runner_package.go
@@ -75,6 +75,8 @@ func (runner *runnerPackage) Prepare(ctx context.Context, opts *Run, machine *ma
 		packmanager.WithTypes(unikraft.ComponentTypeApp),
 		packmanager.WithName(runner.packName),
 		packmanager.WithCache(true),
+		packmanager.WithPlatform(string(opts.platform)),
+		packmanager.WithArchitecture(opts.Architecture),
 	)
 	if err != nil {
 		return err
@@ -88,6 +90,8 @@ func (runner *runnerPackage) Prepare(ctx context.Context, opts *Run, machine *ma
 			packmanager.WithTypes(unikraft.ComponentTypeApp),
 			packmanager.WithName(runner.packName),
 			packmanager.WithCache(false),
+			packmanager.WithPlatform(string(opts.platform)),
+			packmanager.WithArchitecture(opts.Architecture),
 		)
 		if err != nil {
 			return err

--- a/manifest/manager.go
+++ b/manifest/manager.go
@@ -176,7 +176,7 @@ func (m *manifestManager) RemoveSource(ctx context.Context, source string) error
 	return nil
 }
 
-func (m *manifestManager) Pack(ctx context.Context, c component.Component, opts ...packmanager.PackOption) ([]pack.Package, error) {
+func (m *manifestManager) Pack(ctx context.Context, c []component.Component, opts ...packmanager.PackOption) ([]pack.Package, error) {
 	return nil, fmt.Errorf("not implemented manifest.manager.Pack")
 }
 

--- a/oci/handler/directory_image.go
+++ b/oci/handler/directory_image.go
@@ -321,7 +321,7 @@ func (dix DirectoryImageIndex) Image(hash v1.Hash) (v1.Image, error) {
 	}
 
 	// Fetch manifest and config from the filesystem
-	image, err := dix.handle.ResolveImage(context.TODO(), manifest.Digest.Encoded())
+	image, err := dix.handle.ResolveImage(context.TODO(), manifest.Digest.Encoded(), "")
 	if err != nil {
 		return nil, err
 	}

--- a/oci/handler/handler.go
+++ b/oci/handler/handler.go
@@ -37,7 +37,7 @@ type ImagePusher interface {
 }
 
 type ImageResolver interface {
-	ResolveImage(context.Context, string) (ocispec.Image, error)
+	ResolveImage(context.Context, string, string) (ocispec.Image, error)
 }
 
 type ImageFetcher interface {

--- a/oci/handler/handler.go
+++ b/oci/handler/handler.go
@@ -28,6 +28,10 @@ type ManifestLister interface {
 	ListManifests(context.Context) ([]ocispec.Manifest, error)
 }
 
+type IndexLister interface {
+	ListIndexes(context.Context) ([]ocispec.Index, error)
+}
+
 type ImagePusher interface {
 	PushImage(context.Context, string, *ocispec.Descriptor) error
 }
@@ -41,13 +45,14 @@ type ImageFetcher interface {
 }
 
 type ImageUnpacker interface {
-	UnpackImage(context.Context, string, string) error
+	UnpackImage(context.Context, string, string, string) error
 }
 
 type Handler interface {
 	DigestResolver
 	DigestSaver
 	ManifestLister
+	IndexLister
 	ImagePusher
 	ImageResolver
 	ImageFetcher

--- a/oci/image_options.go
+++ b/oci/image_options.go
@@ -22,3 +22,21 @@ func WithAutoSave(autoSave bool) ImageOption {
 		return nil
 	}
 }
+
+type ImageIndexOption func(*ImageIndex) error
+
+// WithIndexAutoSave atomicizes the index as operations occur on its body.
+func WithIndexAutoSave(autoSave bool) ImageIndexOption {
+	return func(index *ImageIndex) error {
+		index.autoSave = autoSave
+		return nil
+	}
+}
+
+// WithIndexWorkdir specifies the working directory of the index.
+func WithIndexWorkdir(workdir string) ImageIndexOption {
+	return func(index *ImageIndex) error {
+		index.workdir = workdir
+		return nil
+	}
+}

--- a/oci/index.go
+++ b/oci/index.go
@@ -1,0 +1,142 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2022, Unikraft GmbH and The KraftKit Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+package oci
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/containerd/containerd/errdefs"
+	"github.com/containerd/containerd/images"
+	"github.com/google/go-containerregistry/pkg/name"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"oras.land/oras-go/v2/content"
+
+	"kraftkit.sh/oci/handler"
+)
+
+type ImageIndex struct {
+	workdir  string
+	autoSave bool
+
+	handle handler.Handler
+
+	index     ocispec.Index
+	indexDesc ocispec.Descriptor
+
+	manifests   []ocispec.Manifest
+	images      []ocispec.Image
+	annotations map[string]string
+}
+
+func NewImageIndex(_ context.Context, handle handler.Handler, opts ...ImageIndexOption) (*ImageIndex, error) {
+	if handle == nil {
+		return nil, fmt.Errorf("cannot use `NewImageIndex` without handler")
+	}
+
+	index := ImageIndex{
+		handle:   handle,
+		autoSave: true,
+	}
+
+	for _, opt := range opts {
+		if err := opt(&index); err != nil {
+			return nil, err
+		}
+	}
+
+	return &index, nil
+}
+
+// AddManifest adds a manifest directly to the index and returns the resulting
+// descriptor
+func (index *ImageIndex) AddManifest(ctx context.Context, manifest *ocispec.Manifest, image *ocispec.Image) (ocispec.Descriptor, error) {
+	manifestJson, err := json.Marshal(manifest)
+	if err != nil {
+		return ocispec.Descriptor{}, fmt.Errorf("failed to marshal manifest: %w", err)
+	}
+
+	descriptor := content.NewDescriptorFromBytes(
+		ocispec.MediaTypeImageManifest,
+		manifestJson,
+	)
+
+	descriptor.Platform = &ocispec.Platform{
+		Architecture: image.Architecture,
+		OS:           image.OS,
+		OSFeatures:   image.OSFeatures,
+	}
+
+	index.index.Manifests = append(index.index.Manifests, descriptor)
+
+	return descriptor, nil
+}
+
+// SetAnnotation sets an anootation of the index with the provided key.
+func (index *ImageIndex) SetAnnotation(_ context.Context, key, val string) {
+	if index.annotations == nil {
+		index.annotations = make(map[string]string)
+	}
+
+	index.annotations[key] = val
+}
+
+// Save the index.
+func (index *ImageIndex) Save(ctx context.Context, source string, onProgress func(float64)) (ocispec.Descriptor, error) {
+	ref, err := name.ParseReference(source,
+		name.WithDefaultRegistry(DefaultRegistry),
+	)
+	if err != nil {
+		return ocispec.Descriptor{}, err
+	}
+
+	// General annotations
+	index.annotations[ocispec.AnnotationRefName] = ref.Context().String()
+	index.annotations[ocispec.AnnotationRevision] = ref.Identifier()
+	index.annotations[ocispec.AnnotationCreated] = time.Now().UTC().Format(time.RFC3339)
+
+	// containerd compatibility annotations
+	index.annotations[images.AnnotationImageName] = ref.String()
+
+	// Add Manifests
+	for idx, manifest := range index.manifests {
+		_, err := index.AddManifest(ctx, &manifest, &index.images[idx])
+		if err != nil {
+			return ocispec.Descriptor{}, err
+		}
+	}
+
+	index.index.Annotations = index.annotations
+	index.index.SchemaVersion = 2
+
+	indexJson, err := json.Marshal(index.index)
+	if err != nil {
+		return ocispec.Descriptor{}, fmt.Errorf("failed to marshal manifest: %w", err)
+	}
+
+	index.indexDesc = content.NewDescriptorFromBytes(
+		ocispec.MediaTypeImageIndex,
+		indexJson,
+	)
+	index.indexDesc.ArtifactType = index.index.ArtifactType
+	index.indexDesc.Size = int64(len(indexJson))
+
+	// save the manifest digest
+	if err := index.handle.SaveDigest(
+		ctx,
+		source,
+		index.indexDesc,
+		bytes.NewReader(indexJson),
+		onProgress,
+	); err != nil && !errors.Is(err, errdefs.ErrAlreadyExists) {
+		return ocispec.Descriptor{}, fmt.Errorf("failed to push manifest: %w", err)
+	}
+
+	return index.indexDesc, nil
+}

--- a/oci/manager.go
+++ b/oci/manager.go
@@ -65,13 +65,19 @@ func (manager *ociManager) Update(ctx context.Context) error {
 }
 
 // Pack implements packmanager.PackageManager
-func (manager *ociManager) Pack(ctx context.Context, entity component.Component, opts ...packmanager.PackOption) ([]pack.Package, error) {
-	targ, ok := entity.(target.Target)
-	if !ok {
-		return nil, fmt.Errorf("entity is not Unikraft target")
+func (manager *ociManager) Pack(ctx context.Context, entities []component.Component, opts ...packmanager.PackOption) ([]pack.Package, error) {
+	var targets []target.Target
+
+	for _, entity := range entities {
+		targ, ok := entity.(target.Target)
+		if !ok {
+			return nil, fmt.Errorf("entity is not Unikraft target")
+		}
+
+		targets = append(targets, targ)
 	}
 
-	pkg, err := NewPackageFromTarget(ctx, targ, opts...)
+	pkg, err := NewPackageFromTargets(ctx, targets, opts...)
 	if err != nil {
 		return nil, err
 	}

--- a/oci/pack.go
+++ b/oci/pack.go
@@ -84,7 +84,13 @@ func NewPackageFromTarget(ctx context.Context, targ target.Target, opts ...packm
 	}
 
 	if popts.Output() != "" {
-		ocipack.ref, err = name.ParseReference(popts.Output(),
+		output := popts.Output()
+		if strings.HasPrefix(popts.Output(), "oci://") {
+			output = strings.TrimPrefix(popts.Output(), "oci://")
+		}
+
+		ocipack.ref, err = name.ParseReference(
+			output,
 			name.WithDefaultRegistry(DefaultRegistry),
 		)
 	} else {
@@ -311,7 +317,13 @@ func NewPackageFromTargets(ctx context.Context, targ []target.Target, opts ...pa
 	}
 
 	if popts.Output() != "" {
-		ref, err = name.ParseReference(popts.Output(),
+		output := popts.Output()
+		if strings.HasPrefix(popts.Output(), "oci://") {
+			output = strings.TrimPrefix(popts.Output(), "oci://")
+		}
+
+		ref, err = name.ParseReference(
+			output,
 			name.WithDefaultRegistry(DefaultRegistry),
 		)
 	} else if len(targ) == 1 {

--- a/oci/pack.go
+++ b/oci/pack.go
@@ -52,6 +52,12 @@ type ociPackage struct {
 	command []string
 }
 
+type ociIndex struct {
+	handle handler.Handler
+	ref    name.Reference
+	index  *ImageIndex
+}
+
 var (
 	_ pack.Package  = (*ociPackage)(nil)
 	_ target.Target = (*ociPackage)(nil)
@@ -482,8 +488,9 @@ func NewPackageFromOCIManifestSpec(ctx context.Context, handle handler.Handler, 
 
 // NewPackageFromRemoteOCIRef generates a new package from a given OCI image
 // reference which is accessed by its remote registry.
-func NewPackageFromRemoteOCIRef(ctx context.Context, handle handler.Handler, ref string) (pack.Package, error) {
+func NewPackageFromRemoteOCIRef(ctx context.Context, handle handler.Handler, ref string, packPlat *v1.Platform) (pack.Package, error) {
 	var err error
+	var copts []crane.Option
 
 	ocipack := ociPackage{
 		handle: handle,
@@ -512,11 +519,17 @@ func NewPackageFromRemoteOCIRef(ctx context.Context, handle handler.Handler, ref
 		authConfig.Username = auth.Username
 	}
 
-	raw, err := crane.Manifest(ref,
+	copts = append(copts,
 		crane.WithAuth(&simpleauth.SimpleAuthenticator{
 			Auth: authConfig,
 		}),
 	)
+
+	if packPlat != nil {
+		copts = append(copts, crane.WithPlatform(packPlat))
+	}
+
+	raw, err := crane.Manifest(ref, copts...)
 	if err != nil {
 		return nil, fmt.Errorf("could not get manifest: %v", err)
 	}
@@ -574,14 +587,29 @@ func (ocipack *ociPackage) Type() unikraft.ComponentType {
 	return unikraft.ComponentTypeApp
 }
 
+// Type implements unikraft.Nameable
+func (ociidx ociIndex) Type() unikraft.ComponentType {
+	return unikraft.ComponentTypeApp
+}
+
 // Name implements unikraft.Nameable
 func (ocipack *ociPackage) Name() string {
 	return ocipack.ref.Context().Name()
 }
 
+// Name implements unikraft.Nameable
+func (ociidx ociIndex) Name() string {
+	return ociidx.ref.Context().Name()
+}
+
 // Version implements unikraft.Nameable
 func (ocipack *ociPackage) Version() string {
 	return ocipack.ref.Identifier()
+}
+
+// Version implements unikraft.Nameable
+func (ociidx ociIndex) Version() string {
+	return ociidx.ref.Identifier()
 }
 
 // imageRef returns the OCI-standard image name in the format `name:tag`
@@ -592,23 +620,41 @@ func (ocipack *ociPackage) imageRef() string {
 	return fmt.Sprintf("%s:%s", ocipack.Name(), ocipack.Version())
 }
 
+// imageRef returns the OCI-standard image name in the format `name:tag`
+func (ociidx ociIndex) imageRef() string {
+	if strings.HasPrefix(ociidx.Version(), "sha256:") {
+		return fmt.Sprintf("%s@%s", ociidx.Name(), ociidx.Version())
+	}
+	return fmt.Sprintf("%s:%s", ociidx.Name(), ociidx.Version())
+}
+
 // Metadata implements pack.Package
 func (ocipack *ociPackage) Metadata() any {
 	return ocipack.image.config
 }
 
+// Metadata implements pack.Package
+func (ociidx ociIndex) Metadata() any {
+	return ociidx.index.index.MediaType
+}
+
 // Push implements pack.Package
 func (ocipack *ociPackage) Push(ctx context.Context, opts ...pack.PushOption) error {
-	manifestJson, err := json.Marshal(ocipack.image.manifest)
+	return fmt.Errorf("cannot push target without OCI image index")
+}
+
+// Push implements pack.Package
+func (ociidx ociIndex) Push(ctx context.Context, opts ...pack.PushOption) error {
+	indexJson, err := json.Marshal(ociidx.index.index)
 	if err != nil {
 		return fmt.Errorf("failed to marshal manifest: %w", err)
 	}
 
-	ocipack.image.manifestDesc = content.NewDescriptorFromBytes(
-		ocispec.MediaTypeImageManifest,
-		manifestJson,
+	ociidx.index.indexDesc = content.NewDescriptorFromBytes(
+		ocispec.MediaTypeImageIndex,
+		indexJson,
 	)
-	return ocipack.image.handle.PushImage(ctx, ocipack.imageRef(), &ocipack.image.manifestDesc)
+	return ociidx.index.handle.PushImage(ctx, ociidx.imageRef(), &ociidx.index.indexDesc)
 }
 
 // Pull implements pack.Package
@@ -626,9 +672,11 @@ func (ocipack *ociPackage) Pull(ctx context.Context, opts ...pack.PullOption) er
 		}
 	}
 
+	plat := fmt.Sprintf("%s/%s", popts.Platform(), pullArch)
+
 	// If it's possible to resolve the image reference, the image has already been
 	// pulled to the local image store
-	image, err := ocipack.handle.ResolveImage(ctx, ocipack.imageRef())
+	image, err := ocipack.handle.ResolveImage(ctx, ocipack.imageRef(), plat)
 	if err == nil {
 		goto unpack
 	}
@@ -643,7 +691,7 @@ func (ocipack *ociPackage) Pull(ctx context.Context, opts ...pack.PullOption) er
 	}
 
 	// Try resolving the image again after pulling it
-	image, err = ocipack.handle.ResolveImage(ctx, ocipack.imageRef())
+	image, err = ocipack.handle.ResolveImage(ctx, ocipack.imageRef(), plat)
 	if err != nil {
 		return err
 	}
@@ -654,6 +702,7 @@ unpack:
 		if err := ocipack.image.handle.UnpackImage(
 			ctx,
 			ocipack.imageRef(),
+			fmt.Sprintf("%s/%s", popts.Platform(), pullArch),
 			popts.Workdir(),
 		); err != nil {
 			return err
@@ -679,8 +728,16 @@ unpack:
 	return nil
 }
 
-// Pull implements pack.Package
+func (ociidx ociIndex) Pull(ctx context.Context, opts ...pack.PullOption) error {
+	return fmt.Errorf("cannot pull OCI image index")
+}
+
+// Format implements pack.Package
 func (ocipack *ociPackage) Format() pack.PackageFormat {
+	return OCIFormat
+}
+
+func (ociidx ociIndex) Format() pack.PackageFormat {
 	return OCIFormat
 }
 

--- a/packmanager/manager.go
+++ b/packmanager/manager.go
@@ -22,11 +22,11 @@ type PackageManager interface {
 	// Update retrieves and stores locally a cache of the upstream registry.
 	Update(context.Context) error
 
-	// Pack turns the provided component into the distributable package.  Since
+	// Pack turns the provided components into the distributable package.  Since
 	// components can comprise of other components, it is possible to return more
 	// than one package.  It is possible to disable this and "flatten" a component
 	// into a single package by setting a relevant `pack.PackOption`.
-	Pack(context.Context, component.Component, ...PackOption) ([]pack.Package, error)
+	Pack(context.Context, []component.Component, ...PackOption) ([]pack.Package, error)
 
 	// Unpack turns a given package into a usable component.  Since a package can
 	// compromise of a multiple components, it is possible to return multiple

--- a/packmanager/query.go
+++ b/packmanager/query.go
@@ -31,6 +31,18 @@ type Query struct {
 
 	// Auth contains required authentication for the query.
 	auths map[string]config.AuthConfig
+
+	// allTargets indicates that the query should package all targets together
+	allTargets bool
+
+	// Architecture specifies the architecture of the package
+	architecture string
+
+	// Platform specifies the platform of the package
+	platform string
+
+	// KConfig specifies the list of config options of the package
+	kConfig []string
 }
 
 // Source specifies where the origin of the package
@@ -51,6 +63,26 @@ func (query *Query) Name() string {
 // Version specifies the version of the package
 func (query *Query) Version() string {
 	return query.version
+}
+
+// AllTargets indicates that the query should package all targets together
+func (query *Query) AllTargets() bool {
+	return query.allTargets
+}
+
+// Architecture specifies the architecture of the package
+func (query *Query) Architecture() string {
+	return query.architecture
+}
+
+// Platform specifies the platform of the package
+func (query *Query) Platform() string {
+	return query.platform
+}
+
+// KConfig specifies the list of config options of the package
+func (query *Query) KConfig() []string {
+	return query.kConfig
 }
 
 // UseCache indicates whether the package manager should use any existing cache.
@@ -87,6 +119,27 @@ func NewQuery(qopts ...QueryOption) *Query {
 	return &query
 }
 
+// WithArchitecture sets the query parameter for the architecture of the package.
+func WithArchitecture(arch string) QueryOption {
+	return func(query *Query) {
+		query.architecture = arch
+	}
+}
+
+// WithPlatform sets the query parameter for the platform of the package.
+func WithPlatform(platform string) QueryOption {
+	return func(query *Query) {
+		query.platform = platform
+	}
+}
+
+// WithKconfig sets the query parameter for the list of configuration options of the package.
+func WithKConfig(kConfig []string) QueryOption {
+	return func(query *Query) {
+		query.kConfig = kConfig
+	}
+}
+
 // WithSource sets the query parameter for the origin source of the package.
 func WithSource(source string) QueryOption {
 	return func(query *Query) {
@@ -120,6 +173,13 @@ func WithVersion(version string) QueryOption {
 func WithCache(useCache bool) QueryOption {
 	return func(query *Query) {
 		query.useCache = useCache
+	}
+}
+
+// WithAllTargets sets whether to package all targets together.
+func WithAllTargets(allTargets bool) QueryOption {
+	return func(query *Query) {
+		query.allTargets = allTargets
 	}
 }
 

--- a/packmanager/umbrella.go
+++ b/packmanager/umbrella.go
@@ -109,14 +109,16 @@ func (u UmbrellaManager) RemoveSource(ctx context.Context, source string) error 
 	return nil
 }
 
-func (u UmbrellaManager) Pack(ctx context.Context, source component.Component, opts ...PackOption) ([]pack.Package, error) {
+func (u UmbrellaManager) Pack(ctx context.Context, source []component.Component, opts ...PackOption) ([]pack.Package, error) {
 	var ret []pack.Package
 
 	for _, manager := range u.packageManagers {
-		log.G(ctx).WithFields(logrus.Fields{
-			"format": manager.Format(),
-			"source": source.Name(),
-		}).Tracef("packing")
+		for _, component := range source {
+			log.G(ctx).WithFields(logrus.Fields{
+				"format": manager.Format(),
+				"source": component.Name(),
+			}).Tracef("packing")
+		}
 		more, err := manager.Pack(ctx, source, opts...)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

This PR offers the ability to work with index oci artifacts.
This translates in pushing a single artifact `helloworld:latest` for multiple platform/architecture permutations.

The outstanding issue of this PR is that containerd support breaks as it still tries to work with images instead of indexes.
Moreover, existing images in the registry might be now unusable and need to be pushed again. Single artifact applications should still have an index.

GitHub-Closes: #704