### PR TITLE
feat(workflows): Add multi-os stable tests

### DIFF
--- a/.github/workflows/gotests-stable.yaml
+++ b/.github/workflows/gotests-stable.yaml
@@ -1,0 +1,176 @@
+name: Stable Tests
+
+on:
+  push:
+    branches: [stable]
+
+jobs:
+  gounit-ubuntu:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-22.04, ubuntu-20.04]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - uses: actions/setup-go@v4
+        with:
+          go-version: 1.20.6
+          cache: false
+
+      - name: Set Go variables
+        id: goenv
+        run: |
+          {
+            echo "cache=$(go env GOCACHE)"
+            echo "modcache=$(go env GOMODCACHE)"
+            echo "mod=$(go env GOMOD)"
+          } >>"$GITHUB_OUTPUT"
+
+      - name: Go caches
+        uses: actions/cache@v3
+        with:
+          path: |
+            ${{ steps.goenv.outputs.cache }}
+            ${{ steps.goenv.outputs.modcache }}
+          key: ${{ github.job }}-${{ runner.os }}-go-${{ hashFiles(steps.goenv.outputs.mod) }}
+          restore-keys: |
+            ${{ github.job }}-${{ runner.os }}-go-
+
+      - name: Run tests
+        run: make test-unit
+
+  gounit-mac:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-11, macos-12]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - uses: actions/setup-go@v4
+        with:
+          go-version: 1.20.6
+          cache: false
+
+      - name: Set Go variables
+        id: goenv
+        run: |
+          {
+            echo "cache=$(go env GOCACHE)"
+            echo "modcache=$(go env GOMODCACHE)"
+            echo "mod=$(go env GOMOD)"
+          } >>"$GITHUB_OUTPUT"
+
+      - name: Go caches
+        uses: actions/cache@v3
+        with:
+          path: |
+            ${{ steps.goenv.outputs.cache }}
+            ${{ steps.goenv.outputs.modcache }}
+          key: ${{ github.job }}-${{ runner.os }}-go-${{ hashFiles(steps.goenv.outputs.mod) }}
+          restore-keys: |
+            ${{ github.job }}-${{ runner.os }}-go-
+
+      - name: Run tests
+        run: make test-unit
+
+  e2e-ubuntu-cli:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-22.04, ubuntu-20.04]
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          submodules: recursive
+
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: 1.20.6
+          cache: false
+
+      - name: Set Go variables
+        id: goenv
+        run: |
+          {
+            echo "cache=$(go env GOCACHE)"
+            echo "modcache=$(go env GOMODCACHE)"
+            echo "mod=$(go env GOMOD)"
+          } >>"$GITHUB_OUTPUT"
+
+      - name: Go caches
+        uses: actions/cache@v3
+        with:
+          path: |
+            ${{ steps.goenv.outputs.cache }}
+            ${{ steps.goenv.outputs.modcache }}
+          key: ${{ github.job }}-${{ runner.os }}-go-${{ hashFiles(steps.goenv.outputs.mod) }}
+          restore-keys: |
+            ${{ github.job }}-${{ runner.os }}-go-
+
+      - name: Run framework unit tests
+        run: go run github.com/onsi/ginkgo/v2/ginkgo -v -p -randomize-all ./test/e2e/framework/...
+
+      - name: Run e2e tests
+        env:
+          KRAFTKIT_NO_CHECK_UPDATES: true
+          DOCKER: ''
+        run: make test-e2e DISTDIR="$(go env GOPATH)"/bin
+
+  e2e-mac-cli:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-11, macos-12]
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          submodules: recursive
+
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: 1.20.6
+          cache: false
+
+      - name: Set Go variables
+        id: goenv
+        run: |
+          {
+            echo "cache=$(go env GOCACHE)"
+            echo "modcache=$(go env GOMODCACHE)"
+            echo "mod=$(go env GOMOD)"
+          } >>"$GITHUB_OUTPUT"
+
+      - name: Go caches
+        uses: actions/cache@v3
+        with:
+          path: |
+            ${{ steps.goenv.outputs.cache }}
+            ${{ steps.goenv.outputs.modcache }}
+          key: ${{ github.job }}-${{ runner.os }}-go-${{ hashFiles(steps.goenv.outputs.mod) }}
+          restore-keys: |
+            ${{ github.job }}-${{ runner.os }}-go-
+
+      - name: Run framework unit tests
+        run: go run github.com/onsi/ginkgo/v2/ginkgo -v -p -randomize-all ./test/e2e/framework/...
+
+      - name: Run e2e tests
+        env:
+          KRAFTKIT_NO_CHECK_UPDATES: true
+          DOCKER: ''
+        run: make test-e2e DISTDIR="$(go env GOPATH)"/bin

--- a/Makefile
+++ b/Makefile
@@ -163,13 +163,13 @@ cicheck: ## Run CI checks.
 test: test-unit test-e2e ## Run all tests.
 
 .PHONY: test-unit
-test-unit: GOTEST_EXCLUDE := third_party/ test/ hack/ buildenvs/ dist/ docs/
+test-unit: GOTEST_EXCLUDE := third_party/ test/ hack/ buildenvs/ dist/ docs/ tools/
 test-unit: GOTEST_PKGS := $(foreach pkg,$(filter-out $(GOTEST_EXCLUDE),$(wildcard */)),$(pkg)...)
 test-unit: ## Run unit tests.
 	$(GO) run github.com/onsi/ginkgo/v2/ginkgo -v -p -randomize-all $(GOTEST_PKGS)
 
 .PHONY: test-e2e
