### PR TITLE
fix(machine): Remove link from store if already deleted

### DIFF
--- a/.github/workflows/gotests.yaml
+++ b/.github/workflows/gotests.yaml
@@ -14,7 +14,7 @@ on:
 jobs:
   gounit:
     name: Go unit tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-arm64-virt
     steps:
       - uses: actions/checkout@v4
         with:
@@ -49,7 +49,7 @@ jobs:
 
   e2e-cli:
     name: kraft CLI end-to-end
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-arm64-virt
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

This fixes the case where someone creates a network with kraftkit and removes it with something else like `ifconfig`/`ip link del` and the entry stays in the list.

Partial fix for: #820 