### PR TITLE
refactor(qemu): Move qemu-system-* binary constant names to own file

### DIFF
--- a/machine/qemu/qemu_system.go
+++ b/machine/qemu/qemu_system.go
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2022, Unikraft GmbH and The KraftKit Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+package qemu
+
+const (
+	QemuSystemX86     = "qemu-system-x86_64"
+	QemuSystemArm     = "qemu-system-arm"
+	QemuSystemAarch64 = "qemu-system-aarch64"
+)

--- a/machine/qemu/v1alpha1.go
+++ b/machine/qemu/v1alpha1.go
@@ -40,12 +40,6 @@ import (
 	"kraftkit.sh/unikraft/export/v0/vfscore"
 )
 
-const (
-	QemuSystemX86     = "qemu-system-x86_64"
-	QemuSystemArm     = "qemu-system-arm"
-	QemuSystemAarch64 = "qemu-system-aarch64"
-)
-
 // machineV1alpha1Service ...
 type machineV1alpha1Service struct {
 	eopts []exec.ExecOption


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

This PR migrates the well-known binary names of the `qemu-system-*` binaries to its own file.

