### PR TITLE
fix(unikraft): Hardcode language libraries before libcs

### DIFF
--- a/unikraft/app/application.go
+++ b/unikraft/app/application.go
@@ -347,6 +347,29 @@ func (app application) MakeArgs(tc target.Target) (*core.MakeArgs, error) {
 		unformattedLibraries[k] = v
 	}
 
+	// Add language libraries that we know require a specific ordering.
+	// Currently, these are C++-related libraries. Others may be added as required.
+	if unformattedLibraries["libcxxabi"] != nil {
+		libraries = append(libraries, unformattedLibraries["libcxxabi"].Path())
+		delete(unformattedLibraries, "libcxxabi")
+	}
+	if unformattedLibraries["libcxx"] != nil {
+		libraries = append(libraries, unformattedLibraries["libcxx"].Path())
+		delete(unformattedLibraries, "libcxx")
+	}
+	if unformattedLibraries["libunwind"] != nil {
+		libraries = append(libraries, unformattedLibraries["libunwind"].Path())
+		delete(unformattedLibraries, "libunwind")
+	}
+	if unformattedLibraries["compiler-rt"] != nil {
+		libraries = append(libraries, unformattedLibraries["compiler-rt"].Path())
+		delete(unformattedLibraries, "compiler-rt")
+	}
+	if unformattedLibraries["libgo"] != nil {
+		libraries = append(libraries, unformattedLibraries["libgo"].Path())
+		delete(unformattedLibraries, "libgo")
+	}
+
 	// All supported libCs right now
 	if unformattedLibraries["musl"] != nil {
 		libraries = append(libraries, unformattedLibraries["musl"].Path())


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

This commit hardcodes all known language libraries that need to sit before musl/newlib.
This is a temporary fix as mentioned in the comment above them.
Before that is fixed, all libraries known to cause problems should be added here.