### PR TITLE
refactor: replace unused 'args' with '_' in several commands

### DIFF
--- a/cmd/kraft/build/build.go
+++ b/cmd/kraft/build/build.go
@@ -365,7 +365,7 @@ func (opts *Build) pull(ctx context.Context, project app.Application, workdir st
 	return nil
 }
 
-func (opts *Build) Run(cmd *cobra.Command, args []string) error {
+func (opts *Build) Run(cmd *cobra.Command, _ []string) error {
 	ctx := cmd.Context()
 
 	// Filter project targets by any provided CLI options

--- a/cmd/kraft/fetch/fetch.go
+++ b/cmd/kraft/fetch/fetch.go
@@ -357,7 +357,7 @@ func (opts *Fetch) pull(ctx context.Context, project app.Application, workdir st
 	return nil
 }
 
-func (opts *Fetch) Run(cmd *cobra.Command, args []string) error {
+func (opts *Fetch) Run(cmd *cobra.Command, _ []string) error {
 	ctx := cmd.Context()
 
 	// Filter project targets by any provided CLI options

--- a/cmd/kraft/menu/menu.go
+++ b/cmd/kraft/menu/menu.go
@@ -354,7 +354,7 @@ func (opts *Menu) pull(ctx context.Context, project app.Application, workdir str
 	return nil
 }
 
-func (opts *Menu) Run(cmd *cobra.Command, args []string) error {
+func (opts *Menu) Run(cmd *cobra.Command, _ []string) error {
 	ctx := cmd.Context()
 
 	// Filter project targets by any provided CLI options

--- a/cmd/kraft/net/list/list.go
+++ b/cmd/kraft/net/list/list.go
@@ -46,7 +46,7 @@ func (opts *List) Pre(cmd *cobra.Command, _ []string) error {
 	return nil
 }
 
-func (opts *List) Run(cmd *cobra.Command, args []string) error {
+func (opts *List) Run(cmd *cobra.Command, _ []string) error {
 	var err error
 
 	ctx := cmd.Context()

--- a/cmd/kraft/net/net.go
+++ b/cmd/kraft/net/net.go
@@ -58,6 +58,6 @@ func (opts *Net) Pre(cmd *cobra.Command, _ []string) error {
 	return nil
 }
 
-func (opts *Net) Run(cmd *cobra.Command, args []string) error {
+func (opts *Net) Run(cmd *cobra.Command, _ []string) error {
 	return cmd.Help()
 }

--- a/cmd/kraft/ps/ps.go
+++ b/cmd/kraft/ps/ps.go
@@ -65,7 +65,7 @@ func (opts *Ps) Pre(cmd *cobra.Command, _ []string) error {
 	return nil
 }
 
-func (opts *Ps) Run(cmd *cobra.Command, args []string) error {
+func (opts *Ps) Run(cmd *cobra.Command, _ []string) error {
 	var err error
 
 	type psTable struct {

--- a/cmd/kraft/version/version.go
+++ b/cmd/kraft/version/version.go
@@ -33,7 +33,7 @@ func New() *cobra.Command {
 	return cmd
 }
 
-func (opts *Version) Run(cmd *cobra.Command, args []string) error {
+func (opts *Version) Run(cmd *cobra.Command, _ []string) error {
 	fmt.Fprintf(iostreams.G(cmd.Context()).Out, "kraft %s", version.String())
 	return nil
 }


### PR DESCRIPTION
### Prerequisite checklist

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [x] Updated relevant documentation.

### Description of changes
This minor thing came up during the cloud subcommand integration work. Sometimes the param is unused. Use an underscore if that's the case.

Improves readability a bit.
