### PR TITLE
fix(qemu): Add pvpanic device only for x86_64

### DIFF
--- a/machine/qemu/v1alpha1.go
+++ b/machine/qemu/v1alpha1.go
@@ -244,7 +244,6 @@ func (service *machineV1alpha1Service) Create(ctx context.Context, machine *mach
 		}),
 		WithDisplay(QemuDisplayNone{}),
 		WithParallel(QemuHostCharDevNone{}),
-		WithDevice(QemuDevicePvpanic{}),
 	}
 
 	// TODO: Parse Rootfs types
@@ -399,6 +398,9 @@ func (service *machineV1alpha1Service) Create(ctx context.Context, machine *mach
 
 	switch machine.Spec.Architecture {
 	case "x86_64", "amd64":
+		qopts = append(qopts,
+			WithDevice(QemuDevicePvpanic{}),
+		)
 		if machine.Spec.Emulation {
 			qopts = append(qopts,
 				WithMachine(QemuMachine{


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->
