### PR TITLE
refactor!: streamline package manager initialization

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -9,7 +9,6 @@ import (
 
 	zip "api.zip"
 	"k8s.io/apimachinery/pkg/api/resource"
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 
 	machinev1alpha1 "kraftkit.sh/api/machine/v1alpha1"
 	networkv1alpha1 "kraftkit.sh/api/network/v1alpha1"
@@ -17,11 +16,13 @@ import (
 )
 
 func init() {
-	utilruntime.Must(zip.Register(
+	gob.Register(resource.Quantity{})
+}
+
+func RegisterSchemes() error {
+	return zip.Register(
 		machinev1alpha1.AddToScheme,
 		networkv1alpha1.AddToScheme,
 		volumev1alpha1.AddToScheme,
-	))
-
-	gob.Register(resource.Quantity{})
+	)
 }

--- a/cmd/kraft/build/build.go
+++ b/cmd/kraft/build/build.go
@@ -82,13 +82,12 @@ func New() *cobra.Command {
 }
 
 func (opts *Build) Pre(cmd *cobra.Command, args []string) error {
-	ctx := cmd.Context()
-	pm, err := packmanager.NewUmbrellaManager(ctx)
+	ctx, err := packmanager.WithDefaultUmbrellaManagerInContext(cmd.Context())
 	if err != nil {
 		return err
 	}
 
-	cmd.SetContext(packmanager.WithPackageManager(ctx, pm))
+	cmd.SetContext(ctx)
 
 	if len(args) == 0 {
 		opts.workdir, err = os.Getwd()

--- a/cmd/kraft/clean/clean.go
+++ b/cmd/kraft/clean/clean.go
@@ -76,13 +76,12 @@ func New() *cobra.Command {
 }
 
 func (opts *Clean) Pre(cmd *cobra.Command, _ []string) error {
-	ctx := cmd.Context()
-	pm, err := packmanager.NewUmbrellaManager(ctx)
+	ctx, err := packmanager.WithDefaultUmbrellaManagerInContext(cmd.Context())
 	if err != nil {
 		return err
 	}
 
-	cmd.SetContext(packmanager.WithPackageManager(ctx, pm))
+	cmd.SetContext(ctx)
 
 	opts.Platform = platform.PlatformByName(opts.Platform).String()
 

--- a/cmd/kraft/fetch/fetch.go
+++ b/cmd/kraft/fetch/fetch.go
@@ -52,13 +52,12 @@ func New() *cobra.Command {
 }
 
 func (opts *Fetch) Pre(cmd *cobra.Command, _ []string) error {
-	ctx := cmd.Context()
-	pm, err := packmanager.NewUmbrellaManager(ctx)
+	ctx, err := packmanager.WithDefaultUmbrellaManagerInContext(cmd.Context())
 	if err != nil {
 		return err
 	}
 
-	cmd.SetContext(packmanager.WithPackageManager(ctx, pm))
+	cmd.SetContext(ctx)
 
 	opts.Platform = platform.PlatformByName(opts.Platform).String()
 

--- a/cmd/kraft/kraft.go
+++ b/cmd/kraft/kraft.go
@@ -14,6 +14,7 @@ import (
 
 	"kraftkit.sh/cmdfactory"
 	"kraftkit.sh/config"
+	"kraftkit.sh/internal/bootstrap"
 	"kraftkit.sh/internal/cli"
 	kitupdate "kraftkit.sh/internal/update"
 	kitversion "kraftkit.sh/internal/version"
@@ -138,6 +139,11 @@ func main() {
 		if err := kitupdate.Check(ctx); err != nil {
 			log.G(ctx).Debugf("could not check for updates: %v", err)
 		}
+	}
+
+	if err := bootstrap.InitKraftkit(ctx); err != nil {
+		log.G(ctx).Errorf("could not init kraftkit: %v", err)
+		os.Exit(1)
 	}
 
 	cmdfactory.Main(ctx, cmd)

--- a/cmd/kraft/menu/menu.go
+++ b/cmd/kraft/menu/menu.go
@@ -55,13 +55,12 @@ func New() *cobra.Command {
 }
 
 func (opts *Menu) Pre(cmd *cobra.Command, _ []string) error {
-	ctx := cmd.Context()
-	pm, err := packmanager.NewUmbrellaManager(ctx)
+	ctx, err := packmanager.WithDefaultUmbrellaManagerInContext(cmd.Context())
 	if err != nil {
 		return err
 	}
 
-	cmd.SetContext(packmanager.WithPackageManager(ctx, pm))
+	cmd.SetContext(ctx)
 
 	opts.Platform = platform.PlatformByName(opts.Platform).String()
 

--- a/cmd/kraft/pkg/list/list.go
+++ b/cmd/kraft/pkg/list/list.go
@@ -58,13 +58,12 @@ func New() *cobra.Command {
 }
 
 func (*List) Pre(cmd *cobra.Command, _ []string) error {
-	ctx := cmd.Context()
-	pm, err := packmanager.NewUmbrellaManager(ctx)
+	ctx, err := packmanager.WithDefaultUmbrellaManagerInContext(cmd.Context())
 	if err != nil {
 		return err
 	}
 
-	cmd.SetContext(packmanager.WithPackageManager(ctx, pm))
+	cmd.SetContext(ctx)
 
 	return nil
 }

--- a/cmd/kraft/pkg/pkg.go
+++ b/cmd/kraft/pkg/pkg.go
@@ -90,13 +90,12 @@ func (opts *Pkg) Pre(cmd *cobra.Command, _ []string) error {
 		return fmt.Errorf("the `--arch` and `--plat` options are not supported in addition to `--target`")
 	}
 
-	ctx := cmd.Context()
-	pm, err := packmanager.NewUmbrellaManager(ctx)
+	ctx, err := packmanager.WithDefaultUmbrellaManagerInContext(cmd.Context())
 	if err != nil {
 		return err
 	}
 
-	cmd.SetContext(packmanager.WithPackageManager(ctx, pm))
+	cmd.SetContext(ctx)
 
 	opts.Platform = platform.PlatformByName(opts.Platform).String()
 

--- a/cmd/kraft/pkg/pull/pull.go
+++ b/cmd/kraft/pkg/pull/pull.go
@@ -70,13 +70,12 @@ func New() *cobra.Command {
 }
 
 func (opts *Pull) Pre(cmd *cobra.Command, _ []string) error {
-	ctx := cmd.Context()
-	pm, err := packmanager.NewUmbrellaManager(ctx)
+	ctx, err := packmanager.WithDefaultUmbrellaManagerInContext(cmd.Context())
 	if err != nil {
 		return err
 	}
 
-	cmd.SetContext(packmanager.WithPackageManager(ctx, pm))
+	cmd.SetContext(ctx)
 
 	opts.Platform = platform.PlatformByName(opts.Platform).String()
 

--- a/cmd/kraft/pkg/push/push.go
+++ b/cmd/kraft/pkg/push/push.go
@@ -56,13 +56,12 @@ func New() *cobra.Command {
 }
 
 func (opts *Push) Pre(cmd *cobra.Command, _ []string) error {
-	ctx := cmd.Context()
-	pm, err := packmanager.NewUmbrellaManager(ctx)
+	ctx, err := packmanager.WithDefaultUmbrellaManagerInContext(cmd.Context())
 	if err != nil {
 		return err
 	}
 
-	cmd.SetContext(packmanager.WithPackageManager(ctx, pm))
+	cmd.SetContext(ctx)
 
 	return nil
 }
@@ -111,7 +110,11 @@ func (opts *Push) Run(cmd *cobra.Command, args []string) error {
 
 	var pmananger packmanager.PackageManager
 	if opts.Format != "auto" {
-		pmananger = packmanager.PackageManagers()[pack.PackageFormat(opts.Format)]
+		umbrella, err := packmanager.PackageManagers()
+		if err != nil {
+			return err
+		}
+		pmananger = umbrella[pack.PackageFormat(opts.Format)]
 		if pmananger == nil {
 			return errors.New("invalid package format specified")
 		}

--- a/cmd/kraft/pkg/source/source.go
+++ b/cmd/kraft/pkg/source/source.go
@@ -44,13 +44,12 @@ func New() *cobra.Command {
 }
 
 func (*Source) Pre(cmd *cobra.Command, _ []string) error {
-	ctx := cmd.Context()
-	pm, err := packmanager.NewUmbrellaManager(ctx)
+	ctx, err := packmanager.WithDefaultUmbrellaManagerInContext(cmd.Context())
 	if err != nil {
 		return err
 	}
 
-	cmd.SetContext(packmanager.WithPackageManager(ctx, pm))
+	cmd.SetContext(ctx)
 
 	return nil
 }

--- a/cmd/kraft/pkg/unsource/unsource.go
+++ b/cmd/kraft/pkg/unsource/unsource.go
@@ -43,13 +43,12 @@ func New() *cobra.Command {
 }
 
 func (*Unsource) Pre(cmd *cobra.Command, _ []string) error {
-	ctx := cmd.Context()
-	pm, err := packmanager.NewUmbrellaManager(ctx)
+	ctx, err := packmanager.WithDefaultUmbrellaManagerInContext(cmd.Context())
 	if err != nil {
 		return err
 	}
 
-	cmd.SetContext(packmanager.WithPackageManager(ctx, pm))
+	cmd.SetContext(ctx)
 
 	return nil
 }

--- a/cmd/kraft/pkg/update/update.go
+++ b/cmd/kraft/pkg/update/update.go
@@ -44,13 +44,12 @@ func New() *cobra.Command {
 }
 
 func (*Update) Pre(cmd *cobra.Command, _ []string) error {
-	ctx := cmd.Context()
-	pm, err := packmanager.NewUmbrellaManager(ctx)
+	ctx, err := packmanager.WithDefaultUmbrellaManagerInContext(cmd.Context())
 	if err != nil {
 		return err
 	}
 
-	cmd.SetContext(packmanager.WithPackageManager(ctx, pm))
+	cmd.SetContext(ctx)
 
 	return nil
 }

--- a/cmd/kraft/prepare/prepare.go
+++ b/cmd/kraft/prepare/prepare.go
@@ -52,13 +52,12 @@ func New() *cobra.Command {
 }
 
 func (opts *Prepare) Pre(cmd *cobra.Command, _ []string) error {
-	ctx := cmd.Context()
-	pm, err := packmanager.NewUmbrellaManager(ctx)
+	ctx, err := packmanager.WithDefaultUmbrellaManagerInContext(cmd.Context())
 	if err != nil {
 		return err
 	}
 
-	cmd.SetContext(packmanager.WithPackageManager(ctx, pm))
+	cmd.SetContext(ctx)
 
 	opts.Platform = platform.PlatformByName(opts.Platform).String()
 

--- a/cmd/kraft/properclean/properclean.go
+++ b/cmd/kraft/properclean/properclean.go
@@ -72,13 +72,12 @@ func New() *cobra.Command {
 }
 
 func (*ProperClean) Pre(cmd *cobra.Command, _ []string) error {
-	ctx := cmd.Context()
-	pm, err := packmanager.NewUmbrellaManager(ctx)
+	ctx, err := packmanager.WithDefaultUmbrellaManagerInContext(cmd.Context())
 	if err != nil {
 		return err
 	}
 
-	cmd.SetContext(packmanager.WithPackageManager(ctx, pm))
+	cmd.SetContext(ctx)
 
 	return nil
 }

--- a/cmd/kraft/run/run.go
+++ b/cmd/kraft/run/run.go
@@ -187,16 +187,19 @@ func (opts *Run) Pre(cmd *cobra.Command, _ []string) error {
 
 	if opts.RunAs == "" || !set.NewStringSet("kernel", "project").Contains(opts.RunAs) {
 		// Set use of the global package manager.
-		pm, err := packmanager.NewUmbrellaManager(ctx)
+		ctx, err := packmanager.WithDefaultUmbrellaManagerInContext(cmd.Context())
 		if err != nil {
 			return err
 		}
 
-		cmd.SetContext(packmanager.WithPackageManager(ctx, pm))
+		cmd.SetContext(ctx)
 	}
 
 	if opts.RunAs != "" {
-		runners := runnersByName()
+		runners, err := runnersByName()
+		if err != nil {
+			return err
+		}
 		if _, ok = runners[opts.RunAs]; !ok {
 			choices := make([]string, len(runners))
 			i := 0
@@ -229,7 +232,10 @@ func (opts *Run) Run(cmd *cobra.Command, args []string) error {
 
 	var run runner
 	var errs []error
-	runners := runners()
+	runners, err := runners()
+	if err != nil {
+		return err
+	}
 
 	// Iterate through the list of built-in runners which sequentially tests and
 	// first test whether the --as flag has been set to force a specific runner or

--- a/cmd/kraft/run/runner.go
+++ b/cmd/kraft/run/runner.go
@@ -32,29 +32,37 @@ type runner interface {
 // runners is the list of built-in runners which are checked sequentially for
 // capability.  The first to test positive via Runnable is used with the
 // controller.
-func runners() []runner {
+func runners() ([]runner, error) {
 	r := []runner{
 		&runnerLinuxu{},
 		&runnerKernel{},
 		&runnerProject{},
 	}
 
-	for _, pm := range packmanager.PackageManagers() {
+	umbrella, err := packmanager.PackageManagers()
+	if err != nil {
+		return nil, err
+	}
+
+	for _, pm := range umbrella {
 		r = append(r, &runnerPackage{
 			pm: pm,
 		})
 	}
 
-	return r
+	return r, nil
 }
 
 // runnersByName is a utility method that returns a map of the available runners
 // such that their alias name can be quickly looked up.
-func runnersByName() map[string]runner {
-	runners := runners()
+func runnersByName() (map[string]runner, error) {
+	runners, err := runners()
+	if err != nil {
+		return nil, err
+	}
 	ret := make(map[string]runner, len(runners))
 	for _, runner := range runners {
 		ret[runner.String()] = runner
 	}
-	return ret
+	return ret, nil
 }

--- a/cmd/kraft/set/set.go
+++ b/cmd/kraft/set/set.go
@@ -75,13 +75,12 @@ func New() *cobra.Command {
 }
 
 func (*Set) Pre(cmd *cobra.Command, _ []string) error {
-	ctx := cmd.Context()
-	pm, err := packmanager.NewUmbrellaManager(ctx)
+	ctx, err := packmanager.WithDefaultUmbrellaManagerInContext(cmd.Context())
 	if err != nil {
 		return err
 	}
 
-	cmd.SetContext(packmanager.WithPackageManager(ctx, pm))
+	cmd.SetContext(ctx)
 
 	return nil
 }

--- a/cmd/kraft/unset/unset.go
+++ b/cmd/kraft/unset/unset.go
@@ -73,13 +73,12 @@ func New() *cobra.Command {
 }
 
 func (*Unset) Pre(cmd *cobra.Command, _ []string) error {
-	ctx := cmd.Context()
-	pm, err := packmanager.NewUmbrellaManager(ctx)
+	ctx, err := packmanager.WithDefaultUmbrellaManagerInContext(cmd.Context())
 	if err != nil {
 		return err
 	}
 
-	cmd.SetContext(packmanager.WithPackageManager(ctx, pm))
+	cmd.SetContext(ctx)
 
 	return nil
 }

--- a/internal/bootstrap/init.go
+++ b/internal/bootstrap/init.go
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2022, Unikraft GmbH and The KraftKit Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+
+// Package bootstrap lets us keep kraftkit initialization logic in one place.
+package bootstrap
+
+import (
+	"context"
+
+	"kraftkit.sh/api"
+	"kraftkit.sh/machine/qemu"
+	"kraftkit.sh/manifest"
+	"kraftkit.sh/oci"
+	"kraftkit.sh/packmanager"
+	"kraftkit.sh/unikraft/elfloader"
+)
+
+// InitKraftkit performs a set of kraftkit setup steps.
+// It allows us to move away from in-package init() magic.
+// It also allows us to propagate initialization errors easily.
+func InitKraftkit(ctx context.Context) error {
+	registerAdditionalFlags()
+
+	if err := registerSchemes(); err != nil {
+		return err
+	}
+
+	return registerPackageManagers(ctx)
+}
+
+func registerAdditionalFlags() {
+	elfloader.RegisterFlags()
+	manifest.RegisterFlags()
+	qemu.RegisterFlags()
+}
+
+func registerSchemes() error {
+	return api.RegisterSchemes()
+}
+
+func registerPackageManagers(ctx context.Context) error {
+	managerConstructors := []func(u *packmanager.UmbrellaManager) error{
+		oci.RegisterPackageManager(),
+		manifest.RegisterPackageManager(),
+	}
+
+	return packmanager.InitUmbrellaManager(ctx, managerConstructors)
+}

--- a/machine/qemu/init.go
+++ b/machine/qemu/init.go
@@ -474,7 +474,9 @@ func init() {
 
 	// CLI configuration
 	gob.Register(QemuConfig{})
+}
 
+func RegisterFlags() {
 	// Register additional command-line arguments
 	cmdfactory.RegisterFlag(
 		"kraft run",

--- a/manifest/init.go
+++ b/manifest/init.go
@@ -14,11 +14,13 @@ import (
 // and is dynamically injected as a CLI option.
 var useGit = false
 
-// FIXME(antoineco): avoid init, initialize things where needed
-func init() {
-	// Register a new pack.Package type
-	_ = packmanager.RegisterPackageManager(ManifestFormat, NewManifestManager)
+func RegisterPackageManager() func(u *packmanager.UmbrellaManager) error {
+	return func(u *packmanager.UmbrellaManager) error {
+		return u.RegisterPackageManager(ManifestFormat, NewManifestManager)
+	}
+}
 
+func RegisterFlags() {
 	// Register additional command-line flags
 	cmdfactory.RegisterFlag(
 		"kraft pkg pull",

--- a/oci/init.go
+++ b/oci/init.go
@@ -8,14 +8,14 @@ import (
 	"kraftkit.sh/packmanager"
 )
 
-// FIXME(antoineco): avoid init, initialize things where needed
-func init() {
-	// Register a new pkg.Package type
-	_ = packmanager.RegisterPackageManager(
-		OCIFormat,
-		NewOCIManager,
-		WithDefaultAuth(),
-		WithDefaultRegistries(),
-		WithDetectHandler(),
-	)
+func RegisterPackageManager() func(u *packmanager.UmbrellaManager) error {
+	return func(u *packmanager.UmbrellaManager) error {
+		return u.RegisterPackageManager(
+			OCIFormat,
+			NewOCIManager,
+			WithDefaultAuth(),
+			WithDefaultRegistries(),
+			WithDetectHandler(),
+		)
+	}
 }

--- a/packmanager/context.go
+++ b/packmanager/context.go
@@ -16,7 +16,7 @@ var (
 	G = FromContext
 
 	// PM is the system-access umbrella package manager.
-	PM = umbrella{}
+	PM = UmbrellaManager{}
 )
 
 // contextKey is used to retrieve the package manager from the context.

--- a/unikraft/elfloader/init.go
+++ b/unikraft/elfloader/init.go
@@ -8,7 +8,7 @@ import "kraftkit.sh/cmdfactory"
 
 var defaultPrebuilt string
 
-func init() {
+func RegisterFlags() {
 	// Register additional command-line arguments
 	cmdfactory.RegisterFlag(
 		"kraft run",


### PR DESCRIPTION
  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [x] Updated relevant documentation.

### Description of changes

Create a singleton for the umbrella package manager and use it instead of global package-scoped maps. Use more dependency injection.

Move the scattered init() calls to RegisterPackageManager into one place. Create a bootstrap package for handling flag/zip registration.

Use the bootstrapping package in main(). Propagate errors up and report them if initialization fails.

This should make things a bit more testable in the future.

GitHub-Fixes: #425
