### PR TITLE
feat: runu, OCI runtime for Unikraft unikernels

### DIFF
--- a/.goreleaser-stable.yaml
+++ b/.goreleaser-stable.yaml
@@ -91,3 +91,20 @@ builds:
       - -X {{ .Env.GOMOD }}/internal/version.buildTime={{ .Date }}
 #@ end
 #@ end
+#@ targets = {
+#@   "linux-amd64": {"os": "linux", "arch": "amd64"},
+#@   "linux-arm64": {"os": "linux", "arch": "arm64"}
+#@ }
+#@ for binary in ["runu"]:
+#@ for target, specs in targets.items():
+  - id: #@ "{}-{}".format(binary, target)
+    binary: #@ binary
+    main: #@ "./cmd/{}".format(binary)
+    goos:
+      - #@ specs["os"]
+    goarch:
+      - #@ specs["arch"]
+    ldflags:
+      - -s -w
+#@ end
+#@ end

--- a/.goreleaser-staging.yaml
+++ b/.goreleaser-staging.yaml
@@ -53,3 +53,20 @@ builds:
       - -X {{ .Env.GOMOD }}/internal/version.buildTime={{ .Date }}
 #@ end
 #@ end
+#@ targets = {
+#@   "linux-amd64": {"os": "linux", "arch": "amd64"},
+#@   "linux-arm64": {"os": "linux", "arch": "arm64"}
+#@ }
+#@ for binary in ["runu"]:
+#@ for target, specs in targets.items():
+  - id: #@ "{}-{}".format(binary, target)
+    binary: #@ binary
+    main: #@ "./cmd/{}".format(binary)
+    goos:
+      - #@ specs["os"]
+    goarch:
+      - #@ specs["arch"]
+    ldflags:
+      - -s -w
+#@ end
+#@ end

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,8 @@ VENDORDIR   ?= $(WORKDIR)/third_party
 REGISTRY    ?= kraftkit.sh
 ORG         ?= unikraft
 REPO        ?= kraftkit
-BIN         ?= kraft
+BIN         ?= kraft \
+               runu
 TOOLS       ?= github-action \
                go-generate-qemu-devices \
                protoc-gen-go-netconn \
@@ -213,3 +214,4 @@ buildenv-qemu: ## OCI image containing a Unikraft-centric build of QEMU.
 buildenv-github-action: ## OCI image used when building Unikraft unikernels in GitHub Actions.
 tools: ## Build all tools.
 kraft: ## The kraft binary.
+runu: ## The runu binary.

