### PR TITLE
fix(run): Fix race-condition related to short-lived instances

### DIFF
--- a/internal/logtail/logtail.go
+++ b/internal/logtail/logtail.go
@@ -112,6 +112,7 @@ func peekAndRead(file *os.File, reader *bufio.Reader, logs *chan string, errs *c
 		}
 
 		reader.Reset(file)
+		*errs <- io.EOF
 		return true
 	}
 

--- a/machine/qemu/v1alpha1.go
+++ b/machine/qemu/v1alpha1.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"io/fs"
 	"net"
 	"os"
@@ -752,7 +753,9 @@ func (service *machineV1alpha1Service) Logs(ctx context.Context, machine *machin
 			return out, errOut, nil
 
 		case err := <-errOut:
-			return nil, nil, err
+			if err != io.EOF {
+				return nil, nil, err
+			}
 
 		case <-ctx.Done():
 			return out, errOut, nil


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

This PR switches the current event-based logging to a hybrid poll-event system.
The main takeaway is that every 10 ms kraftkit checks if the machine has exited and wants to shutdown.
When that is the case, it will check for two subsequent calls where nothing was printed.
The only case when the machine wants to shutdown (nothing more will be outputted) and nothing was printed for 20ms is when it really finished.

The only case where output would be missed is when the console used for ouput writes less than 1 character per 10ms.

This poll method infers ~0.4% stress on a single core, which means 0.1% on a 4-core CPU. (4 GHz)