### PR TITLE
feat: Add support for compiling NetBSD & OpenBSD

### DIFF
--- a/.goreleaser-stable.yaml
+++ b/.goreleaser-stable.yaml
@@ -2,6 +2,8 @@ version: 2
 #! .goreleaser.yaml
 #@ binaries = {
 #@   "kraft": {
+#@     "netbsd": ["amd64", "arm64"],
+#@     "openbsd": ["amd64", "arm64"],
 #@     "darwin": ["amd64", "arm64"],
 #@     "freebsd": ["amd64", "arm64"],
 #@     "linux": ["amd64", "arm64"],
@@ -263,7 +265,7 @@ archives:
 #@ for os, archs in binaries["runu"].items():
 #@ for arch in archs:
   - id: #@ "archive-runu-{}-{}".format(os, arch)
-    format: tar.gz
+    formats: tar.gz
     name_template: runu_{{ .Version }}_{{ .Os }}_{{ .Arch }}
     builds:
       - #@ "runu-{}-{}".format(os, arch)

--- a/Makefile
+++ b/Makefile
@@ -75,7 +75,7 @@ YTT_VERSION        ?= v0.51.0
 YTT                ?= $(GO) run carvel.dev/ytt/cmd/ytt@$(YTT_VERSION)
 GORELEASER_VERSION ?= v2.7.0
 GORELEASER         ?= $(GO) run github.com/goreleaser/goreleaser/v2@$(GORELEASER_VERSION)
-GINKGO_VERSION     ?= v2.22.0
+GINKGO_VERSION     ?= v2.22.2
 GINKGO             ?= $(GO) run github.com/onsi/ginkgo/v2/ginkgo@$(GINKGO_VERSION)
 
 # Misc
@@ -255,7 +255,7 @@ test: test-unit test-framework test-e2e test-cloud-e2e ## Run all tests.
 test-unit: GOTEST_EXCLUDE := third_party/ test/ hack/ buildenvs/ dist/ docs/ tools/
 test-unit: GOTEST_PKGS := $(foreach pkg,$(filter-out $(GOTEST_EXCLUDE),$(wildcard */)),$(pkg)...)
 test-unit: ## Run unit tests.
-	$(GINKGO)  -v -p -randomize-all -tags "containers_image_storage_stub,containers_image_openpgp" $(GOTEST_PKGS)
+	$(GINKGO) -v -p -randomize-all -tags "containers_image_storage_stub,containers_image_openpgp" $(GOTEST_PKGS)
 
 .PHONY: test-e2e
 test-e2e: kraft ## Run CLI end-to-end tests.

--- a/exec/process_netbsd.go
+++ b/exec/process_netbsd.go
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2022, Unikraft GmbH and The KraftKit Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file expect in compliance with the License.
+package exec
+
+import (
+	"syscall"
+)
+
+func hostAttributes() *syscall.SysProcAttr {
+	// the Setpgid flag is used to prevent the child process from exiting when
+	// the parent is killed
+	return &syscall.SysProcAttr{
+		Setpgid: true,
+	}
+}