--- a/cmd/runu/create/create.go
+++ b/cmd/runu/create/create.go
@@ -1,0 +1,496 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2023, Unikraft GmbH and The KraftKit Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+package create
+
+import (
+	"context"
+	"debug/elf"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+
+	"github.com/MakeNowJust/heredoc"
+	securejoin "github.com/cyphar/filepath-securejoin"
+	"github.com/spf13/cobra"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	rtspec "github.com/opencontainers/runtime-spec/specs-go"
+
+	machineapi "kraftkit.sh/api/machine/v1alpha1"
+	"kraftkit.sh/cmdfactory"
+	"kraftkit.sh/exec"
+	"kraftkit.sh/internal/set"
+	libcontainer "kraftkit.sh/libmocktainer"
+	"kraftkit.sh/libmocktainer/specconv"
+	"kraftkit.sh/log"
+	mplatform "kraftkit.sh/machine/platform"
+	"kraftkit.sh/machine/qemu"
+	"kraftkit.sh/oci"
+)
+
+// Create implements the OCI "create" command.
+type Create struct {
+	Bundle        string `long:"bundle" short:"b" usage:"path to the root of the bundle directory"`
+	ConsoleSocket string `long:"console-socket" usage:"path to an AF_UNIX socket which will receive a file descriptor referencing the master end of the console's pseudoterminal"`
+	PidFile       string `long:"pid-file" usage:"specify a file where the process ID will be written"`
+}
+
+func New() *cobra.Command {
+	cmd, err := cmdfactory.New(&Create{}, cobra.Command{
+		Short: "Create a new unikernel",
+		Args:  cobra.ExactArgs(1),
+		Use:   "create [FLAGS] <unikernel-id>",
+		Long: heredoc.Doc(`Create a new unikernel with the given ID.  IDs must be unique.
+
+			The create command creates an instance of a unikernel for a bundle. The bundle
+			is a directory with a specification file named "config.json" and a root
+			filesystem.
+
+			The specification file includes an args parameter. The args parameter is used
+			to specify command(s) that get run when the unikernel is started. To change the
+			command(s) that get executed on start, edit the args parameter of the spec`),
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	return cmd
+}
+
+func (opts *Create) Pre(cmd *cobra.Command, args []string) error {
+	if opts.Bundle == "" {
+		return fmt.Errorf("--bundle is required")
+	}
+
+	bundleConfig := filepath.Join(opts.Bundle, oci.ConfigFilename)
+	fInfo, err := os.Stat(bundleConfig)
+	if err != nil {
+		return err
+	}
+
+	if !fInfo.Mode().IsRegular() {
+		return fmt.Errorf("%q should be a regular file", bundleConfig)
+	}
+
+	return nil
+}
+
+const (
+	flagRoot     = "root"
+	flagSdCgroup = "systemd-cgroup"
+)
+
+// TODO(antoineco): the runtime spec (config.json) doesn't provide any hint
+// about the desired target platform, so we will need to think about ways to
+// figure this out.
+const plat = mplatform.PlatformQEMU
+
+func (opts *Create) Run(cmd *cobra.Command, args []string) (retErr error) {
+	ctx := cmd.Context()
+
+	defer func() {
+		// Make sure the error is written to the configured log destination, so
+		// that the message gets propagated through the caller (e.g. containerd-shim)
+		if retErr != nil {
+			log.G(ctx).Error(retErr)
+		}
+	}()
+
+	rootDir := cmd.Flag(flagRoot).Value.String()
+	if rootDir == "" {
+		return fmt.Errorf("state directory (--%s flag) is not set", flagRoot)
+	}
+
+	sdcg, err := strconv.ParseBool(cmd.Flag(flagSdCgroup).Value.String())
+	if err != nil {
+		return fmt.Errorf("parsing --%s flag: %w", flagSdCgroup, err)
+	}
+	if sdcg {
+		log.G(ctx).Warnf("ignoring --%s flag", flagSdCgroup)
+	}
+
+	var pidFile string
+	if opts.PidFile != "" {
+		if pidFile, err = filepath.Abs(opts.PidFile); err != nil {
+			return fmt.Errorf("getting pid file abs path: %w", err)
+		}
+	}
+
+	if err = os.Chdir(opts.Bundle); err != nil {
+		return fmt.Errorf("changing working dir to OCI bundle: %w", err)
+	}
+
+	spec, err := loadSpec()
+	if err != nil {
+		return fmt.Errorf("loading runtime spec: %w", err)
+	}
+	spec.Linux.Namespaces = supportedNamespaces(spec.Linux.Namespaces)
+
+	cID := args[0]
+
+	cArgs, err := genMachineArgs(ctx, cID, rootDir, spec.Root.Path)
+	if err != nil {
+		return fmt.Errorf("generating machine args: %w", err)
+	}
+	spec.Process.Args = cArgs
+
+	c, err := createContainer(cID, rootDir, spec)
+	if err != nil {
+		return fmt.Errorf("creating container environment: %w", err)
+	}
+
+	if err = bootstrapContainer(ctx, c, spec.Process, pidFile); err != nil {
+		return fmt.Errorf("starting container: %w", err)
+	}
+
+	return nil
+}
+
+const specFile = "config.json"
+
+// loadSpec loads the OCI runtime specification from the provided path.
+func loadSpec() (*rtspec.Spec, error) {
+	f, err := os.Open(specFile)
+	if err != nil {
+		return nil, fmt.Errorf("opening spec file: %w", err)
+	}
+	defer f.Close()
+
+	spec := &rtspec.Spec{}
+	if err = json.NewDecoder(f).Decode(spec); err != nil {
+		return nil, fmt.Errorf("decoding JSON spec: %w", err)
+	}
+
+	return spec, nil
+}
+
+// genMachineArgs returns the command-line arguments for starting a unikernel machine.
+func genMachineArgs(ctx context.Context, cID, rootDir, bundleRoot string) (args []string, retErr error) {
+	m, err := newMachine(cID, rootDir, bundleRoot)
+	if err != nil {
+		return nil, fmt.Errorf("creating machine: %w", err)
+	}
+
+	mSvc, err := newMachineService(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("instantiating machine service: %w", err)
+	}
+
+	// HACK: QMP socket paths are unusable with long container IDs (e.g. in Kubernetes).
+	// Use a short ephemeral directory as a workaround.
+	//
+	//   FATA[0000] failed to create shim task: OCI runtime create failed:
+	//   generating machine args: creating machine: could not start and wait for QEMU process:
+	//   qemu-system-x86_64: -qmp unix:/run/containerd/runc/default/bf6f970d280ba13c36f34f8d8765603244362620d12b405a5e91bd822ead4c8a/qemu_control.sock,server,nowait:
+	//   UNIX socket path '/run/containerd/runc/default/bf6f970d280ba13c36f34f8d8765603244362620d12b405a5e91bd822ead4c8a/qemu_control.sock' is too long
+	//   Path must be less than 108 bytes
+	//
+	origStateDir := m.Status.StateDir
+	m.Status.StateDir, err = os.MkdirTemp("", "runu-")
+	if err != nil {
+		return nil, fmt.Errorf("creating short temp state dir: %w", err)
+	}
+	defer func() {
+		if err := os.RemoveAll(m.Status.StateDir); err != nil {
+			retErr = combineErrors(retErr, fmt.Errorf("deleting short temp state dir: %w", err))
+		}
+	}()
+
+	// HACK: this starts a QEMU process without starting the guest (-S flag, "freeze CPU at startup").
+	// We only do that for the sake of cloning the machine's startup command and
+	// arguments, and set those same arguments inside the OCI container's config.
+	m, err = mSvc.Create(ctx, m)
+	if err != nil {
+		return nil, fmt.Errorf("creating machine: %w", err)
+	}
+
+	defer func() {
+		if _, err := mSvc.Stop(ctx, m); err != nil {
+			retErr = combineErrors(retErr, fmt.Errorf("stopping machine: %w", err))
+		}
+		if _, err := mSvc.Delete(ctx, m); err != nil {
+			retErr = combineErrors(retErr, fmt.Errorf("deleting machine: %w", err))
+		}
+	}()
+
+	qCfg, ok := m.Status.PlatformConfig.(qemu.QemuConfig)
+	if !ok {
+		return nil, fmt.Errorf("machine does not embed a QEMU platform config")
+	}
+
+	var bin string
+	switch mArch := m.Spec.Architecture; mArch {
+	case "x86_64":
+		bin = qemu.QemuSystemX86
+	case "arm":
+		bin = qemu.QemuSystemArm
+	case "arm64":
+		bin = qemu.QemuSystemAarch64
+	default:
+		return nil, fmt.Errorf("unsupported machine architecture: %s", mArch)
+	}
+
+	exe, err := exec.NewExecutable(bin, qCfg)
+	if err != nil {
+		return nil, fmt.Errorf("preparing machine executable: %w", err)
+	}
+
+	args = sanitizeQemuArgs(exe.Args())
+
+	// HACK: restore previously overridden stateDir
+	for i := range args {
+		args[i] = strings.Replace(args[i], m.Status.StateDir, origStateDir, 1)
+	}
+
+	return append([]string{bin}, args...), nil
+}
+
+// sanitizeQemuArgs filters out undesired QEMU commands line arguments, such as
+// the "-daemonize" flag, from the given list.
+func sanitizeQemuArgs(qemuArgs []string) []string {
+	xFlags := set.NewStringSet("-daemonize", "-S")
+	xFlagsVal := set.NewStringSet("-qmp", "-monitor", "-serial")
+
+	filtered := qemuArgs[:0]
+	for i := 0; i < len(qemuArgs); i++ {
+		switch {
+		case xFlags.Contains(qemuArgs[i]):
+		case xFlagsVal.Contains(qemuArgs[i]):
+			i++
+		default:
+			filtered = append(filtered, qemuArgs[i])
+		}
+	}
+	return filtered
+}
+
+// newMachine returns a new Machine with the given ID.
+func newMachine(mID string, rootDir, bundleRoot string) (*machineapi.Machine, error) {
+	kPath, err := kernelAbsPath(bundleRoot)
+	if err != nil {
+		return nil, fmt.Errorf("getting absolute path of kernel: %w", err)
+	}
+
+	irdPath, err := initrdAbsPath(bundleRoot)
+	if err != nil {
+		return nil, fmt.Errorf("getting absolute path of initrd: %w", err)
+	}
+
+	kArch, err := kernelArchitecture(kPath)
+	if err != nil {
+		return nil, fmt.Errorf("getting kernel architecture: %w", err)
+	}
+
+	stateDir, err := securejoin.SecureJoin(rootDir, mID)
+	if err != nil {
+		return nil, fmt.Errorf("joining path components: %w", err)
+	}
+
+	// TODO(antoineco): convert CPU shares and memory limits from runtime spec
+	// into Machine resource requirements.
+	m := &machineapi.Machine{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: mID,
+		},
+		Spec: machineapi.MachineSpec{
+			Platform:     plat.String(),
+			Architecture: kArch,
+		},
+		Status: machineapi.MachineStatus{
+			KernelPath: kPath,
+			InitrdPath: irdPath,
+			StateDir:   stateDir,
+		},
+	}
+
+	return m, nil
+}
+
+const (
+	kernelRelPath = "unikraft/bin/kernel"
+	initrdRelPath = "unikraft/bin/initrd"
+)
+
+// kernelAbsPath returns the absolute path of the bundle's kernel.
+func kernelAbsPath(bundleRoot string) (string, error) {
+	return fileAbsPath(bundleRoot, kernelRelPath)
+}
+
+// initrdAbsPath returns the absolute path of the bundle's initrd.
+func initrdAbsPath(bundleRoot string) (string, error) {
+	p, err := fileAbsPath(bundleRoot, initrdRelPath)
+	if err != nil {
+		if pErr := (*os.PathError)(nil); errors.As(err, &pErr) && os.IsNotExist(pErr) {
+			return "", nil
+		}
+	}
+	return p, err
+}
+
+// fileAbsPath returns the absolute path of the given file relative to the
+// bundle root, and performs some basic sanity checks on the value.
+func fileAbsPath(bundleRoot, relPath string) (string, error) {
+	path, err := securejoin.SecureJoin(bundleRoot, relPath)
+	if err != nil {
+		return "", fmt.Errorf("joining path components: %w", err)
+	}
+
+	if path, err = filepath.Abs(path); err != nil {
+		return "", err
+	}
+	fi, err := os.Stat(path)
+	if err != nil {
+		return "", fmt.Errorf("reading information about file: %w", err)
+	}
+	if !fi.Mode().IsRegular() {
+		return "", fmt.Errorf("file is not regular: %s", path)
+	}
+
+	return path, nil
+}
+
+// newMachineService returns a new MachineService.
+func newMachineService(ctx context.Context) (machineapi.MachineService, error) {
+	ms, ok := mplatform.Strategies()[plat]
+	if !ok {
+		return nil, fmt.Errorf("unsupported platform driver: %s", plat)
+	}
+
+	return ms.NewMachineV1alpha1(ctx)
+}
+
+// kernelArchitecture returns the architecture of the given kernel file.
+// https://github.com/unikraft/kraftkit/blob/v0.6.4/cmd/kraft/run/runner_kernel.go#L47-L85
+func kernelArchitecture(path string) (string, error) {
+	f, err := elf.Open(path)
+	if err != nil {
+		return "", fmt.Errorf("opening ELF file: %w", err)
+	}
+	defer f.Close()
+
+	var arch string
+
+	switch f.Machine {
+	case elf.EM_X86_64, elf.EM_386:
+		arch = "x86_64"
+	case elf.EM_ARM:
+		arch = "arm"
+	case elf.EM_AARCH64:
+		arch = "arm64"
+	default:
+		return "", fmt.Errorf("unsupported kernel architecture: %s", f.Machine)
+	}
+
+	return arch, nil
+}
+
+// supportedNamespaces filters out unsupported Linux namespaces from the given list.
+func supportedNamespaces(nss []rtspec.LinuxNamespace) []rtspec.LinuxNamespace {
+	knownNs := set.NewStringSet(specconv.KnownNamespaces()...)
+
+	filtered := nss[:0]
+	for _, ns := range nss {
+		if knownNs.Contains(string(ns.Type)) {
+			filtered = append(filtered, ns)
+		}
+	}
+	return filtered
+}
+
+// createContainer creates a new container in a stopped state for the given
+// container id inside the provided state directory (root).
+func createContainer(cID, rootDir string, spec *rtspec.Spec) (*libcontainer.Container, error) {
+	config, err := specconv.CreateLibcontainerConfig(&specconv.CreateOpts{
+		Spec: spec,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("creating libcontainer configuration: %w", err)
+	}
+
+	return libcontainer.Create(rootDir, cID, config)
+}
+
+// bootstrapContainer starts the container bootstrap (init) process.
+func bootstrapContainer(ctx context.Context, c *libcontainer.Container, sp *rtspec.Process, pidFile string) (retErr error) {
+	defer func() {
+		if retErr != nil {
+			if err := c.Destroy(); err != nil {
+				retErr = combineErrors(retErr, fmt.Errorf("destroying container: %w", err))
+			}
+		}
+	}()
+
+	p := newProcess(sp)
+	p.LogLevel = strconv.Itoa(int(log.G(ctx).Level))
+
+	if err := c.Start(p); err != nil {
+		return fmt.Errorf("starting container init process: %w", err)
+	}
+
+	if pidFile != "" {
+		if err := createPidFile(pidFile, p); err != nil {
+			_ = p.Signal(syscall.SIGKILL)
+			_, _ = p.Wait()
+			return err
+		}
+	}
+
+	return nil
+}
+
+// newProcess returns a new libcontainer Process with the arguments from the
+// spec and stdio from the current process.
+func newProcess(sp *rtspec.Process) *libcontainer.Process {
+	return &libcontainer.Process{
+		Args:   sp.Args,
+		Env:    sp.Env,
+		Stdin:  os.Stdin,
+		Stdout: os.Stdout,
+		Stderr: os.Stderr,
+	}
+}
+
+// createPidFile creates a file with the processes pid inside it atomically
+// it creates a temp file with the paths filename + '.' infront of it
+// then renames the file
+func createPidFile(path string, process *libcontainer.Process) error {
+	pid, err := process.Pid()
+	if err != nil {
+		return err
+	}
+	var (
+		tmpDir  = filepath.Dir(path)
+		tmpName = filepath.Join(tmpDir, "."+filepath.Base(path))
+	)
+	f, err := os.OpenFile(tmpName, os.O_RDWR|os.O_CREATE|os.O_EXCL|os.O_SYNC, 0o666)
+	if err != nil {
+		return err
+	}
+	_, err = f.WriteString(strconv.Itoa(pid))
+	f.Close()
+	if err != nil {
+		return err
+	}
+	return os.Rename(tmpName, path)
+}
+
+// combineErrors is a helper for handling multiple potential errors, combining
+// them as necessary. It is meant to be used in a deferred function.
+func combineErrors(original, additional error) error {
+	switch {
+	case additional == nil:
+		return original
+	case original != nil:
+		return fmt.Errorf("%w. Additionally: %w", original, additional)
+	default:
+		return additional
+	}
+}

--- a/cmd/runu/delete/delete.go
+++ b/cmd/runu/delete/delete.go
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2023, Unikraft GmbH and The KraftKit Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+package delete
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/spf13/cobra"
+	"golang.org/x/sys/unix"
+
+	"kraftkit.sh/cmdfactory"
+	libcontainer "kraftkit.sh/libmocktainer"
+	"kraftkit.sh/log"
+)
+
+const (
+	flagRoot = "root"
+)
+
+// Delete implements the OCI "delete" command.
+type Delete struct {
+	Force bool `long:"force" short:"f" usage:"forcibly delete the unikernel if it is still running"`
+}
+
+func New() *cobra.Command {
+	cmd, err := cmdfactory.New(&Delete{}, cobra.Command{
+		Short: "Delete a unikernel",
+		Args:  cobra.ExactArgs(1),
+		Use:   "delete <unikernel-id>",
+		Long:  "The delete command deletes any resources held by a unikernel.",
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	return cmd
+}
+
+func (opts *Delete) Run(cmd *cobra.Command, args []string) (retErr error) {
+	ctx := cmd.Context()
+
+	defer func() {
+		// Make sure the error is written to the configured log destination, so
+		// that the message gets propagated through the caller (e.g. containerd-shim)
+		if retErr != nil {
+			log.G(ctx).Error(retErr)
+		}
+	}()
+
+	rootDir := cmd.Flag(flagRoot).Value.String()
+	if rootDir == "" {
+		return fmt.Errorf("state directory (--%s flag) is not set", flagRoot)
+	}
+
+	cID := args[0]
+
+	c, err := libcontainer.Load(rootDir, cID)
+	if err != nil {
+		return fmt.Errorf("loading container from saved state: %w", err)
+	}
+
+	st, err := c.Status()
+	if err != nil {
+		return fmt.Errorf("getting container status: %w", err)
+	}
+
+	switch st {
+	case libcontainer.Stopped:
+		return destroyContainer(c)
+	case libcontainer.Created:
+		return killContainer(c)
+	default:
+		if opts.Force {
+			return killContainer(c)
+		}
+		return fmt.Errorf("container is not stopped: %s", st)
+	}
+}
+
+// destroyContainer destroys the given container.
+func destroyContainer(c *libcontainer.Container) error {
+	if err := c.Destroy(); err != nil {
+		return fmt.Errorf("destroying container: %w", err)
+	}
+	return nil
+}
+
+// killContainer sends a SIGKILL to the container process.
+func killContainer(c *libcontainer.Container) error {
+	_ = c.Signal(unix.SIGKILL)
+	for i := 0; i < 100; i++ {
+		time.Sleep(100 * time.Millisecond)
+		if err := c.Signal(unix.Signal(0)); err != nil {
+			_ = destroyContainer(c)
+			return nil
+		}
+	}
+	return fmt.Errorf("container init still running")
+}

--- a/cmd/runu/init.go
+++ b/cmd/runu/init.go
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2023, Unikraft GmbH and The KraftKit Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+package main
+
+import (
+	"os"
+
+	_ "github.com/opencontainers/runc/libcontainer/nsenter"
+
+	libcontainer "kraftkit.sh/libmocktainer"
+)
+
+func init() {
+	if len(os.Args) > 1 && os.Args[1] == "init" {
+		// This is the golang entry point for runc init, executed
+		// before main() but after libcontainer/nsenter's nsexec().
+		libcontainer.Init()
+	}
+}

--- a/cmd/runu/kill/kill.go
+++ b/cmd/runu/kill/kill.go
@@ -1,0 +1,108 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2023, Unikraft GmbH and The KraftKit Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+package kill
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"golang.org/x/sys/unix"
+
+	"kraftkit.sh/cmdfactory"
+	libcontainer "kraftkit.sh/libmocktainer"
+	"kraftkit.sh/log"
+)
+
+const (
+	flagRoot = "root"
+)
+
+// Kill implements the OCI "kill" command.
+type Kill struct{}
+
+func New() *cobra.Command {
+	cmd, err := cmdfactory.New(&Kill{}, cobra.Command{
+		Short: "Send a signal to a unikernel",
+		Args:  cobra.RangeArgs(1, 2),
+		Use:   "kill <unikernel-id> [signal]",
+		Long:  "The kill command sends a signal to a unikernel.  If the signal is not specified, SIGTERM is sent.",
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	return cmd
+}
+
+func (opts *Kill) Run(cmd *cobra.Command, args []string) (retErr error) {
+	ctx := cmd.Context()
+
+	defer func() {
+		// Make sure the error is written to the configured log destination, so
+		// that the message gets propagated through the caller (e.g. containerd-shim)
+		if retErr != nil {
+			log.G(ctx).Error(retErr)
+		}
+	}()
+
+	rootDir := cmd.Flag(flagRoot).Value.String()
+	if rootDir == "" {
+		return fmt.Errorf("state directory (--%s flag) is not set", flagRoot)
+	}
+
+	cID := args[0]
+
+	sig := unix.SIGTERM
+	if len(args) == 2 {
+		var err error
+		if sig, err = parseSignal(args[1]); err != nil {
+			return err
+		}
+	}
+
+	c, err := libcontainer.Load(rootDir, cID)
+	if err != nil {
+		return fmt.Errorf("loading container from saved state: %w", err)
+	}
+
+	if err = c.Signal(sig); err != nil {
+		return fmt.Errorf("signaling machine process: %w", err)
+	}
+
+	return nil
+}
+
+/*
+Copyright 2014 Docker, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+func parseSignal(rawSignal string) (unix.Signal, error) {
+	s, err := strconv.Atoi(rawSignal)
+	if err == nil {
+		return unix.Signal(s), nil
+	}
+	sig := strings.ToUpper(rawSignal)
+	if !strings.HasPrefix(sig, "SIG") {
+		sig = "SIG" + sig
+	}
+	signal := unix.SignalNum(sig)
+	if signal == 0 {
+		return -1, fmt.Errorf("unknown signal %q", rawSignal)
+	}
+	return signal, nil
+}

--- a/cmd/runu/ps/ps.go
+++ b/cmd/runu/ps/ps.go
@@ -1,0 +1,158 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2023, Unikraft GmbH and The KraftKit Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+package ps
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"kraftkit.sh/cmdfactory"
+	libcontainer "kraftkit.sh/libmocktainer"
+	"kraftkit.sh/log"
+)
+
+const (
+	flagRoot = "root"
+)
+
+const formatJSON = "json"
+
+// Ps implements the runc "ps" command.
+type Ps struct {
+	Format string `long:"format" short:"f" usage:"format of the output (table or json)" default:"table"`
+}
+
+func New() *cobra.Command {
+	cmd, err := cmdfactory.New(&Ps{}, cobra.Command{
+		Short: "Displays the VMM process of a unikernel",
+		Args:  cobra.MinimumNArgs(1),
+		Use:   "ps <unikernel-id> [ps options]",
+		Long:  "The ps command displays the VMM process that runs a unikernel.",
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	return cmd
+}
+
+func (opts *Ps) Run(cmd *cobra.Command, args []string) (retErr error) {
+	ctx := cmd.Context()
+
+	defer func() {
+		// Make sure the error is written to the configured log destination, so
+		// that the message gets propagated through the caller (e.g. containerd-shim)
+		if retErr != nil {
+			log.G(ctx).Error(retErr)
+		}
+	}()
+
+	rootDir := cmd.Flag(flagRoot).Value.String()
+	if rootDir == "" {
+		return fmt.Errorf("state directory (--%s flag) is not set", flagRoot)
+	}
+
+	cID := args[0]
+
+	c, err := libcontainer.Load(rootDir, cID)
+	if err != nil {
+		return fmt.Errorf("loading container from saved state: %w", err)
+	}
+
+	status, err := c.Status()
+	if err != nil {
+		return fmt.Errorf("getting container status: %w", err)
+	}
+
+	state, err := c.State()
+	if err != nil {
+		return fmt.Errorf("getting container state: %w", err)
+	}
+
+	var pids []int
+	if status != libcontainer.Stopped {
+		pids = append(pids, state.BaseState.InitProcessPid)
+	}
+
+	if opts.Format == formatJSON {
+		return json.NewEncoder(os.Stdout).Encode(pids)
+	}
+	return printTable(pids, args[1:])
+}
+
+/*
+Copyright 2014 Docker, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+func printTable(pids []int, psArgs []string) error {
+	if len(psArgs) == 0 {
+		psArgs = []string{"-ef"}
+	}
+
+	cmd := exec.Command("ps", psArgs...)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("%w: %s", err, output)
+	}
+
+	lines := strings.Split(string(output), "\n")
+	pidIndex, err := getPidIndex(lines[0])
+	if err != nil {
+		return err
+	}
+
+	fmt.Println(lines[0])
+	for _, line := range lines[1:] {
+		if len(line) == 0 {
+			continue
+		}
+		fields := strings.Fields(line)
+		p, err := strconv.Atoi(fields[pidIndex])
+		if err != nil {
+			return fmt.Errorf("unable to parse pid: %w", err)
+		}
+
+		for _, pid := range pids {
+			if pid == p {
+				fmt.Println(line)
+				break
+			}
+		}
+	}
+
+	return nil
+}
+
+func getPidIndex(title string) (int, error) {
+	titles := strings.Fields(title)
+
+	pidIndex := -1
+	for i, name := range titles {
+		if name == "PID" {
+			return i, nil
+		}
+	}
+
+	return pidIndex, errors.New("couldn't find PID field in ps output")
+}

--- a/cmd/runu/runu.go
+++ b/cmd/runu/runu.go
@@ -23,6 +23,7 @@ import (
 	"kraftkit.sh/cmd/runu/create"
 	"kraftkit.sh/cmd/runu/delete"
 	"kraftkit.sh/cmd/runu/kill"
+	"kraftkit.sh/cmd/runu/ps"
 	"kraftkit.sh/cmd/runu/start"
 	"kraftkit.sh/cmd/runu/state"
 )
@@ -55,6 +56,7 @@ func New() *cobra.Command {
 	cmd.AddCommand(start.New())
 	cmd.AddCommand(kill.New())
 	cmd.AddCommand(delete.New())
+	cmd.AddCommand(ps.New())
 
 	return cmd
 }

--- a/cmd/runu/runu.go
+++ b/cmd/runu/runu.go
@@ -1,0 +1,126 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2023, Unikraft GmbH and The KraftKit Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+
+	"kraftkit.sh/cmdfactory"
+	"kraftkit.sh/config"
+	"kraftkit.sh/internal/cli"
+	"kraftkit.sh/iostreams"
+	"kraftkit.sh/log"
+
+	"kraftkit.sh/cmd/runu/create"
+	"kraftkit.sh/cmd/runu/delete"
+	"kraftkit.sh/cmd/runu/kill"
+	"kraftkit.sh/cmd/runu/start"
+	"kraftkit.sh/cmd/runu/state"
+)
+
+// [OCI runtime] for unikernels. Implements the runc [command-line interface].
+//
+// [OCI runtime]: https://github.com/opencontainers/runtime-spec/blob/v1.1.0/runtime.md
+// [command-line interface]: https://github.com/opencontainers/runtime-tools/blob/v0.9.0/docs/command-line-interface.md
+type Runu struct {
+	Root          string `long:"root" usage:"Root directory for storage of unikernel state" default:"/run/runu"`
+	Log           string `long:"log" usage:"Set the log file path where internal debug information is written" default:"/run/runu/runu.log"`
+	LogFormat     string `long:"log-format" usage:"set the format used by logs" default:"text"`
+	SystemdCgroup bool   `long:"systemd-cgroup" usage:"enable systemd cgroup support"`
+}
+
+func New() *cobra.Command {
+	cmd, err := cmdfactory.New(&Runu{}, cobra.Command{
+		Short: "Run OCI-compatible unikernels",
+		CompletionOptions: cobra.CompletionOptions{
+			DisableDefaultCmd: true,
+			HiddenDefaultCmd:  true,
+		},
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	cmd.AddCommand(state.New())
+	cmd.AddCommand(create.New())
+	cmd.AddCommand(start.New())
+	cmd.AddCommand(kill.New())
+	cmd.AddCommand(delete.New())
+
+	return cmd
+}
+
+func (opts *Runu) PersistentPre(cmd *cobra.Command, _ []string) error {
+	ctx := cmd.Context()
+
+	if opts.Root == "" {
+		return fmt.Errorf("--root cannot be empty")
+	}
+
+	if opts.Log != "" {
+		f, err := os.OpenFile(opts.Log, os.O_CREATE|os.O_WRONLY|os.O_APPEND|os.O_SYNC, 0o644)
+		if err != nil {
+			return err
+		}
+
+		log.G(ctx).SetOutput(f)
+	}
+
+	if opts.LogFormat == "json" {
+		log.G(ctx).SetFormatter(new(logrus.JSONFormatter))
+	}
+
+	return nil
+}
+
+func (*Runu) Run(cmd *cobra.Command, args []string) error {
+	return cmd.Help()
+}
+
+func main() {
+	cmd := New()
+
+	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer cancel()
+
+	copts := &cli.CliOptions{}
+
+	for _, o := range []cli.CliOption{
+		cli.WithDefaultConfigManager(cmd),
+		cli.WithDefaultIOStreams(),
+		cli.WithDefaultPluginManager(),
+		cli.WithDefaultLogger(),
+		cli.WithDefaultHTTPClient(),
+	} {
+		if err := o(copts); err != nil {
+			fmt.Println(err)
+			os.Exit(1)
+		}
+	}
+
+	// Set up the config manager in the context if it is available
+	if copts.ConfigManager != nil {
+		ctx = config.WithConfigManager(ctx, copts.ConfigManager)
+	}
+
+	// Set up the logger in the context if it is available
+	if copts.Logger != nil {
+		ctx = log.WithLogger(ctx, copts.Logger)
+	}
+
+	// Set up the iostreams in the context if it is available
+	if copts.IOStreams != nil {
+		ctx = iostreams.WithIOStreams(ctx, copts.IOStreams)
+	}
+
+	cmdfactory.Main(ctx, cmd)
+}

--- a/cmd/runu/start/start.go
+++ b/cmd/runu/start/start.go
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2023, Unikraft GmbH and The KraftKit Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+package start
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"kraftkit.sh/cmdfactory"
+	libcontainer "kraftkit.sh/libmocktainer"
+	"kraftkit.sh/log"
+)
+
+const (
+	flagRoot = "root"
+)
+
+// Start implements the OCI "start" command.
+type Start struct{}
+
+func New() *cobra.Command {
+	cmd, err := cmdfactory.New(&Start{}, cobra.Command{
+		Short: "Start a unikernel",
+		Args:  cobra.ExactArgs(1),
+		Use:   "start <unikernel-id>",
+		Long:  "The start command starts a created unikernel.",
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	return cmd
+}
+
+func (opts *Start) Run(cmd *cobra.Command, args []string) (retErr error) {
+	ctx := cmd.Context()
+
+	defer func() {
+		// Make sure the error is written to the configured log destination, so
+		// that the message gets propagated through the caller (e.g. containerd-shim)
+		if retErr != nil {
+			log.G(ctx).Error(retErr)
+		}
+	}()
+
+	rootDir := cmd.Flag(flagRoot).Value.String()
+	if rootDir == "" {
+		return fmt.Errorf("state directory (--%s flag) is not set", flagRoot)
+	}
+
+	cID := args[0]
+
+	c, err := libcontainer.Load(rootDir, cID)
+	if err != nil {
+		return fmt.Errorf("loading container from saved state: %w", err)
+	}
+
+	st, err := c.Status()
+	if err != nil {
+		return fmt.Errorf("getting container status: %w", err)
+	}
+
+	switch st {
+	case libcontainer.Created:
+		if err := c.Exec(); err != nil {
+			return fmt.Errorf("starting machine: %w", err)
+		}
+	case libcontainer.Running:
+		return fmt.Errorf("cannot start a running machine")
+	case libcontainer.Stopped:
+		return fmt.Errorf("cannot start a stopped machine")
+	default:
+		return fmt.Errorf("cannot start a machine in the %s state", st)
+	}
+
+	return nil
+}

--- a/cmd/runu/state/state.go
+++ b/cmd/runu/state/state.go
@@ -1,0 +1,126 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2023, Unikraft GmbH and The KraftKit Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+package state
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/opencontainers/runc/libcontainer/utils"
+	"github.com/spf13/cobra"
+
+	"kraftkit.sh/cmdfactory"
+	libcontainer "kraftkit.sh/libmocktainer"
+	"kraftkit.sh/log"
+)
+
+const (
+	flagRoot = "root"
+)
+
+// State implements the OCI "state" command.
+type State struct{}
+
+func New() *cobra.Command {
+	cmd, err := cmdfactory.New(&State{}, cobra.Command{
+		Short: "Output the state of a unikernel",
+		Args:  cobra.ExactArgs(1),
+		Use:   "state <unikernel-id>",
+		Long:  "The state command outputs current state information for a unikernel.",
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	return cmd
+}
+
+func (opts *State) Run(cmd *cobra.Command, args []string) (retErr error) {
+	ctx := cmd.Context()
+
+	defer func() {
+		// Make sure the error is written to the configured log destination, so
+		// that the message gets propagated through the caller (e.g. containerd-shim)
+		if retErr != nil {
+			log.G(ctx).Error(retErr)
+		}
+	}()
+
+	rootDir := cmd.Flag(flagRoot).Value.String()
+	if rootDir == "" {
+		return fmt.Errorf("state directory (--%s flag) is not set", flagRoot)
+	}
+
+	cID := args[0]
+
+	c, err := libcontainer.Load(rootDir, cID)
+	if err != nil {
+		return fmt.Errorf("loading container from saved state: %w", err)
+	}
+
+	status, err := c.Status()
+	if err != nil {
+		return fmt.Errorf("getting container status: %w", err)
+	}
+
+	state, err := c.State()
+	if err != nil {
+		return fmt.Errorf("getting container state: %w", err)
+	}
+
+	pid := state.BaseState.InitProcessPid
+	if status == libcontainer.Stopped {
+		pid = 0
+	}
+
+	bundle, annotations := utils.Annotations(state.Config.Labels)
+
+	cs := containerState{
+		OCIVersion:  state.BaseState.Config.Version,
+		ID:          state.BaseState.ID,
+		Status:      status.String(),
+		Bundle:      bundle,
+		Pid:         pid,
+		Annotations: annotations,
+		RootFS:      state.BaseState.Config.Rootfs,
+		Created:     state.BaseState.Created,
+	}
+
+	data, err := json.MarshalIndent(cs, "", "  ")
+	if err != nil {
+		return fmt.Errorf("serializing container state: %w", err)
+	}
+
+	_, _ = os.Stdout.Write(data)
+
+	return nil
+}
+
+// containerState is a JSON-serializable representation of the OCI runtime state.
+// https://github.com/opencontainers/runtime-spec/blob/v1.1.0/schema/state-schema.json
+// https://github.com/opencontainers/runtime-spec/blob/v1.1.0/runtime.md#state
+type containerState struct {
+	// The version of OCI Runtime Specification that the document complies with
+	OCIVersion string `json:"ociVersion"`
+	// Container unique ID
+	ID string `json:"id"`
+	// Runtime state of the container
+	Status string `json:"status"`
+	// Absolute path to the container bundle directory
+	Bundle string `json:"bundle"`
+	// ID of the container's init process
+	Pid int `json:"pid"`
+	// User defined annotations associated with the container
+	Annotations map[string]string `json:"annotations,omitempty"`
+
+	/* Additional attributes, for runc compatibility */
+
+	// Absolute path to the directory containing the container's root filesystem
+	RootFS string `json:"rootfs"`
+	// Creation time of the container in UTC
+	Created time.Time `json:"created"`
+}

--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	github.com/compose-spec/compose-go v1.17.0
 	github.com/containerd/containerd v1.7.2
 	github.com/containerd/nerdctl v1.4.0
+	github.com/cyphar/filepath-securejoin v0.2.4
 	github.com/dgraph-io/badger/v3 v3.2103.5
 	github.com/docker/cli v24.0.1+incompatible
 	github.com/docker/docker v24.0.4+incompatible
@@ -48,6 +49,9 @@ require (
 	github.com/onsi/gomega v1.27.10
 	github.com/opencontainers/go-digest v1.0.0
 	github.com/opencontainers/image-spec v1.1.0-rc4
+	github.com/opencontainers/runc v1.1.7
+	github.com/opencontainers/runtime-spec v1.1.0-rc.2
+	github.com/opencontainers/selinux v1.11.0
 	github.com/pkg/errors v0.9.1
 	github.com/rancher/wrangler v1.0.2
 	github.com/shirou/gopsutil/v3 v3.23.6
@@ -60,6 +64,7 @@ require (
 	github.com/xlab/treeprint v1.2.0
 	golang.org/x/oauth2 v0.10.0
 	golang.org/x/sync v0.3.0
+	golang.org/x/sys v0.10.0
 	golang.org/x/term v0.10.0
 	gopkg.in/yaml.v2 v2.4.0
 	gopkg.in/yaml.v3 v3.0.1
@@ -97,7 +102,6 @@ require (
 	github.com/containernetworking/cni v1.1.2 // indirect
 	github.com/containernetworking/plugins v1.3.0 // indirect
 	github.com/coreos/go-iptables v0.6.0 // indirect
-	github.com/cyphar/filepath-securejoin v0.2.4 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/dgraph-io/ristretto v0.1.1 // indirect
 	github.com/docker/distribution v2.8.2+incompatible // indirect
@@ -160,9 +164,6 @@ require (
 	github.com/muesli/ansi v0.0.0-20221106050444-61f0cd9a192a // indirect
 	github.com/muesli/cancelreader v0.2.2 // indirect
 	github.com/oklog/ulid v1.3.1 // indirect
-	github.com/opencontainers/runc v1.1.7 // indirect
-	github.com/opencontainers/runtime-spec v1.1.0-rc.2 // indirect
-	github.com/opencontainers/selinux v1.11.0 // indirect
 	github.com/opentracing/opentracing-go v1.2.0 // indirect
 	github.com/pelletier/go-toml v1.9.5 // indirect
 	github.com/peterhellberg/link v1.0.0 // indirect
@@ -190,7 +191,6 @@ require (
 	golang.org/x/crypto v0.11.0 // indirect
 	golang.org/x/mod v0.10.0 // indirect
 	golang.org/x/net v0.12.0 // indirect
-	golang.org/x/sys v0.10.0 // indirect
 	golang.org/x/text v0.11.0 // indirect
 	golang.org/x/tools v0.9.3 // indirect
 	google.golang.org/appengine v1.6.7 // indirect

--- a/go.sum
+++ b/go.sum
@@ -146,6 +146,7 @@ github.com/charmbracelet/lipgloss v0.6.0/go.mod h1:tHh2wr34xcHjC2HCXIlGSG1jaDF0S
 github.com/charmbracelet/lipgloss v0.7.1 h1:17WMwi7N1b1rVWOjMT+rCh7sQkvDU75B2hbZpc5Kc1E=
 github.com/charmbracelet/lipgloss v0.7.1/go.mod h1:yG0k3giv8Qj8edTCbbg6AlQ5e8KNWpFujkNawKNhE2c=
 github.com/checkpoint-restore/go-criu/v4 v4.1.0/go.mod h1:xUQBLp4RLc5zJtWY++yjOoMoB5lihDt7fai+75m+rGw=
+github.com/checkpoint-restore/go-criu/v5 v5.3.0 h1:wpFFOoomK3389ue2lAb0Boag6XPht5QYpipxmSNL4d8=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
@@ -153,6 +154,7 @@ github.com/cilium/ebpf v0.0.0-20200110133405-4032b1d8aae3/go.mod h1:MA5e5Lr8slmE
 github.com/cilium/ebpf v0.0.0-20200702112145-1c8d4c9ef775/go.mod h1:7cR51M8ViRLIdUjrmSXlK9pkrsDlLHbO8jiB8X8JnOc=
 github.com/cilium/ebpf v0.2.0/go.mod h1:To2CFviqOWL/M0gIMsvSMlqe7em/l1ALkX1PyjrX2Qs=
 github.com/cilium/ebpf v0.4.0/go.mod h1:4tRaxcgiL706VnOzHOdBlY8IEAIdxINsQBcU4xJJXRs=
+github.com/cilium/ebpf v0.9.1 h1:64sn2K3UKw8NbP/blsixRpF3nXuyhz/VjRlRzvlBRu4=
 github.com/cli/cli/v2 v2.32.0 h1:Jb3xT6me/aTVMqQJd9fQB72av6EzUi4O8Yp2NSofYgY=
 github.com/cli/cli/v2 v2.32.0/go.mod h1:KCAx0PsPRNPPXlRhgoRZfPLMIrlvGoYXbkxL+jsqjCQ=
 github.com/cli/go-gh v1.2.1 h1:xFrjejSsgPiwXFP6VYynKWwxLQcNJy3Twbu82ZDlR/o=
@@ -291,10 +293,12 @@ github.com/coreos/go-semver v0.2.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3Ee
 github.com/coreos/go-semver v0.3.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=
 github.com/coreos/go-systemd v0.0.0-20161114122254-48702e0da86b/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
 github.com/coreos/go-systemd v0.0.0-20180511133405-39ca1b05acc7/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
+github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e h1:Wf6HqHfScWJN9/ZjdUKyjop4mf3Qdd+1TvvltAvM3m8=
 github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
 github.com/coreos/go-systemd/v22 v22.0.0/go.mod h1:xO0FLkIi5MaZafQlIrOotqXZ90ih+1atmu1JpKERPPk=
 github.com/coreos/go-systemd/v22 v22.1.0/go.mod h1:xO0FLkIi5MaZafQlIrOotqXZ90ih+1atmu1JpKERPPk=
 github.com/coreos/go-systemd/v22 v22.3.2/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
+github.com/coreos/go-systemd/v22 v22.5.0 h1:RrqgGjYQKalulkV8NGVIfkXQf6YYmOyiJKk8iXXhfZs=
 github.com/coreos/pkg v0.0.0-20160727233714-3ac0863d7acf/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
 github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
 github.com/cpuguy83/go-md2man v1.0.10/go.mod h1:SmD6nW6nTyfqj6ABTjUi3V3JVMnlJmwcJI5acqYI6dE=
@@ -493,9 +497,11 @@ github.com/gobwas/glob v0.2.3 h1:A4xDbljILXROh+kObIiy5kIaPYD8e96x1tgBhUI5J+Y=
 github.com/gobwas/glob v0.2.3/go.mod h1:d3Ez4x06l9bZtSvzIay5+Yzi0fmZzPgnTbPcKjJAkT8=
 github.com/godbus/dbus v0.0.0-20151105175453-c7fdd8b5cd55/go.mod h1:/YcGZj5zSblfDWMMoOzV4fas9FZnQYTkDnsGvmh2Grw=
 github.com/godbus/dbus v0.0.0-20180201030542-885f9cc04c9c/go.mod h1:/YcGZj5zSblfDWMMoOzV4fas9FZnQYTkDnsGvmh2Grw=
+github.com/godbus/dbus v0.0.0-20190422162347-ade71ed3457e h1:BWhy2j3IXJhjCbC68FptL43tDKIq8FladmaTs3Xs7Z8=
 github.com/godbus/dbus v0.0.0-20190422162347-ade71ed3457e/go.mod h1:bBOAhwG1umN6/6ZUMtDFBMQR8jRg9O75tm9K00oMsK4=
 github.com/godbus/dbus/v5 v5.0.3/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
+github.com/godbus/dbus/v5 v5.1.0 h1:4KLkAxT3aOY8Li4FRJe/KvhoNFFxo0m6fNuFUO8QJUk=
 github.com/gogo/googleapis v1.2.0/go.mod h1:Njal3psf3qN6dwBtQfUmBZh2ybovJ0tlu3o/AC7HYjU=
 github.com/gogo/googleapis v1.4.0/go.mod h1:5YRNX2z1oM5gXdAkurHa942MDgEJyk02w4OecKY87+c=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
@@ -762,6 +768,7 @@ github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9G
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/montanaflynn/stats v0.0.0-20171201202039-1bf9dbcd8cbe/go.mod h1:wL8QJuTMNUDYhXwkmfOly8iTdp5TEcJFWZD2D7SIkUc=
 github.com/morikuni/aec v0.0.0-20170113033406-39771216ff4c/go.mod h1:BbKIizmSmc5MMPqRYbxO4ZU0S0+P200+tUnFx7PXmsc=
+github.com/mrunalp/fileutils v0.5.0 h1:NKzVxiH7eSk+OQ4M+ZYW1K6h27RUV3MI6NUTsHhU6Z4=
 github.com/mrunalp/fileutils v0.5.0/go.mod h1:M1WthSahJixYnrXQl/DFQuteStB1weuxD2QJNHXfbSQ=
 github.com/muesli/ansi v0.0.0-20211018074035-2e021307bc4b/go.mod h1:fQuZ0gauxyBcmsdE3ZT4NasjaRdxmbCS0jRHsrWu3Ho=
 github.com/muesli/ansi v0.0.0-20221106050444-61f0cd9a192a h1:jlDOeO5TU0pYlbc/y6PFguab5IjANI0Knrpg3u/ton4=
@@ -912,6 +919,7 @@ github.com/sahilm/fuzzy v0.1.0/go.mod h1:VFvziUEIMCrT6A6tw2RFIXPXXmzXbOsSHF0DOI8
 github.com/satori/go.uuid v1.2.0/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
 github.com/sclevine/agouti v3.0.0+incompatible/go.mod h1:b4WX9W9L1sfQKXeJf1mUTLZKJ48R1S7H23Ji7oFO5Bw=
 github.com/seccomp/libseccomp-golang v0.9.1/go.mod h1:GbW5+tmTXfcxTToHLXlScSlAvWlF4P2Ca7zGrPiEpWo=
+github.com/seccomp/libseccomp-golang v0.9.2-0.20220502022130-f33da4d89646 h1:RpforrEYXWkmGwJHIGnLZ3tTWStkjVVstwzNGqxX2Ds=
 github.com/sergi/go-diff v1.3.1 h1:xkr+Oxo4BOQKmkn/B9eMK0g5Kg/983T9DqqPHwYqD+8=
 github.com/sergi/go-diff v1.3.1/go.mod h1:aMJSSKb2lpPvRNec0+w3fl7LP9IOFzdc9Pa4NFbPK1I=
 github.com/shirou/gopsutil/v3 v3.23.6 h1:5y46WPI9QBKBbK7EEccUPNXpJpNrvPuTD0O2zHEHT08=
@@ -982,6 +990,7 @@ github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcU
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 github.com/syndtr/gocapability v0.0.0-20170704070218-db04d3cc01c8/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
 github.com/syndtr/gocapability v0.0.0-20180916011248-d98352740cb2/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
+github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635 h1:kdXcSzyDtseVEc4yCz2qF8ZrQvIDBJLl4S1c3GCXmoI=
 github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
 github.com/tchap/go-patricia v2.2.6+incompatible/go.mod h1:bmLyhP68RS6kStMGxByiQ23RP/odRBOTVjwp2cDyi6I=
 github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=

--- a/libmocktainer/README.md
+++ b/libmocktainer/README.md
@@ -1,0 +1,21 @@
+# libmocktainer
+
+A stripped down version of [libcontainer][1], with the bare minimum
+functionalities preserved for running Linux VMMs (QEMU, Firecracker) while
+remaining compliant with the [OCI runtime][2] flow.
+
+Its main purpose is to back Unikraft's [`runu`](../cmd/runu) OCI runtime CLI.
+
+## Maintenance
+
+To facilitate the maintenance of this library, please be mindful and keep it as
+close as possible to the upstream libcontainer code.
+
+## Copyright and license
+
+The source code of libcontainer is distributed under the terms of the [Apache
+2.0 license][3], copyright 2014 Docker, inc.
+
+[1]: https://github.com/opencontainers/runc/tree/1f25724a/libcontainer#readme
+[2]: https://github.com/opencontainers/runtime-spec/blob/v1.1.0/runtime.md
+[3]: https://github.com/opencontainers/runc/blob/1f25724a/LICENSE

--- a/libmocktainer/configs/config.go
+++ b/libmocktainer/configs/config.go
@@ -1,0 +1,214 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2014 Docker, Inc.
+// Copyright 2023 Unikraft GmbH and The KraftKit Authors
+
+package configs
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os/exec"
+	"time"
+
+	"github.com/sirupsen/logrus"
+
+	"github.com/opencontainers/runtime-spec/specs-go"
+)
+
+// Config defines configuration options for executing a process inside a contained environment.
+type Config struct {
+	// ParentDeathSignal specifies the signal that is sent to the container's process in the case
+	// that the parent process dies.
+	ParentDeathSignal int `json:"parent_death_signal"`
+
+	// Path to a directory containing the container's root filesystem.
+	Rootfs string `json:"rootfs"`
+
+	// Namespaces specifies the container's namespaces that it should setup when cloning the init process
+	// If a namespace is not provided that namespace is shared from the container's parent process
+	Namespaces Namespaces `json:"namespaces"`
+
+	// Networks specifies the container's network setup to be created
+	Networks []*Network `json:"networks"`
+
+	// Routes can be specified to create entries in the route table as the container is started
+	Routes []*Route `json:"routes"`
+
+	// AppArmorProfile specifies the profile to apply to the process running in the container and is
+	// change at the time the process is execed
+	AppArmorProfile string `json:"apparmor_profile,omitempty"`
+
+	// ProcessLabel specifies the label to apply to the process running in the container.  It is
+	// commonly used by selinux
+	ProcessLabel string `json:"process_label,omitempty"`
+
+	// Hooks are a collection of actions to perform at various container lifecycle events.
+	// CommandHooks are serialized to JSON, but other hooks are not.
+	Hooks Hooks
+
+	// Version is the version of opencontainer specification that is supported.
+	Version string `json:"version"`
+
+	// Labels are user defined metadata that is stored in the config and populated on the state
+	Labels []string `json:"labels"`
+}
+
+type (
+	HookName string
+	HookList []Hook
+	Hooks    map[HookName]HookList
+)
+
+const (
+	// Prestart commands are executed after the container namespaces are created,
+	// but before the user supplied command is executed from init.
+	// Note: This hook is now deprecated
+	// Prestart commands are called in the Runtime namespace.
+	Prestart HookName = "prestart"
+
+	// CreateRuntime commands MUST be called as part of the create operation after
+	// the runtime environment has been created but before the pivot_root has been executed.
+	// CreateRuntime is called immediately after the deprecated Prestart hook.
+	// CreateRuntime commands are called in the Runtime Namespace.
+	CreateRuntime HookName = "createRuntime"
+
+	// CreateContainer commands MUST be called as part of the create operation after
+	// the runtime environment has been created but before the pivot_root has been executed.
+	// CreateContainer commands are called in the Container namespace.
+	CreateContainer HookName = "createContainer"
+
+	// StartContainer commands MUST be called as part of the start operation and before
+	// the container process is started.
+	// StartContainer commands are called in the Container namespace.
+	StartContainer HookName = "startContainer"
+
+	// Poststart commands are executed after the container init process starts.
+	// Poststart commands are called in the Runtime Namespace.
+	Poststart HookName = "poststart"
+
+	// Poststop commands are executed after the container init process exits.
+	// Poststop commands are called in the Runtime Namespace.
+	Poststop HookName = "poststop"
+)
+
+func (hooks HookList) RunHooks(state *specs.State) error {
+	for i, h := range hooks {
+		if err := h.Run(state); err != nil {
+			return fmt.Errorf("error running hook #%d: %w", i, err)
+		}
+	}
+
+	return nil
+}
+
+func (hooks *Hooks) UnmarshalJSON(b []byte) error {
+	var state map[HookName][]CommandHook
+
+	if err := json.Unmarshal(b, &state); err != nil {
+		return err
+	}
+
+	*hooks = Hooks{}
+	for n, commandHooks := range state {
+		if len(commandHooks) == 0 {
+			continue
+		}
+
+		(*hooks)[n] = HookList{}
+		for _, h := range commandHooks {
+			(*hooks)[n] = append((*hooks)[n], h)
+		}
+	}
+
+	return nil
+}
+
+func (hooks *Hooks) MarshalJSON() ([]byte, error) {
+	serialize := func(hooks []Hook) (serializableHooks []CommandHook) {
+		for _, hook := range hooks {
+			switch chook := hook.(type) {
+			case CommandHook:
+				serializableHooks = append(serializableHooks, chook)
+			default:
+				logrus.Warnf("cannot serialize hook of type %T, skipping", hook)
+			}
+		}
+
+		return serializableHooks
+	}
+
+	return json.Marshal(map[string]interface{}{
+		"prestart":        serialize((*hooks)[Prestart]),
+		"createRuntime":   serialize((*hooks)[CreateRuntime]),
+		"createContainer": serialize((*hooks)[CreateContainer]),
+		"startContainer":  serialize((*hooks)[StartContainer]),
+		"poststart":       serialize((*hooks)[Poststart]),
+		"poststop":        serialize((*hooks)[Poststop]),
+	})
+}
+
+type Hook interface {
+	// Run executes the hook with the provided state.
+	Run(*specs.State) error
+}
+
+type Command struct {
+	Path    string         `json:"path"`
+	Args    []string       `json:"args"`
+	Env     []string       `json:"env"`
+	Dir     string         `json:"dir"`
+	Timeout *time.Duration `json:"timeout"`
+}
+
+// NewCommandHook will execute the provided command when the hook is run.
+func NewCommandHook(cmd Command) CommandHook {
+	return CommandHook{
+		Command: cmd,
+	}
+}
+
+type CommandHook struct {
+	Command
+}
+
+func (c Command) Run(s *specs.State) error {
+	b, err := json.Marshal(s)
+	if err != nil {
+		return err
+	}
+	var stdout, stderr bytes.Buffer
+	cmd := exec.Cmd{
+		Path:   c.Path,
+		Args:   c.Args,
+		Env:    c.Env,
+		Stdin:  bytes.NewReader(b),
+		Stdout: &stdout,
+		Stderr: &stderr,
+	}
+	if err := cmd.Start(); err != nil {
+		return err
+	}
+	errC := make(chan error, 1)
+	go func() {
+		err := cmd.Wait()
+		if err != nil {
+			err = fmt.Errorf("error running hook: %w, stdout: %s, stderr: %s", err, stdout.String(), stderr.String())
+		}
+		errC <- err
+	}()
+	var timerCh <-chan time.Time
+	if c.Timeout != nil {
+		timer := time.NewTimer(*c.Timeout)
+		defer timer.Stop()
+		timerCh = timer.C
+	}
+	select {
+	case err := <-errC:
+		return err
+	case <-timerCh:
+		_ = cmd.Process.Kill()
+		<-errC
+		return fmt.Errorf("hook ran past specified timeout of %.1fs", c.Timeout.Seconds())
+	}
+}

--- a/libmocktainer/configs/namespaces.go
+++ b/libmocktainer/configs/namespaces.go
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2014 Docker, Inc.
+// Copyright 2023 Unikraft GmbH and The KraftKit Authors
+
+package configs
+
+type NamespaceType string
+
+type Namespaces []Namespace

--- a/libmocktainer/configs/namespaces_linux.go
+++ b/libmocktainer/configs/namespaces_linux.go
@@ -1,0 +1,97 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2014 Docker, Inc.
+// Copyright 2023 Unikraft GmbH and The KraftKit Authors
+
+package configs
+
+import (
+	"fmt"
+	"os"
+	"sync"
+)
+
+const (
+	NEWNET NamespaceType = "NEWNET"
+)
+
+var (
+	nsLock              sync.Mutex
+	supportedNamespaces = make(map[NamespaceType]bool)
+)
+
+// NsName converts the namespace type to its filename
+func NsName(ns NamespaceType) string {
+	switch ns {
+	case NEWNET:
+		return "net"
+	}
+	return ""
+}
+
+// IsNamespaceSupported returns whether a namespace is available or
+// not
+func IsNamespaceSupported(ns NamespaceType) bool {
+	nsLock.Lock()
+	defer nsLock.Unlock()
+	supported, ok := supportedNamespaces[ns]
+	if ok {
+		return supported
+	}
+	nsFile := NsName(ns)
+	// if the namespace type is unknown, just return false
+	if nsFile == "" {
+		return false
+	}
+	_, err := os.Stat("/proc/self/ns/" + nsFile)
+	// a namespace is supported if it exists and we have permissions to read it
+	supported = err == nil
+	supportedNamespaces[ns] = supported
+	return supported
+}
+
+func NamespaceTypes() []NamespaceType {
+	return []NamespaceType{
+		NEWNET,
+	}
+}
+
+// Namespace defines configuration for each namespace.  It specifies an
+// alternate path that is able to be joined via setns.
+type Namespace struct {
+	Type NamespaceType `json:"type"`
+	Path string        `json:"path"`
+}
+
+func (n *Namespace) GetPath(pid int) string {
+	return fmt.Sprintf("/proc/%d/ns/%s", pid, NsName(n.Type))
+}
+
+func (n *Namespaces) Add(t NamespaceType, path string) {
+	i := n.index(t)
+	if i == -1 {
+		*n = append(*n, Namespace{Type: t, Path: path})
+		return
+	}
+	(*n)[i].Path = path
+}
+
+func (n *Namespaces) index(t NamespaceType) int {
+	for i, ns := range *n {
+		if ns.Type == t {
+			return i
+		}
+	}
+	return -1
+}
+
+func (n *Namespaces) Contains(t NamespaceType) bool {
+	return n.index(t) != -1
+}
+
+func (n *Namespaces) PathOf(t NamespaceType) string {
+	i := n.index(t)
+	if i == -1 {
+		return ""
+	}
+	return (*n)[i].Path
+}

--- a/libmocktainer/configs/namespaces_syscall.go
+++ b/libmocktainer/configs/namespaces_syscall.go
@@ -1,0 +1,27 @@
+//go:build linux
+// +build linux
+
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2014 Docker, Inc.
+// Copyright 2023 Unikraft GmbH and The KraftKit Authors
+
+package configs
+
+import "golang.org/x/sys/unix"
+
+var namespaceInfo = map[NamespaceType]int{
+	NEWNET: unix.CLONE_NEWNET,
+}
+
+// CloneFlags parses the container's Namespaces options to set the correct
+// flags on clone, unshare. This function returns flags only for new namespaces.
+func (n *Namespaces) CloneFlags() uintptr {
+	var flag int
+	for _, v := range *n {
+		if v.Path != "" {
+			continue
+		}
+		flag |= namespaceInfo[v.Type]
+	}
+	return uintptr(flag)
+}

--- a/libmocktainer/configs/network.go
+++ b/libmocktainer/configs/network.go
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2014 Docker, Inc.
+// Copyright 2023 Unikraft GmbH and The KraftKit Authors
+
+package configs
+
+// Network defines configuration for a container's networking stack
+//
+// The network configuration can be omitted from a container causing the
+// container to be setup with the host's networking stack
+type Network struct {
+	// Type sets the networks type, commonly veth and loopback
+	Type string `json:"type"`
+
+	// Name of the network interface
+	Name string `json:"name"`
+
+	// The bridge to use.
+	Bridge string `json:"bridge"`
+
+	// MacAddress contains the MAC address to set on the network interface
+	MacAddress string `json:"mac_address"`
+
+	// Address contains the IPv4 and mask to set on the network interface
+	Address string `json:"address"`
+
+	// Gateway sets the gateway address that is used as the default for the interface
+	Gateway string `json:"gateway"`
+
+	// IPv6Address contains the IPv6 and mask to set on the network interface
+	IPv6Address string `json:"ipv6_address"`
+
+	// IPv6Gateway sets the ipv6 gateway address that is used as the default for the interface
+	IPv6Gateway string `json:"ipv6_gateway"`
+
+	// Mtu sets the mtu value for the interface and will be mirrored on both the host and
+	// container's interfaces if a pair is created, specifically in the case of type veth
+	// Note: This does not apply to loopback interfaces.
+	Mtu int `json:"mtu"`
+
+	// TxQueueLen sets the tx_queuelen value for the interface and will be mirrored on both the host and
+	// container's interfaces if a pair is created, specifically in the case of type veth
+	// Note: This does not apply to loopback interfaces.
+	TxQueueLen int `json:"txqueuelen"`
+
+	// HostInterfaceName is a unique name of a veth pair that resides on in the host interface of the
+	// container.
+	HostInterfaceName string `json:"host_interface_name"`
+
+	// HairpinMode specifies if hairpin NAT should be enabled on the virtual interface
+	// bridge port in the case of type veth
+	// Note: This is unsupported on some systems.
+	// Note: This does not apply to loopback interfaces.
+	HairpinMode bool `json:"hairpin_mode"`
+}
+
+// Route defines a routing table entry.
+//
+// Routes can be specified to create entries in the routing table as the container
+// is started.
+//
+// All of destination, source, and gateway should be either IPv4 or IPv6.
+// One of the three options must be present, and omitted entries will use their
+// IP family default for the route table.  For IPv4 for example, setting the
+// gateway to 1.2.3.4 and the interface to eth0 will set up a standard
+// destination of 0.0.0.0(or *) when viewed in the route table.
+type Route struct {
+	// Destination specifies the destination IP address and mask in the CIDR form.
+	Destination string `json:"destination"`
+
+	// Source specifies the source IP address and mask in the CIDR form.
+	Source string `json:"source"`
+
+	// Gateway specifies the gateway IP address.
+	Gateway string `json:"gateway"`
+
+	// InterfaceName specifies the device to set this route up for, for example eth0.
+	InterfaceName string `json:"interface_name"`
+}

--- a/libmocktainer/configs/validate/validator.go
+++ b/libmocktainer/configs/validate/validator.go
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2014 Docker, Inc.
+// Copyright 2023 Unikraft GmbH and The KraftKit Authors
+
+package validate
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"kraftkit.sh/libmocktainer/configs"
+)
+
+type check func(config *configs.Config) error
+
+func Validate(config *configs.Config) error {
+	checks := []check{
+		rootfs,
+	}
+	for _, c := range checks {
+		if err := c(config); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// rootfs validates if the rootfs is an absolute path and is not a symlink
+// to the container's root filesystem.
+func rootfs(config *configs.Config) error {
+	if _, err := os.Stat(config.Rootfs); err != nil {
+		return fmt.Errorf("invalid rootfs: %w", err)
+	}
+	cleaned, err := filepath.Abs(config.Rootfs)
+	if err != nil {
+		return fmt.Errorf("invalid rootfs: %w", err)
+	}
+	if cleaned, err = filepath.EvalSymlinks(cleaned); err != nil {
+		return fmt.Errorf("invalid rootfs: %w", err)
+	}
+	if filepath.Clean(config.Rootfs) != cleaned {
+		return errors.New("invalid rootfs: not an absolute path, or a symlink")
+	}
+	return nil
+}

--- a/libmocktainer/container.go
+++ b/libmocktainer/container.go
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2014 Docker, Inc.
+// Copyright 2023 Unikraft GmbH and The KraftKit Authors
+
+package libmocktainer
+
+import (
+	"time"
+
+	"kraftkit.sh/libmocktainer/configs"
+)
+
+// Status is the status of a container.
+type Status int
+
+const (
+	// Created is the status that denotes the container exists but has not been run yet.
+	Created Status = iota
+	// Running is the status that denotes the container exists and is running.
+	Running
+	// Stopped is the status that denotes the container does not have a created or running process.
+	Stopped
+)
+
+func (s Status) String() string {
+	switch s {
+	case Created:
+		return "created"
+	case Running:
+		return "running"
+	case Stopped:
+		return "stopped"
+	default:
+		return "unknown"
+	}
+}
+
+// BaseState represents the platform agnostic pieces relating to a
+// running container's state
+type BaseState struct {
+	// ID is the container ID.
+	ID string `json:"id"`
+
+	// InitProcessPid is the init process id in the parent namespace.
+	InitProcessPid int `json:"init_process_pid"`
+
+	// InitProcessStartTime is the init process start time in clock cycles since boot time.
+	InitProcessStartTime uint64 `json:"init_process_start"`
+
+	// Created is the unix timestamp for the creation time of the container in UTC
+	Created time.Time `json:"created"`
+
+	// Config is the container's configuration.
+	Config configs.Config `json:"config"`
+}

--- a/libmocktainer/container_linux.go
+++ b/libmocktainer/container_linux.go
@@ -1,0 +1,639 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2014 Docker, Inc.
+// Copyright 2023 Unikraft GmbH and The KraftKit Authors
+
+package libmocktainer
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/opencontainers/runtime-spec/specs-go"
+	"github.com/sirupsen/logrus"
+	"github.com/vishvananda/netlink/nl"
+	"golang.org/x/sys/unix"
+
+	"github.com/opencontainers/runc/libcontainer/system"
+	"github.com/opencontainers/runc/libcontainer/utils"
+
+	"kraftkit.sh/libmocktainer/configs"
+)
+
+const stdioFdCount = 3
+
+// Container is a libcontainer container object.
+type Container struct {
+	id                   string
+	root                 string
+	config               *configs.Config
+	initProcess          parentProcess
+	initProcessStartTime uint64
+	m                    sync.Mutex
+	state                containerState
+	created              time.Time
+	fifo                 *os.File
+}
+
+// State represents a running container's state
+type State struct {
+	BaseState
+
+	// Platform specific fields below here
+
+	// NamespacePaths are filepaths to the container's namespaces. Key is the namespace type
+	// with the value as the path.
+	NamespacePaths map[configs.NamespaceType]string `json:"namespace_paths"`
+}
+
+// ID returns the container's unique ID
+func (c *Container) ID() string {
+	return c.id
+}
+
+// Config returns the container's configuration
+func (c *Container) Config() configs.Config {
+	return *c.config
+}
+
+// Status returns the current status of the container.
+func (c *Container) Status() (Status, error) {
+	c.m.Lock()
+	defer c.m.Unlock()
+	return c.currentStatus()
+}
+
+// State returns the current container's state information.
+func (c *Container) State() (*State, error) {
+	c.m.Lock()
+	defer c.m.Unlock()
+	return c.currentState()
+}
+
+// Start starts a process inside the container. Returns error if process fails
+// to start. You can track process lifecycle with passed Process structure.
+func (c *Container) Start(process *Process) error {
+	c.m.Lock()
+	defer c.m.Unlock()
+	if err := c.createExecFifo(); err != nil {
+		return err
+	}
+	if err := c.start(process); err != nil {
+		c.deleteExecFifo()
+		return err
+	}
+	return nil
+}
+
+// Exec signals the container to exec the users process at the end of the init.
+func (c *Container) Exec() error {
+	c.m.Lock()
+	defer c.m.Unlock()
+	return c.exec()
+}
+
+func (c *Container) exec() error {
+	path := filepath.Join(c.root, execFifoFilename)
+	pid := c.initProcess.pid()
+	blockingFifoOpenCh := awaitFifoOpen(path)
+	for {
+		select {
+		case result := <-blockingFifoOpenCh:
+			return handleFifoResult(result)
+
+		case <-time.After(time.Millisecond * 100):
+			stat, err := system.Stat(pid)
+			if err != nil || stat.State == system.Zombie {
+				// could be because process started, ran, and completed between our 100ms timeout and our system.Stat() check.
+				// see if the fifo exists and has data (with a non-blocking open, which will succeed if the writing process is complete).
+				if err := handleFifoResult(fifoOpen(path, false)); err != nil {
+					return errors.New("container process is already dead")
+				}
+				return nil
+			}
+		}
+	}
+}
+
+func readFromExecFifo(execFifo io.Reader) error {
+	data, err := io.ReadAll(execFifo)
+	if err != nil {
+		return err
+	}
+	if len(data) <= 0 {
+		return errors.New("cannot start an already running container")
+	}
+	return nil
+}
+
+func awaitFifoOpen(path string) <-chan openResult {
+	fifoOpened := make(chan openResult)
+	go func() {
+		result := fifoOpen(path, true)
+		fifoOpened <- result
+	}()
+	return fifoOpened
+}
+
+func fifoOpen(path string, block bool) openResult {
+	flags := os.O_RDONLY
+	if !block {
+		flags |= unix.O_NONBLOCK
+	}
+	f, err := os.OpenFile(path, flags, 0)
+	if err != nil {
+		return openResult{err: fmt.Errorf("exec fifo: %w", err)}
+	}
+	return openResult{file: f}
+}
+
+func handleFifoResult(result openResult) error {
+	if result.err != nil {
+		return result.err
+	}
+	f := result.file
+	defer f.Close()
+	if err := readFromExecFifo(f); err != nil {
+		return err
+	}
+	return os.Remove(f.Name())
+}
+
+type openResult struct {
+	file *os.File
+	err  error
+}
+
+func (c *Container) start(process *Process) (retErr error) {
+	parent, err := c.newParentProcess(process)
+	if err != nil {
+		return fmt.Errorf("unable to create new parent process: %w", err)
+	}
+
+	logsDone := parent.forwardChildLogs()
+	if logsDone != nil {
+		defer func() {
+			// Wait for log forwarder to finish. This depends on
+			// runc init closing the _LIBCONTAINER_LOGPIPE log fd.
+			err := <-logsDone
+			if err != nil && retErr == nil {
+				retErr = fmt.Errorf("unable to forward init logs: %w", err)
+			}
+		}()
+	}
+
+	if err := parent.start(); err != nil {
+		return fmt.Errorf("unable to start container process: %w", err)
+	}
+
+	c.fifo.Close()
+	if c.config.Hooks != nil {
+		s, err := c.currentOCIState()
+		if err != nil {
+			return err
+		}
+
+		if err := c.config.Hooks[configs.Poststart].RunHooks(s); err != nil {
+			if err := ignoreTerminateErrors(parent.terminate()); err != nil {
+				logrus.Warn(fmt.Errorf("error running poststart hook: %w", err))
+			}
+			return err
+		}
+	}
+	return nil
+}
+
+// Signal sends a specified signal to container's init.
+//
+// When s is SIGKILL and the container does not have its own PID namespace, all
+// the container's processes are killed. In this scenario, the libcontainer
+// user may be required to implement a proper child reaper.
+func (c *Container) Signal(s os.Signal) error {
+	c.m.Lock()
+	defer c.m.Unlock()
+	status, err := c.currentStatus()
+	if err != nil {
+		return err
+	}
+	// To avoid a PID reuse attack, don't kill non-running container.
+	switch status {
+	case Running, Created:
+	default:
+		return ErrNotRunning
+	}
+
+	err = c.initProcess.signal(s)
+	if err != nil {
+		return fmt.Errorf("unable to signal init: %w", err)
+	}
+	return nil
+}
+
+func (c *Container) createExecFifo() error {
+	rootuid := 0
+	rootgid := 0
+
+	fifoName := filepath.Join(c.root, execFifoFilename)
+	if _, err := os.Stat(fifoName); err == nil {
+		return fmt.Errorf("exec fifo %s already exists", fifoName)
+	}
+	oldMask := unix.Umask(0o000)
+	if err := unix.Mkfifo(fifoName, 0o622); err != nil {
+		unix.Umask(oldMask)
+		return err
+	}
+	unix.Umask(oldMask)
+	return os.Chown(fifoName, rootuid, rootgid)
+}
+
+func (c *Container) deleteExecFifo() {
+	fifoName := filepath.Join(c.root, execFifoFilename)
+	os.Remove(fifoName)
+}
+
+// includeExecFifo opens the container's execfifo as a pathfd, so that the
+// container cannot access the statedir (and the FIFO itself remains
+// un-opened). It then adds the FifoFd to the given exec.Cmd as an inherited
+// fd, with _LIBCONTAINER_FIFOFD set to its fd number.
+func (c *Container) includeExecFifo(cmd *exec.Cmd) error {
+	fifoName := filepath.Join(c.root, execFifoFilename)
+	fifo, err := os.OpenFile(fifoName, unix.O_PATH|unix.O_CLOEXEC, 0)
+	if err != nil {
+		return err
+	}
+	c.fifo = fifo
+
+	cmd.ExtraFiles = append(cmd.ExtraFiles, fifo)
+	cmd.Env = append(cmd.Env,
+		"_LIBCONTAINER_FIFOFD="+strconv.Itoa(stdioFdCount+len(cmd.ExtraFiles)-1))
+	return nil
+}
+
+func (c *Container) newParentProcess(p *Process) (parentProcess, error) {
+	parentInitPipe, childInitPipe, err := utils.NewSockPair("init")
+	if err != nil {
+		return nil, fmt.Errorf("unable to create init pipe: %w", err)
+	}
+	messageSockPair := filePair{parentInitPipe, childInitPipe}
+
+	parentLogPipe, childLogPipe, err := os.Pipe()
+	if err != nil {
+		return nil, fmt.Errorf("unable to create log pipe: %w", err)
+	}
+	logFilePair := filePair{parentLogPipe, childLogPipe}
+
+	cmd := c.commandTemplate(p, childInitPipe, childLogPipe)
+
+	if err := c.includeExecFifo(cmd); err != nil {
+		return nil, fmt.Errorf("unable to setup exec fifo: %w", err)
+	}
+	return c.newInitProcess(p, cmd, messageSockPair, logFilePair)
+}
+
+func (c *Container) commandTemplate(p *Process, childInitPipe *os.File, childLogPipe *os.File) *exec.Cmd {
+	cmd := exec.Command("/proc/self/exe", "init")
+	cmd.Args[0] = os.Args[0]
+	cmd.Stdin = p.Stdin
+	cmd.Stdout = p.Stdout
+	cmd.Stderr = p.Stderr
+	cmd.Dir = c.config.Rootfs
+	if cmd.SysProcAttr == nil {
+		cmd.SysProcAttr = &unix.SysProcAttr{}
+	}
+	cmd.Env = append(cmd.Env, "GOMAXPROCS="+os.Getenv("GOMAXPROCS"))
+	cmd.ExtraFiles = append(cmd.ExtraFiles, p.ExtraFiles...)
+	cmd.ExtraFiles = append(cmd.ExtraFiles, childInitPipe)
+	cmd.Env = append(cmd.Env,
+		"_LIBCONTAINER_INITPIPE="+strconv.Itoa(stdioFdCount+len(cmd.ExtraFiles)-1),
+		"_LIBCONTAINER_STATEDIR="+c.root,
+	)
+
+	cmd.ExtraFiles = append(cmd.ExtraFiles, childLogPipe)
+	cmd.Env = append(cmd.Env,
+		"_LIBCONTAINER_LOGPIPE="+strconv.Itoa(stdioFdCount+len(cmd.ExtraFiles)-1))
+	if p.LogLevel != "" {
+		cmd.Env = append(cmd.Env, "_LIBCONTAINER_LOGLEVEL="+p.LogLevel)
+	}
+
+	// NOTE: when running a container with no PID namespace and the parent process spawning the container is
+	// PID1 the pdeathsig is being delivered to the container's init process by the kernel for some reason
+	// even with the parent still running.
+	if c.config.ParentDeathSignal > 0 {
+		cmd.SysProcAttr.Pdeathsig = unix.Signal(c.config.ParentDeathSignal)
+	}
+	return cmd
+}
+
+func (c *Container) newInitProcess(p *Process, cmd *exec.Cmd, messageSockPair, logFilePair filePair) (*initProcess, error) {
+	cmd.Env = append(cmd.Env, "_LIBCONTAINER_INITTYPE="+string(initStandard))
+	nsMaps := make(map[configs.NamespaceType]string)
+	for _, ns := range c.config.Namespaces {
+		if ns.Path != "" {
+			nsMaps[ns.Type] = ns.Path
+		}
+	}
+	data, err := c.bootstrapData(c.config.Namespaces.CloneFlags(), nsMaps, initStandard)
+	if err != nil {
+		return nil, err
+	}
+
+	init := &initProcess{
+		cmd:             cmd,
+		messageSockPair: messageSockPair,
+		logFilePair:     logFilePair,
+		config:          c.newInitConfig(p),
+		container:       c,
+		process:         p,
+		bootstrapData:   data,
+	}
+	c.initProcess = init
+	return init, nil
+}
+
+func (c *Container) newInitConfig(process *Process) *initConfig {
+	cfg := &initConfig{
+		Config:           c.config,
+		Args:             process.Args,
+		Env:              process.Env,
+		PassedFilesCount: len(process.ExtraFiles),
+		ContainerID:      c.ID(),
+		AppArmorProfile:  c.config.AppArmorProfile,
+		ProcessLabel:     c.config.ProcessLabel,
+	}
+	if process.AppArmorProfile != "" {
+		cfg.AppArmorProfile = process.AppArmorProfile
+	}
+	if process.Label != "" {
+		cfg.ProcessLabel = process.Label
+	}
+	return cfg
+}
+
+// Destroy destroys the container, if its in a valid state.
+//
+// Any event registrations are removed before the container is destroyed.
+// No error is returned if the container is already destroyed.
+//
+// Running containers must first be stopped using Signal.
+// Paused containers must first be resumed using Resume.
+func (c *Container) Destroy() error {
+	c.m.Lock()
+	defer c.m.Unlock()
+	return c.state.destroy()
+}
+
+func (c *Container) updateState(process parentProcess) (*State, error) {
+	if process != nil {
+		c.initProcess = process
+	}
+	state, err := c.currentState()
+	if err != nil {
+		return nil, err
+	}
+	err = c.saveState(state)
+	if err != nil {
+		return nil, err
+	}
+	return state, nil
+}
+
+func (c *Container) saveState(s *State) (retErr error) {
+	tmpFile, err := os.CreateTemp(c.root, "state-")
+	if err != nil {
+		return err
+	}
+
+	defer func() {
+		if retErr != nil {
+			tmpFile.Close()
+			os.Remove(tmpFile.Name())
+		}
+	}()
+
+	err = utils.WriteJSON(tmpFile, s)
+	if err != nil {
+		return err
+	}
+	err = tmpFile.Close()
+	if err != nil {
+		return err
+	}
+
+	stateFilePath := filepath.Join(c.root, stateFilename)
+	return os.Rename(tmpFile.Name(), stateFilePath)
+}
+
+func (c *Container) currentStatus() (Status, error) {
+	if err := c.refreshState(); err != nil {
+		return -1, err
+	}
+	return c.state.status(), nil
+}
+
+// refreshState needs to be called to verify that the current state on the
+// container is what is true.  Because consumers of libcontainer can use it
+// out of process we need to verify the container's status based on runtime
+// information and not rely on our in process info.
+func (c *Container) refreshState() error {
+	t := c.runType()
+	switch t {
+	case Created:
+		return c.state.transition(&createdState{c: c})
+	case Running:
+		return c.state.transition(&runningState{c: c})
+	}
+	return c.state.transition(&stoppedState{c: c})
+}
+
+func (c *Container) runType() Status {
+	if c.initProcess == nil {
+		return Stopped
+	}
+	pid := c.initProcess.pid()
+	stat, err := system.Stat(pid)
+	if err != nil {
+		return Stopped
+	}
+	if stat.StartTime != c.initProcessStartTime || stat.State == system.Zombie || stat.State == system.Dead {
+		return Stopped
+	}
+	// We'll create exec fifo and blocking on it after container is created,
+	// and delete it after start container.
+	if _, err := os.Stat(filepath.Join(c.root, execFifoFilename)); err == nil {
+		return Created
+	}
+	return Running
+}
+
+func (c *Container) currentState() (*State, error) {
+	var (
+		startTime uint64
+		pid       = -1
+	)
+	if c.initProcess != nil {
+		pid = c.initProcess.pid()
+		startTime, _ = c.initProcess.startTime()
+	}
+
+	state := &State{
+		BaseState: BaseState{
+			ID:                   c.ID(),
+			Config:               *c.config,
+			InitProcessPid:       pid,
+			InitProcessStartTime: startTime,
+			Created:              c.created,
+		},
+		NamespacePaths: make(map[configs.NamespaceType]string),
+	}
+	if pid > 0 {
+		for _, ns := range c.config.Namespaces {
+			state.NamespacePaths[ns.Type] = ns.GetPath(pid)
+		}
+		for _, nsType := range configs.NamespaceTypes() {
+			if !configs.IsNamespaceSupported(nsType) {
+				continue
+			}
+			if _, ok := state.NamespacePaths[nsType]; !ok {
+				ns := configs.Namespace{Type: nsType}
+				state.NamespacePaths[ns.Type] = ns.GetPath(pid)
+			}
+		}
+	}
+	return state, nil
+}
+
+func (c *Container) currentOCIState() (*specs.State, error) {
+	bundle, annotations := utils.Annotations(c.config.Labels)
+	state := &specs.State{
+		Version:     specs.Version,
+		ID:          c.ID(),
+		Bundle:      bundle,
+		Annotations: annotations,
+	}
+	status, err := c.currentStatus()
+	if err != nil {
+		return nil, err
+	}
+	state.Status = specs.ContainerState(status.String())
+	if status != Stopped {
+		if c.initProcess != nil {
+			state.Pid = c.initProcess.pid()
+		}
+	}
+	return state, nil
+}
+
+// orderNamespacePaths sorts namespace paths into a list of paths that we
+// can setns in order.
+func (c *Container) orderNamespacePaths(namespaces map[configs.NamespaceType]string) ([]string, error) {
+	paths := []string{}
+	for _, ns := range configs.NamespaceTypes() {
+
+		// Remove namespaces that we don't need to join.
+		if !c.config.Namespaces.Contains(ns) {
+			continue
+		}
+
+		if p, ok := namespaces[ns]; ok && p != "" {
+			// check if the requested namespace is supported
+			if !configs.IsNamespaceSupported(ns) {
+				return nil, fmt.Errorf("namespace %s is not supported", ns)
+			}
+			// only set to join this namespace if it exists
+			if _, err := os.Lstat(p); err != nil {
+				return nil, fmt.Errorf("namespace path: %w", err)
+			}
+			// do not allow namespace path with comma as we use it to separate
+			// the namespace paths
+			if strings.ContainsRune(p, ',') {
+				return nil, fmt.Errorf("invalid namespace path %s", p)
+			}
+			paths = append(paths, fmt.Sprintf("%s:%s", configs.NsName(ns), p))
+		}
+
+	}
+
+	return paths, nil
+}
+
+// netlinkError is an error wrapper type for use by custom netlink message
+// types. Panics with errors are wrapped in netlinkError so that the recover
+// in bootstrapData can distinguish intentional panics.
+type netlinkError struct{ error }
+
+// bootstrapData encodes the necessary data in netlink binary format
+// as a io.Reader.
+// Consumer can write the data to a bootstrap program
+// such as one that uses nsenter package to bootstrap the container's
+// init process correctly, i.e. with correct namespaces, uid/gid
+// mapping etc.
+func (c *Container) bootstrapData(cloneFlags uintptr, nsMaps map[configs.NamespaceType]string, _ initType) (_ io.Reader, Err error) {
+	// create the netlink message
+	r := nl.NewNetlinkRequest(int(InitMsg), 0)
+
+	// Our custom messages cannot bubble up an error using returns, instead
+	// they will panic with the specific error type, netlinkError. In that
+	// case, recover from the panic and return that as an error.
+	defer func() {
+		if r := recover(); r != nil {
+			if e, ok := r.(netlinkError); ok {
+				Err = e.error
+			} else {
+				panic(r)
+			}
+		}
+	}()
+
+	// write cloneFlags
+	r.AddData(&Int32msg{
+		Type:  CloneFlagsAttr,
+		Value: uint32(cloneFlags),
+	})
+
+	// write custom namespace paths
+	if len(nsMaps) > 0 {
+		nsPaths, err := c.orderNamespacePaths(nsMaps)
+		if err != nil {
+			return nil, err
+		}
+		r.AddData(&Bytemsg{
+			Type:  NsPathsAttr,
+			Value: []byte(strings.Join(nsPaths, ",")),
+		})
+	}
+
+	return bytes.NewReader(r.Serialize()), nil
+}
+
+// ignoreTerminateErrors returns nil if the given err matches an error known
+// to indicate that the terminate occurred successfully or err was nil, otherwise
+// err is returned unaltered.
+func ignoreTerminateErrors(err error) error {
+	if err == nil {
+		return nil
+	}
+	// terminate() might return an error from either Kill or Wait.
+	// The (*Cmd).Wait documentation says: "If the command fails to run
+	// or doesn't complete successfully, the error is of type *ExitError".
+	// Filter out such errors (like "exit status 1" or "signal: killed").
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) {
+		return nil
+	}
+	if errors.Is(err, os.ErrProcessDone) {
+		return nil
+	}
+	s := err.Error()
+	if strings.Contains(s, "Wait was already called") {
+		return nil
+	}
+	return err
+}

--- a/libmocktainer/error.go
+++ b/libmocktainer/error.go
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2014 Docker, Inc.
+// Copyright 2023 Unikraft GmbH and The KraftKit Authors
+
+package libmocktainer
+
+import "errors"
+
+var (
+	ErrExist      = errors.New("container with given ID already exists")
+	ErrInvalidID  = errors.New("invalid container ID format")
+	ErrNotExist   = errors.New("container does not exist")
+	ErrRunning    = errors.New("container still running")
+	ErrNotRunning = errors.New("container not running")
+)

--- a/libmocktainer/factory_linux.go
+++ b/libmocktainer/factory_linux.go
@@ -1,0 +1,173 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2014 Docker, Inc.
+// Copyright 2023 Unikraft GmbH and The KraftKit Authors
+
+package libmocktainer
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+
+	securejoin "github.com/cyphar/filepath-securejoin"
+
+	"github.com/opencontainers/runc/libcontainer/utils"
+
+	"kraftkit.sh/libmocktainer/configs"
+	"kraftkit.sh/libmocktainer/configs/validate"
+)
+
+const (
+	stateFilename    = "state.json"
+	execFifoFilename = "exec.fifo"
+)
+
+// Create creates a new container with the given id inside a given state
+// directory (root), and returns a Container object.
+//
+// The root is a state directory which many containers can share. It can be
+// used later to get the list of containers, or to get information about a
+// particular container (see Load).
+//
+// The id must not be empty and consist of only the following characters:
+// ASCII letters, digits, underscore, plus, minus, period. The id must be
+// unique and non-existent for the given root path.
+func Create(root, id string, config *configs.Config) (*Container, error) {
+	if root == "" {
+		return nil, errors.New("root not set")
+	}
+	if err := validateID(id); err != nil {
+		return nil, err
+	}
+	if err := validate.Validate(config); err != nil {
+		return nil, err
+	}
+	if err := os.MkdirAll(root, 0o700); err != nil {
+		return nil, err
+	}
+	containerRoot, err := securejoin.SecureJoin(root, id)
+	if err != nil {
+		return nil, err
+	}
+	if _, err := os.Stat(containerRoot); err == nil {
+		return nil, ErrExist
+	} else if !os.IsNotExist(err) {
+		return nil, err
+	}
+
+	// Parent directory is already created above, so Mkdir is enough.
+	if err := os.Mkdir(containerRoot, 0o711); err != nil {
+		return nil, err
+	}
+	c := &Container{
+		id:     id,
+		root:   containerRoot,
+		config: config,
+	}
+	c.state = &stoppedState{c: c}
+	return c, nil
+}
+
+// Load takes a path to the state directory (root) and an id of an existing
+// container, and returns a Container object reconstructed from the saved
+// state. This presents a read only view of the container.
+func Load(root, id string) (*Container, error) {
+	if root == "" {
+		return nil, errors.New("root not set")
+	}
+	// when load, we need to check id is valid or not.
+	if err := validateID(id); err != nil {
+		return nil, err
+	}
+	containerRoot, err := securejoin.SecureJoin(root, id)
+	if err != nil {
+		return nil, err
+	}
+	state, err := loadState(containerRoot)
+	if err != nil {
+		return nil, err
+	}
+	r := &nonChildProcess{
+		processPid:       state.InitProcessPid,
+		processStartTime: state.InitProcessStartTime,
+	}
+	c := &Container{
+		initProcess:          r,
+		initProcessStartTime: state.InitProcessStartTime,
+		id:                   id,
+		config:               &state.Config,
+		root:                 containerRoot,
+		created:              state.Created,
+	}
+	c.state = &loadedState{c: c}
+	if err := c.refreshState(); err != nil {
+		return nil, err
+	}
+	return c, nil
+}
+
+func loadState(root string) (*State, error) {
+	stateFilePath, err := securejoin.SecureJoin(root, stateFilename)
+	if err != nil {
+		return nil, err
+	}
+	f, err := os.Open(stateFilePath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, ErrNotExist
+		}
+		return nil, err
+	}
+	defer f.Close()
+	var state *State
+	if err := json.NewDecoder(f).Decode(&state); err != nil {
+		return nil, err
+	}
+	return state, nil
+}
+
+// validateID checks if the supplied container ID is valid, returning
+// the ErrInvalidID in case it is not.
+//
+// The format of valid ID was never formally defined, instead the code
+// was modified to allow or disallow specific characters.
+//
+// Currently, a valid ID is a non-empty string consisting only of
+// the following characters:
+// - uppercase (A-Z) and lowercase (a-z) Latin letters;
+// - digits (0-9);
+// - underscore (_);
+// - plus sign (+);
+// - minus sign (-);
+// - period (.).
+//
+// In addition, IDs that can't be used to represent a file name
+// (such as . or ..) are rejected.
+func validateID(id string) error {
+	if len(id) < 1 {
+		return ErrInvalidID
+	}
+
+	// Allowed characters: 0-9 A-Z a-z _ + - .
+	for i := 0; i < len(id); i++ {
+		c := id[i]
+		switch {
+		case c >= 'a' && c <= 'z':
+		case c >= 'A' && c <= 'Z':
+		case c >= '0' && c <= '9':
+		case c == '_':
+		case c == '+':
+		case c == '-':
+		case c == '.':
+		default:
+			return ErrInvalidID
+		}
+
+	}
+
+	if string(os.PathSeparator)+id != utils.CleanPath(string(os.PathSeparator)+id) {
+		return ErrInvalidID
+	}
+
+	return nil
+}

--- a/libmocktainer/init_linux.go
+++ b/libmocktainer/init_linux.go
@@ -1,0 +1,273 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2014 Docker, Inc.
+// Copyright 2023 Unikraft GmbH and The KraftKit Authors
+
+package libmocktainer
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net"
+	"os"
+	"runtime"
+	"runtime/debug"
+	"strconv"
+	"strings"
+
+	"github.com/opencontainers/runtime-spec/specs-go"
+	"github.com/sirupsen/logrus"
+	"github.com/vishvananda/netlink"
+	"golang.org/x/sys/unix"
+
+	"github.com/opencontainers/runc/libcontainer/utils"
+
+	"kraftkit.sh/libmocktainer/configs"
+)
+
+type initType string
+
+const (
+	initStandard initType = "standard"
+)
+
+type pid struct {
+	Pid           int `json:"stage2_pid"`
+	PidFirstChild int `json:"stage1_pid"`
+}
+
+// network is an internal struct used to setup container networks.
+type network struct {
+	configs.Network
+
+	// TempVethPeerName is a unique temporary veth peer name that was placed into
+	// the container's namespace.
+	TempVethPeerName string `json:"temp_veth_peer_name"`
+}
+
+type mountFds struct{}
+
+// initConfig is used for transferring parameters from Exec() to Init()
+type initConfig struct {
+	Args             []string        `json:"args"`
+	Env              []string        `json:"env"`
+	ProcessLabel     string          `json:"process_label"`
+	AppArmorProfile  string          `json:"apparmor_profile"`
+	Config           *configs.Config `json:"config"`
+	Networks         []*network      `json:"network"`
+	PassedFilesCount int             `json:"passed_files_count"`
+	ContainerID      string          `json:"containerid"`
+	SpecState        *specs.State    `json:"spec_state,omitempty"`
+}
+
+// Init is part of "runc init" implementation.
+func Init() {
+	runtime.GOMAXPROCS(1)
+	runtime.LockOSThread()
+
+	if err := startInitialization(); err != nil {
+		// If the error is returned, it was not communicated
+		// back to the parent (which is not a common case),
+		// so print it to stderr here as a last resort.
+		//
+		// Do not use logrus as we are not sure if it has been
+		// set up yet, but most important, if the parent is
+		// alive (and its log forwarding is working).
+		fmt.Fprintln(os.Stderr, err)
+	}
+	// Normally, StartInitialization() never returns, meaning
+	// if we are here, it had failed.
+	os.Exit(1)
+}
+
+// Normally, this function does not return. If it returns, with or without an
+// error, it means the initialization has failed. If the error is returned,
+// it means the error can not be communicated back to the parent.
+func startInitialization() (retErr error) {
+	// Get the INITPIPE.
+	envInitPipe := os.Getenv("_LIBCONTAINER_INITPIPE")
+	pipefd, err := strconv.Atoi(envInitPipe)
+	if err != nil {
+		return fmt.Errorf("unable to convert _LIBCONTAINER_INITPIPE: %w", err)
+	}
+	pipe := os.NewFile(uintptr(pipefd), "pipe")
+	defer pipe.Close()
+
+	defer func() {
+		// If this defer is ever called, this means initialization has failed.
+		// Send the error back to the parent process in the form of an initError.
+		ierr := initError{Message: retErr.Error()}
+		if err := writeSyncArg(pipe, procError, ierr); err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			return
+		}
+		// The error is sent, no need to also return it (or it will be reported twice).
+		retErr = nil
+	}()
+
+	// Set up logging. This is used rarely, and mostly for init debugging.
+
+	// Passing log level is optional; currently libcontainer/integration does not do it.
+	if levelStr := os.Getenv("_LIBCONTAINER_LOGLEVEL"); levelStr != "" {
+		logLevel, err := strconv.Atoi(levelStr)
+		if err != nil {
+			return fmt.Errorf("unable to convert _LIBCONTAINER_LOGLEVEL: %w", err)
+		}
+		logrus.SetLevel(logrus.Level(logLevel))
+	}
+
+	logFD, err := strconv.Atoi(os.Getenv("_LIBCONTAINER_LOGPIPE"))
+	if err != nil {
+		return fmt.Errorf("unable to convert _LIBCONTAINER_LOGPIPE: %w", err)
+	}
+
+	logrus.SetOutput(os.NewFile(uintptr(logFD), "logpipe"))
+	logrus.SetFormatter(new(logrus.JSONFormatter))
+	logrus.Debug("child process in init()")
+
+	// Only init processes have FIFOFD.
+	fifofd := -1
+	envInitType := os.Getenv("_LIBCONTAINER_INITTYPE")
+	it := initType(envInitType)
+	if it == initStandard {
+		envFifoFd := os.Getenv("_LIBCONTAINER_FIFOFD")
+		if fifofd, err = strconv.Atoi(envFifoFd); err != nil {
+			return fmt.Errorf("unable to convert _LIBCONTAINER_FIFOFD: %w", err)
+		}
+	}
+
+	// clear the current process's environment to clean any libcontainer
+	// specific env vars.
+	os.Clearenv()
+
+	defer func() {
+		if err := recover(); err != nil {
+			if err2, ok := err.(error); ok {
+				retErr = fmt.Errorf("panic from initialization: %w, %s", err2, debug.Stack())
+			} else {
+				retErr = fmt.Errorf("panic from initialization: %v, %s", err, debug.Stack())
+			}
+		}
+	}()
+
+	// If init succeeds, it will not return, hence none of the defers will be called.
+	return containerInit(it, pipe, nil, fifofd, logFD, mountFds{})
+}
+
+func containerInit(t initType, pipe *os.File, _ *os.File, fifoFd, logFd int, _ mountFds) error {
+	var config *initConfig
+	if err := json.NewDecoder(pipe).Decode(&config); err != nil {
+		return err
+	}
+	if err := populateProcessEnvironment(config.Env); err != nil {
+		return err
+	}
+	switch t {
+	case initStandard:
+		i := &linuxStandardInit{
+			pipe:      pipe,
+			parentPid: unix.Getppid(),
+			config:    config,
+			fifoFd:    fifoFd,
+			logFd:     logFd,
+		}
+		return i.Init()
+	}
+	return fmt.Errorf("unknown init type %q", t)
+}
+
+// current processes's environment.
+func populateProcessEnvironment(env []string) error {
+	for _, pair := range env {
+		p := strings.SplitN(pair, "=", 2)
+		if len(p) < 2 {
+			return errors.New("invalid environment variable: missing '='")
+		}
+		name, val := p[0], p[1]
+		if name == "" {
+			return errors.New("invalid environment variable: name cannot be empty")
+		}
+		if strings.IndexByte(name, 0) >= 0 {
+			return fmt.Errorf("invalid environment variable %q: name contains nul byte (\\x00)", name)
+		}
+		if strings.IndexByte(val, 0) >= 0 {
+			return fmt.Errorf("invalid environment variable %q: value contains nul byte (\\x00)", name)
+		}
+		if err := os.Setenv(name, val); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// finalizeNamespace drops the caps, sets the correct user
+// and working dir, and closes any leaked file descriptors
+// before executing the command inside the namespace
+func finalizeNamespace(config *initConfig) error {
+	// Ensure that all unwanted fds we may have accidentally
+	// inherited are marked close-on-exec so they stay out of the
+	// container
+	if err := utils.CloseExecFrom(config.PassedFilesCount + 3); err != nil {
+		return fmt.Errorf("error closing exec fds: %w", err)
+	}
+
+	return nil
+}
+
+// syncParentReady sends to the given pipe a JSON payload which indicates that
+// the init is ready to Exec the child process. It then waits for the parent to
+// indicate that it is cleared to Exec.
+func syncParentReady(pipe *os.File) error {
+	// Tell parent.
+	if err := writeSync(pipe, procReady); err != nil {
+		return err
+	}
+	// Wait for parent to give the all-clear.
+	return readSync(pipe, procRun)
+}
+
+// setupNetwork sets up and initializes any network interface inside the container.
+func setupNetwork(config *initConfig) error {
+	for _, config := range config.Networks {
+		strategy, err := getStrategy(config.Type)
+		if err != nil {
+			return err
+		}
+		if err := strategy.initialize(config); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func setupRoute(config *configs.Config) error {
+	for _, config := range config.Routes {
+		_, dst, err := net.ParseCIDR(config.Destination)
+		if err != nil {
+			return err
+		}
+		src := net.ParseIP(config.Source)
+		if src == nil {
+			return fmt.Errorf("Invalid source for route: %s", config.Source)
+		}
+		gw := net.ParseIP(config.Gateway)
+		if gw == nil {
+			return fmt.Errorf("Invalid gateway for route: %s", config.Gateway)
+		}
+		l, err := netlink.LinkByName(config.InterfaceName)
+		if err != nil {
+			return err
+		}
+		route := &netlink.Route{
+			Scope:     netlink.SCOPE_UNIVERSE,
+			Dst:       dst,
+			Src:       src,
+			Gw:        gw,
+			LinkIndex: l.Attrs().Index,
+		}
+		if err := netlink.RouteAdd(route); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/libmocktainer/message_linux.go
+++ b/libmocktainer/message_linux.go
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2014 Docker, Inc.
+// Copyright 2023 Unikraft GmbH and The KraftKit Authors
+
+package libmocktainer
+
+import (
+	"fmt"
+	"math"
+
+	"github.com/vishvananda/netlink/nl"
+	"golang.org/x/sys/unix"
+)
+
+// list of known message types we want to send to bootstrap program
+// The number is randomly chosen to not conflict with known netlink types
+const (
+	InitMsg        uint16 = 62000
+	CloneFlagsAttr uint16 = 27281
+	NsPathsAttr    uint16 = 27282
+)
+
+type Int32msg struct {
+	Type  uint16
+	Value uint32
+}
+
+// Serialize serializes the message.
+// Int32msg has the following representation
+// | nlattr len | nlattr type |
+// | uint32 value             |
+func (msg *Int32msg) Serialize() []byte {
+	buf := make([]byte, msg.Len())
+	native := nl.NativeEndian()
+	native.PutUint16(buf[0:2], uint16(msg.Len()))
+	native.PutUint16(buf[2:4], msg.Type)
+	native.PutUint32(buf[4:8], msg.Value)
+	return buf
+}
+
+func (msg *Int32msg) Len() int {
+	return unix.NLA_HDRLEN + 4
+}
+
+// Bytemsg has the following representation
+// | nlattr len | nlattr type |
+// | value              | pad |
+type Bytemsg struct {
+	Type  uint16
+	Value []byte
+}
+
+func (msg *Bytemsg) Serialize() []byte {
+	l := msg.Len()
+	if l > math.MaxUint16 {
+		// We cannot return nil nor an error here, so we panic with
+		// a specific type instead, which is handled via recover in
+		// bootstrapData.
+		panic(netlinkError{fmt.Errorf("netlink: cannot serialize bytemsg of length %d (larger than UINT16_MAX)", l)})
+	}
+	buf := make([]byte, (l+unix.NLA_ALIGNTO-1) & ^(unix.NLA_ALIGNTO-1))
+	native := nl.NativeEndian()
+	native.PutUint16(buf[0:2], uint16(l))
+	native.PutUint16(buf[2:4], msg.Type)
+	copy(buf[4:], msg.Value)
+	return buf
+}
+
+func (msg *Bytemsg) Len() int {
+	return unix.NLA_HDRLEN + len(msg.Value) + 1 // null-terminated
+}

--- a/libmocktainer/network_linux.go
+++ b/libmocktainer/network_linux.go
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2014 Docker, Inc.
+// Copyright 2023 Unikraft GmbH and The KraftKit Authors
+
+package libmocktainer
+
+import (
+	"fmt"
+
+	"github.com/vishvananda/netlink"
+
+	"kraftkit.sh/libmocktainer/configs"
+)
+
+var strategies = map[string]networkStrategy{
+	"loopback": &loopback{},
+}
+
+// networkStrategy represents a specific network configuration for
+// a container's networking stack
+type networkStrategy interface {
+	create(*network, int) error
+	initialize(*network) error
+	detach(*configs.Network) error
+	attach(*configs.Network) error
+}
+
+// getStrategy returns the specific network strategy for the
+// provided type.
+func getStrategy(tpe string) (networkStrategy, error) {
+	s, exists := strategies[tpe]
+	if !exists {
+		return nil, fmt.Errorf("unknown strategy type %q", tpe)
+	}
+	return s, nil
+}
+
+// loopback is a network strategy that provides a basic loopback device
+type loopback struct{}
+
+func (l *loopback) create(n *network, nspid int) error {
+	return nil
+}
+
+func (l *loopback) initialize(config *network) error {
+	return netlink.LinkSetUp(&netlink.Device{LinkAttrs: netlink.LinkAttrs{Name: "lo"}})
+}
+
+func (l *loopback) attach(n *configs.Network) (err error) {
+	return nil
+}
+
+func (l *loopback) detach(n *configs.Network) (err error) {
+	return nil
+}

--- a/libmocktainer/process.go
+++ b/libmocktainer/process.go
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2014 Docker, Inc.
+// Copyright 2023 Unikraft GmbH and The KraftKit Authors
+
+package libmocktainer
+
+import (
+	"errors"
+	"io"
+	"math"
+	"os"
+)
+
+var errInvalidProcess = errors.New("invalid process")
+
+type processOperations interface {
+	wait() (*os.ProcessState, error)
+	signal(sig os.Signal) error
+	pid() int
+}
+
+// Process specifies the configuration and IO for a process inside
+// a container.
+type Process struct {
+	// The command to be run followed by any arguments.
+	Args []string
+
+	// Env specifies the environment variables for the process.
+	Env []string
+
+	// Stdin is a pointer to a reader which provides the standard input stream.
+	Stdin io.Reader
+
+	// Stdout is a pointer to a writer which receives the standard output stream.
+	Stdout io.Writer
+
+	// Stderr is a pointer to a writer which receives the standard error stream.
+	Stderr io.Writer
+
+	// ExtraFiles specifies additional open files to be inherited by the container
+	ExtraFiles []*os.File
+
+	// AppArmorProfile specifies the profile to apply to the process and is
+	// changed at the time the process is execed
+	AppArmorProfile string
+
+	// Label specifies the label to apply to the process.  It is commonly used by selinux
+	Label string
+
+	ops processOperations
+
+	// LogLevel is a string containing a numeric representation of the current
+	// log level (i.e. "4", but never "info"). It is passed on to runc init as
+	// _LIBCONTAINER_LOGLEVEL environment variable.
+	LogLevel string
+}
+
+// Wait waits for the process to exit.
+// Wait releases any resources associated with the Process
+func (p Process) Wait() (*os.ProcessState, error) {
+	if p.ops == nil {
+		return nil, errInvalidProcess
+	}
+	return p.ops.wait()
+}
+
+// Pid returns the process ID
+func (p Process) Pid() (int, error) {
+	// math.MinInt32 is returned here, because it's invalid value
+	// for the kill() system call.
+	if p.ops == nil {
+		return math.MinInt32, errInvalidProcess
+	}
+	return p.ops.pid(), nil
+}
+
+// Signal sends a signal to the Process.
+func (p Process) Signal(sig os.Signal) error {
+	if p.ops == nil {
+		return errInvalidProcess
+	}
+	return p.ops.signal(sig)
+}

--- a/libmocktainer/process_linux.go
+++ b/libmocktainer/process_linux.go
@@ -1,0 +1,363 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2014 Docker, Inc.
+// Copyright 2023 Unikraft GmbH and The KraftKit Authors
+
+package libmocktainer
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"time"
+
+	"github.com/opencontainers/runc/libcontainer/logs"
+	"github.com/opencontainers/runc/libcontainer/system"
+	"github.com/opencontainers/runc/libcontainer/utils"
+	"github.com/opencontainers/runtime-spec/specs-go"
+	"github.com/sirupsen/logrus"
+	"golang.org/x/sys/unix"
+
+	"kraftkit.sh/libmocktainer/configs"
+)
+
+type parentProcess interface {
+	// pid returns the pid for the running process.
+	pid() int
+
+	// start starts the process execution.
+	start() error
+
+	// send a SIGKILL to the process and wait for the exit.
+	terminate() error
+
+	// wait waits on the process returning the process state.
+	wait() (*os.ProcessState, error)
+
+	// startTime returns the process start time.
+	startTime() (uint64, error)
+	signal(os.Signal) error
+	externalDescriptors() []string
+	setExternalDescriptors(fds []string)
+	forwardChildLogs() chan error
+}
+
+type filePair struct {
+	parent *os.File
+	child  *os.File
+}
+
+type initProcess struct {
+	cmd             *exec.Cmd
+	messageSockPair filePair
+	logFilePair     filePair
+	config          *initConfig
+	container       *Container
+	fds             []string
+	process         *Process
+	bootstrapData   io.Reader
+}
+
+func (p *initProcess) pid() int {
+	return p.cmd.Process.Pid
+}
+
+func (p *initProcess) externalDescriptors() []string {
+	return p.fds
+}
+
+// getChildPid receives the final child's pid over the provided pipe.
+func (p *initProcess) getChildPid() (int, error) {
+	var pid pid
+	if err := json.NewDecoder(p.messageSockPair.parent).Decode(&pid); err != nil {
+		_ = p.cmd.Wait()
+		return -1, err
+	}
+
+	// Clean up the zombie parent process
+	// On Unix systems FindProcess always succeeds.
+	firstChildProcess, _ := os.FindProcess(pid.PidFirstChild)
+
+	// Ignore the error in case the child has already been reaped for any reason
+	_, _ = firstChildProcess.Wait()
+
+	return pid.Pid, nil
+}
+
+func (p *initProcess) waitForChildExit(childPid int) error {
+	status, err := p.cmd.Process.Wait()
+	if err != nil {
+		_ = p.cmd.Wait()
+		return err
+	}
+	if !status.Success() {
+		_ = p.cmd.Wait()
+		return &exec.ExitError{ProcessState: status}
+	}
+
+	process, err := os.FindProcess(childPid)
+	if err != nil {
+		return err
+	}
+	p.cmd.Process = process
+	p.process.ops = p
+	return nil
+}
+
+func (p *initProcess) start() (retErr error) {
+	defer p.messageSockPair.parent.Close() //nolint: errcheck
+	err := p.cmd.Start()
+	p.process.ops = p
+	// close the write-side of the pipes (controlled by child)
+	_ = p.messageSockPair.child.Close()
+	_ = p.logFilePair.child.Close()
+	if err != nil {
+		p.process.ops = nil
+		return fmt.Errorf("unable to start init: %w", err)
+	}
+
+	waitInit := initWaiter(p.messageSockPair.parent)
+	defer func() {
+		if retErr != nil {
+			werr := <-waitInit
+			if werr != nil {
+				logrus.WithError(werr).Warn()
+			}
+
+			// Terminate the process to ensure we can remove cgroups.
+			if err := ignoreTerminateErrors(p.terminate()); err != nil {
+				logrus.WithError(err).Warn("unable to terminate initProcess")
+			}
+		}
+	}()
+
+	if _, err := io.Copy(p.messageSockPair.parent, p.bootstrapData); err != nil {
+		return fmt.Errorf("can't copy bootstrap data to pipe: %w", err)
+	}
+	err = <-waitInit
+	if err != nil {
+		return err
+	}
+
+	childPid, err := p.getChildPid()
+	if err != nil {
+		return fmt.Errorf("can't get final child's PID from pipe: %w", err)
+	}
+
+	// Save the standard descriptor names before the container process
+	// can potentially move them (e.g., via dup2()).  If we don't do this now,
+	// we won't know at checkpoint time which file descriptor to look up.
+	fds, err := getPipeFds(childPid)
+	if err != nil {
+		return fmt.Errorf("error getting pipe fds for pid %d: %w", childPid, err)
+	}
+	p.setExternalDescriptors(fds)
+
+	// Wait for our first child to exit
+	if err := p.waitForChildExit(childPid); err != nil {
+		return fmt.Errorf("error waiting for our first child to exit: %w", err)
+	}
+
+	if err := p.createNetworkInterfaces(); err != nil {
+		return fmt.Errorf("error creating network interfaces: %w", err)
+	}
+	if err := p.updateSpecState(); err != nil {
+		return fmt.Errorf("error updating spec state: %w", err)
+	}
+	if err := p.sendConfig(); err != nil {
+		return fmt.Errorf("error sending config to init process: %w", err)
+	}
+
+	var seenProcReady bool
+	ierr := parseSync(p.messageSockPair.parent, func(sync *syncT) error {
+		switch sync.Type {
+		case procReady:
+			seenProcReady = true
+
+			// generate a timestamp indicating when the container was started
+			p.container.created = time.Now().UTC()
+			p.container.state = &createdState{
+				c: p.container,
+			}
+
+			// NOTE: If the procRun state has been synced and the
+			// runc-create process has been killed for some reason,
+			// the runc-init[2:stage] process will be leaky. And
+			// the runc command also fails to parse root directory
+			// because the container doesn't have state.json.
+			//
+			// In order to cleanup the runc-init[2:stage] by
+			// runc-delete/stop, we should store the status before
+			// procRun sync.
+			state, uerr := p.container.updateState(p)
+			if uerr != nil {
+				return fmt.Errorf("unable to store init state: %w", uerr)
+			}
+			p.container.initProcessStartTime = state.InitProcessStartTime
+
+			// Sync with child.
+			if err := writeSync(p.messageSockPair.parent, procRun); err != nil {
+				return err
+			}
+		case procHooks:
+			if len(p.config.Config.Hooks) != 0 {
+				s, err := p.container.currentOCIState()
+				if err != nil {
+					return err
+				}
+				// initProcessStartTime hasn't been set yet.
+				s.Pid = p.cmd.Process.Pid
+				s.Status = specs.StateCreating
+				hooks := p.config.Config.Hooks
+
+				if err := hooks[configs.Prestart].RunHooks(s); err != nil {
+					return err
+				}
+				if err := hooks[configs.CreateRuntime].RunHooks(s); err != nil {
+					return err
+				}
+			}
+			// Sync with child.
+			if err := writeSync(p.messageSockPair.parent, procResume); err != nil {
+				return err
+			}
+		default:
+			return errors.New("invalid JSON payload from child")
+		}
+		return nil
+	})
+
+	if err := unix.Shutdown(int(p.messageSockPair.parent.Fd()), unix.SHUT_WR); err != nil && ierr == nil {
+		return &os.PathError{Op: "shutdown", Path: "(init pipe)", Err: err}
+	}
+	if !seenProcReady && ierr == nil {
+		ierr = errors.New("procReady not received")
+	}
+	if ierr != nil {
+		return fmt.Errorf("error during container init: %w", ierr)
+	}
+	return nil
+}
+
+func (p *initProcess) wait() (*os.ProcessState, error) {
+	err := p.cmd.Wait()
+	return p.cmd.ProcessState, err
+}
+
+func (p *initProcess) terminate() error {
+	if p.cmd.Process == nil {
+		return nil
+	}
+	err := p.cmd.Process.Kill()
+	if _, werr := p.wait(); err == nil {
+		err = werr
+	}
+	return err
+}
+
+func (p *initProcess) startTime() (uint64, error) {
+	stat, err := system.Stat(p.pid())
+	return stat.StartTime, err
+}
+
+func (p *initProcess) updateSpecState() error {
+	s, err := p.container.currentOCIState()
+	if err != nil {
+		return err
+	}
+
+	p.config.SpecState = s
+	return nil
+}
+
+func (p *initProcess) sendConfig() error {
+	// send the config to the container's init process, we don't use JSON Encode
+	// here because there might be a problem in JSON decoder in some cases, see:
+	// https://github.com/docker/docker/issues/14203#issuecomment-174177790
+	return utils.WriteJSON(p.messageSockPair.parent, p.config)
+}
+
+func (p *initProcess) createNetworkInterfaces() error {
+	for _, config := range p.config.Config.Networks {
+		strategy, err := getStrategy(config.Type)
+		if err != nil {
+			return err
+		}
+		n := &network{
+			Network: *config,
+		}
+		if err := strategy.create(n, p.pid()); err != nil {
+			return err
+		}
+		p.config.Networks = append(p.config.Networks, n)
+	}
+	return nil
+}
+
+func (p *initProcess) signal(sig os.Signal) error {
+	s, ok := sig.(unix.Signal)
+	if !ok {
+		return errors.New("os: unsupported signal type")
+	}
+	return unix.Kill(p.pid(), s)
+}
+
+func (p *initProcess) setExternalDescriptors(newFds []string) {
+	p.fds = newFds
+}
+
+func (p *initProcess) forwardChildLogs() chan error {
+	return logs.ForwardLogs(p.logFilePair.parent)
+}
+
+func getPipeFds(pid int) ([]string, error) {
+	fds := make([]string, 3)
+
+	dirPath := filepath.Join("/proc", strconv.Itoa(pid), "/fd")
+	for i := 0; i < 3; i++ {
+		// XXX: This breaks if the path is not a valid symlink (which can
+		//      happen in certain particularly unlucky mount namespace setups).
+		f := filepath.Join(dirPath, strconv.Itoa(i))
+		target, err := os.Readlink(f)
+		if err != nil {
+			// Ignore permission errors, for rootless containers and other
+			// non-dumpable processes. if we can't get the fd for a particular
+			// file, there's not much we can do.
+			if os.IsPermission(err) {
+				continue
+			}
+			return fds, err
+		}
+		fds[i] = target
+	}
+	return fds, nil
+}
+
+// initWaiter returns a channel to wait on for making sure
+// runc init has finished the initial setup.
+func initWaiter(r io.Reader) chan error {
+	ch := make(chan error, 1)
+	go func() {
+		defer close(ch)
+
+		inited := make([]byte, 1)
+		n, err := r.Read(inited)
+		if err == nil {
+			if n < 1 {
+				err = errors.New("short read")
+			} else if inited[0] != 0 {
+				err = fmt.Errorf("unexpected %d != 0", inited[0])
+			} else {
+				ch <- nil
+				return
+			}
+		}
+		ch <- fmt.Errorf("waiting for init preliminary setup: %w", err)
+	}()
+
+	return ch
+}

--- a/libmocktainer/restored_process.go
+++ b/libmocktainer/restored_process.go
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2014 Docker, Inc.
+// Copyright 2023 Unikraft GmbH and The KraftKit Authors
+
+package libmocktainer
+
+import (
+	"errors"
+	"os"
+)
+
+// nonChildProcess represents a process where the calling process is not
+// the parent process. This process is created when Load loads a container
+// from a persisted state.
+type nonChildProcess struct {
+	processPid       int
+	processStartTime uint64
+}
+
+func (p *nonChildProcess) start() error {
+	return errors.New("restored process cannot be started")
+}
+
+func (p *nonChildProcess) pid() int {
+	return p.processPid
+}
+
+func (p *nonChildProcess) terminate() error {
+	return errors.New("restored process cannot be terminated")
+}
+
+func (p *nonChildProcess) wait() (*os.ProcessState, error) {
+	return nil, errors.New("restored process cannot be waited on")
+}
+
+func (p *nonChildProcess) startTime() (uint64, error) {
+	return p.processStartTime, nil
+}
+
+func (p *nonChildProcess) signal(s os.Signal) error {
+	proc, err := os.FindProcess(p.processPid)
+	if err != nil {
+		return err
+	}
+	return proc.Signal(s)
+}
+
+func (p *nonChildProcess) externalDescriptors() []string {
+	return nil
+}
+
+func (p *nonChildProcess) setExternalDescriptors([]string) {
+}
+
+func (p *nonChildProcess) forwardChildLogs() chan error {
+	return nil
+}

--- a/libmocktainer/rootfs_linux.go
+++ b/libmocktainer/rootfs_linux.go
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2014 Docker, Inc.
+// Copyright 2023 Unikraft GmbH and The KraftKit Authors
+
+package libmocktainer
+
+import (
+	"os"
+
+	"github.com/opencontainers/runtime-spec/specs-go"
+	"golang.org/x/sys/unix"
+
+	"kraftkit.sh/libmocktainer/configs"
+)
+
+// prepareRootfs sets up the devices, mount points, and filesystems for use
+// inside a new mount namespace. It doesn't set anything as ro. You must call
+// finalizeRootfs after this function to finish setting up the rootfs.
+func prepareRootfs(pipe *os.File, iConfig *initConfig, _ mountFds) (err error) {
+	config := iConfig.Config
+
+	// Signal the parent to run the pre-start hooks.
+	// The hooks are run after the mounts are setup, but before we switch to the new
+	// root, so that the old root is still available in the hooks for any mount
+	// manipulations.
+	if err := syncParentHooks(pipe); err != nil {
+		return err
+	}
+
+	// The reason these operations are done here rather than in finalizeRootfs
+	// is because the console-handling code gets quite sticky if we have to set
+	// up the console before doing the pivot_root(2). This is because the
+	// Console API has to also work with the ExecIn case, which means that the
+	// API must be able to deal with being inside as well as outside the
+	// container. It's just cleaner to do this here (at the expense of the
+	// operation not being perfectly split).
+
+	if err := unix.Chdir(config.Rootfs); err != nil {
+		return &os.PathError{Op: "chdir", Path: config.Rootfs, Err: err}
+	}
+
+	s := iConfig.SpecState
+	s.Pid = unix.Getpid()
+	s.Status = specs.StateCreating
+	if err := iConfig.Config.Hooks[configs.CreateContainer].RunHooks(s); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// syncParentHooks sends to the given pipe a JSON payload which indicates that
+// the parent should execute pre-start hooks. It then waits for the parent to
+// indicate that it is cleared to resume.
+func syncParentHooks(pipe *os.File) error {
+	// Tell parent.
+	if err := writeSync(pipe, procHooks); err != nil {
+		return err
+	}
+	// Wait for parent to give the all-clear.
+	return readSync(pipe, procResume)
+}

--- a/libmocktainer/specconv/spec_linux.go
+++ b/libmocktainer/specconv/spec_linux.go
@@ -1,0 +1,150 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2014 Docker, Inc.
+// Copyright 2023 Unikraft GmbH and The KraftKit Authors
+
+// Package specconv implements conversion of specifications to libcontainer
+// configurations
+package specconv
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"sync"
+	"time"
+
+	"github.com/opencontainers/runtime-spec/specs-go"
+
+	"kraftkit.sh/libmocktainer/configs"
+)
+
+var (
+	initMapsOnce     sync.Once
+	namespaceMapping map[specs.LinuxNamespaceType]configs.NamespaceType
+)
+
+func initMaps() {
+	initMapsOnce.Do(func() {
+		namespaceMapping = map[specs.LinuxNamespaceType]configs.NamespaceType{
+			specs.NetworkNamespace: configs.NEWNET,
+		}
+	})
+}
+
+// KnownNamespaces returns the list of the known namespaces.
+// Used by `runc features`.
+func KnownNamespaces() []string {
+	initMaps()
+	var res []string
+	for k := range namespaceMapping {
+		res = append(res, string(k))
+	}
+	sort.Strings(res)
+	return res
+}
+
+type CreateOpts struct {
+	Spec *specs.Spec
+}
+
+// CreateLibcontainerConfig creates a new libcontainer configuration from a
+// given specification and a cgroup name
+func CreateLibcontainerConfig(opts *CreateOpts) (*configs.Config, error) {
+	// runc's cwd will always be the bundle path
+	rcwd, err := os.Getwd()
+	if err != nil {
+		return nil, err
+	}
+	cwd, err := filepath.Abs(rcwd)
+	if err != nil {
+		return nil, err
+	}
+	spec := opts.Spec
+	if spec.Root == nil {
+		return nil, errors.New("root must be specified")
+	}
+	rootfsPath := spec.Root.Path
+	if !filepath.IsAbs(rootfsPath) {
+		rootfsPath = filepath.Join(cwd, rootfsPath)
+	}
+	labels := []string{}
+	for k, v := range spec.Annotations {
+		labels = append(labels, k+"="+v)
+	}
+	config := &configs.Config{
+		Rootfs: rootfsPath,
+		Labels: append(labels, "bundle="+cwd),
+	}
+
+	// set linux-specific config
+	if spec.Linux != nil {
+		initMaps()
+
+		for _, ns := range spec.Linux.Namespaces {
+			t, exists := namespaceMapping[ns.Type]
+			if !exists {
+				return nil, fmt.Errorf("namespace %q does not exist", ns)
+			}
+			if config.Namespaces.Contains(t) {
+				return nil, fmt.Errorf("malformed spec file: duplicated ns %q", ns)
+			}
+			config.Namespaces.Add(t, ns.Path)
+		}
+		if config.Namespaces.Contains(configs.NEWNET) && config.Namespaces.PathOf(configs.NEWNET) == "" {
+			config.Networks = []*configs.Network{
+				{
+					Type: "loopback",
+				},
+			}
+		}
+	}
+
+	createHooks(spec, config)
+	config.Version = specs.Version
+	return config, nil
+}
+
+func createHooks(rspec *specs.Spec, config *configs.Config) {
+	config.Hooks = configs.Hooks{}
+	if rspec.Hooks != nil {
+		for _, h := range rspec.Hooks.Prestart {
+			cmd := createCommandHook(h)
+			config.Hooks[configs.Prestart] = append(config.Hooks[configs.Prestart], configs.NewCommandHook(cmd))
+		}
+		for _, h := range rspec.Hooks.CreateRuntime {
+			cmd := createCommandHook(h)
+			config.Hooks[configs.CreateRuntime] = append(config.Hooks[configs.CreateRuntime], configs.NewCommandHook(cmd))
+		}
+		for _, h := range rspec.Hooks.CreateContainer {
+			cmd := createCommandHook(h)
+			config.Hooks[configs.CreateContainer] = append(config.Hooks[configs.CreateContainer], configs.NewCommandHook(cmd))
+		}
+		for _, h := range rspec.Hooks.StartContainer {
+			cmd := createCommandHook(h)
+			config.Hooks[configs.StartContainer] = append(config.Hooks[configs.StartContainer], configs.NewCommandHook(cmd))
+		}
+		for _, h := range rspec.Hooks.Poststart {
+			cmd := createCommandHook(h)
+			config.Hooks[configs.Poststart] = append(config.Hooks[configs.Poststart], configs.NewCommandHook(cmd))
+		}
+		for _, h := range rspec.Hooks.Poststop {
+			cmd := createCommandHook(h)
+			config.Hooks[configs.Poststop] = append(config.Hooks[configs.Poststop], configs.NewCommandHook(cmd))
+		}
+	}
+}
+
+func createCommandHook(h specs.Hook) configs.Command {
+	cmd := configs.Command{
+		Path: h.Path,
+		Args: h.Args,
+		Env:  h.Env,
+	}
+	if h.Timeout != nil {
+		d := time.Duration(*h.Timeout) * time.Second
+		cmd.Timeout = &d
+	}
+	return cmd
+}

--- a/libmocktainer/standard_init_linux.go
+++ b/libmocktainer/standard_init_linux.go
@@ -1,0 +1,168 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2014 Docker, Inc.
+// Copyright 2023 Unikraft GmbH and The KraftKit Authors
+
+package libmocktainer
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"strconv"
+
+	"github.com/opencontainers/runtime-spec/specs-go"
+	"github.com/opencontainers/selinux/go-selinux"
+	"github.com/sirupsen/logrus"
+	"golang.org/x/sys/unix"
+
+	"github.com/opencontainers/runc/libcontainer/apparmor"
+	"github.com/opencontainers/runc/libcontainer/keys"
+	"github.com/opencontainers/runc/libcontainer/system"
+
+	"kraftkit.sh/libmocktainer/configs"
+)
+
+type linuxStandardInit struct {
+	pipe      *os.File
+	parentPid int
+	fifoFd    int
+	logFd     int
+	config    *initConfig
+}
+
+func (l *linuxStandardInit) getSessionRingParams() (string, uint32, uint32) {
+	var newperms uint32 //nolint:gosimple
+
+	// Without user ns we need 'UID' search permissions.
+	newperms = 0x80000
+
+	// Create a unique per session container name that we can join in setns;
+	// However, other containers can also join it.
+	return "_ses." + l.config.ContainerID, 0xffffffff, newperms
+}
+
+func (l *linuxStandardInit) Init() error {
+	if err := selinux.SetKeyLabel(l.config.ProcessLabel); err != nil {
+		return err
+	}
+	defer selinux.SetKeyLabel("") //nolint: errcheck
+	ringname, keepperms, newperms := l.getSessionRingParams()
+
+	// Do not inherit the parent's session keyring.
+	if sessKeyId, err := keys.JoinSessionKeyring(ringname); err != nil {
+		// If keyrings aren't supported then it is likely we are on an
+		// older kernel (or inside an LXC container). While we could bail,
+		// the security feature we are using here is best-effort (it only
+		// really provides marginal protection since VFS credentials are
+		// the only significant protection of keyrings).
+		//
+		// TODO(cyphar): Log this so people know what's going on, once we
+		//               have proper logging in 'runc init'.
+		if !errors.Is(err, unix.ENOSYS) {
+			return fmt.Errorf("unable to join session keyring: %w", err)
+		}
+	} else {
+		// Make session keyring searchable. If we've gotten this far we
+		// bail on any error -- we don't want to have a keyring with bad
+		// permissions.
+		if err := keys.ModKeyringPerm(sessKeyId, keepperms, newperms); err != nil {
+			return fmt.Errorf("unable to mod keyring permissions: %w", err)
+		}
+	}
+
+	if err := setupNetwork(l.config); err != nil {
+		return err
+	}
+	if err := setupRoute(l.config.Config); err != nil {
+		return err
+	}
+
+	// initialises the labeling system
+	selinux.GetEnabled()
+
+	// We don't need the mount nor idmap fds after prepareRootfs() nor if it fails.
+	err := prepareRootfs(l.pipe, l.config, mountFds{})
+	if err != nil {
+		return err
+	}
+
+	if err := apparmor.ApplyProfile(l.config.AppArmorProfile); err != nil {
+		return fmt.Errorf("unable to apply apparmor profile: %w", err)
+	}
+
+	pdeath, err := system.GetParentDeathSignal()
+	if err != nil {
+		return fmt.Errorf("can't get pdeath signal: %w", err)
+	}
+	// Tell our parent that we're ready to Execv. This must be done before the
+	// Seccomp rules have been applied, because we need to be able to read and
+	// write to a socket.
+	if err := syncParentReady(l.pipe); err != nil {
+		return fmt.Errorf("sync ready: %w", err)
+	}
+	if err := selinux.SetExecLabel(l.config.ProcessLabel); err != nil {
+		return fmt.Errorf("can't set process label: %w", err)
+	}
+	defer selinux.SetExecLabel("") //nolint: errcheck
+	if err := finalizeNamespace(l.config); err != nil {
+		return err
+	}
+	// finalizeNamespace can change user/group which clears the parent death
+	// signal, so we restore it here.
+	if err := pdeath.Restore(); err != nil {
+		return fmt.Errorf("can't restore pdeath signal: %w", err)
+	}
+	// Compare the parent from the initial start of the init process and make
+	// sure that it did not change.  if the parent changes that means it died
+	// and we were reparented to something else so we should just kill ourself
+	// and not cause problems for someone else.
+	if unix.Getppid() != l.parentPid {
+		return unix.Kill(unix.Getpid(), unix.SIGKILL)
+	}
+	// Check for the arg before waiting to make sure it exists and it is
+	// returned as a create time error.
+	name, err := exec.LookPath(l.config.Args[0])
+	if err != nil {
+		return err
+	}
+
+	// Close the pipe to signal that we have completed our init.
+	logrus.Debugf("init: closing the pipe to signal completion")
+	_ = l.pipe.Close()
+
+	// Close the log pipe fd so the parent's ForwardLogs can exit.
+	if err := unix.Close(l.logFd); err != nil {
+		return &os.PathError{Op: "close log pipe", Path: "fd " + strconv.Itoa(l.logFd), Err: err}
+	}
+
+	// Wait for the FIFO to be opened on the other side before exec-ing the
+	// user process. We open it through /proc/self/fd/$fd, because the fd that
+	// was given to us was an O_PATH fd to the fifo itself. Linux allows us to
+	// re-open an O_PATH fd through /proc.
+	fifoPath := "/proc/self/fd/" + strconv.Itoa(l.fifoFd)
+	fd, err := unix.Open(fifoPath, unix.O_WRONLY|unix.O_CLOEXEC, 0)
+	if err != nil {
+		return &os.PathError{Op: "open exec fifo", Path: fifoPath, Err: err}
+	}
+	if _, err := unix.Write(fd, []byte("0")); err != nil {
+		return &os.PathError{Op: "write exec fifo", Path: fifoPath, Err: err}
+	}
+
+	// Close the O_PATH fifofd fd before exec because the kernel resets
+	// dumpable in the wrong order. This has been fixed in newer kernels, but
+	// we keep this to ensure CVE-2016-9962 doesn't re-emerge on older kernels.
+	// N.B. the core issue itself (passing dirfds to the host filesystem) has
+	// since been resolved.
+	// https://github.com/torvalds/linux/blob/v4.9/fs/exec.c#L1290-L1318
+	_ = unix.Close(l.fifoFd)
+
+	s := l.config.SpecState
+	s.Pid = unix.Getpid()
+	s.Status = specs.StateCreated
+	if err := l.config.Config.Hooks[configs.StartContainer].RunHooks(s); err != nil {
+		return err
+	}
+
+	return system.Exec(name, l.config.Args[0:], os.Environ())
+}

--- a/libmocktainer/state_linux.go
+++ b/libmocktainer/state_linux.go
@@ -1,0 +1,172 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2014 Docker, Inc.
+// Copyright 2023 Unikraft GmbH and The KraftKit Authors
+
+package libmocktainer
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/opencontainers/runtime-spec/specs-go"
+	"golang.org/x/sys/unix"
+
+	"kraftkit.sh/libmocktainer/configs"
+)
+
+func newStateTransitionError(from, to containerState) error {
+	return &stateTransitionError{
+		From: from.status().String(),
+		To:   to.status().String(),
+	}
+}
+
+// stateTransitionError is returned when an invalid state transition happens from one
+// state to another.
+type stateTransitionError struct {
+	From string
+	To   string
+}
+
+func (s *stateTransitionError) Error() string {
+	return fmt.Sprintf("invalid state transition from %s to %s", s.From, s.To)
+}
+
+type containerState interface {
+	transition(containerState) error
+	destroy() error
+	status() Status
+}
+
+func destroy(c *Container) error {
+	var err error
+	if rerr := os.RemoveAll(c.root); err == nil {
+		err = rerr
+	}
+	c.initProcess = nil
+	if herr := runPoststopHooks(c); err == nil {
+		err = herr
+	}
+	c.state = &stoppedState{c: c}
+	return err
+}
+
+func runPoststopHooks(c *Container) error {
+	hooks := c.config.Hooks
+	if hooks == nil {
+		return nil
+	}
+
+	s, err := c.currentOCIState()
+	if err != nil {
+		return err
+	}
+	s.Status = specs.StateStopped
+
+	if err := hooks[configs.Poststop].RunHooks(s); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// stoppedState represents a container is a stopped/destroyed state.
+type stoppedState struct {
+	c *Container
+}
+
+func (*stoppedState) status() Status {
+	return Stopped
+}
+
+func (b *stoppedState) transition(s containerState) error {
+	switch s.(type) {
+	case *runningState:
+		b.c.state = s
+		return nil
+	case *stoppedState:
+		return nil
+	}
+	return newStateTransitionError(b, s)
+}
+
+func (b *stoppedState) destroy() error {
+	return destroy(b.c)
+}
+
+// runningState represents a container that is currently running.
+type runningState struct {
+	c *Container
+}
+
+func (r *runningState) status() Status {
+	return Running
+}
+
+func (r *runningState) transition(s containerState) error {
+	switch s.(type) {
+	case *stoppedState:
+		if r.c.runType() == Running {
+			return ErrRunning
+		}
+		r.c.state = s
+		return nil
+	case *runningState:
+		return nil
+	}
+	return newStateTransitionError(r, s)
+}
+
+func (r *runningState) destroy() error {
+	if r.c.runType() == Running {
+		return ErrRunning
+	}
+	return destroy(r.c)
+}
+
+type createdState struct {
+	c *Container
+}
+
+func (i *createdState) status() Status {
+	return Created
+}
+
+func (i *createdState) transition(s containerState) error {
+	switch s.(type) {
+	case *runningState, *stoppedState:
+		i.c.state = s
+		return nil
+	case *createdState:
+		return nil
+	}
+	return newStateTransitionError(i, s)
+}
+
+func (i *createdState) destroy() error {
+	_ = i.c.initProcess.signal(unix.SIGKILL)
+	return destroy(i.c)
+}
+
+// loadedState is used whenever a container is restored, loaded, or setting additional
+// processes inside and it should not be destroyed when it is exiting.
+type loadedState struct {
+	c *Container
+	s Status
+}
+
+func (n *loadedState) status() Status {
+	return n.s
+}
+
+func (n *loadedState) transition(s containerState) error {
+	n.c.state = s
+	return nil
+}
+
+func (n *loadedState) destroy() error {
+	if err := n.c.refreshState(); err != nil {
+		return err
+	}
+	return n.c.state.destroy()
+}

--- a/libmocktainer/sync.go
+++ b/libmocktainer/sync.go
@@ -1,0 +1,169 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2014 Docker, Inc.
+// Copyright 2023 Unikraft GmbH and The KraftKit Authors
+
+package libmocktainer
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/opencontainers/runc/libcontainer/utils"
+
+	lmutils "kraftkit.sh/libmocktainer/utils"
+)
+
+type syncType string
+
+// Constants that are used for synchronisation between the parent and child
+// during container setup. They come in pairs (with procError being a generic
+// response which is followed by an &initError).
+//
+//	     [  child  ] <-> [   parent   ]
+//
+//	procSeccomp         --> [forward fd to listenerPath]
+//	  file: seccomp fd
+//	                    --- no return synchronisation
+//
+//	procHooks --> [run hooks]
+//	          <-- procResume
+//
+//	procReady --> [final setup]
+//	          <-- procRun
+//
+//	procSeccomp --> [grab seccomp fd with pidfd_getfd()]
+//	            <-- procSeccompDone
+const (
+	procError  syncType = "procError"
+	procReady  syncType = "procReady"
+	procRun    syncType = "procRun"
+	procHooks  syncType = "procHooks"
+	procResume syncType = "procResume"
+)
+
+type syncFlags int
+
+const (
+	syncFlagHasFd syncFlags = (1 << iota)
+)
+
+type syncT struct {
+	Type  syncType         `json:"type"`
+	Flags syncFlags        `json:"flags"`
+	Arg   *json.RawMessage `json:"arg,omitempty"`
+	File  *os.File         `json:"-"` // passed oob through SCM_RIGHTS
+}
+
+// initError is used to wrap errors for passing them via JSON,
+// as encoding/json can't unmarshal into error type.
+type initError struct {
+	Message string `json:"message,omitempty"`
+}
+
+func (i initError) Error() string {
+	return i.Message
+}
+
+func doWriteSync(pipe *os.File, sync syncT) error {
+	sync.Flags &= ^syncFlagHasFd
+	if sync.File != nil {
+		sync.Flags |= syncFlagHasFd
+	}
+	if err := utils.WriteJSON(pipe, sync); err != nil {
+		return fmt.Errorf("writing sync %q: %w", sync.Type, err)
+	}
+	if sync.Flags&syncFlagHasFd != 0 {
+		if err := lmutils.SendFile(pipe, sync.File); err != nil {
+			return fmt.Errorf("sending file after sync %q: %w", sync.Type, err)
+		}
+	}
+	return nil
+}
+
+func writeSync(pipe *os.File, sync syncType) error {
+	return doWriteSync(pipe, syncT{Type: sync})
+}
+
+func writeSyncArg(pipe *os.File, sync syncType, arg interface{}) error {
+	argJSON, err := json.Marshal(arg)
+	if err != nil {
+		return fmt.Errorf("writing sync %q: marshal argument failed: %w", sync, err)
+	}
+	argJSONMsg := json.RawMessage(argJSON)
+	return doWriteSync(pipe, syncT{Type: sync, Arg: &argJSONMsg})
+}
+
+func doReadSync(pipe *os.File) (syncT, error) {
+	var sync syncT
+	if err := json.NewDecoder(pipe).Decode(&sync); err != nil {
+		if errors.Is(err, io.EOF) {
+			return sync, err
+		}
+		return sync, fmt.Errorf("reading from parent failed: %w", err)
+	}
+	if sync.Type == procError {
+		var ierr initError
+		if sync.Arg == nil {
+			return sync, errors.New("procError missing error payload")
+		}
+		if err := json.Unmarshal(*sync.Arg, &ierr); err != nil {
+			return sync, fmt.Errorf("unmarshal procError failed: %w", err)
+		}
+		return sync, &ierr
+	}
+	if sync.Flags&syncFlagHasFd != 0 {
+		file, err := lmutils.RecvFile(pipe)
+		if err != nil {
+			return sync, fmt.Errorf("receiving fd from sync %q failed: %w", sync.Type, err)
+		}
+		sync.File = file
+	}
+	return sync, nil
+}
+
+func readSyncFull(pipe *os.File, expected syncType) (syncT, error) {
+	sync, err := doReadSync(pipe)
+	if err != nil {
+		return sync, err
+	}
+	if sync.Type != expected {
+		return sync, fmt.Errorf("unexpected synchronisation flag: got %q, expected %q", sync.Type, expected)
+	}
+	return sync, nil
+}
+
+func readSync(pipe *os.File, expected syncType) error {
+	sync, err := readSyncFull(pipe, expected)
+	if err != nil {
+		return err
+	}
+	if sync.Arg != nil {
+		return fmt.Errorf("sync %q had unexpected argument passed: %q", expected, string(*sync.Arg))
+	}
+	if sync.File != nil {
+		_ = sync.File.Close()
+		return fmt.Errorf("sync %q had unexpected file passed", sync.Type)
+	}
+	return nil
+}
+
+// parseSync runs the given callback function on each syncT received from the
+// child. It will return once io.EOF is returned from the given pipe.
+func parseSync(pipe *os.File, fn func(*syncT) error) error {
+	for {
+		sync, err := doReadSync(pipe)
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				break
+			}
+			return err
+		}
+		if err := fn(&sync); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/libmocktainer/unikraft/doc.go
+++ b/libmocktainer/unikraft/doc.go
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2023, Unikraft GmbH and The KraftKit Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+
+// Package unikraft contains libmocktainer code that is not in upstream libcontainer.
+package unikraft

--- a/libmocktainer/unikraft/net_qemu.go
+++ b/libmocktainer/unikraft/net_qemu.go
@@ -1,0 +1,171 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2023, Unikraft GmbH and The KraftKit Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+
+package unikraft
+
+import (
+	"fmt"
+	"net"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/vishvananda/netlink"
+	"golang.org/x/sys/unix"
+)
+
+// SetupQemuNet sets up the network for QEMU within the current network
+// namespace, and returns QEMU network flags for the created netlink.
+func SetupQemuNet() (qemuNetArgs []string, _ error) {
+	defRoute, err := defaultRoute()
+	if err != nil {
+		return nil, fmt.Errorf("getting default route: %w", err)
+	}
+	if defRoute == nil {
+		// no container network
+		return nil, nil
+	}
+
+	defNetlinkIdx := defRoute.LinkIndex
+	defNetlink, err := netlink.LinkByIndex(defNetlinkIdx)
+	if err != nil {
+		return nil, fmt.Errorf("getting default netlink with index %d: %w", defNetlinkIdx, err)
+	}
+
+	defNetlinkAddr, err := netlinkAddress(defNetlink)
+	if err != nil {
+		return nil, fmt.Errorf("getting addr of default netlink %s: %w", defNetlink.Attrs().Name, err)
+	}
+	if defNetlinkAddr == nil {
+		// no container network
+		return nil, nil
+	}
+
+	const tapName = "uktap0"
+	mvt, err := createBridgeMacvtap(tapName, defNetlinkIdx)
+	if err != nil {
+		return nil, fmt.Errorf("creating macvtap netlink %s: %w", tapName, err)
+	}
+
+	tapDev := tapDevicePath(mvt)
+	tapDevFd, err := unix.Open(tapDev, unix.O_RDWR, 0)
+	if err != nil {
+		return nil, &os.PathError{Op: "open macvtap device", Path: tapDev, Err: err}
+	}
+
+	args := append(
+		genQemuKernelNetCmdline(defNetlinkAddr.IP, defRoute.Gw, defNetlinkAddr.Mask),
+		genQemuNetArgs(tapDevFd, mvt.HardwareAddr)...,
+	)
+
+	if err = netlink.AddrDel(defNetlink, defNetlinkAddr); err != nil {
+		return nil, fmt.Errorf("deleting addr of default netlink %s: %w", tapName, err)
+	}
+
+	return args, nil
+}
+
+// genQemuNetArgs returns QEMU network flags for the given MacVTap netlink.
+// devFd is the number of the file descriptor corresponding to the netlink's
+// device, as passed to the QEMU process.
+func genQemuNetArgs(devFd int, hwaddr net.HardwareAddr) []string {
+	return []string{
+		"-netdev", "tap,id=n0,fd=" + strconv.Itoa(devFd),
+		"-device", "virtio-net-pci,netdev=n0,mac=" + hwaddr.String(),
+	}
+}
+
+// genQemuKernelNetCmdline returns network arguments to be passed on the kernel's
+// command line.
+func genQemuKernelNetCmdline(addr, gwaddr net.IP, subnet net.IPMask) []string {
+	var cmdline strings.Builder
+	cmdline.WriteString("netdev.ipv4_addr=" + addr.String())
+	cmdline.WriteByte(' ')
+	cmdline.WriteString("netdev.ipv4_gw_addr=" + gwaddr.String())
+	cmdline.WriteByte(' ')
+	cmdline.WriteString("netdev.ipv4_subnet_mask=" + net.IP(subnet).String())
+	cmdline.WriteByte(' ')
+	cmdline.WriteString("--")
+	cmdline.WriteByte(' ')
+
+	return []string{
+		"-append", cmdline.String(),
+	}
+}
+
+// createBridgeMacvtap creates a MacVTap netlink that is bridged with the
+// netlink for the current namespace's default route.
+func createBridgeMacvtap(name string, parentIdx int) (*netlink.Macvtap, error) {
+	if _, err := netlink.LinkByName(name); err == nil {
+		return nil, fmt.Errorf("netlink %s already exists", name)
+	}
+
+	mvt := newBridgeMacvtap(name, parentIdx)
+	if err := netlink.LinkAdd(mvt); err != nil {
+		return nil, fmt.Errorf("adding macvtap netlink %s: %w", mvt.Name, err)
+	}
+	if err := netlink.LinkSetUp(mvt); err != nil {
+		return mvt, fmt.Errorf("enabling macvtap netlink %s: %w", mvt.Name, err)
+	}
+
+	l, err := netlink.LinkByName(mvt.Name) // refresh attributes such as hwaddr
+	if err != nil {
+		return mvt, fmt.Errorf("getting macvtap netlink %s: %w", mvt.Name, err)
+	}
+
+	return l.(*netlink.Macvtap), nil
+}
+
+// defaultRoute returns the default route for the current namespace.
+func defaultRoute() (*netlink.Route, error) {
+	defaultRouteFilter := &netlink.Route{Dst: nil}
+	routes, err := netlink.RouteListFiltered(netlink.FAMILY_ALL, defaultRouteFilter, netlink.RT_FILTER_DST)
+	if err != nil {
+		return nil, fmt.Errorf("listing default net routes: %w", err)
+	}
+	if n := len(routes); n > 1 {
+		return nil, fmt.Errorf("found more than one default net routes (%d)", n)
+	}
+
+	if len(routes) == 0 {
+		return nil, nil
+	}
+
+	return &routes[0], nil
+}
+
+// netlinkAddress returns the address of the given netlink. If the netlink has
+// multiple addresses, the first one is returned.
+func netlinkAddress(l netlink.Link) (*netlink.Addr, error) {
+	addrs, err := netlink.AddrList(l, netlink.FAMILY_V4) // no ipv6 support in Unikraft
+	if err != nil {
+		return nil, fmt.Errorf("getting addresses of netlink %s: %w", l.Attrs().Name, err)
+	}
+	if len(addrs) == 0 {
+		return nil, nil
+	}
+
+	return &addrs[0], nil
+}
+
+// newBridgeMacvtap initializes a netlink.Macvtap that operates in bridge mode
+// with the given parent netlink.
+func newBridgeMacvtap(name string, parentIdx int) *netlink.Macvtap {
+	mvtAttr := netlink.NewLinkAttrs()
+	mvtAttr.Name = name
+	mvtAttr.ParentIndex = parentIdx
+
+	return &netlink.Macvtap{
+		Macvlan: netlink.Macvlan{
+			LinkAttrs: mvtAttr,
+			Mode:      netlink.MACVLAN_MODE_BRIDGE,
+		},
+	}
+}
+
+// tapDevicePath returns the path of the tap device for the given netlink.
+func tapDevicePath(l *netlink.Macvtap) string {
+	return "/dev/tap" + strconv.Itoa(l.Index)
+}

--- a/libmocktainer/utils/cmsg.go
+++ b/libmocktainer/utils/cmsg.go
@@ -1,0 +1,119 @@
+package utils
+
+/*
+ * Copyright 2016, 2017 SUSE LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import (
+	"fmt"
+	"os"
+	"runtime"
+
+	"golang.org/x/sys/unix"
+)
+
+// MaxNameLen is the maximum length of the name of a file descriptor being sent
+// using SendFile. The name of the file handle returned by RecvFile will never be
+// larger than this value.
+const MaxNameLen = 4096
+
+// oobSpace is the size of the oob slice required to store a single FD. Note
+// that unix.UnixRights appears to make the assumption that fd is always int32,
+// so sizeof(fd) = 4.
+var oobSpace = unix.CmsgSpace(4)
+
+// RecvFile waits for a file descriptor to be sent over the given AF_UNIX
+// socket. The file name of the remote file descriptor will be recreated
+// locally (it is sent as non-auxiliary data in the same payload).
+func RecvFile(socket *os.File) (_ *os.File, Err error) {
+	name := make([]byte, MaxNameLen)
+	oob := make([]byte, oobSpace)
+
+	sockfd := socket.Fd()
+	n, oobn, _, _, err := unix.Recvmsg(int(sockfd), name, oob, unix.MSG_CMSG_CLOEXEC)
+	if err != nil {
+		return nil, err
+	}
+	if n >= MaxNameLen || oobn != oobSpace {
+		return nil, fmt.Errorf("recvfile: incorrect number of bytes read (n=%d oobn=%d)", n, oobn)
+	}
+	// Truncate.
+	name = name[:n]
+	oob = oob[:oobn]
+
+	scms, err := unix.ParseSocketControlMessage(oob)
+	if err != nil {
+		return nil, err
+	}
+
+	// We cannot control how many SCM_RIGHTS we receive, and upon receiving
+	// them all of the descriptors are installed in our fd table, so we need to
+	// parse all of the SCM_RIGHTS we received in order to close all of the
+	// descriptors on error.
+	var fds []int
+	defer func() {
+		for i, fd := range fds {
+			if i == 0 && Err == nil {
+				// Only close the first one on error.
+				continue
+			}
+			// Always close extra ones.
+			_ = unix.Close(fd)
+		}
+	}()
+	var lastErr error
+	for _, scm := range scms {
+		if scm.Header.Type == unix.SCM_RIGHTS {
+			scmFds, err := unix.ParseUnixRights(&scm)
+			if err != nil {
+				lastErr = err
+			} else {
+				fds = append(fds, scmFds...)
+			}
+		}
+	}
+	if lastErr != nil {
+		return nil, lastErr
+	}
+
+	// We do this after collecting the fds to make sure we close them all when
+	// returning an error here.
+	if len(scms) != 1 {
+		return nil, fmt.Errorf("recvfd: number of SCMs is not 1: %d", len(scms))
+	}
+	if len(fds) != 1 {
+		return nil, fmt.Errorf("recvfd: number of fds is not 1: %d", len(fds))
+	}
+	return os.NewFile(uintptr(fds[0]), string(name)), nil
+}
+
+// SendFile sends a file over the given AF_UNIX socket. file.Name() is also
+// included so that if the other end uses RecvFile, the file will have the same
+// name information.
+func SendFile(socket *os.File, file *os.File) error {
+	name := file.Name()
+	if len(name) >= MaxNameLen {
+		return fmt.Errorf("sendfd: filename too long: %s", name)
+	}
+	err := SendRawFd(socket, name, file.Fd())
+	runtime.KeepAlive(file)
+	return err
+}
+
+// SendRawFd sends a specific file descriptor over the given AF_UNIX socket.
+func SendRawFd(socket *os.File, msg string, fd uintptr) error {
+	oob := unix.UnixRights(int(fd))
+	return unix.Sendmsg(int(socket.Fd()), []byte(msg), oob, nil, 0)
+}


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [ ] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

This PR adds an OCI-compliant [runtime](https://github.com/opencontainers/runtime-spec/blob/v1.1.0/runtime.md) "`runu`" for managing the lifecycle of unikernels through the operations of a container runtime like [containerd](https://containerd.io/).

The OCI runtime spec defines the _operations_ that a compliant runtime must support, but remains deliberately vague about its API. To remain as compatible as possible with the existing container ecosystem, `runu` implements the [`runc` command-line interface](https://github.com/opencontainers/runtime-tools/blob/v0.9.0/docs/command-line-interface.md) (the reference implementation). This allows us, for instance, to integrate `runu` with containerd without having to perform any modification to `containerd-shim-runc-v2`.

It does **not** leverage KraftKit's [`MachineService` interface](https://pkg.go.dev/kraftkit.sh@v0.6.6/api/machine/v1alpha1#MachineService), because its flow is not compatible with the two-phases startup expected by the OCI runtime specification. However, it does start one QEMU machine using that interface, then stops it immediately after, as a horrible hack for retrieving the list of arguments passed to the `qemu` command by KraftKit. These arguments are then passed to the container bootstrap process (`runu init`), which uses them to `exec()` a new VM.

### Architecture decisions

1. To achieve the container startup in two phases (create/start), I needed to fork [libcontainer](https://github.com/opencontainers/runc/tree/v1.1.9/libcontainer#readme), and remove all the bits which are actually related to creating a container (how ironic): cgroups, all namespaces except `net`, capabilities, console, mounts, pivot root, ... I called that fork "libmocktainer". I think it's a fair description of what it is.

1. The entire CLI implementation is located inside `cmd/runu/`, and each command is self-contained (no import of shared `runu` packages). I feel that the current implementation is compact enough to fit into this model without causing much duplicate code. (Conversely, moving the common code to helpers would result in extremely small packages which don't quite fit anywhere else. This feels premature to me.)

   `create` is the only command that contains a fair amount of setup logic, and that logic is not reused in any other command.

---

### Network setup

![image](https://github.com/unikraft-io/kraftkit/assets/3299086/86747579-4125-4be4-914e-28295b537451)

---

### Showcase

_All commands require elevated privileges (`sudo`)_

#### Run a "container" (unikernel)

1. Build `runu`
   ```console
   $ go build ./cmd/runu
   ```

1. Run `containerd`

1. Fetch some unikernel image
   ```console
   $ ctr image pull -u user:pw --platform qemu/x86_64 index.unikraft.io/acotten/app-nginx:latest
   index.unikraft.io/acotten/app-nginx:latest:                                       resolved       |++++++++|
   manifest-sha256:18a381f006225d23c168df4cb3da87900a3d9ea536e545c7fe594738c74f8a92: done           |++++++++|
   layer-sha256:887b475c42ab15abee218792252361cc44c7019e24cf3c239ad33c417085c561:    done           |++++++++|
   layer-sha256:60137ba8319574312dec99be3ef4f6952642ee9b1a1d5d568c942da5b53bde56:    done           |++++++++|
   config-sha256:c956efe6e2d158778b831ab08de95b9beb637da5889e12996adb85943ed1efa6:   done           |++++++++|
   elapsed: 1.3 s                                                                    total:   0.0 B (0.0 B/s)
   unpacking qemu/amd64 sha256:18a381f006225d23c168df4cb3da87900a3d9ea536e545c7fe594738c74f8a92...
   done: 7.379499ms
   ```

1. Start a task from that unikernel image,
   ```console
   $ ctr run --cni --detach --runc-binary=$PWD/runu index.unikraft.io/acotten/app-nginx:latest runu-demo
   (no output means success)
   ```

#### Some observations

1. The "container" (unikernel) is running
   ```console
   $ ctr task ls
   TASK         PID     STATUS
   runu-demo    5880    RUNNING
   ```
   ```console
   $ ./runu --root /run/containerd/runc/default --log /dev/null state runu-demo
   {
     "ociVersion": "1.1.0",
     "id": "runu-demo",
     "status": "running",
     "bundle": "/run/containerd/io.containerd.runtime.v2.task/default/runu-demo",
     "pid": 5880,
     "rootfs": "/run/containerd/io.containerd.runtime.v2.task/default/runu-demo/rootfs",
     "created": "2023-08-21T19:44:05.710446539Z"
   }
   ```
   ```console
   $ ps axjf
    PPID   PID  PGID ... COMMAND
       0     1     0 ... /init
    4627  4628  4627 ...  \_ /init
    4628  4629  4629 ...      \_ -zsh
    4628  5852  5852 ...      \_ /usr/local/bin/containerd-shim-runc-v2 ...
    5852  5880  5878 ...          \_ qemu-system-x86_64 -cpu host,+x2apic,-pmu -device pvpanic ...
   ```

1. One end of the virtual ethernet created by CNI was placed in an isolated Linux `net` namespace, and a macvtap was bridged with that interface:
   > **Note**
   > The namespaced veth `eth0@if42` below no longer has an IP address. The routing table is also empty. Those are consequences of removing the IP address allocated by CNI, to be able to give it to the QEMU guest.
   ```console
   $ ip addr
   1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN group default qlen 1000
       link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00
       inet 127.0.0.1/8 scope host lo
          valid_lft forever preferred_lft forever
       inet6 ::1/128 scope host
          valid_lft forever preferred_lft forever
   2: eth0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc mq state UP group default qlen 1000
       link/ether 00:15:5d:27:50:24 brd ff:ff:ff:ff:ff:ff
       inet 172.24.172.99/20 brd 172.24.175.255 scope global eth0
          valid_lft forever preferred_lft forever
       inet6 fe80::215:5dff:fe27:5024/64 scope link
          valid_lft forever preferred_lft forever
   41: cni0: <BROADCAST,MULTICAST,PROMISC,UP,LOWER_UP> mtu 1500 qdisc noqueue state UP group default qlen 1000
       link/ether 5a:b6:8b:6a:06:66 brd ff:ff:ff:ff:ff:ff
       inet 10.88.0.1/16 brd 10.88.255.255 scope global cni0
          valid_lft forever preferred_lft forever
       inet6 2001:4860:4860::1/64 scope global
          valid_lft forever preferred_lft forever
       inet6 fe80::58b6:8bff:fe6a:666/64 scope link
          valid_lft forever preferred_lft forever
   42: vethaa2f1594@if2: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue master cni0 state UP group default
       link/ether 02:5e:f4:ab:3a:33 brd ff:ff:ff:ff:ff:ff link-netnsid 0
       inet6 fe80::5e:f4ff:feab:3a33/64 scope link
          valid_lft forever preferred_lft forever
   ```
   ```console
   $ ln -sT /proc/5880/ns/net /var/run/netns/runu-demo
   ```
   ```console
   $ ip netns exec runu-demo ip addr
   1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN group default qlen 1000
       link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00
       inet 127.0.0.1/8 scope host lo
          valid_lft forever preferred_lft forever
       inet6 ::1/128 scope host
          valid_lft forever preferred_lft forever
   2: eth0@if42: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue state UP group default
       link/ether 5e:5d:6a:d2:7f:28 brd ff:ff:ff:ff:ff:ff link-netnsid 0
       inet6 fe80::5c5d:6aff:fed2:7f28/64 scope link
          valid_lft forever preferred_lft forever
   3: uktap0@eth0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc fq_codel state UP group default qlen 500
       link/ether 0a:19:db:af:f3:ee brd ff:ff:ff:ff:ff:ff
       inet6 fe80::819:dbff:feaf:f3ee/64 scope link
          valid_lft forever preferred_lft forever
   ```
   ```console
   $ ip netns exec runu-demo ip route
   (empty)
   ```

1. The application (nginx) responds to HTTP requests:
   ```console
   $ ps axww
   qemu-system-x86_64 -append netdev.ipv4_addr=10.88.0.2 ...
   ```
   ```console
   $ curl -D- http://10.4.0.2
   HTTP/1.1 200 OK
   Server: nginx/1.15.6
   ...
   ```

1. The "container" (unikernel) can be stopped
   ```console
   $ ctr task kill runu-demo
   (no output means success)
   ```
   ```console
   $ ctr task ls
   TASK         PID     STATUS
   runu-demo    5880    STOPPED
   ```
   ```console
   $ ./runu --root /run/containerd/runc/default --log /dev/null state runu-demo
   {
     "ociVersion": "1.1.0",
     "id": "runu-demo",
     "status": "stopped",
     "bundle": "/run/containerd/io.containerd.runtime.v2.task/default/runu-demo",
     "pid": 0,
     "rootfs": "/run/containerd/io.containerd.runtime.v2.task/default/runu-demo/rootfs",
     "created": "2023-08-21T19:44:05.710446539Z"
   }
   ```
   ```console
   $ ps axjf
    PPID   PID  PGID ... COMMAND
       0     1     0 ... /init
    4627  4628  4627 ...  \_ /init
    4628  4629  4629 ...      \_ -zsh
    4628  5852  5852 ...      \_ /usr/local/bin/containerd-shim-runc-v2 ...
                                 (child was reaped)
   ```

1. The "container" (unikernel) can be deleted, along with its task and snapshot:
   ```console
   $ ctr container delete runu-demo
   (no output means success)
   ```
   ```console
   $ ctr task ls
   TASK    PID     STATUS
   (task is gone)
   ```
   ```console
   $ ./runu --root /run/containerd/runc/default --log /dev/null state runu-demo
   loading container from saved state: container does not exist
   ```
   ```console
   $ ps axjf
    PPID   PID  PGID ... COMMAND
       0     1     0 ... /init
    4627  4628  4627 ...  \_ /init
    4628  4629  4629 ...      \_ -zsh
                             (shim exited)
   ```

---

### Potential follow ups

Things to address:

- **[SOLVED with a workaround]** Containers can't be created via nerdctl or Kubernetes because of a limit on QEMU's QMP socket paths. Although I can accumulate the hacks around the machine interface, I'd rather have access to some internals for generating machine args directly from `runu`:
   ```
   FATA[0000] failed to create shim task: OCI runtime create failed:
   generating machine args: creating machine: could not start and wait for QEMU process:
   qemu-system-x86_64: -qmp unix:/run/containerd/runc/default/bf6f970d280ba13c36f34f8d8765603244362620d12b405a5e91bd822ead4c8a/qemu_control.sock,server,nowait:
   UNIX socket path '/run/containerd/runc/default/bf6f970d280ba13c36f34f8d8765603244362620d12b405a5e91bd822ead4c8a/qemu_control.sock' is too long
   Path must be less than 108 bytes
   ```