### PR TITLE
fix(cmdfactory): Do not set `defValue` for integer attributes

### DIFF
--- a/cmdfactory/builder.go
+++ b/cmdfactory/builder.go
@@ -390,9 +390,6 @@ func AttributeFlags(c *cobra.Command, obj any, args ...string) error {
 		switch fieldType.Type.Kind() {
 		case reflect.Int, reflect.Int64:
 			flags.IntVarP((*int)(unsafe.Pointer(v.Addr().Pointer())), name, alias, defInt, usage)
-			if err := flags.Set(name, strValue); err != nil {
-				return err
-			}
 		case reflect.String:
 			flags.StringVarP((*string)(unsafe.Pointer(v.Addr().Pointer())), name, alias, defValue, usage)
 			if err := flags.Set(name, strValue); err != nil {


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

This commit fixes an issue with setting the value associated with an integer attribute after parsing a struct and how the default value is also set.

The issue is discovered where an attribute that is associated with flag attributes has a non-zero default value:

```go
type MyStruct struct {
  IntAttr int `long:"int-attr" usage:"Int flag" default:"1"`
}
```

In the above, the default value when read by `cobra.Run` is set to `0` instead of `1` when the flag is not set.  This is because the value from `strValue` overwrites the default value.  Unlike an empty string, `flags.Set` recognizes `0` as a real value as opposed to an "unset value".

Removing the logic which sets this for an integer remedies this issue and the value of `IntAttr` without disruping a new value when the flag is set with an alternative value from the default.


