### PR TITLE
feat(run): enable running LLB images

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -9,7 +9,6 @@ import (
 
 	zip "api.zip"
 	"k8s.io/apimachinery/pkg/api/resource"
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 
 	machinev1alpha1 "kraftkit.sh/api/machine/v1alpha1"
 	networkv1alpha1 "kraftkit.sh/api/network/v1alpha1"
@@ -17,11 +16,13 @@ import (
 )
 
 func init() {
-	utilruntime.Must(zip.Register(
+	gob.Register(resource.Quantity{})
+}
+
+func RegisterSchemes() error {
+	return zip.Register(
 		machinev1alpha1.AddToScheme,
 		networkv1alpha1.AddToScheme,
 		volumev1alpha1.AddToScheme,
-	))
-
-	gob.Register(resource.Quantity{})
+	)
 }

--- a/cmd/kraft/build/build.go
+++ b/cmd/kraft/build/build.go
@@ -82,13 +82,12 @@ func New() *cobra.Command {
 }
 
 func (opts *Build) Pre(cmd *cobra.Command, args []string) error {
-	ctx := cmd.Context()
-	pm, err := packmanager.NewUmbrellaManager(ctx)
+	ctx, err := packmanager.WithDefaultUmbrellaManagerInContext(cmd.Context())
 	if err != nil {
 		return err
 	}
 
-	cmd.SetContext(packmanager.WithPackageManager(ctx, pm))
+	cmd.SetContext(ctx)
 
 	if len(args) == 0 {
 		opts.workdir, err = os.Getwd()

--- a/cmd/kraft/clean/clean.go
+++ b/cmd/kraft/clean/clean.go
@@ -76,13 +76,12 @@ func New() *cobra.Command {
 }
 
 func (opts *Clean) Pre(cmd *cobra.Command, _ []string) error {
-	ctx := cmd.Context()
-	pm, err := packmanager.NewUmbrellaManager(ctx)
+	ctx, err := packmanager.WithDefaultUmbrellaManagerInContext(cmd.Context())
 	if err != nil {
 		return err
 	}
 
-	cmd.SetContext(packmanager.WithPackageManager(ctx, pm))
+	cmd.SetContext(ctx)
 
 	opts.Platform = platform.PlatformByName(opts.Platform).String()
 

--- a/cmd/kraft/fetch/fetch.go
+++ b/cmd/kraft/fetch/fetch.go
@@ -52,13 +52,12 @@ func New() *cobra.Command {
 }
 
 func (opts *Fetch) Pre(cmd *cobra.Command, _ []string) error {
-	ctx := cmd.Context()
-	pm, err := packmanager.NewUmbrellaManager(ctx)
+	ctx, err := packmanager.WithDefaultUmbrellaManagerInContext(cmd.Context())
 	if err != nil {
 		return err
 	}
 
-	cmd.SetContext(packmanager.WithPackageManager(ctx, pm))
+	cmd.SetContext(ctx)
 
 	opts.Platform = platform.PlatformByName(opts.Platform).String()
 

--- a/cmd/kraft/kraft.go
+++ b/cmd/kraft/kraft.go
@@ -14,6 +14,7 @@ import (
 
 	"kraftkit.sh/cmdfactory"
 	"kraftkit.sh/config"
+	"kraftkit.sh/internal/bootstrap"
 	"kraftkit.sh/internal/cli"
 	kitupdate "kraftkit.sh/internal/update"
 	kitversion "kraftkit.sh/internal/version"
@@ -144,6 +145,11 @@ func main() {
 			log.G(ctx).Debug("")
 			log.G(ctx).Debug("or use the globally accessible flag '--no-check-updates'")
 		}
+	}
+
+	if err := bootstrap.InitKraftkit(ctx); err != nil {
+		log.G(ctx).Errorf("could not init kraftkit: %v", err)
+		os.Exit(1)
 	}
 
 	cmdfactory.Main(ctx, cmd)

--- a/cmd/kraft/menu/menu.go
+++ b/cmd/kraft/menu/menu.go
@@ -55,13 +55,12 @@ func New() *cobra.Command {
 }
 
 func (opts *Menu) Pre(cmd *cobra.Command, _ []string) error {
-	ctx := cmd.Context()
-	pm, err := packmanager.NewUmbrellaManager(ctx)
+	ctx, err := packmanager.WithDefaultUmbrellaManagerInContext(cmd.Context())
 	if err != nil {
 		return err
 	}
 
-	cmd.SetContext(packmanager.WithPackageManager(ctx, pm))
+	cmd.SetContext(ctx)
 
 	opts.Platform = platform.PlatformByName(opts.Platform).String()
 

--- a/cmd/kraft/pkg/list/list.go
+++ b/cmd/kraft/pkg/list/list.go
@@ -58,13 +58,12 @@ func New() *cobra.Command {
 }
 
 func (*List) Pre(cmd *cobra.Command, _ []string) error {
-	ctx := cmd.Context()
-	pm, err := packmanager.NewUmbrellaManager(ctx)
+	ctx, err := packmanager.WithDefaultUmbrellaManagerInContext(cmd.Context())
 	if err != nil {
 		return err
 	}
 
-	cmd.SetContext(packmanager.WithPackageManager(ctx, pm))
+	cmd.SetContext(ctx)
 
 	return nil
 }

--- a/cmd/kraft/pkg/pkg.go
+++ b/cmd/kraft/pkg/pkg.go
@@ -90,13 +90,12 @@ func (opts *Pkg) Pre(cmd *cobra.Command, _ []string) error {
 		return fmt.Errorf("the `--arch` and `--plat` options are not supported in addition to `--target`")
 	}
 
-	ctx := cmd.Context()
-	pm, err := packmanager.NewUmbrellaManager(ctx)
+	ctx, err := packmanager.WithDefaultUmbrellaManagerInContext(cmd.Context())
 	if err != nil {
 		return err
 	}
 
-	cmd.SetContext(packmanager.WithPackageManager(ctx, pm))
+	cmd.SetContext(ctx)
 
 	opts.Platform = platform.PlatformByName(opts.Platform).String()
 

--- a/cmd/kraft/pkg/pull/pull.go
+++ b/cmd/kraft/pkg/pull/pull.go
@@ -74,13 +74,12 @@ func New() *cobra.Command {
 }
 
 func (opts *Pull) Pre(cmd *cobra.Command, _ []string) error {
-	ctx := cmd.Context()
-	pm, err := packmanager.NewUmbrellaManager(ctx)
+	ctx, err := packmanager.WithDefaultUmbrellaManagerInContext(cmd.Context())
 	if err != nil {
 		return err
 	}
 
-	cmd.SetContext(packmanager.WithPackageManager(ctx, pm))
+	cmd.SetContext(ctx)
 
 	opts.Platform = platform.PlatformByName(opts.Platform).String()
 

--- a/cmd/kraft/pkg/push/push.go
+++ b/cmd/kraft/pkg/push/push.go
@@ -56,13 +56,12 @@ func New() *cobra.Command {
 }
 
 func (opts *Push) Pre(cmd *cobra.Command, _ []string) error {
-	ctx := cmd.Context()
-	pm, err := packmanager.NewUmbrellaManager(ctx)
+	ctx, err := packmanager.WithDefaultUmbrellaManagerInContext(cmd.Context())
 	if err != nil {
 		return err
 	}
 
-	cmd.SetContext(packmanager.WithPackageManager(ctx, pm))
+	cmd.SetContext(ctx)
 
 	return nil
 }
@@ -111,7 +110,11 @@ func (opts *Push) Run(cmd *cobra.Command, args []string) error {
 
 	var pmananger packmanager.PackageManager
 	if opts.Format != "auto" {
-		pmananger = packmanager.PackageManagers()[pack.PackageFormat(opts.Format)]
+		umbrella, err := packmanager.PackageManagers()
+		if err != nil {
+			return err
+		}
+		pmananger = umbrella[pack.PackageFormat(opts.Format)]
 		if pmananger == nil {
 			return errors.New("invalid package format specified")
 		}

--- a/cmd/kraft/pkg/source/source.go
+++ b/cmd/kraft/pkg/source/source.go
@@ -44,13 +44,12 @@ func New() *cobra.Command {
 }
 
 func (*Source) Pre(cmd *cobra.Command, _ []string) error {
-	ctx := cmd.Context()
-	pm, err := packmanager.NewUmbrellaManager(ctx)
+	ctx, err := packmanager.WithDefaultUmbrellaManagerInContext(cmd.Context())
 	if err != nil {
 		return err
 	}
 
-	cmd.SetContext(packmanager.WithPackageManager(ctx, pm))
+	cmd.SetContext(ctx)
 
 	return nil
 }

--- a/cmd/kraft/pkg/unsource/unsource.go
+++ b/cmd/kraft/pkg/unsource/unsource.go
@@ -43,13 +43,12 @@ func New() *cobra.Command {
 }
 
 func (*Unsource) Pre(cmd *cobra.Command, _ []string) error {
-	ctx := cmd.Context()
-	pm, err := packmanager.NewUmbrellaManager(ctx)
+	ctx, err := packmanager.WithDefaultUmbrellaManagerInContext(cmd.Context())
 	if err != nil {
 		return err
 	}
 
-	cmd.SetContext(packmanager.WithPackageManager(ctx, pm))
+	cmd.SetContext(ctx)
 
 	return nil
 }

--- a/cmd/kraft/pkg/update/update.go
+++ b/cmd/kraft/pkg/update/update.go
@@ -44,13 +44,12 @@ func New() *cobra.Command {
 }
 
 func (*Update) Pre(cmd *cobra.Command, _ []string) error {
-	ctx := cmd.Context()
-	pm, err := packmanager.NewUmbrellaManager(ctx)
+	ctx, err := packmanager.WithDefaultUmbrellaManagerInContext(cmd.Context())
 	if err != nil {
 		return err
 	}
 
-	cmd.SetContext(packmanager.WithPackageManager(ctx, pm))
+	cmd.SetContext(ctx)
 
 	return nil
 }

--- a/cmd/kraft/prepare/prepare.go
+++ b/cmd/kraft/prepare/prepare.go
@@ -52,13 +52,12 @@ func New() *cobra.Command {
 }
 
 func (opts *Prepare) Pre(cmd *cobra.Command, _ []string) error {
-	ctx := cmd.Context()
-	pm, err := packmanager.NewUmbrellaManager(ctx)
+	ctx, err := packmanager.WithDefaultUmbrellaManagerInContext(cmd.Context())
 	if err != nil {
 		return err
 	}
 
-	cmd.SetContext(packmanager.WithPackageManager(ctx, pm))
+	cmd.SetContext(ctx)
 
 	opts.Platform = platform.PlatformByName(opts.Platform).String()
 

--- a/cmd/kraft/properclean/properclean.go
+++ b/cmd/kraft/properclean/properclean.go
@@ -72,13 +72,12 @@ func New() *cobra.Command {
 }
 
 func (*ProperClean) Pre(cmd *cobra.Command, _ []string) error {
-	ctx := cmd.Context()
-	pm, err := packmanager.NewUmbrellaManager(ctx)
+	ctx, err := packmanager.WithDefaultUmbrellaManagerInContext(cmd.Context())
 	if err != nil {
 		return err
 	}
 
-	cmd.SetContext(packmanager.WithPackageManager(ctx, pm))
+	cmd.SetContext(ctx)
 
 	return nil
 }

--- a/cmd/kraft/run/run.go
+++ b/cmd/kraft/run/run.go
@@ -187,16 +187,19 @@ func (opts *Run) Pre(cmd *cobra.Command, _ []string) error {
 
 	if opts.RunAs == "" || !set.NewStringSet("kernel", "project").Contains(opts.RunAs) {
 		// Set use of the global package manager.
-		pm, err := packmanager.NewUmbrellaManager(ctx)
+		ctx, err := packmanager.WithDefaultUmbrellaManagerInContext(cmd.Context())
 		if err != nil {
 			return err
 		}
 
-		cmd.SetContext(packmanager.WithPackageManager(ctx, pm))
+		cmd.SetContext(ctx)
 	}
 
 	if opts.RunAs != "" {
-		runners := runnersByName()
+		runners, err := runnersByName()
+		if err != nil {
+			return err
+		}
 		if _, ok = runners[opts.RunAs]; !ok {
 			choices := make([]string, len(runners))
 			i := 0
@@ -229,7 +232,10 @@ func (opts *Run) Run(cmd *cobra.Command, args []string) error {
 
 	var run runner
 	var errs []error
-	runners := runners()
+	runners, err := runners()
+	if err != nil {
+		return err
+	}
 
 	// Iterate through the list of built-in runners which sequentially tests and
 	// first test whether the --as flag has been set to force a specific runner or

--- a/cmd/kraft/run/runner.go
+++ b/cmd/kraft/run/runner.go
@@ -32,29 +32,37 @@ type runner interface {
 // runners is the list of built-in runners which are checked sequentially for
 // capability.  The first to test positive via Runnable is used with the
 // controller.
-func runners() []runner {
+func runners() ([]runner, error) {
 	r := []runner{
 		&runnerLinuxu{},
 		&runnerKernel{},
 		&runnerProject{},
 	}
 
-	for _, pm := range packmanager.PackageManagers() {
+	umbrella, err := packmanager.PackageManagers()
+	if err != nil {
+		return nil, err
+	}
+
+	for _, pm := range umbrella {
 		r = append(r, &runnerPackage{
 			pm: pm,
 		})
 	}
 
-	return r
+	return r, nil
 }
 
 // runnersByName is a utility method that returns a map of the available runners
 // such that their alias name can be quickly looked up.
-func runnersByName() map[string]runner {
-	runners := runners()
+func runnersByName() (map[string]runner, error) {
+	runners, err := runners()
+	if err != nil {
+		return nil, err
+	}
 	ret := make(map[string]runner, len(runners))
 	for _, runner := range runners {
 		ret[runner.String()] = runner
 	}
-	return ret
+	return ret, nil
 }

--- a/cmd/kraft/set/set.go
+++ b/cmd/kraft/set/set.go
@@ -75,13 +75,12 @@ func New() *cobra.Command {
 }
 
 func (*Set) Pre(cmd *cobra.Command, _ []string) error {
-	ctx := cmd.Context()
-	pm, err := packmanager.NewUmbrellaManager(ctx)
+	ctx, err := packmanager.WithDefaultUmbrellaManagerInContext(cmd.Context())
 	if err != nil {
 		return err
 	}
 
-	cmd.SetContext(packmanager.WithPackageManager(ctx, pm))
+	cmd.SetContext(ctx)
 
 	return nil
 }

--- a/cmd/kraft/unset/unset.go
+++ b/cmd/kraft/unset/unset.go
@@ -73,13 +73,12 @@ func New() *cobra.Command {
 }
 
 func (*Unset) Pre(cmd *cobra.Command, _ []string) error {
-	ctx := cmd.Context()
-	pm, err := packmanager.NewUmbrellaManager(ctx)
+	ctx, err := packmanager.WithDefaultUmbrellaManagerInContext(cmd.Context())
 	if err != nil {
 		return err
 	}
 
-	cmd.SetContext(packmanager.WithPackageManager(ctx, pm))
+	cmd.SetContext(ctx)
 
 	return nil
 }

--- a/docker/docker.go
+++ b/docker/docker.go
@@ -1,0 +1,281 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2022, Unikraft GmbH and The KraftKit Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+package docker
+
+import (
+	"archive/tar"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+
+	"github.com/docker/docker/api/types"
+	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/moby/moby/client"
+
+	"kraftkit.sh/initrd"
+	"kraftkit.sh/kconfig"
+	"kraftkit.sh/oci"
+	"kraftkit.sh/pack"
+	"kraftkit.sh/unikraft"
+	"kraftkit.sh/unikraft/arch"
+	"kraftkit.sh/unikraft/plat"
+)
+
+type DockerImage struct {
+	ID  string
+	ref name.Reference
+
+	// Embedded attributes which represent target.Target
+	arch    arch.Architecture
+	plat    plat.Platform
+	kconfig kconfig.KeyValueMap
+	kernel  string
+	initrd  *initrd.InitrdConfig
+	command []string
+}
+
+// Type implements unikraft.Nameable
+func (dockerImage *DockerImage) Type() unikraft.ComponentType {
+	return unikraft.ComponentTypeApp
+}
+
+// Name implements unikraft.Nameable
+func (dockerImage *DockerImage) Name() string {
+	return dockerImage.ref.Context().Name()
+}
+
+// Version implements unikraft.Nameable
+func (dockerImage *DockerImage) Version() string {
+	return dockerImage.ref.Identifier()
+}
+
+// Metadata implements pack.Package
+func (dockerImage *DockerImage) Metadata() any {
+	return nil
+}
+
+// Push implements pack.Package
+func (dockerImage *DockerImage) Push(ctx context.Context, opts ...pack.PushOption) error {
+	return errors.New("not implemented")
+}
+
+func (dockerImage *DockerImage) Pull(ctx context.Context, opts ...pack.PullOption) error {
+	targetImageID := dockerImage.ID
+
+	// Setup the pull options
+	popts, err := pack.NewPullOptions(opts...)
+	if err != nil {
+		return err
+	}
+
+	// Connect to Docker client
+	dockerClient, err := client.NewClientWithOpts(client.FromEnv)
+	if err != nil {
+		return err
+	}
+	defer dockerClient.Close()
+
+	// Check if image is in local Docker storage
+	images, err := dockerClient.ImageList(ctx, types.ImageListOptions{})
+	if err != nil {
+		return err
+	}
+
+	imageFound := false
+	for _, img := range images {
+		if img.ID == targetImageID {
+			imageFound = true
+			break
+		}
+	}
+
+	if !imageFound {
+		return errors.New("target image not found in local Docker storage")
+	}
+
+	if len(popts.Workdir()) > 0 {
+		// Unpack the image to the provided working directory
+		reader, err := dockerClient.ImageSave(context.Background(), []string{targetImageID})
+		if err != nil {
+			return err
+		}
+		defer reader.Close()
+
+		// Create a unique path to save the image tarball in the temp directory
+		file, err := os.CreateTemp(os.TempDir(), "docker_image_*.tar")
+		if err != nil {
+			return err
+		}
+		savePath := file.Name()
+		defer file.Close()
+
+		// Copy the image data from reader to file
+		_, err = io.Copy(file, reader)
+		if err != nil {
+			return err
+		}
+
+		if err := unpackTar(savePath, popts.Workdir()); err != nil {
+			return err
+		}
+
+		if err := mergeLayersFromManifest(popts.Workdir()); err != nil {
+			return err
+		}
+
+		// Set the kernel path
+		dockerImage.kernel = filepath.Join(popts.Workdir(), oci.WellKnownKernelPath)
+	}
+
+	return nil
+}
+
+type ImageManifest struct {
+	Layers []string `json:"Layers"`
+}
+
+func mergeLayersFromManifest(workdir string) error {
+	// Read manifest.json to get the order of layers
+	manifestData, err := os.ReadFile(filepath.Join(workdir, "manifest.json"))
+	if err != nil {
+		return err
+	}
+
+	var manifests []ImageManifest
+	if err := json.Unmarshal(manifestData, &manifests); err != nil {
+		return err
+	}
+
+	for _, layerPath := range manifests[0].Layers {
+		layerTarPath := filepath.Join(workdir, layerPath)
+		if err := unpackTar(layerTarPath, workdir); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func unpackTar(src, dest string) error {
+	tarFile, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer tarFile.Close()
+
+	tr := tar.NewReader(tarFile)
+	for {
+		header, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return err
+		}
+
+		targetPath := filepath.Join(dest, header.Name)
+		switch header.Typeflag {
+		case tar.TypeDir:
+			if err := os.MkdirAll(targetPath, header.FileInfo().Mode()); err != nil {
+				return err
+			}
+		case tar.TypeReg:
+			f, err := os.OpenFile(targetPath, os.O_CREATE|os.O_RDWR, header.FileInfo().Mode())
+			if err != nil {
+				return err
+			}
+			if _, err := io.Copy(f, tr); err != nil {
+				f.Close()
+				return err
+			}
+			f.Close()
+		}
+	}
+	return nil
+}
+
+// Pull implements pack.Package
+func (dockerImage *DockerImage) Format() pack.PackageFormat {
+	return DockerFormat
+}
+
+// Source implements unikraft.component.Component
+func (dockerImage *DockerImage) Source() string {
+	return ""
+}
+
+// Path implements unikraft.component.Component
+func (dockerImage *DockerImage) Path() string {
+	return ""
+}
+
+// KConfigTree implements unikraft.component.Component
+func (dockerImage DockerImage) KConfigTree(context.Context, ...*kconfig.KeyValue) (*kconfig.KConfigFile, error) {
+	return nil, fmt.Errorf("not implemented: docker.dockerImage.KConfigTree")
+}
+
+// KConfig implements unikraft.component.Component
+func (dockerImage DockerImage) KConfig() kconfig.KeyValueMap {
+	return dockerImage.kconfig
+}
+
+// PrintInfo implements unikraft.component.Component
+func (dockerImage DockerImage) PrintInfo(context.Context) string {
+	return "not implemented: docker.dockerImage.PrintInfo"
+}
+
+// Architecture implements unikraft.target.Target
+func (dockerImage DockerImage) Architecture() arch.Architecture {
+	return dockerImage.arch
+}
+
+// Platform implements unikraft.target.Target
+func (dockerImage DockerImage) Platform() plat.Platform {
+	return dockerImage.plat
+}
+
+// Kernel implements unikraft.target.Target
+func (dockerImage DockerImage) Kernel() string {
+	return dockerImage.kernel
+}
+
+// KernelDbg implements unikraft.target.Target
+func (dockerImage DockerImage) KernelDbg() string {
+	return dockerImage.kernel
+}
+
+// Initrd implements unikraft.target.Target
+func (dockerImage DockerImage) Initrd() *initrd.InitrdConfig {
+	return dockerImage.initrd
+}
+
+// Command implements unikraft.target.Target
+func (dockerImage DockerImage) Command() []string {
+	if len(dockerImage.command) == 0 {
+		return []string{"--"}
+	}
+
+	return dockerImage.command
+}
+
+// ConfigFilename implements unikraft.target.Target
+func (dockerImage DockerImage) ConfigFilename() string {
+	return ""
+}
+
+// MarshalYAML implements unikraft.target.Target (yaml.Marshaler)
+func (dockerImage *DockerImage) MarshalYAML() (interface{}, error) {
+	if dockerImage == nil {
+		return nil, nil
+	}
+
+	return map[string]interface{}{
+		"architecture": dockerImage.arch.Name(),
+		"platform":     dockerImage.plat.Name(),
+	}, nil
+}

--- a/docker/docker_manager.go
+++ b/docker/docker_manager.go
@@ -1,0 +1,177 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2022, Unikraft GmbH and The KraftKit Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+package docker
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/docker/docker/api/types"
+	"github.com/moby/moby/client"
+
+	"kraftkit.sh/pack"
+	"kraftkit.sh/packmanager"
+	"kraftkit.sh/unikraft/arch"
+	"kraftkit.sh/unikraft/component"
+	"kraftkit.sh/unikraft/plat"
+	"kraftkit.sh/unikraft/target"
+)
+
+type dockerManager struct {
+	registries []string
+}
+
+const DockerFormat pack.PackageFormat = "docker"
+
+// NewDockerManager instantiates a new package manager based on local docker images.
+func NewDockerManager(ctx context.Context, opts ...any) (packmanager.PackageManager, error) {
+	manager := dockerManager{}
+
+	for _, mopt := range opts {
+		opt, ok := mopt.(dockerManagerOption)
+		if !ok {
+			return nil, fmt.Errorf("cannot cast docker Manager option")
+		}
+
+		if err := opt(ctx, &manager); err != nil {
+			return nil, err
+		}
+	}
+
+	return &manager, nil
+}
+
+// Update implements packmanager.PackageManager
+func (manager *dockerManager) Update(ctx context.Context) error {
+	return nil
+}
+
+// Pack implements packmanager.PackageManager
+func (manager *dockerManager) Pack(ctx context.Context, entity component.Component, opts ...packmanager.PackOption) ([]pack.Package, error) {
+	_, ok := entity.(target.Target)
+	if !ok {
+		return nil, fmt.Errorf("entity is not Unikraft target")
+	}
+
+	return nil, fmt.Errorf("not implemented: docker.manager.Pack")
+}
+
+// Unpack implements packmanager.PackageManager
+func (manager *dockerManager) Unpack(ctx context.Context, entity pack.Package, opts ...packmanager.UnpackOption) ([]component.Component, error) {
+	return nil, fmt.Errorf("not implemented: docker.manager.Unpack")
+}
+
+// Catalog implements packmanager.PackageManager
+func (manager *dockerManager) Catalog(ctx context.Context, qopts ...packmanager.QueryOption) ([]pack.Package, error) {
+	// isolate the name of the image
+	query := packmanager.NewQuery(qopts...)
+
+	// Connect to Docker client
+	dockerClient, err := client.NewClientWithOpts(client.FromEnv)
+	if err != nil {
+		return nil, err
+	}
+	defer dockerClient.Close()
+
+	// Check if image is in local Docker storage
+	images, err := dockerClient.ImageList(ctx, types.ImageListOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	for _, i := range images {
+		for _, t := range i.RepoTags {
+			if t == query.Name() {
+				// TODO(jake-ciolek): right now we default to qemu/x86_64
+				// figure out what's the best way of passing this in the image.
+				arch, err := arch.NewArchitectureFromSchema("x86_64")
+				if err != nil {
+					return nil, err
+				}
+				plat, err := plat.NewPlatformFromOptions(plat.WithName("qemu"))
+				if err != nil {
+					return nil, err
+				}
+				return []pack.Package{&DockerImage{
+					ID:   i.ID,
+					arch: arch,
+					plat: plat,
+				}}, nil
+			}
+		}
+	}
+
+	return nil, errors.New("unable to find the requested image in local docker storage")
+}
+
+// SetSources implements packmanager.PackageManager
+func (manager *dockerManager) SetSources(_ context.Context, sources ...string) error {
+	manager.registries = sources
+	return nil
+}
+
+// AddSource implements packmanager.PackageManager
+func (manager *dockerManager) AddSource(ctx context.Context, source string) error {
+	if manager.registries == nil {
+		manager.registries = make([]string, 0)
+	}
+
+	manager.registries = append(manager.registries, source)
+
+	return nil
+}
+
+// RemoveSource implements packmanager.PackageManager
+func (manager *dockerManager) RemoveSource(ctx context.Context, source string) error {
+	for i, needle := range manager.registries {
+		if needle == source {
+			ret := make([]string, 0)
+			ret = append(ret, manager.registries[:i]...)
+			manager.registries = append(ret, manager.registries[i+1:]...)
+			break
+		}
+	}
+
+	return nil
+}
+
+// IsCompatible implements packmanager.PackageManager
+func (manager *dockerManager) IsCompatible(ctx context.Context, source string, qopts ...packmanager.QueryOption) (packmanager.PackageManager, bool, error) {
+	// Check if an image with given name exists in local docker image storage
+
+	// Connect to Docker client
+	dockerClient, err := client.NewClientWithOpts(client.FromEnv)
+	if err != nil {
+		return nil, false, err
+	}
+	defer dockerClient.Close()
+
+	// Check if image is in local Docker storage
+	images, err := dockerClient.ImageList(ctx, types.ImageListOptions{})
+	if err != nil {
+		return nil, false, err
+	}
+
+	for _, i := range images {
+		for _, t := range i.RepoTags {
+			if t == source {
+				return manager, true, nil
+			}
+		}
+	}
+
+	return nil, false, nil
+}
+
+// From implements packmanager.PackageManager
+func (manager *dockerManager) From(pack.PackageFormat) (packmanager.PackageManager, error) {
+	return nil, fmt.Errorf("not possible: docker.manager.From")
+}
+
+// Format implements packmanager.PackageManager
+func (manager *dockerManager) Format() pack.PackageFormat {
+	return DockerFormat
+}

--- a/docker/docker_options.go
+++ b/docker/docker_options.go
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2022, Unikraft GmbH and The KraftKit Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+package docker
+
+import (
+	"context"
+)
+
+type dockerManagerOption func(context.Context, *dockerManager) error

--- a/docker/init.go
+++ b/docker/init.go
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2022, Unikraft GmbH and The KraftKit Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+package docker
+
+import "kraftkit.sh/packmanager"
+
+func RegisterPackageManager() func(u *packmanager.UmbrellaManager) error {
+	return func(u *packmanager.UmbrellaManager) error {
+		return u.RegisterPackageManager(
+			DockerFormat,
+			NewDockerManager,
+		)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -41,6 +41,7 @@ require (
 	github.com/mgutz/ansi v0.0.0-20200706080929-d51e80ef957d
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/mitchellh/mapstructure v1.5.0
+	github.com/moby/moby v24.0.5+incompatible
 	github.com/muesli/reflow v0.3.0
 	github.com/muesli/termenv v0.15.2
 	github.com/onsi/ginkgo/v2 v2.11.0

--- a/go.sum
+++ b/go.sum
@@ -33,6 +33,7 @@ github.com/AdamKorcz/go-118-fuzz-build v0.0.0-20221215162035-5330a85ea652/go.mod
 github.com/AlecAivazis/survey/v2 v2.3.7 h1:6I/u8FvytdGsgonrYsVn2t8t4QiRnh6QSTqkkhIiSjQ=
 github.com/AlecAivazis/survey/v2 v2.3.7/go.mod h1:xUTIdE4KCOIjsBAE1JYsUPoCqYdZ1reCfTwbto0Fduo=
 github.com/Azure/azure-sdk-for-go v16.2.1+incompatible/go.mod h1:9XXNKU+eRnpl9moKnB4QOLf1HestfXbmab5FXxiDBjc=
+github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78 h1:w+iIsaOQNcT7OZ575w+acHgRric5iCyQh+xv+KJ4HB8=
 github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78/go.mod h1:LmzpDX56iTiv29bbRTIsUNlaFfuhWRQBWjQdVyAevI8=
 github.com/Azure/go-autorest v10.8.1+incompatible/go.mod h1:r+4oMnoxhatjLLJ6zxSWATqVooLgysK6ZNox3g/xq24=
 github.com/Azure/go-autorest v14.2.0+incompatible/go.mod h1:r+4oMnoxhatjLLJ6zxSWATqVooLgysK6ZNox3g/xq24=
@@ -743,6 +744,8 @@ github.com/mitchellh/mapstructure v1.5.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RR
 github.com/mitchellh/osext v0.0.0-20151018003038-5e2d6d41470f/go.mod h1:OkQIRizQZAeMln+1tSwduZz7+Af5oFlKirV/MSYes2A=
 github.com/moby/locker v1.0.1 h1:fOXqR41zeveg4fFODix+1Ch4mj/gT0NE1XJbp/epuBg=
 github.com/moby/locker v1.0.1/go.mod h1:S7SDdo5zpBK84bzzVlKr2V0hz+7x9hWbYC/kq7oQppc=
+github.com/moby/moby v24.0.5+incompatible h1:uUbydai/Y9J7Ybt+lFI3zBdnsMYXnXE9vEcfZDoEE8Q=
+github.com/moby/moby v24.0.5+incompatible/go.mod h1:fDXVQ6+S340veQPv35CzDahGBmHsiclFwfEygB/TWMc=
 github.com/moby/sys/mountinfo v0.4.0/go.mod h1:rEr8tzG/lsIZHBtN/JjGG+LMYx9eXgW2JI+6q0qou+A=
 github.com/moby/sys/mountinfo v0.4.1/go.mod h1:rEr8tzG/lsIZHBtN/JjGG+LMYx9eXgW2JI+6q0qou+A=
 github.com/moby/sys/mountinfo v0.6.2 h1:BzJjoreD5BMFNmD9Rus6gdd1pLuecOFPt8wC+Vygl78=
@@ -753,6 +756,7 @@ github.com/moby/sys/signal v0.7.0 h1:25RW3d5TnQEoKvRbEKUGay6DCQ46IxAVTT9CUMgmsSI
 github.com/moby/sys/signal v0.7.0/go.mod h1:GQ6ObYZfqacOwTtlXvcmh9A26dVRul/hbOZn88Kg8Tg=
 github.com/moby/sys/symlink v0.1.0/go.mod h1:GGDODQmbFOjFsXvfLVn3+ZRxkch54RkSiGqsZeMYowQ=
 github.com/moby/term v0.0.0-20200312100748-672ec06f55cd/go.mod h1:DdlQx2hp0Ss5/fLikoLlEeIYiATotOjgB//nb973jeo=
+github.com/moby/term v0.0.0-20221205130635-1aeaba878587 h1:HfkjXDfhgVaN5rmueG8cL8KKeFNecRCXFhaJ2qZ5SKA=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
@@ -762,6 +766,7 @@ github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9G
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/montanaflynn/stats v0.0.0-20171201202039-1bf9dbcd8cbe/go.mod h1:wL8QJuTMNUDYhXwkmfOly8iTdp5TEcJFWZD2D7SIkUc=
 github.com/morikuni/aec v0.0.0-20170113033406-39771216ff4c/go.mod h1:BbKIizmSmc5MMPqRYbxO4ZU0S0+P200+tUnFx7PXmsc=
+github.com/morikuni/aec v1.0.0 h1:nP9CBfwrvYnBRgY6qfDQkygYDmYwOilePFkwzv4dU8A=
 github.com/mrunalp/fileutils v0.5.0/go.mod h1:M1WthSahJixYnrXQl/DFQuteStB1weuxD2QJNHXfbSQ=
 github.com/muesli/ansi v0.0.0-20211018074035-2e021307bc4b/go.mod h1:fQuZ0gauxyBcmsdE3ZT4NasjaRdxmbCS0jRHsrWu3Ho=
 github.com/muesli/ansi v0.0.0-20221106050444-61f0cd9a192a h1:jlDOeO5TU0pYlbc/y6PFguab5IjANI0Knrpg3u/ton4=
@@ -1315,6 +1320,7 @@ golang.org/x/time v0.0.0-20181108054448-85acf8d2951c/go.mod h1:tRJNPiyCQ0inRvYxb
 golang.org/x/time v0.0.0-20190308202827-9d24e82272b4/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20191024005414-555d28b269f0/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20200630173020-3af7569d3a1e/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
+golang.org/x/time v0.3.0 h1:rg5rLMjNzMS1RkNLzCG38eapWhnYLFYXDXj2gOlr8j4=
 golang.org/x/tools v0.0.0-20180221164845-07fd8470d635/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20181030221726-6c7e314b6563/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=

--- a/internal/bootstrap/init.go
+++ b/internal/bootstrap/init.go
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2022, Unikraft GmbH and The KraftKit Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+
+// Package bootstrap lets us keep kraftkit initialization logic in one place.
+package bootstrap
+
+import (
+	"context"
+
+	"kraftkit.sh/api"
+	"kraftkit.sh/machine/qemu"
+	"kraftkit.sh/manifest"
+	"kraftkit.sh/oci"
+	"kraftkit.sh/packmanager"
+	"kraftkit.sh/unikraft/elfloader"
+)
+
+// InitKraftkit performs a set of kraftkit setup steps.
+// It allows us to move away from in-package init() magic.
+// It also allows us to propagate initialization errors easily.
+func InitKraftkit(ctx context.Context) error {
+	registerAdditionalFlags()
+
+	if err := registerSchemes(); err != nil {
+		return err
+	}
+
+	return registerPackageManagers(ctx)
+}
+
+func registerAdditionalFlags() {
+	elfloader.RegisterFlags()
+	manifest.RegisterFlags()
+	qemu.RegisterFlags()
+}
+
+func registerSchemes() error {
+	return api.RegisterSchemes()
+}
+
+func registerPackageManagers(ctx context.Context) error {
+	managerConstructors := []func(u *packmanager.UmbrellaManager) error{
+		oci.RegisterPackageManager(),
+		manifest.RegisterPackageManager(),
+	}
+
+	return packmanager.InitUmbrellaManager(ctx, managerConstructors)
+}

--- a/internal/bootstrap/init.go
+++ b/internal/bootstrap/init.go
@@ -10,6 +10,7 @@ import (
 	"context"
 
 	"kraftkit.sh/api"
+	"kraftkit.sh/docker"
 	"kraftkit.sh/machine/qemu"
 	"kraftkit.sh/manifest"
 	"kraftkit.sh/oci"
@@ -44,6 +45,7 @@ func registerPackageManagers(ctx context.Context) error {
 	managerConstructors := []func(u *packmanager.UmbrellaManager) error{
 		oci.RegisterPackageManager(),
 		manifest.RegisterPackageManager(),
+		docker.RegisterPackageManager(),
 	}
 
 	return packmanager.InitUmbrellaManager(ctx, managerConstructors)

--- a/machine/qemu/init.go
+++ b/machine/qemu/init.go
@@ -474,7 +474,9 @@ func init() {
 
 	// CLI configuration
 	gob.Register(QemuConfig{})
+}
 
+func RegisterFlags() {
 	// Register additional command-line arguments
 	cmdfactory.RegisterFlag(
 		"kraft run",

--- a/manifest/init.go
+++ b/manifest/init.go
@@ -14,11 +14,13 @@ import (
 // and is dynamically injected as a CLI option.
 var useGit = false
 
-// FIXME(antoineco): avoid init, initialize things where needed
-func init() {
-	// Register a new pack.Package type
-	_ = packmanager.RegisterPackageManager(ManifestFormat, NewManifestManager)
+func RegisterPackageManager() func(u *packmanager.UmbrellaManager) error {
+	return func(u *packmanager.UmbrellaManager) error {
+		return u.RegisterPackageManager(ManifestFormat, NewManifestManager)
+	}
+}
 
+func RegisterFlags() {
 	// Register additional command-line flags
 	cmdfactory.RegisterFlag(
 		"kraft pkg pull",

--- a/oci/init.go
+++ b/oci/init.go
@@ -8,14 +8,14 @@ import (
 	"kraftkit.sh/packmanager"
 )
 
-// FIXME(antoineco): avoid init, initialize things where needed
-func init() {
-	// Register a new pkg.Package type
-	_ = packmanager.RegisterPackageManager(
-		OCIFormat,
-		NewOCIManager,
-		WithDefaultAuth(),
-		WithDefaultRegistries(),
-		WithDetectHandler(),
-	)
+func RegisterPackageManager() func(u *packmanager.UmbrellaManager) error {
+	return func(u *packmanager.UmbrellaManager) error {
+		return u.RegisterPackageManager(
+			OCIFormat,
+			NewOCIManager,
+			WithDefaultAuth(),
+			WithDefaultRegistries(),
+			WithDetectHandler(),
+		)
+	}
 }

--- a/packmanager/context.go
+++ b/packmanager/context.go
@@ -16,7 +16,7 @@ var (
 	G = FromContext
 
 	// PM is the system-access umbrella package manager.
-	PM = umbrella{}
+	PM = UmbrellaManager{}
 )
 
 // contextKey is used to retrieve the package manager from the context.

--- a/packmanager/umbrella.go
+++ b/packmanager/umbrella.go
@@ -268,7 +268,7 @@ func NewUmbrellaManager(ctx context.Context, constructors []func(*UmbrellaManage
 			log.G(ctx).
 				WithField("format", format).
 				Debugf("could not initialize package manager: %v", err)
-			continue
+			return nil, err
 		}
 
 		if format, ok := u.packageManagers[manager.Format()]; ok {

--- a/tools/github-action/go.mod
+++ b/tools/github-action/go.mod
@@ -124,6 +124,7 @@ require (
 	github.com/mitchellh/go-homedir v1.1.0 // indirect
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/moby/locker v1.0.1 // indirect
+	github.com/moby/moby v24.0.5+incompatible // indirect
 	github.com/moby/sys/mountinfo v0.6.2 // indirect
 	github.com/moby/sys/sequential v0.5.0 // indirect
 	github.com/moby/sys/signal v0.7.0 // indirect

--- a/tools/github-action/go.sum
+++ b/tools/github-action/go.sum
@@ -33,6 +33,7 @@ github.com/AdamKorcz/go-118-fuzz-build v0.0.0-20221215162035-5330a85ea652/go.mod
 github.com/AlecAivazis/survey/v2 v2.3.7 h1:6I/u8FvytdGsgonrYsVn2t8t4QiRnh6QSTqkkhIiSjQ=
 github.com/AlecAivazis/survey/v2 v2.3.7/go.mod h1:xUTIdE4KCOIjsBAE1JYsUPoCqYdZ1reCfTwbto0Fduo=
 github.com/Azure/azure-sdk-for-go v16.2.1+incompatible/go.mod h1:9XXNKU+eRnpl9moKnB4QOLf1HestfXbmab5FXxiDBjc=
+github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78 h1:w+iIsaOQNcT7OZ575w+acHgRric5iCyQh+xv+KJ4HB8=
 github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78/go.mod h1:LmzpDX56iTiv29bbRTIsUNlaFfuhWRQBWjQdVyAevI8=
 github.com/Azure/go-autorest v10.8.1+incompatible/go.mod h1:r+4oMnoxhatjLLJ6zxSWATqVooLgysK6ZNox3g/xq24=
 github.com/Azure/go-autorest v14.2.0+incompatible/go.mod h1:r+4oMnoxhatjLLJ6zxSWATqVooLgysK6ZNox3g/xq24=
@@ -728,6 +729,8 @@ github.com/mitchellh/mapstructure v1.5.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RR
 github.com/mitchellh/osext v0.0.0-20151018003038-5e2d6d41470f/go.mod h1:OkQIRizQZAeMln+1tSwduZz7+Af5oFlKirV/MSYes2A=
 github.com/moby/locker v1.0.1 h1:fOXqR41zeveg4fFODix+1Ch4mj/gT0NE1XJbp/epuBg=
 github.com/moby/locker v1.0.1/go.mod h1:S7SDdo5zpBK84bzzVlKr2V0hz+7x9hWbYC/kq7oQppc=
+github.com/moby/moby v24.0.5+incompatible h1:uUbydai/Y9J7Ybt+lFI3zBdnsMYXnXE9vEcfZDoEE8Q=
+github.com/moby/moby v24.0.5+incompatible/go.mod h1:fDXVQ6+S340veQPv35CzDahGBmHsiclFwfEygB/TWMc=
 github.com/moby/sys/mountinfo v0.4.0/go.mod h1:rEr8tzG/lsIZHBtN/JjGG+LMYx9eXgW2JI+6q0qou+A=
 github.com/moby/sys/mountinfo v0.4.1/go.mod h1:rEr8tzG/lsIZHBtN/JjGG+LMYx9eXgW2JI+6q0qou+A=
 github.com/moby/sys/mountinfo v0.6.2 h1:BzJjoreD5BMFNmD9Rus6gdd1pLuecOFPt8wC+Vygl78=
@@ -738,6 +741,7 @@ github.com/moby/sys/signal v0.7.0 h1:25RW3d5TnQEoKvRbEKUGay6DCQ46IxAVTT9CUMgmsSI
 github.com/moby/sys/signal v0.7.0/go.mod h1:GQ6ObYZfqacOwTtlXvcmh9A26dVRul/hbOZn88Kg8Tg=
 github.com/moby/sys/symlink v0.1.0/go.mod h1:GGDODQmbFOjFsXvfLVn3+ZRxkch54RkSiGqsZeMYowQ=
 github.com/moby/term v0.0.0-20200312100748-672ec06f55cd/go.mod h1:DdlQx2hp0Ss5/fLikoLlEeIYiATotOjgB//nb973jeo=
+github.com/moby/term v0.0.0-20221205130635-1aeaba878587 h1:HfkjXDfhgVaN5rmueG8cL8KKeFNecRCXFhaJ2qZ5SKA=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
@@ -747,6 +751,7 @@ github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9G
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/montanaflynn/stats v0.0.0-20171201202039-1bf9dbcd8cbe/go.mod h1:wL8QJuTMNUDYhXwkmfOly8iTdp5TEcJFWZD2D7SIkUc=
 github.com/morikuni/aec v0.0.0-20170113033406-39771216ff4c/go.mod h1:BbKIizmSmc5MMPqRYbxO4ZU0S0+P200+tUnFx7PXmsc=
+github.com/morikuni/aec v1.0.0 h1:nP9CBfwrvYnBRgY6qfDQkygYDmYwOilePFkwzv4dU8A=
 github.com/mrunalp/fileutils v0.5.0/go.mod h1:M1WthSahJixYnrXQl/DFQuteStB1weuxD2QJNHXfbSQ=
 github.com/muesli/ansi v0.0.0-20211018074035-2e021307bc4b/go.mod h1:fQuZ0gauxyBcmsdE3ZT4NasjaRdxmbCS0jRHsrWu3Ho=
 github.com/muesli/ansi v0.0.0-20221106050444-61f0cd9a192a h1:jlDOeO5TU0pYlbc/y6PFguab5IjANI0Knrpg3u/ton4=
@@ -1295,6 +1300,7 @@ golang.org/x/time v0.0.0-20181108054448-85acf8d2951c/go.mod h1:tRJNPiyCQ0inRvYxb
 golang.org/x/time v0.0.0-20190308202827-9d24e82272b4/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20191024005414-555d28b269f0/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20200630173020-3af7569d3a1e/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
+golang.org/x/time v0.3.0 h1:rg5rLMjNzMS1RkNLzCG38eapWhnYLFYXDXj2gOlr8j4=
 golang.org/x/tools v0.0.0-20180221164845-07fd8470d635/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20181030221726-6c7e314b6563/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=

--- a/unikraft/elfloader/init.go
+++ b/unikraft/elfloader/init.go
@@ -8,7 +8,7 @@ import "kraftkit.sh/cmdfactory"
 
 var defaultPrebuilt string
 
-func init() {
+func RegisterFlags() {
 	// Register additional command-line arguments
 	cmdfactory.RegisterFlag(
 		"kraft run",


### PR DESCRIPTION
### Prerequisite checklist

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

WIP

We have to decide how to pass the arch/plat if we are to use docker. As brought up previously, it doesn't allow us to use qemu/fc for OS thus we can't source architecture from this field. Perhaps we could use labels instead.

To use, build the LLB plugin image, prepend a selector to kraft.yaml (tested with app-helloworld at 5845459d):

``
#syntax=kraftkit.sh/llb:latest
``

Build the image with:

``
docker build path/to/helloworld-root -f path/to/helloworld-root/kraft.yaml -t mydockerhelloworld:latest
``

Run with kraft:

``
kraft run mydockerhelloworld:latest
``

This will pull the image from docker image storage, unpack it somewhere in /tmp/ and then we do the usual kraft run stuff.

Waiting for @nderjung to have a look. We also need https://github.com/unikraft/kraftkit/pull/727