--- a/exec/process_openbsd.go
+++ b/exec/process_openbsd.go
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2022, Unikraft GmbH and The KraftKit Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file expect in compliance with the License.
+package exec
+
+import (
+	"syscall"
+)
+
+func hostAttributes() *syscall.SysProcAttr {
+	// the Setpgid flag is used to prevent the child process from exiting when
+	// the parent is killed
+	return &syscall.SysProcAttr{
+		Setpgid: true,
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/Masterminds/semver v1.5.0
 	github.com/Masterminds/semver/v3 v3.3.1
 	github.com/acorn-io/baaah v0.0.0-20230522221318-afcc93619e30
-	github.com/anchore/stereoscope v0.0.12
+	github.com/anchore/stereoscope v0.0.13
 	github.com/briandowns/spinner v1.23.2
 	github.com/charmbracelet/bubbles v0.20.0
 	github.com/charmbracelet/bubbletea v1.3.0
@@ -27,7 +27,7 @@ require (
 	github.com/containerd/platforms v1.0.0-rc.1
 	github.com/containers/image/v5 v5.34.0
 	github.com/cpuguy83/go-md2man/v2 v2.0.6
-	github.com/cyphar/filepath-securejoin v0.3.6
+	github.com/cyphar/filepath-securejoin v0.4.1
 	github.com/dgraph-io/badger/v3 v3.2103.5
 	github.com/docker/cli v27.5.1+incompatible
 	github.com/docker/docker v27.5.1+incompatible
@@ -58,7 +58,7 @@ require (
 	github.com/onsi/gomega v1.36.2
 	github.com/opencontainers/go-digest v1.0.0
 	github.com/opencontainers/image-spec v1.1.0
-	github.com/opencontainers/runc v1.2.3
+	github.com/opencontainers/runc v1.2.5-0.20250205120131-de92f4b40dd5
 	github.com/opencontainers/runtime-spec v1.2.0
 	github.com/opencontainers/selinux v1.11.1
 	github.com/pkg/errors v0.9.1
@@ -249,7 +249,7 @@ require (
 	github.com/sigstore/sigstore v1.8.12 // indirect
 	github.com/skeema/knownhosts v1.3.0 // indirect
 	github.com/smallstep/pkcs7 v0.1.1 // indirect
-	github.com/spf13/afero v1.11.0 // indirect
+	github.com/spf13/afero v1.12.0 // indirect
 	github.com/stefanberger/go-pkcs11uri v0.0.0-20230803200340-78284954bff6 // indirect
 	github.com/sylabs/sif/v2 v2.20.2 // indirect
 	github.com/sylabs/squashfs v1.0.4 // indirect
@@ -294,7 +294,7 @@ require (
 	google.golang.org/genproto v0.0.0-20241118233622-e639e219e697 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20241209162323-e6fa225c2576 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20250102185135-69823020774d // indirect
-	google.golang.org/protobuf v1.36.3 // indirect
+	google.golang.org/protobuf v1.36.4 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect
 	k8s.io/component-base v0.32.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -115,8 +115,8 @@ github.com/anchore/go-struct-converter v0.0.0-20221118182256-c68fdcfa2092 h1:aM1
 github.com/anchore/go-struct-converter v0.0.0-20221118182256-c68fdcfa2092/go.mod h1:rYqSE9HbjzpHTI74vwPvae4ZVYZd1lue2ta6xHPdblA=
 github.com/anchore/go-testutils v0.0.0-20200925183923-d5f45b0d3c04 h1:VzprUTpc0vW0nnNKJfJieyH/TZ9UYAnTZs5/gHTdAe8=
 github.com/anchore/go-testutils v0.0.0-20200925183923-d5f45b0d3c04/go.mod h1:6dK64g27Qi1qGQZ67gFmBFvEHScy0/C8qhQhNe5B5pQ=
-github.com/anchore/stereoscope v0.0.12 h1:ovUWeyeZGml6pTGiu/uha/rCbToANFPu+cnhLbeperY=
-github.com/anchore/stereoscope v0.0.12/go.mod h1:cmb/MGya7ccOd6fZZEREuhdSH2kFALBMrkY/66Sfv1o=
+github.com/anchore/stereoscope v0.0.13 h1:9Ivkh7k+vOeG3JHrt44jOg/8UdZrCvMsSjLQ7trHBig=
+github.com/anchore/stereoscope v0.0.13/go.mod h1:QfhhFc2pezp5aX/dVJ5qnBFpBUv5+KUTphwaQLxMUig=
 github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883/go.mod h1:rCTlJbsFo29Kk6CurOXKm700vrz8f0KW0JNfpkRJY/8=
 github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be h1:9AeTilPcZAjCFIImctFaOjnTIavg87rW78vTPkQqLI8=
 github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be/go.mod h1:ySMOLuWl6zY27l47sB3qLNK6tF2fkHG55UZxx8oIVo4=
@@ -379,8 +379,8 @@ github.com/creack/pty v1.1.24/go.mod h1:08sCNb52WyoAwi2QDyzUCTgcvVFhUzewun7wtTfv
 github.com/cyberphone/json-canonicalization v0.0.0-20231217050601-ba74d44ecf5f h1:eHnXnuK47UlSTOQexbzxAZfekVz6i+LKRdj1CU5DPaM=
 github.com/cyberphone/json-canonicalization v0.0.0-20231217050601-ba74d44ecf5f/go.mod h1:uzvlm1mxhHkdfqitSA92i7Se+S9ksOn3a3qmv/kyOCw=
 github.com/cyphar/filepath-securejoin v0.2.2/go.mod h1:FpkQEhXnPnOthhzymB7CGsFk2G9VLXONKD9G7QGMM+4=
-github.com/cyphar/filepath-securejoin v0.3.6 h1:4d9N5ykBnSp5Xn2JkhocYDkOpURL/18CYMpo6xB9uWM=
-github.com/cyphar/filepath-securejoin v0.3.6/go.mod h1:Sdj7gXlvMcPZsbhwhQ33GguGLDGQL7h7bg04C/+u9jI=
+github.com/cyphar/filepath-securejoin v0.4.1 h1:JyxxyPEaktOD+GAnqIqTf9A8tHyAG22rowi7HkoSU1s=
+github.com/cyphar/filepath-securejoin v0.4.1/go.mod h1:Sdj7gXlvMcPZsbhwhQ33GguGLDGQL7h7bg04C/+u9jI=
 github.com/d2g/dhcp4 v0.0.0-20170904100407-a1d1b6c41b1c/go.mod h1:Ct2BUK8SB0YC1SMSibvLzxjeJLnrYEVLULFNiHY9YfQ=
 github.com/d2g/dhcp4client v1.0.0/go.mod h1:j0hNfjhrt2SxUOw55nL0ATM/z4Yt3t2Kd1mW34z5W5s=
 github.com/d2g/dhcp4server v0.0.0-20181031114812-7d4a0a7f59a5/go.mod h1:Eo87+Kg/IX2hfWJfwxMzLyuSZyxSoAug2nGa1G2QAi8=
@@ -973,8 +973,8 @@ github.com/opencontainers/runc v0.1.1/go.mod h1:qT5XzbpPznkRYVz/mWwUaVBUv2rmF59P
 github.com/opencontainers/runc v1.0.0-rc8.0.20190926000215-3e425f80a8c9/go.mod h1:qT5XzbpPznkRYVz/mWwUaVBUv2rmF59PVA73FjuZG0U=
 github.com/opencontainers/runc v1.0.0-rc9/go.mod h1:qT5XzbpPznkRYVz/mWwUaVBUv2rmF59PVA73FjuZG0U=
 github.com/opencontainers/runc v1.0.0-rc93/go.mod h1:3NOsor4w32B2tC0Zbl8Knk4Wg84SM2ImC1fxBuqJ/H0=
-github.com/opencontainers/runc v1.2.3 h1:fxE7amCzfZflJO2lHXf4y/y8M1BoAqp+FVmG19oYB80=
-github.com/opencontainers/runc v1.2.3/go.mod h1:nSxcWUydXrsBZVYNSkTjoQ/N6rcyTtn+1SD5D4+kRIM=
+github.com/opencontainers/runc v1.2.5-0.20250205120131-de92f4b40dd5 h1:zD27DZt1QmdjGqxHsCDMObGyDJu+Sexp9LA0kIdm654=
+github.com/opencontainers/runc v1.2.5-0.20250205120131-de92f4b40dd5/go.mod h1:sSb4y8/LK8sTpWYcStm5vPCTvW4E3xWdg/IB4Em4Qks=
 github.com/opencontainers/runtime-spec v0.1.2-0.20190507144316-5b71a03e2700/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
 github.com/opencontainers/runtime-spec v1.0.1/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
 github.com/opencontainers/runtime-spec v1.0.2-0.20190207185410-29686dbc5559/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
@@ -1131,8 +1131,8 @@ github.com/spdx/tools-golang v0.5.3 h1:ialnHeEYUC4+hkm5vJm4qz2x+oEJbS0mAMFrNXdQr
 github.com/spdx/tools-golang v0.5.3/go.mod h1:/ETOahiAo96Ob0/RAIBmFZw6XN0yTnyr/uFZm2NTMhI=
 github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=
 github.com/spf13/afero v1.2.2/go.mod h1:9ZxEEn6pIJ8Rxe320qSDBk6AsU0r9pR7Q4OcevTdifk=
-github.com/spf13/afero v1.11.0 h1:WJQKhtpdm3v2IzqG8VMqrr6Rf3UYpEF239Jy9wNepM8=
-github.com/spf13/afero v1.11.0/go.mod h1:GH9Y3pIexgf1MTIWtNGyogA5MwRIDXGUr+hbWNoBjkY=
+github.com/spf13/afero v1.12.0 h1:UcOPyRBYczmFn6yvphxkn9ZEOY65cpwGKb5mL36mrqs=
+github.com/spf13/afero v1.12.0/go.mod h1:ZTlWwG4/ahT8W7T0WQ5uYmjI9duaLQGy3Q2OAl4sk/4=
 github.com/spf13/cast v1.3.0/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=
 github.com/spf13/cobra v0.0.2-0.20171109065643-2da4a54c5cee/go.mod h1:1l0Ry5zgKvJasoi3XT1TypsSe7PqH0Sj9dhYf7v3XqQ=
 github.com/spf13/cobra v0.0.3/go.mod h1:1l0Ry5zgKvJasoi3XT1TypsSe7PqH0Sj9dhYf7v3XqQ=
@@ -1726,8 +1726,8 @@ google.golang.org/protobuf v1.24.0/go.mod h1:r/3tXBNzIEhYS9I1OUVjXDlt8tc493IdKGj
 google.golang.org/protobuf v1.25.0/go.mod h1:9JNX74DMeImyA3h4bdi1ymwjUzf21/xIlbajtzgsN7c=
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
 google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
-google.golang.org/protobuf v1.36.3 h1:82DV7MYdb8anAVi3qge1wSnMDrnKK7ebr+I0hHRN1BU=
-google.golang.org/protobuf v1.36.3/go.mod h1:9fA7Ob0pmnwhb644+1+CVWFRbNajQ6iRojtC/QF5bRE=
+google.golang.org/protobuf v1.36.4 h1:6A3ZDJHn/eNqc1i+IdefRzy/9PokBTPvcqMySR7NNIM=
+google.golang.org/protobuf v1.36.4/go.mod h1:9fA7Ob0pmnwhb644+1+CVWFRbNajQ6iRojtC/QF5bRE=
 gopkg.in/airbrake/gobrake.v2 v2.0.9/go.mod h1:/h5ZAUhDkGaJfjzjKLSjv6zCL6O0LLBxU4K+aSYdM/U=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/initrd/ociimage.go
+++ b/initrd/ociimage.go
@@ -1,3 +1,6 @@
+//go:build !openbsd && !netbsd
+// +build !openbsd,!netbsd
+
 // SPDX-License-Identifier: BSD-3-Clause
 // Copyright (c) 2022, Unikraft GmbH and The KraftKit Authors.
 // Licensed under the BSD-3-Clause License (the "License").

--- a/initrd/ociimage_netbsd.go
+++ b/initrd/ociimage_netbsd.go
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2022, Unikraft GmbH and The KraftKit Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+package initrd
+
+import (
+	"context"
+)
+
+type ociimage struct{}
+
+// NewFromOCIImage creates a new initrd from a remote container image.
+func NewFromOCIImage(ctx context.Context, path string, opts ...InitrdOption) (Initrd, error) {
+	return nil, nil
+}
+
+// Build implements Initrd.
+func (initrd *ociimage) Name() string {
+	return "OCI image"
+}
+
+// Build implements Initrd.
+func (initrd *ociimage) Build(ctx context.Context) (string, error) {
+	return "", nil
+}
+
+// Env implements Initrd.
+func (initrd *ociimage) Env() []string {
+	return nil
+}
+
+// Args implements Initrd.
+func (initrd *ociimage) Args() []string {
+	return nil
+}

--- a/initrd/ociimage_openbsd.go
+++ b/initrd/ociimage_openbsd.go
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2022, Unikraft GmbH and The KraftKit Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+package initrd
+
+import (
+	"context"
+)
+
+type ociimage struct{}
+
+// NewFromOCIImage creates a new initrd from a remote container image.
+func NewFromOCIImage(ctx context.Context, path string, opts ...InitrdOption) (Initrd, error) {
+	return nil, nil
+}
+
+// Build implements Initrd.
+func (initrd *ociimage) Name() string {
+	return "OCI image"
+}
+
+// Build implements Initrd.
+func (initrd *ociimage) Build(ctx context.Context) (string, error) {
+	return "", nil
+}
+
+// Env implements Initrd.
+func (initrd *ociimage) Env() []string {
+	return nil
+}
+
+// Args implements Initrd.
+func (initrd *ociimage) Args() []string {
+	return nil
+}

--- a/initrd/ociimage_test.go
+++ b/initrd/ociimage_test.go
@@ -1,3 +1,6 @@
+//go:build !openbsd && !netbsd
+// +build !openbsd,!netbsd
+
 // SPDX-License-Identifier: BSD-3-Clause
 // Copyright (c) 2023, Unikraft GmbH and The KraftKit Authors.
 // Licensed under the BSD-3-Clause License (the "License").

--- a/machine/network/register_netbsd.go
+++ b/machine/network/register_netbsd.go
@@ -19,7 +19,7 @@ func hostSupportedStrategies() map[string]*Strategy {
 	return map[string]*Strategy{
 		"bridge": {
 			NewNetworkV1alpha1: func(ctx context.Context, opts ...any) (networkv1alpha1.NetworkService, error) {
-				return nil, errors.New("network service is not supported on freeBSD")
+				return nil, errors.New("network service is not supported on netBSD")
 			},
 		},
 	}

--- a/machine/network/register_openbsd.go
+++ b/machine/network/register_openbsd.go
@@ -19,7 +19,7 @@ func hostSupportedStrategies() map[string]*Strategy {
 	return map[string]*Strategy{
 		"bridge": {
 			NewNetworkV1alpha1: func(ctx context.Context, opts ...any) (networkv1alpha1.NetworkService, error) {
-				return nil, errors.New("network service is not supported on freeBSD")
+				return nil, errors.New("network service is not supported on openBSD")
 			},
 		},
 	}

--- a/machine/platform/register_netbsd.go
+++ b/machine/platform/register_netbsd.go
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2022, Unikraft GmbH and The KraftKit Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+package platform
+
+func unixVariantStrategies() map[Platform]*Strategy {
+	return map[Platform]*Strategy{}
+}

--- a/machine/platform/register_openbsd.go
+++ b/machine/platform/register_openbsd.go
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2022, Unikraft GmbH and The KraftKit Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+package platform
+
+func unixVariantStrategies() map[Platform]*Strategy {
+	return map[Platform]*Strategy{}
+}

--- a/oci/handler/containerd.go
+++ b/oci/handler/containerd.go
@@ -1,3 +1,6 @@
+//go:build !openbsd && !netbsd
+// +build !openbsd,!netbsd
+
 // SPDX-License-Identifier: BSD-3-Clause
 // Copyright (c) 2022, Unikraft GmbH and The KraftKit Authors.
 // Licensed under the BSD-3-Clause License (the "License").

--- a/oci/handler/containerd_netbsd.go
+++ b/oci/handler/containerd_netbsd.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/containerd/containerd"
 	"github.com/containerd/containerd/content"
 	"github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
@@ -14,7 +13,7 @@ import (
 
 type ContainerdHandler struct{}
 
-func NewContainerdHandler(ctx context.Context, address, namespace string, auths map[string]config.AuthConfig, opts ...containerd.ClientOpt) (context.Context, *ContainerdHandler, error) {
+func NewContainerdHandler(ctx context.Context, address, namespace string, auths map[string]config.AuthConfig, opts ...any) (context.Context, *ContainerdHandler, error) {
 	return ctx, nil, fmt.Errorf("containerd is not supported on netbsd")
 }
 

--- a/oci/handler/containerd_netbsd.go
+++ b/oci/handler/containerd_netbsd.go
@@ -1,0 +1,87 @@
+package handler
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	"github.com/containerd/containerd"
+	"github.com/containerd/containerd/content"
+	"github.com/opencontainers/go-digest"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"kraftkit.sh/config"
+)
+
+type ContainerdHandler struct{}
+
+func NewContainerdHandler(ctx context.Context, address, namespace string, auths map[string]config.AuthConfig, opts ...containerd.ClientOpt) (context.Context, *ContainerdHandler, error) {
+	return ctx, nil, fmt.Errorf("containerd is not supported on netbsd")
+}
+
+// DigestInfo implements DigestResolver.
+func (handle *ContainerdHandler) DigestInfo(ctx context.Context, dgst digest.Digest) (*content.Info, error) {
+	return nil, fmt.Errorf("not implemented: oci.handler.ContainerdHandler.DigestInfo")
+}
+
+// PullDigest implements DigestPuller.
+func (handle *ContainerdHandler) PullDigest(ctx context.Context, mediaType, fullref string, dgst digest.Digest, plat *ocispec.Platform, onProgress func(float64)) error {
+	return fmt.Errorf("not implemented: oci.handler.ContainerdHandler.PullDigest")
+}
+
+// ListDigest implements DigestResolver.
+func (handle *ContainerdHandler) ListDigests(ctx context.Context) ([]digest.Digest, error) {
+	return nil, fmt.Errorf("not implemented: oci.handler.ContainerdHandler.ListDigests")
+}
+
+// PushDescriptor implements DescriptorPusher.
+func (handle *ContainerdHandler) PushDescriptor(ctx context.Context, ref string, target *ocispec.Descriptor) error {
+	return fmt.Errorf("not implemented: oci.handler.ContainerdHandler.PushDescriptor")
+}
+
+// DeleteDigest implements DigestDeleter.
+func (handle *ContainerdHandler) DeleteDigest(ctx context.Context, dgst digest.Digest) error {
+	return fmt.Errorf("not implemented: oci.handler.ContainerdHandler.DeleteDigest")
+}
+
+// ListIndexes implements IndexLister.
+func (handle *ContainerdHandler) ListIndexes(ctx context.Context) (map[string]*ocispec.Index, error) {
+	return nil, fmt.Errorf("not implemented: oci.handler.ContainerdHandler.ListIndexes")
+}
+
+func (handle *ContainerdHandler) DeleteIndex(ctx context.Context, fullref string, deps bool) error {
+	return fmt.Errorf("not implemented: oci.handler.ContainerdHandler.DeleteIndex")
+}
+
+// ResolveIndex implements IndexResolver.
+func (handle *ContainerdHandler) ResolveIndex(ctx context.Context, fullref string) (*ocispec.Index, error) {
+	return nil, fmt.Errorf("not implemented: oci.handler.ContainerdHandler.ResolveIndex")
+}
+
+// SaveDescriptor implements DescriptorSaver.
+func (handle *ContainerdHandler) SaveDescriptor(ctx context.Context, fullref string, desc ocispec.Descriptor, reader io.Reader, onProgress func(float64)) (err error) {
+	return fmt.Errorf("not implemented: oci.handler.ContainerdHandler.SavedDescriptor")
+}
+
+// ResolveManifest implements ManifestResolver.
+func (handle *ContainerdHandler) ResolveManifest(ctx context.Context, _ string, digest digest.Digest) (*ocispec.Manifest, *ocispec.Image, error) {
+	return nil, nil, fmt.Errorf("not implemented: oci.handler.ContainerdHandler.ResolveManifest")
+}
+
+// ListManifests implements DigestResolver.
+func (handle *ContainerdHandler) ListManifests(ctx context.Context) (manifests map[string]*ocispec.Manifest, err error) {
+	return nil, fmt.Errorf("not implemented: oci.handler.ContainerdHandler.ListManifests")
+}
+
+func (handle *ContainerdHandler) DeleteManifest(ctx context.Context, fullref string, dgst digest.Digest) error {
+	return fmt.Errorf("not implemented: oci.handler.ContainerdHandler.DeleteManifest")
+}
+
+// UnpackImage implements ImageUnpacker.
+func (handle *ContainerdHandler) UnpackImage(ctx context.Context, ref string, dgst digest.Digest, dest string) (*ocispec.Image, error) {
+	return nil, fmt.Errorf("not implemented: oci.handler.ContainerdHandler.UnpackImage")
+}
+
+// FinalizeImage implements ImageFinalizer.
+func (handle *ContainerdHandler) FinalizeImage(ctx context.Context, image ocispec.Image) error {
+	return fmt.Errorf("not implemented: oci.handler.ContainerdHandler.FinalizeImage")
+}

--- a/oci/handler/containerd_openbsd.go
+++ b/oci/handler/containerd_openbsd.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/containerd/containerd"
 	"github.com/containerd/containerd/content"
 	"github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
@@ -14,7 +13,7 @@ import (
 
 type ContainerdHandler struct{}
 
-func NewContainerdHandler(ctx context.Context, address, namespace string, auths map[string]config.AuthConfig, opts ...containerd.ClientOpt) (context.Context, *ContainerdHandler, error) {
+func NewContainerdHandler(ctx context.Context, address, namespace string, auths map[string]config.AuthConfig, opts ...any) (context.Context, *ContainerdHandler, error) {
 	return ctx, nil, fmt.Errorf("containerd is not supported on openbsd")
 }
 

--- a/oci/handler/containerd_openbsd.go
+++ b/oci/handler/containerd_openbsd.go
@@ -1,0 +1,87 @@
+package handler
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	"github.com/containerd/containerd"
+	"github.com/containerd/containerd/content"
+	"github.com/opencontainers/go-digest"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"kraftkit.sh/config"
+)
+
+type ContainerdHandler struct{}
+
+func NewContainerdHandler(ctx context.Context, address, namespace string, auths map[string]config.AuthConfig, opts ...containerd.ClientOpt) (context.Context, *ContainerdHandler, error) {
+	return ctx, nil, fmt.Errorf("containerd is not supported on openbsd")
+}
+
+// DigestInfo implements DigestResolver.
+func (handle *ContainerdHandler) DigestInfo(ctx context.Context, dgst digest.Digest) (*content.Info, error) {
+	return nil, fmt.Errorf("not implemented: oci.handler.ContainerdHandler.DigestInfo")
+}
+
+// PullDigest implements DigestPuller.
+func (handle *ContainerdHandler) PullDigest(ctx context.Context, mediaType, fullref string, dgst digest.Digest, plat *ocispec.Platform, onProgress func(float64)) error {
+	return fmt.Errorf("not implemented: oci.handler.ContainerdHandler.PullDigest")
+}
+
+// ListDigest implements DigestResolver.
+func (handle *ContainerdHandler) ListDigests(ctx context.Context) ([]digest.Digest, error) {
+	return nil, fmt.Errorf("not implemented: oci.handler.ContainerdHandler.ListDigests")
+}
+
+// PushDescriptor implements DescriptorPusher.
+func (handle *ContainerdHandler) PushDescriptor(ctx context.Context, ref string, target *ocispec.Descriptor) error {
+	return fmt.Errorf("not implemented: oci.handler.ContainerdHandler.PushDescriptor")
+}
+
+// DeleteDigest implements DigestDeleter.
+func (handle *ContainerdHandler) DeleteDigest(ctx context.Context, dgst digest.Digest) error {
+	return fmt.Errorf("not implemented: oci.handler.ContainerdHandler.DeleteDigest")
+}
+
+// ListIndexes implements IndexLister.
+func (handle *ContainerdHandler) ListIndexes(ctx context.Context) (map[string]*ocispec.Index, error) {
+	return nil, fmt.Errorf("not implemented: oci.handler.ContainerdHandler.ListIndexes")
+}
+
+func (handle *ContainerdHandler) DeleteIndex(ctx context.Context, fullref string, deps bool) error {
+	return fmt.Errorf("not implemented: oci.handler.ContainerdHandler.DeleteIndex")
+}
+
+// ResolveIndex implements IndexResolver.
+func (handle *ContainerdHandler) ResolveIndex(ctx context.Context, fullref string) (*ocispec.Index, error) {
+	return nil, fmt.Errorf("not implemented: oci.handler.ContainerdHandler.ResolveIndex")
+}
+
+// SaveDescriptor implements DescriptorSaver.
+func (handle *ContainerdHandler) SaveDescriptor(ctx context.Context, fullref string, desc ocispec.Descriptor, reader io.Reader, onProgress func(float64)) (err error) {
+	return fmt.Errorf("not implemented: oci.handler.ContainerdHandler.SavedDescriptor")
+}
+
+// ResolveManifest implements ManifestResolver.
+func (handle *ContainerdHandler) ResolveManifest(ctx context.Context, _ string, digest digest.Digest) (*ocispec.Manifest, *ocispec.Image, error) {
+	return nil, nil, fmt.Errorf("not implemented: oci.handler.ContainerdHandler.ResolveManifest")
+}
+
+// ListManifests implements DigestResolver.
+func (handle *ContainerdHandler) ListManifests(ctx context.Context) (manifests map[string]*ocispec.Manifest, err error) {
+	return nil, fmt.Errorf("not implemented: oci.handler.ContainerdHandler.ListManifests")
+}
+
+func (handle *ContainerdHandler) DeleteManifest(ctx context.Context, fullref string, dgst digest.Digest) error {
+	return fmt.Errorf("not implemented: oci.handler.ContainerdHandler.DeleteManifest")
+}
+
+// UnpackImage implements ImageUnpacker.
+func (handle *ContainerdHandler) UnpackImage(ctx context.Context, ref string, dgst digest.Digest, dest string) (*ocispec.Image, error) {
+	return nil, fmt.Errorf("not implemented: oci.handler.ContainerdHandler.UnpackImage")
+}
+
+// FinalizeImage implements ImageFinalizer.
+func (handle *ContainerdHandler) FinalizeImage(ctx context.Context, image ocispec.Image) error {
+	return fmt.Errorf("not implemented: oci.handler.ContainerdHandler.FinalizeImage")
+}


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

Similar to the FreeBSD PR #603 this adds support for OpenBSD and NetBSD.

Unfortunately, right now, because of a dependency bug in `containerd` this fails to compile. The fix seems simple, but it is up to them to fix right now. The errors are like following.

For OpenBSD:
```
# github.com/containerd/containerd/archive
/go/pkg/mod/github.com/containerd/containerd@v1.7.2/archive/tar_mostunix.go:35:14: undefined: unix.Lsetxattr
/go/pkg/mod/github.com/containerd/containerd@v1.7.2/archive/tar_mostunix.go:35:47: undefined: unix.XATTR_CREATE
/go/pkg/mod/github.com/containerd/containerd@v1.7.2/archive/tar_mostunix.go:36:40: undefined: unix.ENODATA
/go/pkg/mod/github.com/containerd/containerd@v1.7.2/archive/tar_unix.go:139:14: undefined: unix.Lsetxattr
```

For NetBSD:
```
# github.com/containerd/containerd/archive
/go/pkg/mod/github.com/containerd/containerd@v1.7.2/archive/tar_mostunix.go:35:47: undefined: unix.XATTR_CREATE
# github.com/containerd/containerd/mount
/go/pkg/mod/github.com/containerd/containerd@v1.7.2/mount/mount.go:62:13: undefined: UnmountAll
/go/pkg/mod/github.com/containerd/containerd@v1.7.2/mount/mount.go:88:11: m.mount undefined (type *Mount has no field or method mount, but does have Mount)
/go/pkg/mod/github.com/containerd/containerd@v1.7.2/mount/mount_unix.go:54:13: undefined: UnmountAll
/go/pkg/mod/github.com/containerd/containerd@v1.7.2/mount/temp_unix.go:53:13: undefined: UnmountAll
```

As such, we mark this as Draft until it is ready.