### PR TITLE
fix(oci): Populate image information after fetching

### DIFF
--- a/oci/pack.go
+++ b/oci/pack.go
@@ -472,6 +472,12 @@ func (ocipack *ociPackage) Pull(ctx context.Context, opts ...pack.PullOption) er
 		return err
 	}
 
+	// Try resolving the image again after pulling it
+	image, err = ocipack.handle.ResolveImage(ctx, ocipack.imageRef())
+	if err != nil {
+		return err
+	}
+
 unpack:
 	// Unpack the image if a working directory has been provided
 	if len(popts.Workdir()) > 0 {


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

Fetching a new image would mean that the image config information was no longer populated when unpacking, which resulted in nil/empty fields in this part:
```go
		// Set the command
		ocipack.command = image.Config.Cmd
		ocipack.image.config = image
```
