### PR TITLE
fix: Handle registry authentication

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -77,5 +77,30 @@ inputs:
     default: false
 
 runs:
-  using: docker
-  image: docker://kraftkit.sh/github-action:v0
+  # Use a composite type so we can execute a bash script before the invocation
+  # of the container image.
+  using: composite
+  steps:
+  - shell: bash
+    run: ${{ github.action_path }}/tools/github-action/pre.sh
+  - uses: docker://kraftkit.sh/github-action:v0
+    # This is a bit of a hack, since we are using a composite-type, the actions
+    # input are not passed when the container image is instantiated.  Instead,
+    # we simply pass all inputs as environmental variables which are already
+    # compatible with the action itself.
+    env:
+      INPUT_LOGLEVEL: ${{ inputs.loglevel }}
+      INPUT_WORKDIR: ${{ inputs.workdir }}
+      INPUT_KRAFTFILE: ${{ inputs.kraftfile }}
+      INPUT_ARCH: ${{ inputs.arch }}
+      INPUT_PLAT: ${{ inputs.plat }}
+      INPUT_TARGET: ${{ inputs.target }}
+      INPUT_EXECUTE: ${{ inputs.execute }}
+      INPUT_TIMEOUT: ${{ inputs.timeout }}
+      INPUT_ARGS: ${{ inputs.args }}
+      INPUT_INITRD: ${{ inputs.initrd }}
+      INPUT_MEMORY: ${{ inputs.memory }}
+      INPUT_NAME: ${{ inputs.name }}
+      INPUT_OUTPUT: ${{ inputs.output }}
+      INPUT_KCONFIG: ${{ inputs.kconfig }}
+      INPUT_PUSH: ${{ inputs.push }}

