### PR TITLE
fix(run): Send finish signal after removing from store

### DIFF
--- a/cmd/kraft/run/run.go
+++ b/cmd/kraft/run/run.go
@@ -420,7 +420,7 @@ func (opts *Run) Run(cmd *cobra.Command, args []string) error {
 	}
 
 	// Start the machine
-	machine, err = opts.machineController.Start(ctx, machine)
+	_, err = opts.machineController.Start(ctx, machine)
 	if err != nil {
 		signals.RequestShutdown()
 		return err
@@ -461,7 +461,6 @@ func (opts *Run) Run(cmd *cobra.Command, args []string) error {
 				break loop
 			}
 		}
-		logsFinished <- true
 
 		// Remove the instance on Ctrl+C if the --rm flag is passed
 		if opts.Remove {
@@ -504,6 +503,10 @@ func (opts *Run) Run(cmd *cobra.Command, args []string) error {
 		if _, err = opts.networkController.Update(ctx, found); err != nil {
 			return fmt.Errorf("could not update network %s: %v", opts.networkName, err)
 		}
+	}
+
+	if !opts.Detach {
+		logsFinished <- true
 	}
 
 	return exitErr


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

If the signal is sent before, the process stops before it has a chance to signal the fact that the machine must be stopped/removed.

Tested on 3 different machines and the fix worked.
The situation before can't always be replicated because it's a race condition