### PR TITLE
fix(workflows): Skip tidy checks if dependabot bumps

### DIFF
--- a/.github/workflows/gochecks.yaml
+++ b/.github/workflows/gochecks.yaml
@@ -47,6 +47,7 @@ jobs:
             ${{ github.job }}-${{ runner.os }}-go-
 
       - name: Check that go.mod is tidy
+        if: startsWith(github.ref_name, 'dependabot/') == false
         uses: protocol/multiple-go-modules@v1.4
         with:
           run: |


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

Most, if not all, dependency bumps are now done by dependabot. They are single-commit PRs and have fail because of the `replace` statement inside `github-action`.

Because of this, it's safe to just remove the check for all gomod cases.
