### PR TITLE
feat: Downgrade make `stderr` to Warnings & highlight errors at the end

### DIFF
--- a/cmd/kraft/build/build.go
+++ b/cmd/kraft/build/build.go
@@ -472,7 +472,7 @@ func (opts *Build) Run(cmd *cobra.Command, args []string) error {
 					app.WithBuildMakeOptions(append(mopts,
 						make.WithExecOptions(
 							exec.WithStdout(log.G(ctx).Writer()),
-							exec.WithStderr(log.G(ctx).WriterLevel(logrus.ErrorLevel)),
+							exec.WithStderr(log.G(ctx).WriterLevel(logrus.WarnLevel)),
 						),
 					)...),
 					app.WithBuildLogFile(opts.SaveBuildLog),

--- a/cmd/kraft/build/build.go
+++ b/cmd/kraft/build/build.go
@@ -465,7 +465,7 @@ func (opts *Build) Run(cmd *cobra.Command, args []string) error {
 		processes = append(processes, paraprogress.NewProcess(
 			fmt.Sprintf("building %s (%s)", targ.Name(), target.TargetPlatArchName(targ)),
 			func(ctx context.Context, w func(progress float64)) error {
-				return opts.project.Build(
+				err := opts.project.Build(
 					ctx,
 					targ, // Target-specific options
 					app.WithBuildProgressFunc(w),
@@ -477,6 +477,10 @@ func (opts *Build) Run(cmd *cobra.Command, args []string) error {
 					)...),
 					app.WithBuildLogFile(opts.SaveBuildLog),
 				)
+				if err != nil {
+					return fmt.Errorf("build failed: %w", err)
+				}
+				return nil
 			},
 		))
 	}

--- a/cmdfactory/builder.go
+++ b/cmdfactory/builder.go
@@ -20,6 +20,8 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
+
+	"kraftkit.sh/log"
 )
 
 var (
@@ -318,7 +320,7 @@ func Main(ctx context.Context, cmd *cobra.Command) {
 	cmd.SetContext(ctx)
 
 	if _, err := executeC(cmd); err != nil {
-		fmt.Println(err)
+		log.G(ctx).Error(err)
 		os.Exit(1)
 	}
 }

--- a/test/e2e/cli/pkg_test.go
+++ b/test/e2e/cli/pkg_test.go
@@ -75,7 +75,7 @@ var _ = Describe("kraft pkg", func() {
 					Expect(err).ToNot(HaveOccurred())
 
 					Expect(stderr.String()).To(BeEmpty())
-					Expect(stdout).To(MatchRegexp(`^Retrieve new lists of Unikraft components, libraries and packages.\n`))
+					Expect(stdout.String()).To(MatchRegexp(`^Retrieve new lists of Unikraft components, libraries and packages.\n`))
 				})
 			})
 		})

--- a/test/e2e/cli/version_test.go
+++ b/test/e2e/cli/version_test.go
@@ -37,7 +37,7 @@ var _ = Describe("kraft version", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			Expect(stderr.String()).To(BeEmpty())
-			Expect(stdout).To(MatchRegexp(`^kraft [\w\.-]+ \(\w+\) [\w\.-]+ .+\n$`))
+			Expect(stdout.String()).To(MatchRegexp(`^kraft [\w\.-]+ \(\w+\) [\w\.-]+ .+\n$`))
 		})
 	})
 
@@ -51,7 +51,7 @@ var _ = Describe("kraft version", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			Expect(stderr.String()).To(BeEmpty())
-			Expect(stdout).To(MatchRegexp(`^Show kraft version information\n`))
+			Expect(stdout.String()).To(MatchRegexp(`^Show kraft version information\n`))
 		})
 	})
 
@@ -66,7 +66,9 @@ var _ = Describe("kraft version", func() {
 			Expect(err).To(MatchError("exit status 1"))
 
 			Expect(stderr.String()).To(BeEmpty())
-			Expect(stdout).To(MatchRegexp(`^unknown command "some-arg" for "kraft version"\n$`))
+			Expect(stdout.String()).To(MatchRegexp(
+				`^(level=error msg="unknown command "some-arg" for "kraft version"")|(unknown command "some-arg" for "kraft version")\n$`,
+			))
 		})
 	})
 })


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

Changes in this PR were brought by the verbose nature of the build system which resulted in lots of errors that were actually just information messages or warnings at most.

To fix this we explicitly highlight errors at the end and everything else becomes a Warning.

This is how a failed build looks like now:
![image](https://github.com/unikraft/kraftkit/assets/46280801/63caba76-ce02-496c-85da-0d976993dafa)
