### PR TITLE
feat(dockerfile-llb-frontend): Set the Entrypoint on LLB images

### DIFF
--- a/tools/dockerfile-llb-frontend/build/build.go
+++ b/tools/dockerfile-llb-frontend/build/build.go
@@ -12,7 +12,6 @@ import (
 	"fmt"
 	"path"
 
-	"github.com/containerd/containerd/platforms"
 	"github.com/moby/buildkit/client/llb"
 	"github.com/moby/buildkit/exporter/containerimage/exptypes"
 	"github.com/moby/buildkit/frontend/gateway/client"
@@ -113,7 +112,6 @@ func (driver *DefaultBuildkitDriver) Run(ctx context.Context) (*client.Result, e
 
 	// We then annotate the result with additional metadata.
 	// BuildKit will pick it up from the returned client.Result.
-	// (todo) This section shall be expanded once we focus on the run part.
 	return driver.annotateBuildResult(result)
 }
 
@@ -138,17 +136,13 @@ func (driver DefaultBuildkitDriver) annotateBuildResult(result *result.Result[cl
 		return nil, fmt.Errorf("failed to get the referece to BuildKit's result: %w", err)
 	}
 
-	result.SetRef(ref)
-
-	config, err := json.Marshal(image.NewImageConfig())
+	config, err := json.Marshal(image.UnikraftImageConfig())
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshal the base image config: %w", err)
 	}
 
-	// This annotates the image with values from the client's runtime.GOOS and runtime.GOARCH.
-	platformSpec := platforms.Format(platforms.DefaultSpec())
-
-	result.AddMeta(fmt.Sprintf("%s/%s", exptypes.ExporterImageConfigKey, platformSpec), config)
+	result.AddMeta(exptypes.ExporterImageConfigKey, config)
+	result.SetRef(ref)
 
 	return result, nil
 }

--- a/tools/dockerfile-llb-frontend/go.mod
+++ b/tools/dockerfile-llb-frontend/go.mod
@@ -3,7 +3,6 @@ module kraftkit.sh/tools/dockerfile-llb-frontend
 go 1.20
 
 require (
-	github.com/containerd/containerd v1.7.2
 	github.com/moby/buildkit v0.12.0
 	github.com/opencontainers/go-digest v1.0.0
 	github.com/opencontainers/image-spec v1.1.0-rc4
@@ -35,6 +34,7 @@ require (
 	github.com/compose-spec/compose-go v1.17.0 // indirect
 	github.com/containerd/cgroups v1.1.0 // indirect
 	github.com/containerd/console v1.0.4-0.20230313162750-1ae8d489ac81 // indirect
+	github.com/containerd/containerd v1.7.2 // indirect
 	github.com/containerd/continuity v0.4.1 // indirect
 	github.com/containerd/fifo v1.1.0 // indirect
 	github.com/containerd/go-cni v1.1.9 // indirect

--- a/tools/dockerfile-llb-frontend/image/image.go
+++ b/tools/dockerfile-llb-frontend/image/image.go
@@ -7,20 +7,25 @@
 package image
 
 import (
-	"github.com/moby/buildkit/util/system"
+	"runtime"
+
 	specs "github.com/opencontainers/image-spec/specs-go/v1"
+	"kraftkit.sh/oci"
 )
 
-func emptyImage() *specs.Image {
-	image := &specs.Image{}
-	image.RootFS.Type = "layers"
-	image.Config.WorkingDir = "/"
-	image.Config.Env = []string{"PATH=" + system.DefaultPathEnv("linux")}
-	return image
-}
-
-// NewImageConfig returns empty container image metadata.
-func NewImageConfig() *specs.Image {
-	// (todo): We might decide what else to set here once we get to the run part.
-	return emptyImage()
+// UnikraftImageConfig provided metadata enables running unikraft images through docker run.
+func UnikraftImageConfig() *specs.Image {
+	return &specs.Image{
+		Platform: specs.Platform{
+			Architecture: runtime.GOARCH,
+			OS:           runtime.GOOS,
+		},
+		RootFS: specs.RootFS{
+			Type: "layers",
+		},
+		Config: specs.ImageConfig{
+			WorkingDir: "/",
+			Entrypoint: []string{oci.WellKnownKernelPath},
+		},
+	}
 }


### PR DESCRIPTION
### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [x] Updated relevant documentation.

### Description of changes


This patch makes it so that the resulting container image embeds /unikraft/bin/kernel as the entrypoint. 

The user does not have to provide it when invoking docker run.

GitHub-Fixes: #778

