### PR TITLE
fix(goreleaser): Enable multi-binary releases

### DIFF
--- a/.goreleaser-stable.yaml
+++ b/.goreleaser-stable.yaml
@@ -39,6 +39,7 @@ release:
 
 nfpms:
   - vendor: Unikraft
+    id: nfpm-default
     maintainer: Alexander Jung <alex@unikraft.io>
     description: Build and use highly customized and ultra-lightweight unikernels.
     license: BSD 3-clause

--- a/.goreleaser-stable.yaml
+++ b/.goreleaser-stable.yaml
@@ -120,14 +120,15 @@ builds:
 #@ end
 #@ end
 #@ targets = {
-#@   "linux-amd64": {"os": "linux", "arch": "amd64"},
-#@   "linux-arm64": {"os": "linux", "arch": "arm64"}
+#@   "linux-amd64": {"os": "linux", "arch": "amd64"}
 #@ }
 #@ for binary in ["runu"]:
 #@ for target, specs in targets.items():
   - id: #@ "{}-{}".format(binary, target)
     binary: #@ binary
     main: #@ "./cmd/{}".format(binary)
+    env:
+      - CGO_ENABLED=1
     goos:
       - #@ specs["os"]
     goarch:

--- a/.goreleaser-stable.yaml
+++ b/.goreleaser-stable.yaml
@@ -67,6 +67,16 @@ publishers:
     cmd: curl -F package=@{{ .ArtifactName }} https://{{ .Env.FURY_TOKEN }}@push.fury.io/{{ .Env.FURY_USER }}/
 aurs:
   - homepage: https://kraftkit.sh
+    ids:
+#@ targets = [
+#@   "linux-amd64",
+#@   "linux-arm64"
+#@ ]
+#@ for binary in ["kraft"]:
+#@ for target in targets:
+      - #@ "archive-{}-{}".format(binary, target)
+#@ end
+#@ end
     description: Build and use highly customized and ultra-lightweight unikernels
     maintainers:
       - "Alexander Jung <alex at unikraft dot io>"
@@ -83,6 +93,16 @@ aurs:
       email: monkey+aur@unikraft.io
 nix:
   - name: kraftkit
+    ids:
+#@ targets = [
+#@   "linux-amd64",
+#@   "linux-arm64"
+#@ ]
+#@ for binary in ["kraft"]:
+#@ for target in targets:
+      - #@ "archive-{}-{}".format(binary, target)
+#@ end
+#@ end
     repository:
       owner: unikraft
       name: nur
@@ -136,5 +156,34 @@ builds:
       - #@ specs["arch"]
     ldflags:
       - -s -w
+#@ end
+#@ end
+
+archives:
+#@ targets = [
+#@   "linux-amd64",
+#@   "linux-arm64",
+#@   "darwin-arm64",
+#@   "darwin-amd64"
+#@ ]
+#@ for binary in ["kraft"]:
+#@ for target in targets:
+  - id: #@ "archive-{}-{}".format(binary, target)
+    format: tar.gz
+    name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+    builds:
+      - #@ "{}-{}".format(binary, target)
+#@ end
+#@ end
+#@ targets = [
+#@   "linux-amd64"
+#@ ]
+#@ for binary in ["runu"]:
+#@ for target in targets:
+  - id: #@ "archive-{}-{}".format(binary, target)
+    format: tar.gz
+    name_template: "{{ .ProjectName }}_runu_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+    builds:
+      - #@ "{}-{}".format(binary, target)
 #@ end
 #@ end

--- a/.goreleaser-staging.yaml
+++ b/.goreleaser-staging.yaml
@@ -93,3 +93,32 @@ builds:
       - -s -w
 #@ end
 #@ end
+
+archives:
+#@ targets = [
+#@   "linux-amd64",
+#@   "linux-arm64",
+#@   "darwin-arm64",
+#@   "darwin-amd64"
+#@ ]
+#@ for binary in ["kraft"]:
+#@ for target in targets:
+  - id: #@ "archive-{}-{}".format(binary, target)
+    format: tar.gz
+    name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+    builds:
+      - #@ "{}-{}".format(binary, target)
+#@ end
+#@ end
+#@ targets = [
+#@   "linux-amd64"
+#@ ]
+#@ for binary in ["runu"]:
+#@ for target in targets:
+  - id: #@ "archive-{}-{}".format(binary, target)
+    format: tar.gz
+    name_template: "{{ .ProjectName }}_runu_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+    builds:
+      - #@ "{}-{}".format(binary, target)
+#@ end
+#@ end

--- a/.goreleaser-staging.yaml
+++ b/.goreleaser-staging.yaml
@@ -76,14 +76,15 @@ builds:
 #@ end
 #@ end
 #@ targets = {
-#@   "linux-amd64": {"os": "linux", "arch": "amd64"},
-#@   "linux-arm64": {"os": "linux", "arch": "arm64"}
+#@   "linux-amd64": {"os": "linux", "arch": "amd64"}
 #@ }
 #@ for binary in ["runu"]:
 #@ for target, specs in targets.items():
   - id: #@ "{}-{}".format(binary, target)
     binary: #@ binary
     main: #@ "./cmd/{}".format(binary)
+    env:
+      - CGO_ENABLED=1
     goos:
       - #@ specs["os"]
     goarch:


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

This PR fixes 3 aspects:
1. Arm64 does not work for runu so we disable for now (it would require including the gcc toolchain in the workflow)
1. Publishers had different ids from the nfpms so it lead to it not doing anything
1. We now have multiple binaries so we need to specify the archives for each one and what to do with them