-test-e2e: $(BIN) ## Run CLI end-to-end tests.
+test-e2e: kraft ## Run CLI end-to-end tests.
 	$(GO) run github.com/onsi/ginkgo/v2/ginkgo -v -p -randomize-all test/e2e/cli/...
 
 .PHONY: install-golangci-lint

--- a/test/e2e/cli/net_create_test.go
+++ b/test/e2e/cli/net_create_test.go
@@ -7,6 +7,7 @@ package cli_test
 
 import (
 	"fmt"
+	"runtime"
 
 	. "github.com/onsi/ginkgo/v2" //nolint:stylecheck
 	. "github.com/onsi/gomega"    //nolint:stylecheck
@@ -24,6 +25,10 @@ var _ = Describe("kraft net create", func() {
 	var cfg *fcfg.Config
 
 	BeforeEach(func() {
+		if runtime.GOOS != "linux" {
+			Skip("This test only supports Linux. See here for more information: https://github.com/unikraft/kraftkit/issues/840")
+		}
+
 		stdout = fcmd.NewIOStream()
 		stderr = fcmd.NewIOStream()
 

--- a/test/e2e/cli/net_down_test.go
+++ b/test/e2e/cli/net_down_test.go
@@ -7,6 +7,7 @@ package cli_test
 
 import (
 	"fmt"
+	"runtime"
 
 	. "github.com/onsi/ginkgo/v2" //nolint:stylecheck
 	. "github.com/onsi/gomega"    //nolint:stylecheck
@@ -24,6 +25,10 @@ var _ = Describe("kraft net down", func() {
 	var cfg *fcfg.Config
 
 	BeforeEach(func() {
+		if runtime.GOOS != "linux" {
+			Skip("This test only supports Linux. See here for more information: https://github.com/unikraft/kraftkit/issues/840")
+		}
+
 		stdout = fcmd.NewIOStream()
 		stderr = fcmd.NewIOStream()
 

--- a/test/e2e/cli/net_inspect_test.go
+++ b/test/e2e/cli/net_inspect_test.go
@@ -8,6 +8,7 @@ package cli_test
 import (
 	"encoding/json"
 	"fmt"
+	"runtime"
 
 	. "github.com/onsi/ginkgo/v2" //nolint:stylecheck
 	. "github.com/onsi/gomega"    //nolint:stylecheck
@@ -25,6 +26,10 @@ var _ = Describe("kraft net inspect", func() {
 	var cfg *fcfg.Config
 
 	BeforeEach(func() {
+		if runtime.GOOS != "linux" {
+			Skip("This test only supports Linux. See here for more information: https://github.com/unikraft/kraftkit/issues/840")
+		}
+
 		stdout = fcmd.NewIOStream()
 		stderr = fcmd.NewIOStream()
 

--- a/test/e2e/cli/net_ls_test.go
+++ b/test/e2e/cli/net_ls_test.go
@@ -7,6 +7,7 @@ package cli_test
 
 import (
 	"fmt"
+	"runtime"
 
 	. "github.com/onsi/ginkgo/v2" //nolint:stylecheck
 	. "github.com/onsi/gomega"    //nolint:stylecheck
@@ -24,6 +25,10 @@ var _ = Describe("kraft net ls", func() {
 	var cfg *fcfg.Config
 
 	BeforeEach(func() {
+		if runtime.GOOS != "linux" {
+			Skip("This test only supports Linux. See here for more information: https://github.com/unikraft/kraftkit/issues/840")
+		}
+
 		stdout = fcmd.NewIOStream()
 		stderr = fcmd.NewIOStream()
 

--- a/test/e2e/cli/net_rm_test.go
+++ b/test/e2e/cli/net_rm_test.go
@@ -7,6 +7,7 @@ package cli_test
 
 import (
 	"fmt"
+	"runtime"
 
 	. "github.com/onsi/ginkgo/v2" //nolint:stylecheck
 	. "github.com/onsi/gomega"    //nolint:stylecheck
@@ -24,6 +25,10 @@ var _ = Describe("kraft net rm", func() {
 	var cfg *fcfg.Config
 
 	BeforeEach(func() {
+		if runtime.GOOS != "linux" {
+			Skip("This test only supports Linux. See here for more information: https://github.com/unikraft/kraftkit/issues/840")
+		}
+
 		stdout = fcmd.NewIOStream()
 		stderr = fcmd.NewIOStream()
 

--- a/test/e2e/cli/net_up_test.go
+++ b/test/e2e/cli/net_up_test.go
@@ -7,6 +7,7 @@ package cli_test
 
 import (
 	"fmt"
+	"runtime"
 
 	. "github.com/onsi/ginkgo/v2" //nolint:stylecheck
 	. "github.com/onsi/gomega"    //nolint:stylecheck
@@ -24,6 +25,10 @@ var _ = Describe("kraft net up", func() {
 	var cfg *fcfg.Config
 
 	BeforeEach(func() {
+		if runtime.GOOS != "linux" {
+			Skip("This test only supports Linux. See here for more information: https://github.com/unikraft/kraftkit/issues/840")
+		}
+
 		stdout = fcmd.NewIOStream()
 		stderr = fcmd.NewIOStream()
 


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

This adds testing when pushing to stable on all OSes available through GitHub on Linux and Mac.
Of course we should catch this before pushing to stable, but it will take A Lot of time ti run all those so it's better if we only do it ~once a week.

I only copied the existing tests and added some duplication + matrixes.