### PR TITLE
fix(kconfig): Correctly handle integer conversions from map interface

### DIFF
--- a/kconfig/config.go
+++ b/kconfig/config.go
@@ -24,7 +24,13 @@ func NewKeyValueMapFromSlice(values ...interface{}) KeyValueMap {
 	mapping := KeyValueMap{}
 
 	for _, value := range values {
-		str := fmt.Sprintf("%s", value)
+		var str string
+		switch t := value.(type) {
+		case string:
+			str = t
+		case int, int8, int16, int32, int64, uint, uint8, uint16, uint32, uint64:
+			str = fmt.Sprintf("%d", t)
+		}
 		tokens := strings.SplitN(str, "=", 2)
 		if len(tokens) > 1 {
 			mapping[tokens[0]] = &KeyValue{
@@ -57,6 +63,8 @@ func NewKeyValueMapFromMap(values map[string]interface{}) KeyValueMap {
 				v = "y"
 			}
 			mapping[key].Value = v
+		case int, int8, int16, int32, int64, uint, uint8, uint16, uint32, uint64:
+			mapping[key].Value = fmt.Sprintf("%d", casting)
 		default:
 			mapping[key].Value = fmt.Sprintf("%s", casting)
 		}


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

When the `NewKeyValueMapFromMap` was used with integers, this would result in a Golang value of `(int=5)%s` for example.  Correctly handle by doing a type check.