--- a/cmd/kraft/login/login.go
+++ b/cmd/kraft/login/login.go
@@ -6,11 +6,7 @@ package login
 
 import (
 	"bufio"
-	"encoding/base64"
-	"encoding/json"
 	"fmt"
-	"os"
-	"path/filepath"
 	"strings"
 
 	"golang.org/x/term"
@@ -18,14 +14,12 @@ import (
 	"kraftkit.sh/config"
 	"kraftkit.sh/iostreams"
 
-	"github.com/mitchellh/go-homedir"
 	"github.com/spf13/cobra"
 )
 
 type Login struct {
-	Registry bool   `long:"registry" short:"r" usage:"Specify whether to login to a registry"`
-	Token    string `long:"token" short:"t" usage:"Authentication token" env:"KRAFTKIT_LOGIN_TOKEN"`
-	User     string `long:"user" short:"u" usage:"Username" env:"KRAFTKIT_LOGIN_USER"`
+	User  string `long:"user" short:"u" usage:"Username" env:"KRAFTKIT_LOGIN_USER"`
+	Token string `long:"token" short:"t" usage:"Authentication token" env:"KRAFTKIT_LOGIN_TOKEN"`
 }
 
 func New() *cobra.Command {
@@ -88,72 +82,10 @@ func (opts *Login) Run(cmd *cobra.Command, args []string) error {
 		authConfig.Token = opts.Token
 	}
 
-	if opts.Registry {
-		home, err := homedir.Dir()
-		if err != nil {
-			return err
-		}
-
-		// The default path for registry credentials is:
-		defaultPath := filepath.Join(home, ".docker", "config.json")
-
-		// If the DOCKER_CONFIG environment variable is set, use that instead
-		if os.Getenv("DOCKER_CONFIG") != "" {
-			defaultPath = filepath.Join(os.Getenv("DOCKER_CONFIG"), "config.json")
-		}
-
-		var bytes []byte
-		var config map[string](map[string]interface{})
-		if _, err := os.Stat(defaultPath); !os.IsNotExist(err) {
-			bytes, err := os.ReadFile(defaultPath)
-			if err != nil {
-				return err
-			}
-
-			err = json.Unmarshal(bytes, &config)
-			if err != nil {
-				return err
-			}
-		} else {
-			// Create parent directories
-			err := os.MkdirAll(filepath.Dir(defaultPath), 0o755)
-			if err != nil {
-				return err
-			}
-
-			config = make(map[string](map[string]interface{}))
-			config["auths"] = make(map[string]interface{})
-		}
-
-		// Add the new auth config
-		auth := make(map[string]interface{})
-
-		var token string
-		if opts.User != "" {
-			token = opts.User + ":" + opts.Token
-
-			// Base64 encode the token
-			token = base64.StdEncoding.EncodeToString([]byte(token))
-		} else {
-			token = opts.Token
-		}
-
-		auth["auth"] = token
-		config["auths"][host] = auth
-
-		// Write it back
-		bytes, err = json.Marshal(config)
-		if err != nil {
-			return err
-		}
-
-		return os.WriteFile(defaultPath, bytes, 0o644)
-	} else {
-		if config.G[config.KraftKit](ctx).Auth == nil {
-			config.G[config.KraftKit](ctx).Auth = make(map[string]config.AuthConfig)
-		}
-		config.G[config.KraftKit](ctx).Auth[host] = authConfig
-
-		return config.M[config.KraftKit](ctx).Write(true)
+	if config.G[config.KraftKit](ctx).Auth == nil {
+		config.G[config.KraftKit](ctx).Auth = make(map[string]config.AuthConfig)
 	}
+	config.G[config.KraftKit](ctx).Auth[host] = authConfig
+
+	return config.M[config.KraftKit](ctx).Write(true)
 }

--- a/go.mod
+++ b/go.mod
@@ -21,6 +21,7 @@ require (
 	github.com/containerd/containerd v1.7.2
 	github.com/containerd/nerdctl v1.4.0
 	github.com/dgraph-io/badger/v3 v3.2103.5
+	github.com/docker/cli v24.0.1+incompatible
 	github.com/docker/docker v24.0.4+incompatible
 	github.com/dustin/go-humanize v1.0.1
 	github.com/erikgeiser/promptkit v0.8.0
@@ -99,7 +100,6 @@ require (
 	github.com/cyphar/filepath-securejoin v0.2.3 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/dgraph-io/ristretto v0.1.1 // indirect
-	github.com/docker/cli v24.0.1+incompatible // indirect
 	github.com/docker/distribution v2.8.2+incompatible // indirect
 	github.com/docker/docker-credential-helpers v0.7.0 // indirect
 	github.com/docker/go-connections v0.4.0 // indirect

--- a/oci/manager_options.go
+++ b/oci/manager_options.go
@@ -6,12 +6,16 @@ import (
 	"os"
 	"path/filepath"
 
-	regtypes "github.com/docker/docker/api/types/registry"
-	"github.com/genuinetools/reg/repoutils"
 	"github.com/sirupsen/logrus"
 	"kraftkit.sh/config"
 	"kraftkit.sh/log"
 	"kraftkit.sh/oci/handler"
+
+	cliconfig "github.com/docker/cli/cli/config"
+	"github.com/docker/cli/cli/config/configfile"
+	regtypes "github.com/docker/docker/api/types/registry"
+	"github.com/genuinetools/reg/repoutils"
+	"github.com/mitchellh/go-homedir"
 )
 
 type OCIManagerOption func(context.Context, *ociManager) error
@@ -34,7 +38,7 @@ func WithDetectHandler() OCIManagerOption {
 			}).Trace("using oci containerd handler")
 
 			manager.handle = func(ctx context.Context) (context.Context, handler.Handler, error) {
-				return handler.NewContainerdHandler(ctx, contAddr, namespace)
+				return handler.NewContainerdHandler(ctx, contAddr, namespace, manager.auths)
 			}
 
 			return nil
@@ -48,7 +52,7 @@ func WithDetectHandler() OCIManagerOption {
 		}).Trace("using oci directory handler")
 
 		manager.handle = func(ctx context.Context) (context.Context, handler.Handler, error) {
-			handle, err := handler.NewDirectoryHandler(ociDir)
+			handle, err := handler.NewDirectoryHandler(ociDir, manager.auths)
 			if err != nil {
 				return nil, nil, err
 			}
@@ -77,7 +81,7 @@ func WithContainerd(ctx context.Context, addr, namespace string) OCIManagerOptio
 		}).Trace("using containerd handler")
 
 		manager.handle = func(ctx context.Context) (context.Context, handler.Handler, error) {
-			return handler.NewContainerdHandler(ctx, addr, namespace)
+			return handler.NewContainerdHandler(ctx, addr, namespace, manager.auths)
 		}
 
 		return nil
@@ -104,21 +108,99 @@ func WithDefaultRegistries() OCIManagerOption {
 	}
 }
 
