### PR TITLE
fix(webinstall): Correct use of `makepkg` for Arch Linux

### DIFF
--- a/tools/webinstall/install.sh
+++ b/tools/webinstall/install.sh
@@ -1064,9 +1064,10 @@ install_linux_gnu() {
         need_cmd "$GIT"
         need_cmd "$MAKEPKG"
         need_cmd "$RM"
-
         do_cmd "$GIT clone https://aur.archlinux.org/kraftkit-bin.git /tmp/kraftkit-bin"
-        do_cmd "$MAKEPKG -si /tmp/kraftkit-bin"
+        cd /tmp/kraftkit-bin
+        do_cmd "$MAKEPKG -si"
+        cd - 1> /dev/null
         $RM -rf /tmp/kraftkit-bin
     else
         _ilg_msg=$(printf "error: %s%s%s"                               \


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [ X ] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [ ] Tested your changes against relevant architectures and platforms;
  - [ ] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

This change does not impact building, thus there is no need for running make fmt nor updating relevant documentation. This patch is Arch Linux platform specific.

### Description of changes
Fixed makepkg command for ArchLinux, addressing issue https://github.com/unikraft/kraftkit/issues/837
<!--
Please provide a detailed description of the changes made in this new PR.
-->
Signed-off-by: Yunchuan "Winslow" Hu <i@winsloweric.com>