### PR TITLE
feat(e2e): Add tests for the 'net' set of commands

### DIFF
--- a/test/e2e/cli/net_create_test.go
+++ b/test/e2e/cli/net_create_test.go
@@ -27,7 +27,7 @@ var _ = Describe("kraft net create", func() {
 
 		cfg = fcfg.NewTempConfig()
 
-		cmd = fcmd.NewKraft(stdout, stderr, cfg.Path())
+		cmd = fcmd.NewKraftPrivileged(stdout, stderr, cfg.Path())
 		cmd.Args = append(cmd.Args, "net", "create", "--log-level", "info", "--log-type", "json")
 	})
 
@@ -157,7 +157,7 @@ var _ = Describe("kraft net create", func() {
 			// Remove the network
 			stdoutRm := fcmd.NewIOStream()
 			stderrRm := fcmd.NewIOStream()
-			cmdRm := fcmd.NewKraft(stdoutRm, stderrRm, cfg.Path())
+			cmdRm := fcmd.NewKraftPrivileged(stdoutRm, stderrRm, cfg.Path())
 			cmdRm.Args = append(cmdRm.Args, "net", "rm", "test-create-4")
 
 			err := cmdRm.Run()
@@ -175,7 +175,7 @@ var _ = Describe("kraft net create", func() {
 			// Check that the network exists
 			stdoutLs := fcmd.NewIOStream()
 			stderrLs := fcmd.NewIOStream()
-			cmdLs := fcmd.NewKraft(stdoutLs, stderrLs, cfg.Path())
+			cmdLs := fcmd.NewKraftPrivileged(stdoutLs, stderrLs, cfg.Path())
 			cmdLs.Args = append(cmdLs.Args, "net", "ls", "--log-level", "info", "--log-type", "json")
 			err = cmdLs.Run()
 

--- a/test/e2e/cli/net_create_test.go
+++ b/test/e2e/cli/net_create_test.go
@@ -6,6 +6,8 @@
 package cli_test
 
 import (
+	"fmt"
+
 	. "github.com/onsi/ginkgo/v2" //nolint:stylecheck
 	. "github.com/onsi/gomega"    //nolint:stylecheck
 
@@ -48,6 +50,9 @@ var _ = Describe("kraft net create", func() {
 
 		It("should print the command's help", func() {
 			err := cmd.Run()
+			if err != nil {
+				fmt.Printf("Error running command, dumping output:\n%s\n%s\n%s\n", err, stderr, stdout)
+			}
 			Expect(err).ToNot(HaveOccurred())
 
 			Expect(stderr.String()).To(BeEmpty())
@@ -161,13 +166,17 @@ var _ = Describe("kraft net create", func() {
 			cmdRm.Args = append(cmdRm.Args, "net", "rm", "test-create-4")
 
 			err := cmdRm.Run()
-
+			if err != nil {
+				fmt.Printf("Error running command, dumping output:\n%s\n%s\n%s\n", err, stderr, stdout)
+			}
 			Expect(err).ToNot(HaveOccurred())
 		})
 
 		It("should create the network, print the network name, and exit", func() {
 			err := cmd.Run()
-
+			if err != nil {
+				fmt.Printf("Error running command, dumping output:\n%s\n%s\n%s\n", err, stderr, stdout)
+			}
 			Expect(err).ToNot(HaveOccurred())
 			Expect(stderr.String()).To(BeEmpty())
 			Expect(stdout.String()).To(MatchRegexp(`^test-create-4\n$`))
@@ -179,6 +188,9 @@ var _ = Describe("kraft net create", func() {
 			cmdLs.Args = append(cmdLs.Args, "net", "ls", "--log-level", "info", "--log-type", "json")
 			err = cmdLs.Run()
 
+			if err != nil {
+				fmt.Printf("Error running command, dumping output:\n%s\n%s\n%s\n", err, stderr, stdout)
+			}
 			Expect(err).ToNot(HaveOccurred())
 			Expect(stderrLs.String()).To(BeEmpty())
 			Expect(stdoutLs.String()).To(MatchRegexp(`^NAME[\t ]+NETWORK[\t ]+DRIVER[\t ]+STATUS\n`))

--- a/test/e2e/cli/net_create_test.go
+++ b/test/e2e/cli/net_create_test.go
@@ -1,0 +1,188 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2023, Unikraft GmbH and The KraftKit Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+
+package cli_test
+
+import (
+	. "github.com/onsi/ginkgo/v2" //nolint:stylecheck
+	. "github.com/onsi/gomega"    //nolint:stylecheck
+
+	fcmd "kraftkit.sh/test/e2e/framework/cmd"
+	fcfg "kraftkit.sh/test/e2e/framework/config"
+)
+
+var _ = Describe("kraft net create", func() {
+	var cmd *fcmd.Cmd
+
+	var stdout *fcmd.IOStream
+	var stderr *fcmd.IOStream
+
+	var cfg *fcfg.Config
+
+	BeforeEach(func() {
+		stdout = fcmd.NewIOStream()
+		stderr = fcmd.NewIOStream()
+
+		cfg = fcfg.NewTempConfig()
+
+		cmd = fcmd.NewKraft(stdout, stderr, cfg.Path())
+		cmd.Args = append(cmd.Args, "net", "create", "--log-level", "info", "--log-type", "json")
+	})
+
+	When("invoked without flags or positional arguments", func() {
+		It("should print an error and exit with an error", func() {
+			err := cmd.Run()
+			Expect(err).To(HaveOccurred())
+
+			Expect(stderr.String()).To(BeEmpty())
+			Expect(stdout.String()).To(MatchRegexp(`^{"level":"error","msg":"accepts 1 arg\(s\), received 0"}\n`))
+		})
+	})
+
+	When("invoked with the --help flag", func() {
+		BeforeEach(func() {
+			cmd.Args = append(cmd.Args, "--help")
+		})
+
+		It("should print the command's help", func() {
+			err := cmd.Run()
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(stderr.String()).To(BeEmpty())
+			Expect(stdout.String()).To(MatchRegexp(`^Create a new machine network\n`))
+		})
+	})
+
+	When("invoked with two positional arguments", func() {
+		BeforeEach(func() {
+			cmd.Args = append(cmd.Args, "some-arg")
+			cmd.Args = append(cmd.Args, "some-other-arg")
+		})
+
+		It("should print an error and exit with an error", func() {
+			err := cmd.Run()
+			Expect(err).To(HaveOccurred())
+
+			Expect(stderr.String()).To(BeEmpty())
+			Expect(stdout.String()).To(MatchRegexp(`^{"level":"error","msg":"accepts 1 arg\(s\), received 2"}\n$`))
+		})
+	})
+
+	When("invoked with one positional argument without a network", func() {
+		BeforeEach(func() {
+			cmd.Args = append(cmd.Args, "some-arg")
+		})
+
+		It("should print an error and exit with an error", func() {
+			err := cmd.Run()
+			Expect(err).To(HaveOccurred())
+
+			Expect(stderr.String()).To(BeEmpty())
+			Expect(stdout.String()).To(MatchRegexp(`^{"level":"error","msg":"cannot create network without gateway and subnet in CIDR format"}\n$`))
+		})
+	})
+
+	When("invoked with one positional argument and a network without a subnet", func() {
+		BeforeEach(func() {
+			cmd.Args = append(cmd.Args, "--network", "172.45.1.1")
+			cmd.Args = append(cmd.Args, "test-create-0")
+		})
+
+		It("should print an error and exit with an error", func() {
+			err := cmd.Run()
+			Expect(err).To(HaveOccurred())
+
+			Expect(stderr.String()).To(BeEmpty())
+			Expect(stdout.String()).To(MatchRegexp(`^{"level":"error","msg":"invalid CIDR address: 172\.45\.1\.1"}\n$`))
+		})
+	})
+
+	When("invoked with one positional argument and a network without a complete ip", func() {
+		BeforeEach(func() {
+			cmd.Args = append(cmd.Args, "--network", "172.45.2/24")
+			cmd.Args = append(cmd.Args, "test-create-1")
+		})
+
+		It("should print an error and exit with an error", func() {
+			err := cmd.Run()
+			Expect(err).To(HaveOccurred())
+
+			Expect(stderr.String()).To(BeEmpty())
+			Expect(stdout.String()).To(MatchRegexp(`^{"level":"error","msg":"invalid CIDR address: 172\.45\.2/24"}\n$`))
+		})
+	})
+
+	When("invoked with one positional argument and an invalid network", func() {
+		BeforeEach(func() {
+			cmd.Args = append(cmd.Args, "--network", "1234")
+			cmd.Args = append(cmd.Args, "test-create-2")
+		})
+
+		It("should print an error and exit with an error", func() {
+			err := cmd.Run()
+			Expect(err).To(HaveOccurred())
+
+			Expect(stderr.String()).To(BeEmpty())
+			Expect(stdout.String()).To(MatchRegexp(`^{"level":"error","msg":"invalid CIDR address: 1234"}\n$`))
+		})
+	})
+
+	When("invoked with one positional argument, invalid driver, and a valid network", func() {
+		BeforeEach(func() {
+			cmd.Args = append(cmd.Args, "--driver", "unknown")
+			cmd.Args = append(cmd.Args, "--network", "172.45.3.1/24")
+			cmd.Args = append(cmd.Args, "test-create-3")
+		})
+
+		It("should print an error and exit", func() {
+			err := cmd.Run()
+			Expect(err).To(HaveOccurred())
+
+			Expect(stderr.String()).To(BeEmpty())
+			Expect(stdout.String()).To(MatchRegexp(`^{"level":"error","msg":"unsupported network driver strategy: unknown \(contributions welcome\!\)"}\n$`))
+		})
+	})
+
+	// Requires root privileges
+	When("invoked with one positional argument, valid driver, and a valid network", func() {
+		BeforeEach(func() {
+			cmd.Args = append(cmd.Args, "--driver", "bridge")
+			cmd.Args = append(cmd.Args, "--network", "172.45.4.1/24")
+			cmd.Args = append(cmd.Args, "test-create-4")
+		})
+
+		AfterEach(func() {
+			// Remove the network
+			stdoutRm := fcmd.NewIOStream()
+			stderrRm := fcmd.NewIOStream()
+			cmdRm := fcmd.NewKraft(stdoutRm, stderrRm, cfg.Path())
+			cmdRm.Args = append(cmdRm.Args, "net", "rm", "test-create-4")
+
+			err := cmdRm.Run()
+
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("should create the network, print the network name, and exit", func() {
+			err := cmd.Run()
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(stderr.String()).To(BeEmpty())
+			Expect(stdout.String()).To(MatchRegexp(`^test-create-4\n$`))
+
+			// Check that the network exists
+			stdoutLs := fcmd.NewIOStream()
+			stderrLs := fcmd.NewIOStream()
+			cmdLs := fcmd.NewKraft(stdoutLs, stderrLs, cfg.Path())
+			cmdLs.Args = append(cmdLs.Args, "net", "ls", "--log-level", "info", "--log-type", "json")
+			err = cmdLs.Run()
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(stderrLs.String()).To(BeEmpty())
+			Expect(stdoutLs.String()).To(MatchRegexp(`^NAME[\t ]+NETWORK[\t ]+DRIVER[\t ]+STATUS\n`))
+			Expect(stdoutLs.String()).To(MatchRegexp(`test-create-4[\t ]+172.45.4.1/24[\t ]+bridge[\t ]+up`))
+		})
+	})
+})

--- a/test/e2e/cli/net_down_test.go
+++ b/test/e2e/cli/net_down_test.go
@@ -27,7 +27,7 @@ var _ = Describe("kraft net down", func() {
 
 		cfg = fcfg.NewTempConfig()
 
-		cmd = fcmd.NewKraft(stdout, stderr, cfg.Path())
+		cmd = fcmd.NewKraftPrivileged(stdout, stderr, cfg.Path())
 		cmd.Args = append(cmd.Args, "net", "down", "--log-level", "info", "--log-type", "json")
 	})
 
@@ -63,7 +63,7 @@ var _ = Describe("kraft net down", func() {
 			// Create the network
 			stdoutCreate := fcmd.NewIOStream()
 			stderrCreate := fcmd.NewIOStream()
-			cmdCreate := fcmd.NewKraft(stdoutCreate, stderrCreate, cfg.Path())
+			cmdCreate := fcmd.NewKraftPrivileged(stdoutCreate, stderrCreate, cfg.Path())
 			cmdCreate.Args = append(cmdCreate.Args, "net", "create", "--log-level", "info", "--log-type", "json")
 			cmdCreate.Args = append(cmdCreate.Args, "--driver", "bridge")
 			cmdCreate.Args = append(cmdCreate.Args, "--network", "172.48.0.1/24")
@@ -81,7 +81,7 @@ var _ = Describe("kraft net down", func() {
 		AfterEach(func() {
 			stdoutRm := fcmd.NewIOStream()
 			stderrRm := fcmd.NewIOStream()
-			cmdRm := fcmd.NewKraft(stdoutRm, stderrRm, cfg.Path())
+			cmdRm := fcmd.NewKraftPrivileged(stdoutRm, stderrRm, cfg.Path())
 			cmdRm.Args = append(cmdRm.Args, "net", "rm", "test-down-1")
 
 			err := cmdRm.Run()
@@ -99,7 +99,7 @@ var _ = Describe("kraft net down", func() {
 			// Check if the network is down
 			stdoutLs := fcmd.NewIOStream()
 			stderrLs := fcmd.NewIOStream()
-			cmdLs := fcmd.NewKraft(stdoutLs, stderrLs, cfg.Path())
+			cmdLs := fcmd.NewKraftPrivileged(stdoutLs, stderrLs, cfg.Path())
 			cmdLs.Args = append(cmdLs.Args, "net", "ls", "--log-level", "info", "--log-type", "json")
 
 			err = cmdLs.Run()

--- a/test/e2e/cli/net_down_test.go
+++ b/test/e2e/cli/net_down_test.go
@@ -1,0 +1,127 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2023, Unikraft GmbH and The KraftKit Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+
+package cli_test
+
+import (
+	. "github.com/onsi/ginkgo/v2" //nolint:stylecheck
+	. "github.com/onsi/gomega"    //nolint:stylecheck
+
+	fcmd "kraftkit.sh/test/e2e/framework/cmd"
+	fcfg "kraftkit.sh/test/e2e/framework/config"
+)
+
+var _ = Describe("kraft net down", func() {
+	var cmd *fcmd.Cmd
+
+	var stdout *fcmd.IOStream
+	var stderr *fcmd.IOStream
+
+	var cfg *fcfg.Config
+
+	BeforeEach(func() {
+		stdout = fcmd.NewIOStream()
+		stderr = fcmd.NewIOStream()
+
+		cfg = fcfg.NewTempConfig()
+
+		cmd = fcmd.NewKraft(stdout, stderr, cfg.Path())
+		cmd.Args = append(cmd.Args, "net", "down", "--log-level", "info", "--log-type", "json")
+	})
+
+	When("invoked without flags or positional arguments", func() {
+		It("should print an error and exit with an error", func() {
+			err := cmd.Run()
+			Expect(err).To(HaveOccurred())
+
+			Expect(stderr.String()).To(BeEmpty())
+			Expect(stdout.String()).To(MatchRegexp(`^{"level":"error","msg":"accepts 1 arg\(s\), received 0"}\n`))
+		})
+	})
+
+	// Requires root privileges
+	When("invoked with a non-existing network", func() {
+		BeforeEach(func() {
+			cmd.Args = append(cmd.Args, "--driver", "bridge")
+			cmd.Args = append(cmd.Args, "test-down-0")
+		})
+
+		It("should error out and exit with an error", func() {
+			err := cmd.Run()
+			Expect(err).To(HaveOccurred())
+
+			Expect(stderr.String()).To(BeEmpty())
+			Expect(stdout.String()).To(MatchRegexp(`^{"level":"error","msg":"getting bridge test-down-0 failed: Link not found"}\n$`))
+		})
+	})
+
+	// Requires root privileges
+	When("invoked with an existing network", func() {
+		BeforeEach(func() {
+			// Create the network
+			stdoutCreate := fcmd.NewIOStream()
+			stderrCreate := fcmd.NewIOStream()
+			cmdCreate := fcmd.NewKraft(stdoutCreate, stderrCreate, cfg.Path())
+			cmdCreate.Args = append(cmdCreate.Args, "net", "create", "--log-level", "info", "--log-type", "json")
+			cmdCreate.Args = append(cmdCreate.Args, "--driver", "bridge")
+			cmdCreate.Args = append(cmdCreate.Args, "--network", "172.48.0.1/24")
+			cmdCreate.Args = append(cmdCreate.Args, "test-down-1")
+
+			err := cmdCreate.Run()
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(stderrCreate.String()).To(BeEmpty())
+
+			cmd.Args = append(cmd.Args, "--driver", "bridge")
+			cmd.Args = append(cmd.Args, "test-down-1")
+		})
+
+		AfterEach(func() {
+			stdoutRm := fcmd.NewIOStream()
+			stderrRm := fcmd.NewIOStream()
+			cmdRm := fcmd.NewKraft(stdoutRm, stderrRm, cfg.Path())
+			cmdRm.Args = append(cmdRm.Args, "net", "rm", "test-down-1")
+
+			err := cmdRm.Run()
+
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("should bring the network down and print its name", func() {
+			err := cmd.Run()
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(stderr.String()).To(BeEmpty())
+			Expect(stdout.String()).To(MatchRegexp(`^test-down-1\n$`))
+
+			// Check if the network is down
+			stdoutLs := fcmd.NewIOStream()
+			stderrLs := fcmd.NewIOStream()
+			cmdLs := fcmd.NewKraft(stdoutLs, stderrLs, cfg.Path())
+			cmdLs.Args = append(cmdLs.Args, "net", "ls", "--log-level", "info", "--log-type", "json")
+
+			err = cmdLs.Run()
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(stderrLs.String()).To(BeEmpty())
+			Expect(stdoutLs.String()).To(MatchRegexp(`^NAME[\t ]+NETWORK[\t ]+DRIVER[\t ]+STATUS\n`))
+			Expect(stdoutLs.String()).To(MatchRegexp(`test-down-1[\t ]+172.48.0.1/24[\t ]+bridge[\t ]+down`))
+		})
+	})
+
+	When("invoked with the --help flag", func() {
+		BeforeEach(func() {
+			cmd.Args = append(cmd.Args, "--help")
+		})
+
+		It("should print the command's help", func() {
+			err := cmd.Run()
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(stderr.String()).To(BeEmpty())
+			Expect(stdout.String()).To(MatchRegexp(`^Bring a network offline\n`))
+		})
+	})
+})

--- a/test/e2e/cli/net_down_test.go
+++ b/test/e2e/cli/net_down_test.go
@@ -6,6 +6,8 @@
 package cli_test
 
 import (
+	"fmt"
+
 	. "github.com/onsi/ginkgo/v2" //nolint:stylecheck
 	. "github.com/onsi/gomega"    //nolint:stylecheck
 
@@ -70,7 +72,9 @@ var _ = Describe("kraft net down", func() {
 			cmdCreate.Args = append(cmdCreate.Args, "test-down-1")
 
 			err := cmdCreate.Run()
-
+			if err != nil {
+				fmt.Printf("Error running command, dumping output:\n%s\n%s\n%s\n", err, stderr, stdout)
+			}
 			Expect(err).ToNot(HaveOccurred())
 			Expect(stderrCreate.String()).To(BeEmpty())
 
@@ -85,13 +89,17 @@ var _ = Describe("kraft net down", func() {
 			cmdRm.Args = append(cmdRm.Args, "net", "rm", "test-down-1")
 
 			err := cmdRm.Run()
-
+			if err != nil {
+				fmt.Printf("Error running command, dumping output:\n%s\n%s\n%s\n", err, stderr, stdout)
+			}
 			Expect(err).ToNot(HaveOccurred())
 		})
 
 		It("should bring the network down and print its name", func() {
 			err := cmd.Run()
-
+			if err != nil {
+				fmt.Printf("Error running command, dumping output:\n%s\n%s\n%s\n", err, stderr, stdout)
+			}
 			Expect(err).ToNot(HaveOccurred())
 			Expect(stderr.String()).To(BeEmpty())
 			Expect(stdout.String()).To(MatchRegexp(`^test-down-1\n$`))
@@ -104,6 +112,9 @@ var _ = Describe("kraft net down", func() {
 
 			err = cmdLs.Run()
 
+			if err != nil {
+				fmt.Printf("Error running command, dumping output:\n%s\n%s\n%s\n", err, stderr, stdout)
+			}
 			Expect(err).ToNot(HaveOccurred())
 			Expect(stderrLs.String()).To(BeEmpty())
 			Expect(stdoutLs.String()).To(MatchRegexp(`^NAME[\t ]+NETWORK[\t ]+DRIVER[\t ]+STATUS\n`))
@@ -118,6 +129,9 @@ var _ = Describe("kraft net down", func() {
 
 		It("should print the command's help", func() {
 			err := cmd.Run()
+			if err != nil {
+				fmt.Printf("Error running command, dumping output:\n%s\n%s\n%s\n", err, stderr, stdout)
+			}
 			Expect(err).ToNot(HaveOccurred())
 
 			Expect(stderr.String()).To(BeEmpty())

--- a/test/e2e/cli/net_inspect_test.go
+++ b/test/e2e/cli/net_inspect_test.go
@@ -1,0 +1,124 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2023, Unikraft GmbH and The KraftKit Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+
+package cli_test
+
+import (
+	"encoding/json"
+
+	. "github.com/onsi/ginkgo/v2" //nolint:stylecheck
+	. "github.com/onsi/gomega"    //nolint:stylecheck
+
+	fcmd "kraftkit.sh/test/e2e/framework/cmd"
+	fcfg "kraftkit.sh/test/e2e/framework/config"
+)
+
+var _ = Describe("kraft net inspect", func() {
+	var cmd *fcmd.Cmd
+
+	var stdout *fcmd.IOStream
+	var stderr *fcmd.IOStream
+
+	var cfg *fcfg.Config
+
+	BeforeEach(func() {
+		stdout = fcmd.NewIOStream()
+		stderr = fcmd.NewIOStream()
+
+		cfg = fcfg.NewTempConfig()
+
+		cmd = fcmd.NewKraft(stdout, stderr, cfg.Path())
+		cmd.Args = append(cmd.Args, "net", "inspect", "--log-level", "info", "--log-type", "json")
+	})
+
+	When("invoked without flags or positional arguments", func() {
+		It("should print an error and exit with an error", func() {
+			err := cmd.Run()
+			Expect(err).To(HaveOccurred())
+
+			Expect(stderr.String()).To(BeEmpty())
+			Expect(stdout.String()).To(MatchRegexp(`^{"level":"error","msg":"accepts 1 arg\(s\), received 0"}\n`))
+		})
+	})
+
+	// Requires root privileges
+	When("invoked with a non-existing network", func() {
+		BeforeEach(func() {
+			cmd.Args = append(cmd.Args, "--driver", "bridge")
+			cmd.Args = append(cmd.Args, "test-inspect-0")
+		})
+
+		It("should error out and exit with an error", func() {
+			err := cmd.Run()
+			Expect(err).To(HaveOccurred())
+
+			Expect(stderr.String()).To(BeEmpty())
+			Expect(stdout.String()).To(MatchRegexp(`^{"level":"error","msg":"could not get link test-inspect-0: Link not found"}\n$`))
+		})
+	})
+
+	// Requires root privileges
+	When("invoked with an existing network", func() {
+		BeforeEach(func() {
+			// Create the network
+			stdoutCreate := fcmd.NewIOStream()
+			stderrCreate := fcmd.NewIOStream()
+			cmdCreate := fcmd.NewKraft(stdoutCreate, stderrCreate, cfg.Path())
+			cmdCreate.Args = append(cmdCreate.Args, "net", "create", "--log-level", "info", "--log-type", "json")
+			cmdCreate.Args = append(cmdCreate.Args, "--driver", "bridge")
+			cmdCreate.Args = append(cmdCreate.Args, "--network", "172.50.0.1/24")
+			cmdCreate.Args = append(cmdCreate.Args, "test-inspect-1")
+
+			err := cmdCreate.Run()
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(stderrCreate.String()).To(BeEmpty())
+			Expect(stdoutCreate.String()).To(MatchRegexp(`^test-inspect-1\n$`))
+
+			cmd.Args = append(cmd.Args, "--driver", "bridge")
+			cmd.Args = append(cmd.Args, "test-inspect-1")
+		})
+
+		AfterEach(func() {
+			stdoutRm := fcmd.NewIOStream()
+			stderrRm := fcmd.NewIOStream()
+			cmdRm := fcmd.NewKraft(stdoutRm, stderrRm, cfg.Path())
+			cmdRm.Args = append(cmdRm.Args, "net", "rm", "test-inspect-1")
+			err := cmdRm.Run()
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("should print a detailed, valid, json for the interface", func() {
+			err := cmd.Run()
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(stderr.String()).To(BeEmpty())
+
+			// Unmarshal stdout to json
+			inspectData := make(map[string]interface{})
+			err = json.Unmarshal([]byte(stdout.String()), &inspectData)
+			Expect(err).ToNot(HaveOccurred())
+
+			// Check if network is correct
+			Expect(inspectData["spec"].(map[string]interface{})["ifName"]).To(Equal("test-inspect-1"))
+			// Check if the network is up
+			Expect(inspectData["status"].(map[string]interface{})["state"]).To(Equal("up"))
+		})
+	})
+
+	When("invoked with the --help flag", func() {
+		BeforeEach(func() {
+			cmd.Args = append(cmd.Args, "--help")
+		})
+
+		It("should print the command's help", func() {
+			err := cmd.Run()
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(stderr.String()).To(BeEmpty())
+			Expect(stdout.String()).To(MatchRegexp(`^Inspect a machine network\n`))
+		})
+	})
+})

--- a/test/e2e/cli/net_inspect_test.go
+++ b/test/e2e/cli/net_inspect_test.go
@@ -7,6 +7,7 @@ package cli_test
 
 import (
 	"encoding/json"
+	"fmt"
 
 	. "github.com/onsi/ginkgo/v2" //nolint:stylecheck
 	. "github.com/onsi/gomega"    //nolint:stylecheck
@@ -72,7 +73,9 @@ var _ = Describe("kraft net inspect", func() {
 			cmdCreate.Args = append(cmdCreate.Args, "test-inspect-1")
 
 			err := cmdCreate.Run()
-
+			if err != nil {
+				fmt.Printf("Error running command, dumping output:\n%s\n%s\n%s\n", err, stderr, stdout)
+			}
 			Expect(err).ToNot(HaveOccurred())
 			Expect(stderrCreate.String()).To(BeEmpty())
 			Expect(stdoutCreate.String()).To(MatchRegexp(`^test-inspect-1\n$`))
@@ -87,18 +90,26 @@ var _ = Describe("kraft net inspect", func() {
 			cmdRm := fcmd.NewKraftPrivileged(stdoutRm, stderrRm, cfg.Path())
 			cmdRm.Args = append(cmdRm.Args, "net", "rm", "test-inspect-1")
 			err := cmdRm.Run()
+			if err != nil {
+				fmt.Printf("Error running command, dumping output:\n%s\n%s\n%s\n", err, stderr, stdout)
+			}
 			Expect(err).ToNot(HaveOccurred())
 		})
 
 		It("should print a detailed, valid, json for the interface", func() {
 			err := cmd.Run()
-
+			if err != nil {
+				fmt.Printf("Error running command, dumping output:\n%s\n%s\n%s\n", err, stderr, stdout)
+			}
 			Expect(err).ToNot(HaveOccurred())
 			Expect(stderr.String()).To(BeEmpty())
 
 			// Unmarshal stdout to json
 			inspectData := make(map[string]interface{})
 			err = json.Unmarshal([]byte(stdout.String()), &inspectData)
+			if err != nil {
+				fmt.Printf("Error running command, dumping output:\n%s\n%s\n%s\n", err, stderr, stdout)
+			}
 			Expect(err).ToNot(HaveOccurred())
 
 			// Check if network is correct
@@ -115,6 +126,9 @@ var _ = Describe("kraft net inspect", func() {
 
 		It("should print the command's help", func() {
 			err := cmd.Run()
+			if err != nil {
+				fmt.Printf("Error running command, dumping output:\n%s\n%s\n%s\n", err, stderr, stdout)
+			}
 			Expect(err).ToNot(HaveOccurred())
 
 			Expect(stderr.String()).To(BeEmpty())

--- a/test/e2e/cli/net_inspect_test.go
+++ b/test/e2e/cli/net_inspect_test.go
@@ -29,7 +29,7 @@ var _ = Describe("kraft net inspect", func() {
 
 		cfg = fcfg.NewTempConfig()
 
-		cmd = fcmd.NewKraft(stdout, stderr, cfg.Path())
+		cmd = fcmd.NewKraftPrivileged(stdout, stderr, cfg.Path())
 		cmd.Args = append(cmd.Args, "net", "inspect", "--log-level", "info", "--log-type", "json")
 	})
 
@@ -65,7 +65,7 @@ var _ = Describe("kraft net inspect", func() {
 			// Create the network
 			stdoutCreate := fcmd.NewIOStream()
 			stderrCreate := fcmd.NewIOStream()
-			cmdCreate := fcmd.NewKraft(stdoutCreate, stderrCreate, cfg.Path())
+			cmdCreate := fcmd.NewKraftPrivileged(stdoutCreate, stderrCreate, cfg.Path())
 			cmdCreate.Args = append(cmdCreate.Args, "net", "create", "--log-level", "info", "--log-type", "json")
 			cmdCreate.Args = append(cmdCreate.Args, "--driver", "bridge")
 			cmdCreate.Args = append(cmdCreate.Args, "--network", "172.50.0.1/24")
@@ -84,7 +84,7 @@ var _ = Describe("kraft net inspect", func() {
 		AfterEach(func() {
 			stdoutRm := fcmd.NewIOStream()
 			stderrRm := fcmd.NewIOStream()
-			cmdRm := fcmd.NewKraft(stdoutRm, stderrRm, cfg.Path())
+			cmdRm := fcmd.NewKraftPrivileged(stdoutRm, stderrRm, cfg.Path())
 			cmdRm.Args = append(cmdRm.Args, "net", "rm", "test-inspect-1")
 			err := cmdRm.Run()
 			Expect(err).ToNot(HaveOccurred())

--- a/test/e2e/cli/net_ls_test.go
+++ b/test/e2e/cli/net_ls_test.go
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2023, Unikraft GmbH and The KraftKit Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+
+package cli_test
+
+import (
+	. "github.com/onsi/ginkgo/v2" //nolint:stylecheck
+	. "github.com/onsi/gomega"    //nolint:stylecheck
+
+	fcmd "kraftkit.sh/test/e2e/framework/cmd"
+	fcfg "kraftkit.sh/test/e2e/framework/config"
+)
+
+var _ = Describe("kraft net ls", func() {
+	var cmd *fcmd.Cmd
+
+	var stdout *fcmd.IOStream
+	var stderr *fcmd.IOStream
+
+	var cfg *fcfg.Config
+
+	BeforeEach(func() {
+		stdout = fcmd.NewIOStream()
+		stderr = fcmd.NewIOStream()
+
+		cfg = fcfg.NewTempConfig()
+
+		cmd = fcmd.NewKraft(stdout, stderr, cfg.Path())
+		cmd.Args = append(cmd.Args, "net", "ls", "--log-level", "info", "--log-type", "json")
+	})
+
+	When("invoked with a positional argument", func() {
+		BeforeEach(func() {
+			cmd.Args = append(cmd.Args, "test")
+		})
+
+		It("should print an error and exit with an error", func() {
+			err := cmd.Run()
+			Expect(err).To(HaveOccurred())
+
+			Expect(stderr.String()).To(BeEmpty())
+			Expect(stdout.String()).To(MatchRegexp(`^{"level":"error","msg":"unknown command \\"test\\" for \\"kraft net ls\\""}`))
+		})
+	})
+
+	// Requires root privileges
+	When("invoked without flags or positional arguments", func() {
+		BeforeEach(func() {
+			stdoutCreate := fcmd.NewIOStream()
+			stderrCreate := fcmd.NewIOStream()
+			cmdCreate := fcmd.NewKraft(stdoutCreate, stderrCreate, cfg.Path())
+			cmdCreate.Args = append(cmdCreate.Args, "net", "create", "--log-level", "info", "--log-type", "json")
+			cmdCreate.Args = append(cmdCreate.Args, "--driver", "bridge")
+			cmdCreate.Args = append(cmdCreate.Args, "--network", "172.47.0.1/24")
+			cmdCreate.Args = append(cmdCreate.Args, "test-ls-0")
+
+			err := cmdCreate.Run()
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(stderr.String()).To(BeEmpty())
+
+			cmd = fcmd.NewKraft(stdout, stderr, cfg.Path())
+			cmd.Args = append(cmd.Args, "net", "ls", "--log-level", "info", "--log-type", "json")
+		})
+
+		AfterEach(func() {
+			stdoutRm := fcmd.NewIOStream()
+			stderrRm := fcmd.NewIOStream()
+			cmdRm := fcmd.NewKraft(stdoutRm, stderrRm, cfg.Path())
+			cmdRm.Args = append(cmdRm.Args, "net", "rm", "--log-level", "info", "--log-type", "json")
+			cmdRm.Args = append(cmdRm.Args, "test-ls-0")
+
+			err := cmdRm.Run()
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(stderrRm.String()).To(BeEmpty())
+		})
+
+		It("should print a table of networks and exit", func() {
+			err := cmd.Run()
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(stderr.String()).To(BeEmpty())
+			Expect(stdout.String()).To(MatchRegexp(`^NAME[\t ]+NETWORK[\t ]+DRIVER[\t ]+STATUS\n`))
+			Expect(stdout.String()).To(MatchRegexp(`test-ls-0[\t ]+172.47.0.1/24[\t ]+bridge[\t ]+up`))
+		})
+	})
+
+	When("invoked with the --help flag", func() {
+		BeforeEach(func() {
+			cmd.Args = append(cmd.Args, "--help")
+		})
+
+		It("should print the command's help", func() {
+			err := cmd.Run()
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(stderr.String()).To(BeEmpty())
+			Expect(stdout.String()).To(MatchRegexp(`^List machine networks\n`))
+		})
+	})
+})

--- a/test/e2e/cli/net_ls_test.go
+++ b/test/e2e/cli/net_ls_test.go
@@ -27,7 +27,7 @@ var _ = Describe("kraft net ls", func() {
 
 		cfg = fcfg.NewTempConfig()
 
-		cmd = fcmd.NewKraft(stdout, stderr, cfg.Path())
+		cmd = fcmd.NewKraftPrivileged(stdout, stderr, cfg.Path())
 		cmd.Args = append(cmd.Args, "net", "ls", "--log-level", "info", "--log-type", "json")
 	})
 
@@ -50,7 +50,7 @@ var _ = Describe("kraft net ls", func() {
 		BeforeEach(func() {
 			stdoutCreate := fcmd.NewIOStream()
 			stderrCreate := fcmd.NewIOStream()
-			cmdCreate := fcmd.NewKraft(stdoutCreate, stderrCreate, cfg.Path())
+			cmdCreate := fcmd.NewKraftPrivileged(stdoutCreate, stderrCreate, cfg.Path())
 			cmdCreate.Args = append(cmdCreate.Args, "net", "create", "--log-level", "info", "--log-type", "json")
 			cmdCreate.Args = append(cmdCreate.Args, "--driver", "bridge")
 			cmdCreate.Args = append(cmdCreate.Args, "--network", "172.47.0.1/24")
@@ -61,14 +61,14 @@ var _ = Describe("kraft net ls", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(stderr.String()).To(BeEmpty())
 
-			cmd = fcmd.NewKraft(stdout, stderr, cfg.Path())
+			cmd = fcmd.NewKraftPrivileged(stdout, stderr, cfg.Path())
 			cmd.Args = append(cmd.Args, "net", "ls", "--log-level", "info", "--log-type", "json")
 		})
 
 		AfterEach(func() {
 			stdoutRm := fcmd.NewIOStream()
 			stderrRm := fcmd.NewIOStream()
-			cmdRm := fcmd.NewKraft(stdoutRm, stderrRm, cfg.Path())
+			cmdRm := fcmd.NewKraftPrivileged(stdoutRm, stderrRm, cfg.Path())
 			cmdRm.Args = append(cmdRm.Args, "net", "rm", "--log-level", "info", "--log-type", "json")
 			cmdRm.Args = append(cmdRm.Args, "test-ls-0")
 

--- a/test/e2e/cli/net_ls_test.go
+++ b/test/e2e/cli/net_ls_test.go
@@ -6,6 +6,8 @@
 package cli_test
 
 import (
+	"fmt"
+
 	. "github.com/onsi/ginkgo/v2" //nolint:stylecheck
 	. "github.com/onsi/gomega"    //nolint:stylecheck
 
@@ -57,7 +59,9 @@ var _ = Describe("kraft net ls", func() {
 			cmdCreate.Args = append(cmdCreate.Args, "test-ls-0")
 
 			err := cmdCreate.Run()
-
+			if err != nil {
+				fmt.Printf("Error running command, dumping output:\n%s\n%s\n%s\n", err, stderr, stdout)
+			}
 			Expect(err).ToNot(HaveOccurred())
 			Expect(stderr.String()).To(BeEmpty())
 
@@ -73,14 +77,18 @@ var _ = Describe("kraft net ls", func() {
 			cmdRm.Args = append(cmdRm.Args, "test-ls-0")
 
 			err := cmdRm.Run()
-
+			if err != nil {
+				fmt.Printf("Error running command, dumping output:\n%s\n%s\n%s\n", err, stderr, stdout)
+			}
 			Expect(err).ToNot(HaveOccurred())
 			Expect(stderrRm.String()).To(BeEmpty())
 		})
 
 		It("should print a table of networks and exit", func() {
 			err := cmd.Run()
-
+			if err != nil {
+				fmt.Printf("Error running command, dumping output:\n%s\n%s\n%s\n", err, stderr, stdout)
+			}
 			Expect(err).ToNot(HaveOccurred())
 			Expect(stderr.String()).To(BeEmpty())
 			Expect(stdout.String()).To(MatchRegexp(`^NAME[\t ]+NETWORK[\t ]+DRIVER[\t ]+STATUS\n`))
@@ -95,6 +103,9 @@ var _ = Describe("kraft net ls", func() {
 
 		It("should print the command's help", func() {
 			err := cmd.Run()
+			if err != nil {
+				fmt.Printf("Error running command, dumping output:\n%s\n%s\n%s\n", err, stderr, stdout)
+			}
 			Expect(err).ToNot(HaveOccurred())
 
 			Expect(stderr.String()).To(BeEmpty())

--- a/test/e2e/cli/net_rm_test.go
+++ b/test/e2e/cli/net_rm_test.go
@@ -27,7 +27,7 @@ var _ = Describe("kraft net rm", func() {
 
 		cfg = fcfg.NewTempConfig()
 
-		cmd = fcmd.NewKraft(stdout, stderr, cfg.Path())
+		cmd = fcmd.NewKraftPrivileged(stdout, stderr, cfg.Path())
 		cmd.Args = append(cmd.Args, "net", "rm", "--log-level", "info", "--log-type", "json")
 	})
 
@@ -75,7 +75,7 @@ var _ = Describe("kraft net rm", func() {
 		BeforeEach(func() {
 			stdoutCreate := fcmd.NewIOStream()
 			stderrCreate := fcmd.NewIOStream()
-			cmdCreate := fcmd.NewKraft(stdoutCreate, stderrCreate, cfg.Path())
+			cmdCreate := fcmd.NewKraftPrivileged(stdoutCreate, stderrCreate, cfg.Path())
 			cmdCreate.Args = append(cmdCreate.Args, "net", "create", "--log-level", "info", "--log-type", "json")
 			cmdCreate.Args = append(cmdCreate.Args, "--driver", "bridge")
 			cmdCreate.Args = append(cmdCreate.Args, "--network", "172.46.0.1/24")
@@ -100,7 +100,7 @@ var _ = Describe("kraft net rm", func() {
 			// Check that the network no longer exists
 			stdoutLs := fcmd.NewIOStream()
 			stderrLs := fcmd.NewIOStream()
-			cmdLs := fcmd.NewKraft(stdoutLs, stderrLs, cfg.Path())
+			cmdLs := fcmd.NewKraftPrivileged(stdoutLs, stderrLs, cfg.Path())
 			cmdLs.Args = append(cmdLs.Args, "net", "ls", "--log-level", "info", "--log-type", "json")
 
 			err = cmdLs.Run()

--- a/test/e2e/cli/net_rm_test.go
+++ b/test/e2e/cli/net_rm_test.go
@@ -6,6 +6,8 @@
 package cli_test
 
 import (
+	"fmt"
+
 	. "github.com/onsi/ginkgo/v2" //nolint:stylecheck
 	. "github.com/onsi/gomega"    //nolint:stylecheck
 
@@ -63,6 +65,9 @@ var _ = Describe("kraft net rm", func() {
 
 		It("should print the command's help", func() {
 			err := cmd.Run()
+			if err != nil {
+				fmt.Printf("Error running command, dumping output:\n%s\n%s\n%s\n", err, stderr, stdout)
+			}
 			Expect(err).ToNot(HaveOccurred())
 
 			Expect(stderr.String()).To(BeEmpty())
@@ -82,7 +87,9 @@ var _ = Describe("kraft net rm", func() {
 			cmdCreate.Args = append(cmdCreate.Args, "test-rm-0")
 
 			err := cmdCreate.Run()
-
+			if err != nil {
+				fmt.Printf("Error running command, dumping output:\n%s\n%s\n%s\n", err, stderr, stdout)
+			}
 			Expect(err).ToNot(HaveOccurred())
 			Expect(stderr.String()).To(BeEmpty())
 
@@ -92,7 +99,9 @@ var _ = Describe("kraft net rm", func() {
 
 		It("should delete the network, print the network name, and exit", func() {
 			err := cmd.Run()
-
+			if err != nil {
+				fmt.Printf("Error running command, dumping output:\n%s\n%s\n%s\n", err, stderr, stdout)
+			}
 			Expect(err).ToNot(HaveOccurred())
 			Expect(stderr.String()).To(BeEmpty())
 			Expect(stdout.String()).To(MatchRegexp(`^test-rm-0\n$`))
@@ -105,6 +114,9 @@ var _ = Describe("kraft net rm", func() {
 
 			err = cmdLs.Run()
 
+			if err != nil {
+				fmt.Printf("Error running command, dumping output:\n%s\n%s\n%s\n", err, stderr, stdout)
+			}
 			Expect(err).ToNot(HaveOccurred())
 			Expect(stderrLs.String()).To(BeEmpty())
 			Expect(stdoutLs.String()).To(MatchRegexp(`^NAME[\t ]+NETWORK[\t ]+DRIVER[\t ]+STATUS\n`))

--- a/test/e2e/cli/net_rm_test.go
+++ b/test/e2e/cli/net_rm_test.go
@@ -1,0 +1,130 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2023, Unikraft GmbH and The KraftKit Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+
+package cli_test
+
+import (
+	. "github.com/onsi/ginkgo/v2" //nolint:stylecheck
+	. "github.com/onsi/gomega"    //nolint:stylecheck
+
+	fcmd "kraftkit.sh/test/e2e/framework/cmd"
+	fcfg "kraftkit.sh/test/e2e/framework/config"
+)
+
+var _ = Describe("kraft net rm", func() {
+	var cmd *fcmd.Cmd
+
+	var stdout *fcmd.IOStream
+	var stderr *fcmd.IOStream
+
+	var cfg *fcfg.Config
+
+	BeforeEach(func() {
+		stdout = fcmd.NewIOStream()
+		stderr = fcmd.NewIOStream()
+
+		cfg = fcfg.NewTempConfig()
+
+		cmd = fcmd.NewKraft(stdout, stderr, cfg.Path())
+		cmd.Args = append(cmd.Args, "net", "rm", "--log-level", "info", "--log-type", "json")
+	})
+
+	When("invoked without flags or positional arguments", func() {
+		It("should print an error and exit with an error", func() {
+			err := cmd.Run()
+			Expect(err).To(HaveOccurred())
+
+			Expect(stderr.String()).To(BeEmpty())
+			Expect(stdout.String()).To(MatchRegexp(`^{"level":"error","msg":"accepts 1 arg\(s\), received 0"}\n`))
+		})
+	})
+
+	When("invoked with two positional arguments", func() {
+		BeforeEach(func() {
+			cmd.Args = append(cmd.Args, "some-arg")
+			cmd.Args = append(cmd.Args, "some-other-arg")
+		})
+
+		It("should print an error and exit with an error", func() {
+			err := cmd.Run()
+			Expect(err).To(HaveOccurred())
+
+			Expect(stderr.String()).To(BeEmpty())
+			Expect(stdout.String()).To(MatchRegexp(`^{"level":"error","msg":"accepts 1 arg\(s\), received 2"}\n$`))
+		})
+	})
+
+	When("invoked with the --help flag", func() {
+		BeforeEach(func() {
+			cmd.Args = append(cmd.Args, "--help")
+		})
+
+		It("should print the command's help", func() {
+			err := cmd.Run()
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(stderr.String()).To(BeEmpty())
+			Expect(stdout.String()).To(MatchRegexp(`^Remove a network\n`))
+		})
+	})
+
+	// Requires root privileges
+	When("invoked with one positional argument, valid driver, and a valid network", func() {
+		BeforeEach(func() {
+			stdoutCreate := fcmd.NewIOStream()
+			stderrCreate := fcmd.NewIOStream()
+			cmdCreate := fcmd.NewKraft(stdoutCreate, stderrCreate, cfg.Path())
+			cmdCreate.Args = append(cmdCreate.Args, "net", "create", "--log-level", "info", "--log-type", "json")
+			cmdCreate.Args = append(cmdCreate.Args, "--driver", "bridge")
+			cmdCreate.Args = append(cmdCreate.Args, "--network", "172.46.0.1/24")
+			cmdCreate.Args = append(cmdCreate.Args, "test-rm-0")
+
+			err := cmdCreate.Run()
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(stderr.String()).To(BeEmpty())
+
+			cmd.Args = append(cmd.Args, "--driver", "bridge")
+			cmd.Args = append(cmd.Args, "test-rm-0")
+		})
+
+		It("should delete the network, print the network name, and exit", func() {
+			err := cmd.Run()
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(stderr.String()).To(BeEmpty())
+			Expect(stdout.String()).To(MatchRegexp(`^test-rm-0\n$`))
+
+			// Check that the network no longer exists
+			stdoutLs := fcmd.NewIOStream()
+			stderrLs := fcmd.NewIOStream()
+			cmdLs := fcmd.NewKraft(stdoutLs, stderrLs, cfg.Path())
+			cmdLs.Args = append(cmdLs.Args, "net", "ls", "--log-level", "info", "--log-type", "json")
+
+			err = cmdLs.Run()
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(stderrLs.String()).To(BeEmpty())
+			Expect(stdoutLs.String()).To(MatchRegexp(`^NAME[\t ]+NETWORK[\t ]+DRIVER[\t ]+STATUS\n`))
+			Expect(stdoutLs.String()).ToNot(MatchRegexp(`test-rm-0[\t ]+172.46.0.1/24[\t ]+bridge[\t ]+up`))
+		})
+	})
+
+	// Requires root privileges
+	When("invoked with one positional argument, valid driver, and an invalid network", func() {
+		BeforeEach(func() {
+			cmd.Args = append(cmd.Args, "--driver", "bridge")
+			cmd.Args = append(cmd.Args, "test-rm-1")
+		})
+
+		It("should delete the network, print the network name, and exit", func() {
+			err := cmd.Run()
+			Expect(err).To(HaveOccurred())
+
+			Expect(stderr.String()).To(BeEmpty())
+			Expect(stdout.String()).To(MatchRegexp(`^{"level":"error","msg":"getting bridge test-rm-1 failed: Link not found"}\n$`))
+		})
+	})
+})

--- a/test/e2e/cli/net_up_test.go
+++ b/test/e2e/cli/net_up_test.go
@@ -6,6 +6,8 @@
 package cli_test
 
 import (
+	"fmt"
+
 	. "github.com/onsi/ginkgo/v2" //nolint:stylecheck
 	. "github.com/onsi/gomega"    //nolint:stylecheck
 
@@ -70,7 +72,9 @@ var _ = Describe("kraft net up", func() {
 			cmdCreate.Args = append(cmdCreate.Args, "test-up-1")
 
 			err := cmdCreate.Run()
-
+			if err != nil {
+				fmt.Printf("Error running command, dumping output:\n%s\n%s\n%s\n", err, stderr, stdout)
+			}
 			Expect(err).ToNot(HaveOccurred())
 			Expect(stderrCreate.String()).To(BeEmpty())
 
@@ -84,6 +88,9 @@ var _ = Describe("kraft net up", func() {
 			cmdRm := fcmd.NewKraftPrivileged(stdoutRm, stderrRm, cfg.Path())
 			cmdRm.Args = append(cmdRm.Args, "net", "rm", "test-up-1")
 			err := cmdRm.Run()
+			if err != nil {
+				fmt.Printf("Error running command, dumping output:\n%s\n%s\n%s\n", err, stderr, stdout)
+			}
 			Expect(err).ToNot(HaveOccurred())
 		})
 
@@ -97,7 +104,9 @@ var _ = Describe("kraft net up", func() {
 			cmdDown.Args = append(cmdDown.Args, "test-up-1")
 
 			err := cmdDown.Run()
-
+			if err != nil {
+				fmt.Printf("Error running command, dumping output:\n%s\n%s\n%s\n", err, stderr, stdout)
+			}
 			Expect(err).ToNot(HaveOccurred())
 			Expect(stderrDown.String()).To(BeEmpty())
 			Expect(stdoutDown.String()).To(MatchRegexp(`^test-up-1\n$`))
@@ -110,6 +119,9 @@ var _ = Describe("kraft net up", func() {
 
 			err = cmdLs.Run()
 
+			if err != nil {
+				fmt.Printf("Error running command, dumping output:\n%s\n%s\n%s\n", err, stderr, stdout)
+			}
 			Expect(err).ToNot(HaveOccurred())
 			Expect(stderrLs.String()).To(BeEmpty())
 			Expect(stdoutLs.String()).To(MatchRegexp(`^NAME[\t ]+NETWORK[\t ]+DRIVER[\t ]+STATUS\n`))
@@ -118,6 +130,9 @@ var _ = Describe("kraft net up", func() {
 			// Bring the network back up
 			err = cmd.Run()
 
+			if err != nil {
+				fmt.Printf("Error running command, dumping output:\n%s\n%s\n%s\n", err, stderr, stdout)
+			}
 			Expect(err).ToNot(HaveOccurred())
 			Expect(stderr.String()).To(BeEmpty())
 
@@ -129,6 +144,9 @@ var _ = Describe("kraft net up", func() {
 
 			err = cmdLs.Run()
 
+			if err != nil {
+				fmt.Printf("Error running command, dumping output:\n%s\n%s\n%s\n", err, stderr, stdout)
+			}
 			Expect(err).ToNot(HaveOccurred())
 			Expect(stderrLs.String()).To(BeEmpty())
 			Expect(stdoutLs.String()).To(MatchRegexp(`^NAME[\t ]+NETWORK[\t ]+DRIVER[\t ]+STATUS\n`))
@@ -143,6 +161,9 @@ var _ = Describe("kraft net up", func() {
 
 		It("should print the command's help", func() {
 			err := cmd.Run()
+			if err != nil {
+				fmt.Printf("Error running command, dumping output:\n%s\n%s\n%s\n", err, stderr, stdout)
+			}
 			Expect(err).ToNot(HaveOccurred())
 
 			Expect(stderr.String()).To(BeEmpty())

--- a/test/e2e/cli/net_up_test.go
+++ b/test/e2e/cli/net_up_test.go
@@ -1,0 +1,152 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2023, Unikraft GmbH and The KraftKit Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+
+package cli_test
+
+import (
+	. "github.com/onsi/ginkgo/v2" //nolint:stylecheck
+	. "github.com/onsi/gomega"    //nolint:stylecheck
+
+	fcmd "kraftkit.sh/test/e2e/framework/cmd"
+	fcfg "kraftkit.sh/test/e2e/framework/config"
+)
+
+var _ = Describe("kraft net up", func() {
+	var cmd *fcmd.Cmd
+
+	var stdout *fcmd.IOStream
+	var stderr *fcmd.IOStream
+
+	var cfg *fcfg.Config
+
+	BeforeEach(func() {
+		stdout = fcmd.NewIOStream()
+		stderr = fcmd.NewIOStream()
+
+		cfg = fcfg.NewTempConfig()
+
+		cmd = fcmd.NewKraft(stdout, stderr, cfg.Path())
+		cmd.Args = append(cmd.Args, "net", "up", "--log-level", "info", "--log-type", "json")
+	})
+
+	When("invoked without flags or positional arguments", func() {
+		It("should print an error and exit with an error", func() {
+			err := cmd.Run()
+			Expect(err).To(HaveOccurred())
+
+			Expect(stderr.String()).To(BeEmpty())
+			Expect(stdout.String()).To(MatchRegexp(`^{"level":"error","msg":"accepts 1 arg\(s\), received 0"}\n`))
+		})
+	})
+
+	// Requires root privileges
+	When("invoked with a non-existing network", func() {
+		BeforeEach(func() {
+			cmd.Args = append(cmd.Args, "--driver", "bridge")
+			cmd.Args = append(cmd.Args, "test-up-0")
+		})
+
+		It("should error out and exit with an error", func() {
+			err := cmd.Run()
+			Expect(err).To(HaveOccurred())
+
+			Expect(stderr.String()).To(BeEmpty())
+			Expect(stdout.String()).To(MatchRegexp(`^{"level":"error","msg":"getting bridge test-up-0 failed: Link not found"}\n$`))
+		})
+	})
+
+	// Requires root privileges
+	When("invoked with an existing network", func() {
+		BeforeEach(func() {
+			// Create the network
+			stdoutCreate := fcmd.NewIOStream()
+			stderrCreate := fcmd.NewIOStream()
+			cmdCreate := fcmd.NewKraft(stdoutCreate, stderrCreate, cfg.Path())
+			cmdCreate.Args = append(cmdCreate.Args, "net", "create", "--log-level", "info", "--log-type", "json")
+			cmdCreate.Args = append(cmdCreate.Args, "--driver", "bridge")
+			cmdCreate.Args = append(cmdCreate.Args, "--network", "172.49.0.1/24")
+			cmdCreate.Args = append(cmdCreate.Args, "test-up-1")
+
+			err := cmdCreate.Run()
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(stderrCreate.String()).To(BeEmpty())
+
+			cmd.Args = append(cmd.Args, "--driver", "bridge")
+			cmd.Args = append(cmd.Args, "test-up-1")
+		})
+
+		AfterEach(func() {
+			stdoutRm := fcmd.NewIOStream()
+			stderrRm := fcmd.NewIOStream()
+			cmdRm := fcmd.NewKraft(stdoutRm, stderrRm, cfg.Path())
+			cmdRm.Args = append(cmdRm.Args, "net", "rm", "test-up-1")
+			err := cmdRm.Run()
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("should bring the network up and print its name", func() {
+			// Bring the network down
+			stdoutDown := fcmd.NewIOStream()
+			stderrDown := fcmd.NewIOStream()
+			cmdDown := fcmd.NewKraft(stdoutDown, stderrDown, cfg.Path())
+			cmdDown.Args = append(cmdDown.Args, "net", "down", "--log-level", "info", "--log-type", "json")
+			cmdDown.Args = append(cmdDown.Args, "--driver", "bridge")
+			cmdDown.Args = append(cmdDown.Args, "test-up-1")
+
+			err := cmdDown.Run()
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(stderrDown.String()).To(BeEmpty())
+			Expect(stdoutDown.String()).To(MatchRegexp(`^test-up-1\n$`))
+
+			// Check if the network is down
+			stdoutLs := fcmd.NewIOStream()
+			stderrLs := fcmd.NewIOStream()
+			cmdLs := fcmd.NewKraft(stdoutLs, stderrLs, cfg.Path())
+			cmdLs.Args = append(cmdLs.Args, "net", "ls", "--log-level", "info", "--log-type", "json")
+
+			err = cmdLs.Run()
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(stderrLs.String()).To(BeEmpty())
+			Expect(stdoutLs.String()).To(MatchRegexp(`^NAME[\t ]+NETWORK[\t ]+DRIVER[\t ]+STATUS\n`))
+			Expect(stdoutLs.String()).To(MatchRegexp(`test-up-1[\t ]+172.49.0.1/24[\t ]+bridge[\t ]+down`))
+
+			// Bring the network back up
+			err = cmd.Run()
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(stderr.String()).To(BeEmpty())
+
+			// Check if the network is up
+			stdoutLs = fcmd.NewIOStream()
+			stderrLs = fcmd.NewIOStream()
+			cmdLs = fcmd.NewKraft(stdoutLs, stderrLs, cfg.Path())
+			cmdLs.Args = append(cmdLs.Args, "net", "ls", "--log-level", "info", "--log-type", "json")
+
+			err = cmdLs.Run()
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(stderrLs.String()).To(BeEmpty())
+			Expect(stdoutLs.String()).To(MatchRegexp(`^NAME[\t ]+NETWORK[\t ]+DRIVER[\t ]+STATUS\n`))
+			Expect(stdoutLs.String()).To(MatchRegexp(`test-up-1[\t ]+172.49.0.1/24[\t ]+bridge[\t ]+up`))
+		})
+	})
+
+	When("invoked with the --help flag", func() {
+		BeforeEach(func() {
+			cmd.Args = append(cmd.Args, "--help")
+		})
+
+		It("should print the command's help", func() {
+			err := cmd.Run()
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(stderr.String()).To(BeEmpty())
+			Expect(stdout.String()).To(MatchRegexp(`^Bring a network online\n`))
+		})
+	})
+})

--- a/test/e2e/cli/net_up_test.go
+++ b/test/e2e/cli/net_up_test.go
@@ -27,7 +27,7 @@ var _ = Describe("kraft net up", func() {
 
 		cfg = fcfg.NewTempConfig()
 
-		cmd = fcmd.NewKraft(stdout, stderr, cfg.Path())
+		cmd = fcmd.NewKraftPrivileged(stdout, stderr, cfg.Path())
 		cmd.Args = append(cmd.Args, "net", "up", "--log-level", "info", "--log-type", "json")
 	})
 
@@ -63,7 +63,7 @@ var _ = Describe("kraft net up", func() {
 			// Create the network
 			stdoutCreate := fcmd.NewIOStream()
 			stderrCreate := fcmd.NewIOStream()
-			cmdCreate := fcmd.NewKraft(stdoutCreate, stderrCreate, cfg.Path())
+			cmdCreate := fcmd.NewKraftPrivileged(stdoutCreate, stderrCreate, cfg.Path())
 			cmdCreate.Args = append(cmdCreate.Args, "net", "create", "--log-level", "info", "--log-type", "json")
 			cmdCreate.Args = append(cmdCreate.Args, "--driver", "bridge")
 			cmdCreate.Args = append(cmdCreate.Args, "--network", "172.49.0.1/24")
@@ -81,7 +81,7 @@ var _ = Describe("kraft net up", func() {
 		AfterEach(func() {
 			stdoutRm := fcmd.NewIOStream()
 			stderrRm := fcmd.NewIOStream()
-			cmdRm := fcmd.NewKraft(stdoutRm, stderrRm, cfg.Path())
+			cmdRm := fcmd.NewKraftPrivileged(stdoutRm, stderrRm, cfg.Path())
 			cmdRm.Args = append(cmdRm.Args, "net", "rm", "test-up-1")
 			err := cmdRm.Run()
 			Expect(err).ToNot(HaveOccurred())
@@ -91,7 +91,7 @@ var _ = Describe("kraft net up", func() {
 			// Bring the network down
 			stdoutDown := fcmd.NewIOStream()
 			stderrDown := fcmd.NewIOStream()
-			cmdDown := fcmd.NewKraft(stdoutDown, stderrDown, cfg.Path())
+			cmdDown := fcmd.NewKraftPrivileged(stdoutDown, stderrDown, cfg.Path())
 			cmdDown.Args = append(cmdDown.Args, "net", "down", "--log-level", "info", "--log-type", "json")
 			cmdDown.Args = append(cmdDown.Args, "--driver", "bridge")
 			cmdDown.Args = append(cmdDown.Args, "test-up-1")
@@ -105,7 +105,7 @@ var _ = Describe("kraft net up", func() {
 			// Check if the network is down
 			stdoutLs := fcmd.NewIOStream()
 			stderrLs := fcmd.NewIOStream()
-			cmdLs := fcmd.NewKraft(stdoutLs, stderrLs, cfg.Path())
+			cmdLs := fcmd.NewKraftPrivileged(stdoutLs, stderrLs, cfg.Path())
 			cmdLs.Args = append(cmdLs.Args, "net", "ls", "--log-level", "info", "--log-type", "json")
 
 			err = cmdLs.Run()
@@ -124,7 +124,7 @@ var _ = Describe("kraft net up", func() {
 			// Check if the network is up
 			stdoutLs = fcmd.NewIOStream()
 			stderrLs = fcmd.NewIOStream()
-			cmdLs = fcmd.NewKraft(stdoutLs, stderrLs, cfg.Path())
+			cmdLs = fcmd.NewKraftPrivileged(stdoutLs, stderrLs, cfg.Path())
 			cmdLs.Args = append(cmdLs.Args, "net", "ls", "--log-level", "info", "--log-type", "json")
 
 			err = cmdLs.Run()

--- a/test/e2e/cli/pkg_source_test.go
+++ b/test/e2e/cli/pkg_source_test.go
@@ -7,6 +7,7 @@ package cli_test
 
 import (
 	"crypto/sha1"
+	"fmt"
 	"os"
 
 	. "github.com/onsi/ginkgo/v2" //nolint:stylecheck
@@ -46,27 +47,41 @@ var _ = Describe("kraft pkg", func() {
 				BeforeEach(func() {
 					// Save the config file by moving it to a temporary location
 					err := os.Rename(cfg.Path(), cfg.Path()+".tmp")
+					if err != nil {
+						fmt.Printf("Error running command, dumping output:\n%s\n%s\n%s\n", err, stderr, stdout)
+					}
 					Expect(err).ToNot(HaveOccurred())
 				})
 
 				AfterEach(func() {
 					// Restore the config file
 					err := os.Rename(cfg.Path()+".tmp", cfg.Path())
+					if err != nil {
+						fmt.Printf("Error running command, dumping output:\n%s\n%s\n%s\n", err, stderr, stdout)
+					}
 					Expect(err).ToNot(HaveOccurred())
 				})
 				It("should create the config file, add the default manifests, and the new link, and print nothing", func() {
 					cmd.Args = append(cmd.Args, "https://example.com")
 					err := cmd.Run()
-
+					if err != nil {
+						fmt.Printf("Error running command, dumping output:\n%s\n%s\n%s\n", err, stderr, stdout)
+					}
 					Expect(err).ToNot(HaveOccurred())
 					Expect(stderr.String()).To(BeEmpty())
 
 					// Read the config file
 					osFile, err := os.Open(cfg.Path())
+					if err != nil {
+						fmt.Printf("Error running command, dumping output:\n%s\n%s\n%s\n", err, stderr, stdout)
+					}
 					Expect(err).ToNot(HaveOccurred())
 					defer osFile.Close()
 
 					osFileInfo, err := osFile.Stat()
+					if err != nil {
+						fmt.Printf("Error running command, dumping output:\n%s\n%s\n%s\n", err, stderr, stdout)
+					}
 					Expect(err).ToNot(HaveOccurred())
 
 					// Check if the config file is not empty
@@ -77,11 +92,17 @@ var _ = Describe("kraft pkg", func() {
 
 					// Read file content
 					readBytes, err := os.ReadFile(cfg.Path())
+					if err != nil {
+						fmt.Printf("Error running command, dumping output:\n%s\n%s\n%s\n", err, stderr, stdout)
+					}
 					Expect(err).ToNot(HaveOccurred())
 
 					// Marshal the yaml file into a map
 					var cfgMap map[string]interface{}
 					err = yaml.Unmarshal([]byte(readBytes), &cfgMap)
+					if err != nil {
+						fmt.Printf("Error running command, dumping output:\n%s\n%s\n%s\n", err, stderr, stdout)
+					}
 					Expect(err).ToNot(HaveOccurred())
 
 					// Check if the config file contains the default manifests
@@ -111,7 +132,9 @@ var _ = Describe("kraft pkg", func() {
 
 					cmd.Args = append(cmd.Args, "https://example1.com")
 					err := cmd.Run()
-
+					if err != nil {
+						fmt.Printf("Error running command, dumping output:\n%s\n%s\n%s\n", err, stderr, stdout)
+					}
 					Expect(err).ToNot(HaveOccurred())
 					Expect(stderr.String()).To(BeEmpty())
 
@@ -126,16 +149,24 @@ var _ = Describe("kraft pkg", func() {
 				It("should leave the config file intact, add the new link, and print nothing", func() {
 					cmd.Args = append(cmd.Args, "https://example2.com")
 					err := cmd.Run()
-
+					if err != nil {
+						fmt.Printf("Error running command, dumping output:\n%s\n%s\n%s\n", err, stderr, stdout)
+					}
 					Expect(err).ToNot(HaveOccurred())
 					Expect(stderr.String()).To(BeEmpty())
 
 					// Read the config file
 					osFile, err := os.Open(cfg.Path())
+					if err != nil {
+						fmt.Printf("Error running command, dumping output:\n%s\n%s\n%s\n", err, stderr, stdout)
+					}
 					Expect(err).ToNot(HaveOccurred())
 					defer osFile.Close()
 
 					osFileInfo, err := osFile.Stat()
+					if err != nil {
+						fmt.Printf("Error running command, dumping output:\n%s\n%s\n%s\n", err, stderr, stdout)
+					}
 					Expect(err).ToNot(HaveOccurred())
 
 					// Check if the config file is not empty
@@ -146,11 +177,17 @@ var _ = Describe("kraft pkg", func() {
 
 					// Read file content
 					readBytes, err := os.ReadFile(cfg.Path())
+					if err != nil {
+						fmt.Printf("Error running command, dumping output:\n%s\n%s\n%s\n", err, stderr, stdout)
+					}
 					Expect(err).ToNot(HaveOccurred())
 
 					// Marshal the yaml file into a map
 					var cfgMap map[string]interface{}
 					err = yaml.Unmarshal([]byte(readBytes), &cfgMap)
+					if err != nil {
+						fmt.Printf("Error running command, dumping output:\n%s\n%s\n%s\n", err, stderr, stdout)
+					}
 					Expect(err).ToNot(HaveOccurred())
 
 					// Check if the config file contains the default manifests
@@ -182,12 +219,17 @@ var _ = Describe("kraft pkg", func() {
 					// Generate a clean config file
 					cmd.Args = append(cmd.Args, "https://manifests.kraftkit.sh/index.yaml")
 					err := cmd.Run()
-
+					if err != nil {
+						fmt.Printf("Error running command, dumping output:\n%s\n%s\n%s\n", err, stderr, stdout)
+					}
 					Expect(err).ToNot(HaveOccurred())
 					Expect(stderr.String()).To(BeEmpty())
 
 					// Calculate config file hash
 					bytes, err := os.ReadFile(cfg.Path())
+					if err != nil {
+						fmt.Printf("Error running command, dumping output:\n%s\n%s\n%s\n", err, stderr, stdout)
+					}
 					Expect(err).ToNot(HaveOccurred())
 
 					// Calculate sha1 hash of bytes
@@ -203,6 +245,9 @@ var _ = Describe("kraft pkg", func() {
 					cmd.Args = append(cmd.Args, "https://manifests.kraftkit.sh/index.yaml")
 					err = cmd.Run()
 
+					if err != nil {
+						fmt.Printf("Error running command, dumping output:\n%s\n%s\n%s\n", err, stderr, stdout)
+					}
 					Expect(err).ToNot(HaveOccurred())
 					Expect(stderr.String()).To(BeEmpty())
 
@@ -211,6 +256,9 @@ var _ = Describe("kraft pkg", func() {
 
 					// Check if the config file was not modified
 					newBytes, err := os.ReadFile(cfg.Path())
+					if err != nil {
+						fmt.Printf("Error running command, dumping output:\n%s\n%s\n%s\n", err, stderr, stdout)
+					}
 					Expect(err).ToNot(HaveOccurred())
 
 					newSha1Hash := sha1.Sum(newBytes)
@@ -226,16 +274,24 @@ var _ = Describe("kraft pkg", func() {
 					cmd.Args = append(cmd.Args, "https://example2.com")
 					cmd.Args = append(cmd.Args, "https://example3.com")
 					err := cmd.Run()
-
+					if err != nil {
+						fmt.Printf("Error running command, dumping output:\n%s\n%s\n%s\n", err, stderr, stdout)
+					}
 					Expect(err).ToNot(HaveOccurred())
 					Expect(stderr.String()).To(BeEmpty())
 
 					// Read the config file
 					osFile, err := os.Open(cfg.Path())
+					if err != nil {
+						fmt.Printf("Error running command, dumping output:\n%s\n%s\n%s\n", err, stderr, stdout)
+					}
 					Expect(err).ToNot(HaveOccurred())
 					defer osFile.Close()
 
 					osFileInfo, err := osFile.Stat()
+					if err != nil {
+						fmt.Printf("Error running command, dumping output:\n%s\n%s\n%s\n", err, stderr, stdout)
+					}
 					Expect(err).ToNot(HaveOccurred())
 
 					// Check if the config file is not empty
@@ -246,11 +302,17 @@ var _ = Describe("kraft pkg", func() {
 
 					// Read file content
 					readBytes, err := os.ReadFile(cfg.Path())
+					if err != nil {
+						fmt.Printf("Error running command, dumping output:\n%s\n%s\n%s\n", err, stderr, stdout)
+					}
 					Expect(err).ToNot(HaveOccurred())
 
 					// Marshal the yaml file into a map
 					var cfgMap map[string]interface{}
 					err = yaml.Unmarshal([]byte(readBytes), &cfgMap)
+					if err != nil {
+						fmt.Printf("Error running command, dumping output:\n%s\n%s\n%s\n", err, stderr, stdout)
+					}
 					Expect(err).ToNot(HaveOccurred())
 
 					// Check if the config file contains the default manifests
@@ -281,16 +343,24 @@ var _ = Describe("kraft pkg", func() {
 					cmd.Args = append(cmd.Args, "https://example.com")
 					cmd.Args = append(cmd.Args, "https://example2.com")
 					err := cmd.Run()
-
+					if err != nil {
+						fmt.Printf("Error running command, dumping output:\n%s\n%s\n%s\n", err, stderr, stdout)
+					}
 					Expect(err).ToNot(HaveOccurred())
 					Expect(stderr.String()).To(BeEmpty())
 
 					// Read the config file
 					osFile, err := os.Open(cfg.Path())
+					if err != nil {
+						fmt.Printf("Error running command, dumping output:\n%s\n%s\n%s\n", err, stderr, stdout)
+					}
 					Expect(err).ToNot(HaveOccurred())
 					defer osFile.Close()
 
 					osFileInfo, err := osFile.Stat()
+					if err != nil {
+						fmt.Printf("Error running command, dumping output:\n%s\n%s\n%s\n", err, stderr, stdout)
+					}
 					Expect(err).ToNot(HaveOccurred())
 
 					// Check if the config file is not empty
@@ -301,11 +371,17 @@ var _ = Describe("kraft pkg", func() {
 
 					// Read file content
 					readBytes, err := os.ReadFile(cfg.Path())
+					if err != nil {
+						fmt.Printf("Error running command, dumping output:\n%s\n%s\n%s\n", err, stderr, stdout)
+					}
 					Expect(err).ToNot(HaveOccurred())
 
 					// Marshal the yaml file into a map
 					var cfgMap map[string]interface{}
 					err = yaml.Unmarshal([]byte(readBytes), &cfgMap)
+					if err != nil {
+						fmt.Printf("Error running command, dumping output:\n%s\n%s\n%s\n", err, stderr, stdout)
+					}
 					Expect(err).ToNot(HaveOccurred())
 
 					// Check if the config file contains the default manifests

--- a/test/e2e/cli/pkg_unsource_test.go
+++ b/test/e2e/cli/pkg_unsource_test.go
@@ -6,6 +6,7 @@
 package cli_test
 
 import (
+	"fmt"
 	"os"
 
 	. "github.com/onsi/ginkgo/v2" //nolint:stylecheck
@@ -45,16 +46,24 @@ var _ = Describe("kraft pkg", func() {
 				It("should remove the link and print nothing", func() {
 					cmd.Args = append(cmd.Args, "https://manifests.kraftkit.sh/index.yaml")
 					err := cmd.Run()
-
+					if err != nil {
+						fmt.Printf("Error running command, dumping output:\n%s\n%s\n%s\n", err, stderr, stdout)
+					}
 					Expect(err).ToNot(HaveOccurred())
 					Expect(stderr.String()).To(BeEmpty())
 
 					// Read the config file
 					osFile, err := os.Open(cfg.Path())
+					if err != nil {
+						fmt.Printf("Error running command, dumping output:\n%s\n%s\n%s\n", err, stderr, stdout)
+					}
 					Expect(err).ToNot(HaveOccurred())
 					defer osFile.Close()
 
 					osFileInfo, err := osFile.Stat()
+					if err != nil {
+						fmt.Printf("Error running command, dumping output:\n%s\n%s\n%s\n", err, stderr, stdout)
+					}
 					Expect(err).ToNot(HaveOccurred())
 
 					// Check if the config file is not empty
@@ -65,11 +74,17 @@ var _ = Describe("kraft pkg", func() {
 
 					// Read file content
 					readBytes, err := os.ReadFile(cfg.Path())
+					if err != nil {
+						fmt.Printf("Error running command, dumping output:\n%s\n%s\n%s\n", err, stderr, stdout)
+					}
 					Expect(err).ToNot(HaveOccurred())
 
 					// Marshal the yaml file into a map
 					var cfgMap map[string]interface{}
 					err = yaml.Unmarshal([]byte(readBytes), &cfgMap)
+					if err != nil {
+						fmt.Printf("Error running command, dumping output:\n%s\n%s\n%s\n", err, stderr, stdout)
+					}
 					Expect(err).ToNot(HaveOccurred())
 
 					// Check if the config file contains the default manifests
@@ -92,26 +107,40 @@ var _ = Describe("kraft pkg", func() {
 				BeforeEach(func() {
 					// Save the config file by moving it to a temporary location
 					err := os.Rename(cfg.Path(), cfg.Path()+".tmp")
+					if err != nil {
+						fmt.Printf("Error running command, dumping output:\n%s\n%s\n%s\n", err, stderr, stdout)
+					}
 					Expect(err).ToNot(HaveOccurred())
 				})
 				AfterEach(func() {
 					// Restore the config file
 					err := os.Rename(cfg.Path()+".tmp", cfg.Path())
+					if err != nil {
+						fmt.Printf("Error running command, dumping output:\n%s\n%s\n%s\n", err, stderr, stdout)
+					}
 					Expect(err).ToNot(HaveOccurred())
 				})
 				It("should create the config file, add the default manifests, remove the link, and print nothing", func() {
 					cmd.Args = append(cmd.Args, "https://manifests.kraftkit.sh/index.yaml")
 					err := cmd.Run()
-
+					if err != nil {
+						fmt.Printf("Error running command, dumping output:\n%s\n%s\n%s\n", err, stderr, stdout)
+					}
 					Expect(err).ToNot(HaveOccurred())
 					Expect(stderr.String()).To(BeEmpty())
 
 					// Read the config file
 					osFile, err := os.Open(cfg.Path())
+					if err != nil {
+						fmt.Printf("Error running command, dumping output:\n%s\n%s\n%s\n", err, stderr, stdout)
+					}
 					Expect(err).ToNot(HaveOccurred())
 					defer osFile.Close()
 
 					osFileInfo, err := osFile.Stat()
+					if err != nil {
+						fmt.Printf("Error running command, dumping output:\n%s\n%s\n%s\n", err, stderr, stdout)
+					}
 					Expect(err).ToNot(HaveOccurred())
 
 					// Check if the config file is not empty
@@ -122,11 +151,17 @@ var _ = Describe("kraft pkg", func() {
 
 					// Read file content
 					readBytes, err := os.ReadFile(cfg.Path())
+					if err != nil {
+						fmt.Printf("Error running command, dumping output:\n%s\n%s\n%s\n", err, stderr, stdout)
+					}
 					Expect(err).ToNot(HaveOccurred())
 
 					// Marshal the yaml file into a map
 					var cfgMap map[string]interface{}
 					err = yaml.Unmarshal([]byte(readBytes), &cfgMap)
+					if err != nil {
+						fmt.Printf("Error running command, dumping output:\n%s\n%s\n%s\n", err, stderr, stdout)
+					}
 					Expect(err).ToNot(HaveOccurred())
 
 					// Check if the config file contains the default manifests
@@ -149,26 +184,40 @@ var _ = Describe("kraft pkg", func() {
 				BeforeEach(func() {
 					// Save the config file by moving it to a temporary location
 					err := os.Rename(cfg.Path(), cfg.Path()+".tmp")
+					if err != nil {
+						fmt.Printf("Error running command, dumping output:\n%s\n%s\n%s\n", err, stderr, stdout)
+					}
 					Expect(err).ToNot(HaveOccurred())
 				})
 				AfterEach(func() {
 					// Restore the config file
 					err := os.Rename(cfg.Path()+".tmp", cfg.Path())
+					if err != nil {
+						fmt.Printf("Error running command, dumping output:\n%s\n%s\n%s\n", err, stderr, stdout)
+					}
 					Expect(err).ToNot(HaveOccurred())
 				})
 				It("should do nothing and print a warning", func() {
 					cmd.Args = append(cmd.Args, "https://example.com")
 					err := cmd.Run()
-
+					if err != nil {
+						fmt.Printf("Error running command, dumping output:\n%s\n%s\n%s\n", err, stderr, stdout)
+					}
 					Expect(err).ToNot(HaveOccurred())
 					Expect(stderr.String()).To(BeEmpty())
 
 					// Read the config file
 					osFile, err := os.Open(cfg.Path())
+					if err != nil {
+						fmt.Printf("Error running command, dumping output:\n%s\n%s\n%s\n", err, stderr, stdout)
+					}
 					Expect(err).ToNot(HaveOccurred())
 					defer osFile.Close()
 
 					osFileInfo, err := osFile.Stat()
+					if err != nil {
+						fmt.Printf("Error running command, dumping output:\n%s\n%s\n%s\n", err, stderr, stdout)
+					}
 					Expect(err).ToNot(HaveOccurred())
 
 					// Check if the config file is not empty
@@ -179,11 +228,17 @@ var _ = Describe("kraft pkg", func() {
 
 					// Read file content
 					readBytes, err := os.ReadFile(cfg.Path())
+					if err != nil {
+						fmt.Printf("Error running command, dumping output:\n%s\n%s\n%s\n", err, stderr, stdout)
+					}
 					Expect(err).ToNot(HaveOccurred())
 
 					// Marshal the yaml file into a map
 					var cfgMap map[string]interface{}
 					err = yaml.Unmarshal([]byte(readBytes), &cfgMap)
+					if err != nil {
+						fmt.Printf("Error running command, dumping output:\n%s\n%s\n%s\n", err, stderr, stdout)
+					}
 					Expect(err).ToNot(HaveOccurred())
 
 					// Check if the config file contains the default manifests
@@ -220,7 +275,9 @@ var _ = Describe("kraft pkg", func() {
 					cmd.Args = append(cmd.Args, "https://example2.com")
 					cmd.Args = append(cmd.Args, "https://example3.com")
 					err := cmd.Run()
-
+					if err != nil {
+						fmt.Printf("Error running command, dumping output:\n%s\n%s\n%s\n", err, stderr, stdout)
+					}
 					Expect(err).ToNot(HaveOccurred())
 					Expect(stderr.String()).To(BeEmpty())
 
@@ -237,16 +294,24 @@ var _ = Describe("kraft pkg", func() {
 					cmd.Args = append(cmd.Args, "https://example2.com")
 					cmd.Args = append(cmd.Args, "https://example3.com")
 					err := cmd.Run()
-
+					if err != nil {
+						fmt.Printf("Error running command, dumping output:\n%s\n%s\n%s\n", err, stderr, stdout)
+					}
 					Expect(err).ToNot(HaveOccurred())
 					Expect(stderr.String()).To(BeEmpty())
 
 					// Read the config file
 					osFile, err := os.Open(cfg.Path())
+					if err != nil {
+						fmt.Printf("Error running command, dumping output:\n%s\n%s\n%s\n", err, stderr, stdout)
+					}
 					Expect(err).ToNot(HaveOccurred())
 					defer osFile.Close()
 
 					osFileInfo, err := osFile.Stat()
+					if err != nil {
+						fmt.Printf("Error running command, dumping output:\n%s\n%s\n%s\n", err, stderr, stdout)
+					}
 					Expect(err).ToNot(HaveOccurred())
 
 					// Check if the config file is not empty
@@ -257,11 +322,17 @@ var _ = Describe("kraft pkg", func() {
 
 					// Read file content
 					readBytes, err := os.ReadFile(cfg.Path())
+					if err != nil {
+						fmt.Printf("Error running command, dumping output:\n%s\n%s\n%s\n", err, stderr, stdout)
+					}
 					Expect(err).ToNot(HaveOccurred())
 
 					// Marshal the yaml file into a map
 					var cfgMap map[string]interface{}
 					err = yaml.Unmarshal([]byte(readBytes), &cfgMap)
+					if err != nil {
+						fmt.Printf("Error running command, dumping output:\n%s\n%s\n%s\n", err, stderr, stdout)
+					}
 					Expect(err).ToNot(HaveOccurred())
 
 					// Check if the config file contains the default manifests
@@ -296,7 +367,9 @@ var _ = Describe("kraft pkg", func() {
 					cmd.Args = append(cmd.Args, "https://example2.com")
 					cmd.Args = append(cmd.Args, "https://example3.com")
 					err := cmd.Run()
-
+					if err != nil {
+						fmt.Printf("Error running command, dumping output:\n%s\n%s\n%s\n", err, stderr, stdout)
+					}
 					Expect(err).ToNot(HaveOccurred())
 					Expect(stderr.String()).To(BeEmpty())
 
@@ -313,16 +386,24 @@ var _ = Describe("kraft pkg", func() {
 					cmd.Args = append(cmd.Args, "https://example2.com")
 					cmd.Args = append(cmd.Args, "https://example2.com")
 					err := cmd.Run()
-
+					if err != nil {
+						fmt.Printf("Error running command, dumping output:\n%s\n%s\n%s\n", err, stderr, stdout)
+					}
 					Expect(err).ToNot(HaveOccurred())
 					Expect(stderr.String()).To(BeEmpty())
 
 					// Read the config file
 					osFile, err := os.Open(cfg.Path())
+					if err != nil {
+						fmt.Printf("Error running command, dumping output:\n%s\n%s\n%s\n", err, stderr, stdout)
+					}
 					Expect(err).ToNot(HaveOccurred())
 					defer osFile.Close()
 
 					osFileInfo, err := osFile.Stat()
+					if err != nil {
+						fmt.Printf("Error running command, dumping output:\n%s\n%s\n%s\n", err, stderr, stdout)
+					}
 					Expect(err).ToNot(HaveOccurred())
 
 					// Check if the config file is not empty
@@ -333,11 +414,17 @@ var _ = Describe("kraft pkg", func() {
 
 					// Read file content
 					readBytes, err := os.ReadFile(cfg.Path())
+					if err != nil {
+						fmt.Printf("Error running command, dumping output:\n%s\n%s\n%s\n", err, stderr, stdout)
+					}
 					Expect(err).ToNot(HaveOccurred())
 
 					// Marshal the yaml file into a map
 					var cfgMap map[string]interface{}
 					err = yaml.Unmarshal([]byte(readBytes), &cfgMap)
+					if err != nil {
+						fmt.Printf("Error running command, dumping output:\n%s\n%s\n%s\n", err, stderr, stdout)
+					}
 					Expect(err).ToNot(HaveOccurred())
 
 					// Check if the config file contains the default manifests

--- a/test/e2e/cli/pkg_update_test.go
+++ b/test/e2e/cli/pkg_update_test.go
@@ -6,6 +6,8 @@
 package cli_test
 
 import (
+	"fmt"
+
 	. "github.com/onsi/ginkgo/v2" //nolint:stylecheck
 	. "github.com/onsi/gomega"    //nolint:stylecheck
 
@@ -51,6 +53,9 @@ var _ = Describe("kraft pkg", func() {
 			When("invoked without flags or positional arguments", func() {
 				It("should retrieve the list of components, libraries and packages", func() {
 					err := cmd.Run()
+					if err != nil {
+						fmt.Printf("Error running command, dumping output:\n%s\n%s\n%s\n", err, stderr, stdout)
+					}
 					Expect(err).ToNot(HaveOccurred())
 
 					Expect(stderr.String()).To(BeEmpty())
@@ -68,6 +73,9 @@ var _ = Describe("kraft pkg", func() {
 
 				It("should print the command's help", func() {
 					err := cmd.Run()
+					if err != nil {
+						fmt.Printf("Error running command, dumping output:\n%s\n%s\n%s\n", err, stderr, stdout)
+					}
 					Expect(err).ToNot(HaveOccurred())
 
 					Expect(stderr.String()).To(BeEmpty())

--- a/test/e2e/cli/version_test.go
+++ b/test/e2e/cli/version_test.go
@@ -6,6 +6,8 @@
 package cli_test
 
 import (
+	"fmt"
+
 	. "github.com/onsi/ginkgo/v2" //nolint:stylecheck
 	. "github.com/onsi/gomega"    //nolint:stylecheck
 
@@ -34,6 +36,9 @@ var _ = Describe("kraft version", func() {
 	When("invoked without flags or positional arguments", func() {
 		It("should print the version and exit gracefully", func() {
 			err := cmd.Run()
+			if err != nil {
+				fmt.Printf("Error running command, dumping output:\n%s\n%s\n%s\n", err, stderr, stdout)
+			}
 			Expect(err).ToNot(HaveOccurred())
 
 			Expect(stderr.String()).To(BeEmpty())
@@ -48,6 +53,9 @@ var _ = Describe("kraft version", func() {
 
 		It("should print the command's help", func() {
 			err := cmd.Run()
+			if err != nil {
+				fmt.Printf("Error running command, dumping output:\n%s\n%s\n%s\n", err, stderr, stdout)
+			}
 			Expect(err).ToNot(HaveOccurred())
 
 			Expect(stderr.String()).To(BeEmpty())


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

To run the tests you will need to be root or run with `sudo` because the commands manipulate network interfaces.

Hopefully this works in the actions, otherwise we can just try to skip them in the action.