+// fileExists returns true if the given path exists and is not a directory.
+func fileExists(path string) bool {
+	fi, err := os.Stat(path)
+	return err == nil && !fi.IsDir()
+}
+
+// defaultAuths uses the provided context to locate possible authentication
+// values which can be used when speaking with remote registries.
+func defaultAuths(ctx context.Context) (map[string]regtypes.AuthConfig, error) {
+	auths := make(map[string]regtypes.AuthConfig)
+
+	for domain, auth := range config.G[config.KraftKit](ctx).Auth {
+		auth, err := repoutils.GetAuthConfig(auth.User, auth.Token, domain)
+		if err != nil {
+			return nil, err
+		}
+
+		auths[domain] = auth
+	}
+
+	// Podman users may have their container registry auth configured in a
+	// different location, that Docker packages aren't aware of.
+	// If the Docker config file isn't found, we'll fallback to look where
+	// Podman configures it, and parse that as a Docker auth config instead.
+
+	// First, check $HOME/.docker/
+	var home string
+	var err error
+	foundDockerConfig := false
+
+	// If this is run in the context of GitHub actions, use an alternative path
+	// for the $HOME.
+	if os.Getenv("GITUB_ACTION") == "yes" {
+		home = "/github/home"
+	} else {
+		home, err = homedir.Dir()
+	}
+	if err == nil {
+		foundDockerConfig = fileExists(filepath.Join(home, ".docker/config.json"))
+	}
+
+	// If $HOME/.docker/config.json isn't found, check $DOCKER_CONFIG (if set)
+	if !foundDockerConfig && os.Getenv("DOCKER_CONFIG") != "" {
+		foundDockerConfig = fileExists(filepath.Join(os.Getenv("DOCKER_CONFIG"), "config.json"))
+	}
+
+	// If either of those locations are found, load it using Docker's
+	// config.Load, which may fail if the config can't be parsed.
+	//
+	// If neither was found, look for Podman's auth at
+	// $XDG_RUNTIME_DIR/containers/auth.json and attempt to load it as a
+	// Docker config.
+	var cf *configfile.ConfigFile
+	if foundDockerConfig {
+		cf, err = cliconfig.Load(os.Getenv("DOCKER_CONFIG"))
+		if err != nil {
+			return nil, err
+		}
+	} else if f, err := os.Open(filepath.Join(os.Getenv("XDG_RUNTIME_DIR"), "containers/auth.json")); err == nil {
+		defer f.Close()
+
+		cf, err = cliconfig.LoadFromReader(f)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if cf != nil {
+		for domain, config := range cf.AuthConfigs {
+			auths[domain] = regtypes.AuthConfig{
+				Auth:          config.Auth,
+				Email:         config.Email,
+				IdentityToken: config.IdentityToken,
+				Password:      config.Password,
+				RegistryToken: config.RegistryToken,
+				ServerAddress: config.ServerAddress,
+				Username:      config.Username,
+			}
+		}
+	}
+
+	return auths, nil
+}
+
 // WithDefaultAuth uses the KraftKit-set configuration for authentication
 // against remote registries.
 func WithDefaultAuth() OCIManagerOption {
 	return func(ctx context.Context, manager *ociManager) error {
-		if manager.auths == nil {
-			manager.auths = make(map[string]regtypes.AuthConfig)
-		}
+		var err error
 
-		for domain, auth := range config.G[config.KraftKit](ctx).Auth {
-			auth, err := repoutils.GetAuthConfig(auth.User, auth.Token, domain)
-			if err != nil {
-				return err
-			}
-
-			manager.auths[domain] = auth
+		manager.auths, err = defaultAuths(ctx)
+		if err != nil {
+			return err
 		}
 
 		return nil

--- a/oci/simpleauth/simpleauth.go
+++ b/oci/simpleauth/simpleauth.go
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2022, Unikraft GmbH and The KraftKit Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+
+// Package simpleauth implements a basic pass-by-reference of credentials for
+// the authn.Authenticator interface.
+package simpleauth
+
+import "github.com/google/go-containerregistry/pkg/authn"
+
+// SimpleAuthenticator is used to handle looking up the already populated
+// user configuration that is used when speaking with the remote registry.
+type SimpleAuthenticator struct {
+	Auth *authn.AuthConfig
+}
+
+// Authorization implements authn.Authenticator.
+func (auth *SimpleAuthenticator) Authorization() (*authn.AuthConfig, error) {
+	return auth.Auth, nil
+}

--- a/tools/github-action/pre.sh
+++ b/tools/github-action/pre.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+RUNNER_HOME=/home/runner/work/_temp/_github_home
+
+# Copy over any credentials from the Actions home directory that may have been
+# initialized via docker/login-action
+if [[ -f ${HOME}/.docker/config.json ]]; then
+  mkdir -p ${RUNNER_HOME}/.docker
+  cp ${HOME}/.docker/config.json ${RUNNER_HOME}/.docker
+fi


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

This PR essentially reverts #738 for two reasons as well as correctly handling authentication in the context of GitHub Actions:
    
- We should not be manipulating the `~/.docker/config.json` file as it is not owned by KraftKit.  Modifying this file can be seen as malicious or unintended behaviour from users.
- Ultimately, this does not solve the underlying issue of communicating with registries in a pragmatic way: KraftKit already has an internal "auths" section which can be referenced and reading the docker config file should simply be properly supplemented in the existing implementation which looks up user credentials.

Included in this PR is a fix which makes it possible to use the typical action, [`docker/action-login`](https://github.com/docker/login-action), for logging into a container registry, making the KraftKit action a drop-in replacement to existing pipelines.

