### PR TITLE
fix(cmdfactory): Set arguments during initial object attribution

### DIFF
--- a/cmdfactory/builder.go
+++ b/cmdfactory/builder.go
@@ -508,7 +508,7 @@ func New(obj Runnable, cmd cobra.Command) (*cobra.Command, error) {
 		c.RunE = obj.Run
 
 		// Parse the attributes of this object into addressable flags for this command
-		if err := AttributeFlags(&c, obj); err != nil {
+		if err := AttributeFlags(&c, obj, os.Args[1:]...); err != nil {
 			return nil, err
 		}
 	}


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

This commit fixes an issue where arguments were not attributed to the initial object (representing the command invoked by `New`).  In KraftKit, this did not matter since the arguments are passed again by `AttributeFlags` when the internal config is associated with the root command during the bootstrapping of the core application.  However, when used externally, and without using the `AttributeFlags` method independently from `New`, this causes a late-parsing issue where flags were not fully parsed before relevant subsystems were invoked.  For example, when calling the `--help` flag would not work because the system to recognise this has already executed.