### PR TITLE
build(webinstall): switch to distroless base image

### DIFF
--- a/tools/webinstall/Dockerfile
+++ b/tools/webinstall/Dockerfile
@@ -22,13 +22,8 @@ COPY . /go/src/webinstall
 RUN set -xe; \
     go build -tags static -a -ldflags='-s -w' -ldflags '-extldflags "-static"' .
 
-FROM alpine:3.17.2 as ca-certificates
+FROM gcr.io/distroless/static:nonroot AS prod
 
-RUN apk add -U --no-cache ca-certificates
-
-FROM scratch AS prod
-
-COPY --from=ca-certificates /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --from=base /go/src/webinstall/webinstall /webinstall
 
 EXPOSE 8080


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [ ] Tested your changes against relevant architectures and platforms;
  - [ ] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

Use `gcr.io/distroless/static:nonroot` as the container base image for the following reasons:

- Already [includes ca-certificates](https://github.com/GoogleContainerTools/distroless/tree/main/base#image-contents)
- [Rootless](https://github.com/GoogleContainerTools/distroless/blob/af669b4175e9bbbe6ea2a514663852237cff070a/base/BUILD#L33-L41) by default
- Enables the usage of secret injectors at runtime, which are often themselves injected as a static binary via Kubernetes mutating webhooks, and tend to fail if there is no basic directory structure inside the image (`/tmp`, ...)