### PR TITLE
feat: Enable initial Windows support

### DIFF
--- a/archive/archive.go
+++ b/archive/archive.go
@@ -39,10 +39,10 @@ func TarFileWriter(ctx context.Context, src, dst string, tw *tar.Writer, opts ..
 
 	if dst == "" {
 		return fmt.Errorf("cannot tar file with no specified destination")
-	} else if dst[0] == '/' {
+	} else if dst[0] == filepath.Separator {
 		dst = dst[1:]
 	}
-	if strings.HasSuffix(dst, "/") {
+	if strings.HasSuffix(dst, string(filepath.Separator)) {
 		return fmt.Errorf("attempting to use TarFileWriter with directory")
 	}
 

--- a/archive/unarchive.go
+++ b/archive/unarchive.go
@@ -66,8 +66,8 @@ func Untar(src io.Reader, dst string, opts ...UnarchiveOption) error {
 		if uc.stripComponents > 0 {
 			// We don't use the context-(host-)specific filepath.SplitList because
 			// this is a UNIX tarball
-			parts := strings.Split(header.Name, "/")
-			path = strings.Join(parts[uc.stripComponents:], "/")
+			parts := filepath.SplitList(header.Name)
+			path = strings.Join(parts[uc.stripComponents:], string(filepath.Separator))
 			path = filepath.Join(dst, path)
 		} else {
 			path = filepath.Join(dst, header.Name)

--- a/config/config_file.go
+++ b/config/config_file.go
@@ -241,7 +241,7 @@ func findRegularFile(p string) string {
 			return p
 		}
 		newPath := filepath.Dir(p)
-		if newPath == p || newPath == "/" || newPath == "." {
+		if newPath == p || newPath == string(filepath.Separator) || newPath == "." {
 			break
 		}
 		p = newPath

--- a/exec/process.go
+++ b/exec/process.go
@@ -110,11 +110,7 @@ func (e *Process) Start(ctx context.Context) error {
 	log.G(ctx).Debug(e.Cmdline())
 
 	if e.opts.detach {
-		// the Setpgid flag is used to prevent the child process from exiting when
-		// the parent is killed
-		e.cmd.SysProcAttr = &syscall.SysProcAttr{
-			Setpgid: true,
-		}
+		e.cmd.SysProcAttr = hostAttributes()
 		e.cmd.Stdin = nil
 	}
 

--- a/exec/process_darwin.go
+++ b/exec/process_darwin.go
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2022, Unikraft GmbH and The KraftKit Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file expect in compliance with the License.
+package exec
+
+import (
+	"syscall"
+)
+
+func hostAttributes() *syscall.SysProcAttr {
+	// the Setpgid flag is used to prevent the child process from exiting when
+	// the parent is killed
+	return &syscall.SysProcAttr{
+		Setpgid: true,
+	}
+}

--- a/exec/process_linux.go
+++ b/exec/process_linux.go
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2022, Unikraft GmbH and The KraftKit Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file expect in compliance with the License.
+package exec
+
+import (
+	"syscall"
+)
+
+func hostAttributes() *syscall.SysProcAttr {
+	// the Setpgid flag is used to prevent the child process from exiting when
+	// the parent is killed
+	return &syscall.SysProcAttr{
+		Setpgid: true,
+	}
+}

--- a/exec/process_windows.go
+++ b/exec/process_windows.go
@@ -1,0 +1,20 @@
+// process_windows.go
+//go:build windows
+
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2022, Unikraft GmbH and The KraftKit Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file expect in compliance with the License.
+package exec
+
+import (
+	"syscall"
+)
+
+func hostAttributes() *syscall.SysProcAttr {
+	// the CREATE_NEW_PROCESS_GROUP flag is used to prevent the child process from exiting when
+	// the parent is killed
+	return &syscall.SysProcAttr{
+		CreationFlags: syscall.CREATE_NEW_PROCESS_GROUP,
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -75,6 +75,8 @@ require (
 	sigs.k8s.io/kustomize/kyaml v0.14.3
 )
 
+replace github.com/vishvananda/netlink => github.com/craciunoiuc/netlink v1.2.1-beta.2
+
 require (
 	dario.cat/mergo v1.0.0 // indirect
 	github.com/AdaLogics/go-fuzz-headers v0.0.0-20230106234847-43070de90fa1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -305,6 +305,8 @@ github.com/cpuguy83/go-md2man v1.0.10/go.mod h1:SmD6nW6nTyfqj6ABTjUi3V3JVMnlJmwc
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
+github.com/craciunoiuc/netlink v1.2.1-beta.2 h1:77jIchlL4g+LqbmQdxVWg8QthxM/MoG1FMOSPHqZJvc=
+github.com/craciunoiuc/netlink v1.2.1-beta.2/go.mod h1:whJevzBpTrid75eZy99s3DqCmy05NfibNaF2Ol5Ox5A=
 github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7DoTY=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/creack/pty v1.1.17/go.mod h1:MOBLtS5ELjhRRrroQr9kyvTxUAFNvYEK993ew/Vr4O4=
@@ -1010,14 +1012,7 @@ github.com/urfave/cli v1.22.2/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtX
 github.com/urfave/cli v1.22.12/go.mod h1:sSBEIC79qR6OvcmsD4U3KABeOTxDqQtdDnaFuUN30b8=
 github.com/vbatts/tar-split v0.11.3 h1:hLFqsOLQ1SsppQNTMpkpPXClLDfC2A3Zgy9OUU+RVck=
 github.com/vbatts/tar-split v0.11.3/go.mod h1:9QlHN18E+fEH7RdG+QAJJcuya3rqT7eXSTY7wGrAokY=
-github.com/vishvananda/netlink v0.0.0-20181108222139-023a6dafdcdf/go.mod h1:+SR5DhBJrl6ZM7CoCKvpw5BKroDKQ+PJqOg65H/2ktk=
-github.com/vishvananda/netlink v1.1.0/go.mod h1:cTgwzPIzzgDAYoQrMm0EdrjRUBkTqKYppBueQtXaqoE=
-github.com/vishvananda/netlink v1.1.1-0.20201029203352-d40f9887b852/go.mod h1:twkDnbuQxJYemMlGd4JFIcuhgX83tXhKS2B/PRMpOho=
-github.com/vishvananda/netlink v1.1.1-0.20210330154013-f5de75959ad5/go.mod h1:twkDnbuQxJYemMlGd4JFIcuhgX83tXhKS2B/PRMpOho=
-github.com/vishvananda/netlink v1.2.1-beta.2 h1:Llsql0lnQEbHj0I1OuKyp8otXp0r3q0mPkuhwHfStVs=
-github.com/vishvananda/netlink v1.2.1-beta.2/go.mod h1:twkDnbuQxJYemMlGd4JFIcuhgX83tXhKS2B/PRMpOho=
 github.com/vishvananda/netns v0.0.0-20180720170159-13995c7128cc/go.mod h1:ZjcWmFBXmLKZu9Nxj3WKYEafiSqer2rnvPr0en9UNpI=
-github.com/vishvananda/netns v0.0.0-20191106174202-0a2b9b5464df/go.mod h1:JP3t17pCcGlemwknint6hfoeCVQrEMVwxRLRjXpq+BU=
 github.com/vishvananda/netns v0.0.0-20200728191858-db3c7e526aae/go.mod h1:DD4vA1DwXk04H54A1oHXtwZmA0grkVMdPxx/VGLCah0=
 github.com/vishvananda/netns v0.0.0-20210104183010-2eb08e3e575f/go.mod h1:DD4vA1DwXk04H54A1oHXtwZmA0grkVMdPxx/VGLCah0=
 github.com/vishvananda/netns v0.0.4 h1:Oeaw1EM2JMxD51g9uhtC0D7erkIjgmj8+JZc26m1YX8=
@@ -1224,7 +1219,6 @@ golang.org/x/sys v0.0.0-20190522044717-8097e1b27ff5/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20190531175056-4c3a928424d2/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190602015325-4c4f7f33c9ed/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190606165138-5da285871e9c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20190606203320-7fc4e5ec1444/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190616124812-15dcb6c0061f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190624142023-c5567b49c5d0/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190726091711-fc99dfbffb4e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/initrd/initrd.go
+++ b/initrd/initrd.go
@@ -111,17 +111,16 @@ func (i *InitrdConfig) NewReader(w io.Reader) (*cpio.Reader, error) {
 
 // NewFromPath accepts a positional argument base which is the directory that
 // the provided files should be serialized from.  The prefix positional argument
-// is used to affix all embedded files to the provided location.  Left empty,
-// the defeault prefix is "/".
+// is used to affix all embedded files to the provided location.
 func NewFromPath(base string, prefix string, files ...string) (*InitrdConfig, error) {
 	initrd := &InitrdConfig{
 		Format: NEWC,
 	}
 
 	if prefix == "" {
-		prefix = "/"
+		prefix = string(filepath.Separator)
 	}
-	if !strings.HasPrefix(prefix, "/") {
+	if !strings.HasPrefix(prefix, string(filepath.Separator)) {
 		return nil, fmt.Errorf("must use absolute path in prefix: %s", prefix)
 	}
 
@@ -177,7 +176,7 @@ func NewFromMapping(workdir, output string, maps ...string) (*InitrdConfig, erro
 					return nil
 				}
 
-				internal = "." + strings.ReplaceAll(filepath.Join(initrdPath, internal), "//", "/")
+				internal = "." + strings.ReplaceAll(filepath.Join(initrdPath, internal), string(filepath.Separator)+string(filepath.Separator), string(filepath.Separator))
 
 				info, err := d.Info()
 				if err != nil {

--- a/internal/findsh/find_windows.go
+++ b/internal/findsh/find_windows.go
@@ -24,14 +24,11 @@
 package findsh
 
 import (
-	"os"
-	"path/filepath"
-
 	"github.com/cli/safeexec"
 )
 
 func Find() (string, error) {
-	shPath, err := safeexec.LookPath("sh")
+	shPath, err := safeexec.LookPath("cmd")
 	if err != nil {
 		return "", err
 	}

--- a/kconfig/kconfig.go
+++ b/kconfig/kconfig.go
@@ -370,7 +370,7 @@ func (kp *kconfigParser) includeSource(file string) {
 		return
 	}
 	kp.newCurrent(nil)
-	if file[0] != '/' {
+	if file[0] != filepath.Separator {
 		file = filepath.Join(kp.baseDir, file)
 	}
 	data, err := os.ReadFile(file)

--- a/machine/network/register_windows.go
+++ b/machine/network/register_windows.go
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2022, Unikraft GmbH and The KraftKit Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+package network
+
+import (
+	"context"
+	"errors"
+
+	networkv1alpha1 "kraftkit.sh/api/network/v1alpha1"
+)
+
+// hostSupportedStrategies returns the map of known supported drivers for the
+// given host.
+func hostSupportedStrategies() map[string]*Strategy {
+	return map[string]*Strategy{
+		"bridge": {
+			NewNetworkV1alpha1: func(ctx context.Context, opts ...any) (networkv1alpha1.NetworkService, error) {
+				return nil, errors.New("network service is not supported on Windows")
+			},
+		},
+	}
+}

--- a/machine/platform/detect.go
+++ b/machine/platform/detect.go
@@ -1,3 +1,6 @@
+//go:build !windows
+// +build !windows
+
 // SPDX-License-Identifier: BSD-3-Clause
 // Copyright (c) 2022, Unikraft GmbH and The KraftKit Authors.
 // Licensed under the BSD-3-Clause License (the "License").

--- a/machine/platform/detect_windows.go
+++ b/machine/platform/detect_windows.go
@@ -9,6 +9,14 @@ import (
 	"fmt"
 )
 
+type SystemMode string
+
+const (
+	SystemUnknown = SystemMode("unknown")
+	SystemGuest   = SystemMode("guest")
+	SystemHost    = SystemMode("host")
+)
+
 // Detect returns the hypervisor and system mode in the context to the
 // determined hypervisor or an error if not detectable.
 func Detect(ctx context.Context) (Platform, SystemMode, error) {

--- a/machine/platform/detect_windows.go
+++ b/machine/platform/detect_windows.go
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2022, Unikraft GmbH and The KraftKit Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+package platform
+
+import (
+	"context"
+	"fmt"
+)
+
+// Detect returns the hypervisor and system mode in the context to the
+// determined hypervisor or an error if not detectable.
+func Detect(ctx context.Context) (Platform, SystemMode, error) {
+	return PlatformUnknown, SystemUnknown, fmt.Errorf("Hypervisor detection is not supported on Windows")
+}

--- a/machine/platform/register_darwin.go
+++ b/machine/platform/register_darwin.go
@@ -1,6 +1,3 @@
-//go:build darwin
-// +build darwin
-
 // SPDX-License-Identifier: BSD-3-Clause
 // Copyright (c) 2022, Unikraft GmbH and The KraftKit Authors.
 // Licensed under the BSD-3-Clause License (the "License").

--- a/machine/platform/register_unix.go
+++ b/machine/platform/register_unix.go
@@ -1,3 +1,6 @@
+//go:build !windows
+// +build !windows
+
 // SPDX-License-Identifier: BSD-3-Clause
 // Copyright (c) 2022, Unikraft GmbH and The KraftKit Authors.
 // Licensed under the BSD-3-Clause License (the "License").

--- a/machine/platform/register_windows.go
+++ b/machine/platform/register_windows.go
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2022, Unikraft GmbH and The KraftKit Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+package platform
+
+// hostSupportedStrategies returns the map of known supported drivers for the
+// given host.
+// No drivers are supported on Windows currently. Future HyperV support is possible.
+func hostSupportedStrategies() map[Platform]*Strategy {
+	s := map[Platform]*Strategy{}
+
+	return s
+}

--- a/manifest/manager.go
+++ b/manifest/manager.go
@@ -119,7 +119,7 @@ func (m *manifestManager) Update(ctx context.Context) error {
 		filename := manifest.Name + ".yaml"
 
 		if manifest.Type != unikraft.ComponentTypeCore {
-			filename = manifest.Type.Plural() + "/" + filename
+			filename = manifest.Type.Plural() + string(filepath.Separator) + filename
 		}
 
 		fileloc := filepath.Join(m.LocalManifestsDir(ctx), filename)

--- a/oci/handler/directory.go
+++ b/oci/handler/directory.go
@@ -327,7 +327,7 @@ func (handle *DirectoryHandler) FetchImage(ctx context.Context, fullref, platfor
 	)
 
 	// Recursively create the directory
-	if err = os.MkdirAll(manifestPath[:strings.LastIndex(manifestPath, "/")], 0o775); err != nil {
+	if err = os.MkdirAll(manifestPath[:strings.LastIndex(manifestPath, string(filepath.Separator))], 0o775); err != nil {
 		return err
 	}
 
@@ -365,7 +365,7 @@ func (handle *DirectoryHandler) FetchImage(ctx context.Context, fullref, platfor
 	}
 
 	// Recursively create the directory
-	if err = os.MkdirAll(configPath[:strings.LastIndex(configPath, "/")], 0o775); err != nil {
+	if err = os.MkdirAll(configPath[:strings.LastIndex(configPath, string(filepath.Separator))], 0o775); err != nil {
 		return err
 	}
 
@@ -400,7 +400,7 @@ func (handle *DirectoryHandler) FetchImage(ctx context.Context, fullref, platfor
 		)
 
 		// Recursively create the directory
-		if err = os.MkdirAll(layerPath[:strings.LastIndex(layerPath, "/")], 0o775); err != nil {
+		if err = os.MkdirAll(layerPath[:strings.LastIndex(layerPath, string(filepath.Separator))], 0o775); err != nil {
 			return err
 		}
 
@@ -518,8 +518,8 @@ func (handle *DirectoryHandler) UnpackImage(ctx context.Context, ref string, des
 			}
 
 			// If the directory in the path doesn't exist, create it
-			if _, err := os.Stat(path[:strings.LastIndex(path, "/")]); os.IsNotExist(err) {
-				if err := os.MkdirAll(path[:strings.LastIndex(path, "/")], 0o775); err != nil {
+			if _, err := os.Stat(path[:strings.LastIndex(path, string(filepath.Separator))]); os.IsNotExist(err) {
+				if err := os.MkdirAll(path[:strings.LastIndex(path, string(filepath.Separator))], 0o775); err != nil {
 					return err
 				}
 			}

--- a/oci/image.go
+++ b/oci/image.go
@@ -143,14 +143,11 @@ func (image *Image) AddBlob(ctx context.Context, blob *Blob) (ocispec.Descriptor
 		return ocispec.Descriptor{}, err
 	}
 
-	defer func() {
-		closeErr := fp.Close()
-		if err == nil {
-			err = closeErr
-		}
-	}()
-
 	if err := image.handle.SaveDigest(ctx, "", blob.desc, fp, nil); err != nil {
+		return ocispec.Descriptor{}, err
+	}
+
+	if err := fp.Close(); err != nil {
 		return ocispec.Descriptor{}, err
 	}
 

--- a/oci/layer.go
+++ b/oci/layer.go
@@ -37,7 +37,6 @@ func NewLayerFromFile(ctx context.Context, mediaType, src, dst string, opts ...L
 		if err != nil {
 			return nil, err
 		}
-		defer tmp.Close()
 
 		if err := archive.TarFileTo(ctx,
 			src, dst, tmp.Name(),


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

This PR offers initial support for using kraftkit inside Windows.
Because a library (`netlink`) was not available on Windows, a fork was created to ensure it works.
```
replace github.com/vishvananda/netlink => github.com/craciunoiuc/netlink v1.2.1-beta.2
```

### 1. Compiling
Because Makefile does not work easily in windows, we can just compile directly:
```
go build -ldflags='-s -w' -o dist/kraft.exe .\cmd\kraft\
```

With go 1.20 and 1.21 it should compile just fine.
For correct `kraft version` output we also need to translate these 3 lines from the Makefile. Feel free to do so:
```
$(addprefix $(.PROXY), $(BIN)): GO_LDFLAGS += -X "$(GOMOD)/internal/version.version=$(VERSION)"
$(addprefix $(.PROXY), $(BIN)): GO_LDFLAGS += -X "$(GOMOD)/internal/version.commit=$(GIT_SHA)"
$(addprefix $(.PROXY), $(BIN)): GO_LDFLAGS += -X "$(GOMOD)/internal/version.buildTime=$(shell date)"
```

### 2. Running

As expected, running is limited, but most important workflows for Windows users should work:

| Command              | Status |
|----------------------|--------|
| `kraft build`        | ❌     |
| `kraft clean`        | ❌     |
| `kraft fetch`        | ❌     |
| `kraft menu`         | ❌     |
| `kraft properclean`  | ❌     |
| `kraft pkg`          | ✅     |
| `kraft pkg ls`       | ✅     |
| `kraft pkg pull`     | ✅     |
| `kraft pkg push`     | ✅     |
| `kraft pkg source`   | ✅     |
| `kraft pkg unsource` | ✅     |
| `kraft pkg update`   | ✅     |
| `kraft ps`           | ❌     |
| `kraft rm`           | ❌     |
| `kraft run`          | ❌     |
| `kraft stop`         | ❌     |
| `kraft net create`   | ❌     |
| `kraft net down`     | ❌     |
| `kraft net inspect`  | ❌     |
| `kraft net ls`       | ❌     |
| `kraft net rm`       | ❌     |
| `kraft net up`       | ❌     |
| `kraft login`        | ✅     |
| `kraft version`      | ✅     |

All commands without an X work.

As such, windows users can easily pull + repackage + push to the registry and then use `cloud` commands.

GitHub-Fixes: #267
GitHub-Closes: #661 