### PR TITLE
fix(oci): Add filtering capability to package manager

### DIFF
--- a/oci/manager.go
+++ b/oci/manager.go
@@ -25,6 +25,7 @@ import (
 	"kraftkit.sh/oci/handler"
 	"kraftkit.sh/pack"
 	"kraftkit.sh/packmanager"
+	"kraftkit.sh/unikraft"
 	"kraftkit.sh/unikraft/component"
 	"kraftkit.sh/unikraft/target"
 )
@@ -123,7 +124,7 @@ func (manager *ociManager) Catalog(ctx context.Context, qopts ...packmanager.Que
 	query := packmanager.NewQuery(qopts...)
 	qname := query.Name()
 	qversion := query.Version()
-
+	types := query.Types()
 	// Adjust for the version being suffixed in a prototypical OCI reference
 	// format
 	ref, refErr := name.ParseReference(qname,
@@ -223,6 +224,18 @@ func (manager *ociManager) Catalog(ctx context.Context, qopts ...packmanager.Que
 	}
 
 	for _, manifest := range manifests {
+		if len(types) > 0 {
+			found := false
+			for _, t := range types {
+				if unikraft.ComponentTypeApp == t {
+					found = true
+					break
+				}
+			}
+			if !found {
+				continue
+			}
+		}
 		// Check if the OCI image has a known annotation which identifies if a
 		// unikernel is contained within
 		if _, ok := manifest.Annotations[AnnotationKernelVersion]; !ok {


### PR DESCRIPTION
Adds missing filtering capability to OCI package-manager catalog to not to return OCI packages on setting up filtering flags -C, -L with `kraft pkg list` command.
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [ ] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->
