### PR TITLE
feat: Introduce `kraft cloud` subcommand

### DIFF
--- a/cmd/kraft/cloud/cloud.go
+++ b/cmd/kraft/cloud/cloud.go
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2023, Unikraft GmbH and The KraftKit Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+
+package cloud
+
+import (
+	"github.com/MakeNowJust/heredoc"
+	"github.com/spf13/cobra"
+
+	"kraftkit.sh/cmd/kraft/cloud/img"
+	"kraftkit.sh/cmd/kraft/cloud/instance"
+
+	"kraftkit.sh/cmdfactory"
+)
+
+type Cloud struct {
+	Metro string `long:"metro" env:"KRAFTCLOUD_METRO" usage:"Set the KraftCloud metro."`
+}
+
+func New() *cobra.Command {
+	cmd, err := cmdfactory.New(&Cloud{}, cobra.Command{
+		Short:  "KraftCloud",
+		Use:    "cloud [FLAGS] [SUBCOMMAND|DIR]",
+		Hidden: true,
+		Long: heredoc.Docf(`
+		Manage resources on KraftCloud: The Millisecond Platform.
+
+		Learn more & sign up for the beta at https://kraft.cloud
+	
+		Quickly switch between metros using the %[1]s--metro%[1]s flag or use the
+		%[1]sKRAFTCLOUD_METRO%[1]s environmental variable.
+		
+		Set authentication by using %[1]skraft login%[1]s or set
+		%[1]sKRAFTCLOUD_TOKEN%[1]s environmental variable.`, "`"),
+		Example: heredoc.Doc(`
+		# List all images in your account
+		$ kraft cloud img ls
+
+		# List all instances in Frankfurt
+		$ kraft cloud --metro fra0 instance ls
+
+		# Create a new NGINX instance in Frankfurt and start it immediately
+		$ kraft cloud --metro fra0 instance create \
+			--start \
+			--port 80:443 \
+			unikraft.io/$KRAFTCLOUD_USER/nginx:latest -- nginx -c /usr/local/nginx/conf/nginx.conf
+
+		# Get the status of an instance based on its UUID and output as JSON
+		$ kraft cloud --metro fra0 instance status -o json UUID
+
+		# Stop an instance based on its UUID
+		$ kraft cloud instance stop UUID
+
+		# Start an instance based on its UUID
+		$ kraft cloud instance start UUID
+
+		# Get logs of an instance based on its UUID
+		$ kraft cloud instance logs UUID
+
+		# Delete an instance based on its UUID
+		$ kraft cloud instance rm UUID`),
+		Annotations: map[string]string{
+			cmdfactory.AnnotationHelpGroup: "kraftcloud",
+		},
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	cmd.AddGroup(&cobra.Group{ID: "kraftcloud-img", Title: "IMAGE COMMANDS"})
+	cmd.AddCommand(img.New())
+
+	cmd.AddGroup(&cobra.Group{ID: "kraftcloud-instance", Title: "INSTANCE COMMANDS"})
+	cmd.AddCommand(instance.New())
+
+	return cmd
+}
+
+func (opts *Cloud) Run(cmd *cobra.Command, args []string) error {
+	return nil
+}

--- a/cmd/kraft/cloud/img/img.go
+++ b/cmd/kraft/cloud/img/img.go
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2023, Unikraft GmbH and The KraftKit Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+
+package img
+
+import (
+	"github.com/spf13/cobra"
+
+	"kraftkit.sh/cmd/kraft/cloud/img/list"
+
+	"kraftkit.sh/cmdfactory"
+)
+
+type Img struct{}
+
+func New() *cobra.Command {
+	cmd, err := cmdfactory.New(&Img{}, cobra.Command{
+		Short:   "Manage images on KraftCloud",
+		Use:     "img",
+		Aliases: []string{"images", "image"},
+		Hidden:  true,
+		Annotations: map[string]string{
+			cmdfactory.AnnotationHelpGroup: "kraftcloud-img",
+		},
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	cmd.AddCommand(list.New())
+
+	return cmd
+}
+
+func (opts *Img) Run(cmd *cobra.Command, args []string) error {
+	return cmd.Help()
+}

--- a/cmd/kraft/cloud/img/list/list.go
+++ b/cmd/kraft/cloud/img/list/list.go
@@ -1,0 +1,122 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2023, Unikraft GmbH and The KraftKit Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+
+package list
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/MakeNowJust/heredoc"
+	"github.com/dustin/go-humanize"
+	"github.com/spf13/cobra"
+
+	kraftcloud "sdk.kraft.cloud"
+	kcimage "sdk.kraft.cloud/image"
+
+	"kraftkit.sh/cmdfactory"
+	"kraftkit.sh/config"
+	"kraftkit.sh/internal/tableprinter"
+	"kraftkit.sh/iostreams"
+	"kraftkit.sh/log"
+)
+
+type List struct {
+	Output string `long:"output" short:"o" usage:"Set output format" default:"table"`
+
+	metro string
+}
+
+func New() *cobra.Command {
+	cmd, err := cmdfactory.New(&List{}, cobra.Command{
+		Short:   "List all images at a metro for your account",
+		Use:     "ls",
+		Aliases: []string{"list"},
+		Long: heredoc.Doc(`
+			List all images in your account.
+		`),
+		Example: heredoc.Doc(`
+			# List all images in your account.
+			$ kraft cloud img ls
+		`),
+		Annotations: map[string]string{
+			cmdfactory.AnnotationHelpGroup: "kraftcloud-img",
+		},
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	return cmd
+}
+
+func (opts *List) Pre(cmd *cobra.Command, _ []string) error {
+	opts.metro = cmd.Flag("metro").Value.String()
+	if opts.metro == "" {
+		opts.metro = os.Getenv("KRAFTCLOUD_METRO")
+	}
+	if opts.metro == "" {
+		return fmt.Errorf("kraftcloud metro is unset")
+	}
+	log.G(cmd.Context()).WithField("metro", opts.metro).Debug("using")
+	return nil
+}
+
+func (opts *List) Run(cmd *cobra.Command, args []string) error {
+	ctx := cmd.Context()
+	auth, err := config.GetKraftCloudLoginFromContext(ctx)
+	if err != nil {
+		return fmt.Errorf("could not retrieve credentials: %w", err)
+	}
+
+	client := kcimage.NewImagesClient(
+		kraftcloud.WithToken(auth.Token),
+	)
+
+	images, err := client.WithMetro(opts.metro).List(ctx, map[string]interface{}{})
+	if err != nil {
+		return fmt.Errorf("could not list images: %w", err)
+	}
+
+	err = iostreams.G(ctx).StartPager()
+	if err != nil {
+		log.G(ctx).Errorf("error starting pager: %v", err)
+	}
+
+	defer iostreams.G(ctx).StopPager()
+
+	cs := iostreams.G(ctx).ColorScheme()
+	table, err := tableprinter.NewTablePrinter(ctx,
+		tableprinter.WithMaxWidth(iostreams.G(ctx).TerminalWidth()),
+		tableprinter.WithOutputFormatFromString(opts.Output),
+	)
+	if err != nil {
+		return err
+	}
+
+	// Header row
+	table.AddField("IMAGE", cs.Bold)
+	table.AddField("PUBLIC", cs.Bold)
+	table.AddField("ROOTFS", cs.Bold)
+	table.AddField("ARGS", cs.Bold)
+	table.AddField("SIZE", cs.Bold)
+	table.EndRow()
+
+	for _, image := range images {
+		if len(image.Tags) > 0 {
+			table.AddField(image.Tags[0], nil)
+		} else {
+			table.AddField(image.Digest, nil)
+		}
+		table.AddField(fmt.Sprintf("%v", image.Public), nil)
+		table.AddField(fmt.Sprintf("%v", image.Initrd), nil)
+		table.AddField(strings.TrimSpace(fmt.Sprintf("%s -- %s", image.KernelArgs, image.Args)), nil)
+		table.AddField(humanize.Bytes(uint64(image.SizeInBytes)), nil)
+		table.EndRow()
+	}
+
+	return table.Render(iostreams.G(ctx).Out)
+}

--- a/cmd/kraft/cloud/instance/create/create.go
+++ b/cmd/kraft/cloud/instance/create/create.go
@@ -1,0 +1,149 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2023, Unikraft GmbH and The KraftKit Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+
+package create
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/MakeNowJust/heredoc"
+	"github.com/spf13/cobra"
+
+	kraftcloud "sdk.kraft.cloud"
+	kcinstance "sdk.kraft.cloud/instance"
+
+	"kraftkit.sh/cmd/kraft/cloud/utils"
+	"kraftkit.sh/cmdfactory"
+	"kraftkit.sh/config"
+	"kraftkit.sh/log"
+)
+
+type Create struct {
+	Env      []string `local:"true" long:"env" short:"e" usage:"Environmental variables"`
+	Memory   int64    `local:"true" long:"memory" short:"M" usage:"Specify the amount of memory to allocate"`
+	Name     string   `local:"true" long:"name" short:"n" usage:"Specify the name of the package"`
+	Output   string   `local:"true" long:"output" short:"o" usage:"Set output format" default:"table"`
+	Port     string   `local:"true" long:"port" short:"p" usage:"Specify the port the app serves on locally"`
+	Replicas int      `local:"true" long:"replicas" short:"R" usage:"Number of replicas of the instance" default:"1"`
+	Start    bool     `local:"true" long:"start" short:"S" usage:"Immediately start the instance after creation"`
+
+	metro string
+}
+
+func New() *cobra.Command {
+	cmd, err := cmdfactory.New(&Create{}, cobra.Command{
+		Short:   "Create an instance",
+		Use:     "create [FLAGS] IMAGE [-- ARGS]",
+		Args:    cobra.MinimumNArgs(1),
+		Aliases: []string{"new"},
+		Example: heredoc.Doc(`
+			# Create a hello world instance
+			$ kraft cloud instance create -M 64 -p 80 unikraft.org/helloworld:latest
+
+			# Create a new NGINX instance in Frankfurt and start it immediately
+			$ kraft cloud --metro fra0 instance create \
+				--start \
+				--port 80:443 \
+				unikraft.io/$KRAFTCLOUD_USER/nginx:latest -- nginx -c /usr/local/nginx/conf/nginx.conf
+		`),
+		Annotations: map[string]string{
+			cmdfactory.AnnotationHelpGroup: "kraftcloud-instance",
+		},
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	return cmd
+}
+
+func (opts *Create) Pre(cmd *cobra.Command, _ []string) error {
+	opts.metro = cmd.Flag("metro").Value.String()
+	if opts.metro == "" {
+		opts.metro = os.Getenv("KRAFTCLOUD_METRO")
+	}
+	if opts.metro == "" {
+		return fmt.Errorf("kraftcloud metro is unset")
+	}
+	log.G(cmd.Context()).WithField("metro", opts.metro).Debug("using")
+	return nil
+}
+
+func (opts *Create) Run(cmd *cobra.Command, args []string) error {
+	ctx := cmd.Context()
+	image := args[0]
+	auth, err := config.GetKraftCloudLoginFromContext(ctx)
+	if err != nil {
+		return fmt.Errorf("could not retrieve credentials: %w", err)
+	}
+
+	client := kcinstance.NewInstancesClient(
+		kraftcloud.WithToken(auth.Token),
+	)
+
+	services := []kcinstance.CreateInstanceServicesRequest{}
+
+	if len(opts.Port) > 0 {
+		var internalPort int
+		var externalPort int
+		if strings.ContainsRune(opts.Port, ':') {
+			ports := strings.Split(opts.Port, ":")
+			if len(ports) != 2 {
+				return fmt.Errorf("invalid --port value expected --port <internal>:<external>")
+			}
+
+			internalPort, err = strconv.Atoi(ports[0])
+			if err != nil {
+				return fmt.Errorf("invalid internal port: %w", err)
+			}
+
+			externalPort, err = strconv.Atoi(ports[1])
+			if err != nil {
+				return fmt.Errorf("invalid external port: %w", err)
+			}
+		} else {
+			port, err := strconv.Atoi(opts.Port)
+			if err != nil {
+				return fmt.Errorf("could not parse port number: %w", err)
+			}
+			internalPort = port
+			externalPort = port
+		}
+
+		services = append(services, kcinstance.CreateInstanceServicesRequest{
+			Handlers:     []string{kcinstance.DefaultHandler},
+			InternalPort: int(internalPort),
+			Port:         int(externalPort),
+		})
+	}
+
+	envs := make(map[string]string)
+	for _, env := range opts.Env {
+		if strings.ContainsRune(env, '=') {
+			split := strings.SplitN(env, "=", 2)
+			envs[split[0]] = split[1]
+		} else {
+			envs[env] = os.Getenv(env)
+		}
+	}
+
+	instance, err := client.WithMetro(opts.metro).Create(ctx, kcinstance.CreateInstanceRequest{
+		Image:     image,
+		Args:      args[1:],
+		MemoryMB:  opts.Memory,
+		Services:  services,
+		Autostart: opts.Start,
+		Instances: opts.Replicas,
+		Env:       envs,
+	})
+	if err != nil {
+		return fmt.Errorf("could not create instance: %w", err)
+	}
+
+	return utils.PrintInstances(ctx, opts.Output, *instance)
+}

--- a/cmd/kraft/cloud/instance/instance.go
+++ b/cmd/kraft/cloud/instance/instance.go
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2023, Unikraft GmbH and The KraftKit Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+
+package instance
+
+import (
+	"github.com/spf13/cobra"
+
+	"kraftkit.sh/cmdfactory"
+
+	"kraftkit.sh/cmd/kraft/cloud/instance/create"
+	"kraftkit.sh/cmd/kraft/cloud/instance/list"
+	"kraftkit.sh/cmd/kraft/cloud/instance/logs"
+	"kraftkit.sh/cmd/kraft/cloud/instance/remove"
+	"kraftkit.sh/cmd/kraft/cloud/instance/start"
+	"kraftkit.sh/cmd/kraft/cloud/instance/status"
+	"kraftkit.sh/cmd/kraft/cloud/instance/stop"
+)
+
+type Instance struct{}
+
+func New() *cobra.Command {
+	cmd, err := cmdfactory.New(&Instance{}, cobra.Command{
+		Short:   "Manage KraftCloud instances",
+		Use:     "instance SUBCOMMAND",
+		Aliases: []string{"inst", "instances"},
+		Hidden:  true,
+		Annotations: map[string]string{
+			cmdfactory.AnnotationHelpGroup: "kraftcloud-instance",
+		},
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	cmd.AddCommand(create.New())
+	cmd.AddCommand(list.New())
+	cmd.AddCommand(logs.New())
+	cmd.AddCommand(remove.New())
+	cmd.AddCommand(start.New())
+	cmd.AddCommand(status.New())
+	cmd.AddCommand(stop.New())
+
+	return cmd
+}
+
+func (opts *Instance) Run(cmd *cobra.Command, _ []string) error {
+	return cmd.Help()
+}

--- a/cmd/kraft/cloud/instance/list/list.go
+++ b/cmd/kraft/cloud/instance/list/list.go
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2023, Unikraft GmbH and The KraftKit Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+package list
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/MakeNowJust/heredoc"
+	"github.com/spf13/cobra"
+
+	kraftcloud "sdk.kraft.cloud"
+	kcinstance "sdk.kraft.cloud/instance"
+
+	"kraftkit.sh/cmd/kraft/cloud/utils"
+	"kraftkit.sh/cmdfactory"
+	"kraftkit.sh/config"
+	"kraftkit.sh/log"
+)
+
+type List struct {
+	Output string `long:"output" short:"o" usage:"Set output format" default:"table"`
+
+	metro string
+}
+
+func New() *cobra.Command {
+	cmd, err := cmdfactory.New(&List{}, cobra.Command{
+		Short:   "List instances",
+		Use:     "ls [FLAGS]",
+		Aliases: []string{"list"},
+		Example: heredoc.Doc(`
+			# List all instances in your account.
+			$ kraft cloud instances list
+		`),
+		Annotations: map[string]string{
+			cmdfactory.AnnotationHelpGroup: "kraftcloud-instance",
+		},
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	return cmd
+}
+
+func (opts *List) Pre(cmd *cobra.Command, _ []string) error {
+	opts.metro = cmd.Flag("metro").Value.String()
+	if opts.metro == "" {
+		opts.metro = os.Getenv("KRAFTCLOUD_METRO")
+	}
+	if opts.metro == "" {
+		return fmt.Errorf("kraftcloud metro is unset")
+	}
+	log.G(cmd.Context()).WithField("metro", opts.metro).Debug("using")
+	return nil
+}
+
+func (opts *List) Run(cmd *cobra.Command, args []string) error {
+	ctx := cmd.Context()
+	auth, err := config.GetKraftCloudLoginFromContext(ctx)
+	if err != nil {
+		return fmt.Errorf("could not retrieve credentials: %w", err)
+	}
+
+	client := kcinstance.NewInstancesClient(
+		kraftcloud.WithToken(auth.Token),
+	)
+
+	uuids, err := client.WithMetro(opts.metro).List(ctx)
+	if err != nil {
+		return fmt.Errorf("could not list instances: %w", err)
+	}
+
+	// TODO(nderjung): For now, the KraftCloud API does not support
+	// returning the full details of each instance.  Temporarily request a
+	// status for each instance.
+	var instances []kcinstance.Instance
+	for _, uuid := range uuids {
+		instance, err := client.WithMetro(opts.metro).Status(ctx, uuid.UUID)
+		if err != nil {
+			return fmt.Errorf("could not get instance status: %w", err)
+		}
+
+		instances = append(instances, *instance)
+	}
+
+	return utils.PrintInstances(ctx, opts.Output, instances...)
+}

--- a/cmd/kraft/cloud/instance/logs/logs.go
+++ b/cmd/kraft/cloud/instance/logs/logs.go
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2022, Unikraft GmbH and The KraftKit Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+package logs
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/MakeNowJust/heredoc"
+	"github.com/spf13/cobra"
+
+	kraftcloud "sdk.kraft.cloud"
+	"sdk.kraft.cloud/instance"
+
+	"kraftkit.sh/cmdfactory"
+	"kraftkit.sh/config"
+	"kraftkit.sh/iostreams"
+	"kraftkit.sh/log"
+)
+
+type Logs struct {
+	Tail int `local:"true" long:"tail" short:"n" usage:"Lines of recent logs to display" default:"-1"`
+
+	metro string
+}
+
+func New() *cobra.Command {
+	cmd, err := cmdfactory.New(&Logs{}, cobra.Command{
+		Short: "Get console output of an instance",
+		Use:   "logs [UUID]",
+		Args:  cobra.ExactArgs(1),
+		Example: heredoc.Doc(`
+			# Get console output of a kraftcloud instance
+			$ kraft cloud inst logs 77d0316a-fbbe-488d-8618-5bf7a612477a
+	`),
+		Annotations: map[string]string{
+			cmdfactory.AnnotationHelpGroup: "kraftcloud-instance",
+		},
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	return cmd
+}
+
+func (opts *Logs) Pre(cmd *cobra.Command, _ []string) error {
+	opts.metro = cmd.Flag("metro").Value.String()
+	if opts.metro == "" {
+		opts.metro = os.Getenv("KRAFTCLOUD_METRO")
+	}
+	if opts.metro == "" {
+		return fmt.Errorf("kraftcloud metro is unset")
+	}
+	log.G(cmd.Context()).WithField("metro", opts.metro).Debug("using")
+	return nil
+}
+
+func (opts *Logs) Run(cmd *cobra.Command, args []string) error {
+	ctx := cmd.Context()
+	auth, err := config.GetKraftCloudLoginFromContext(ctx)
+	if err != nil {
+		return fmt.Errorf("could not retrieve credentials: %w", err)
+	}
+
+	uuid := args[0]
+
+	client := instance.NewInstancesClient(
+		kraftcloud.WithToken(auth.Token),
+	)
+
+	logs, err := client.WithMetro(opts.metro).Logs(ctx, uuid, opts.Tail, true)
+	if err != nil {
+		return fmt.Errorf("could not retrieve logs: %w", err)
+	}
+
+	fmt.Fprintf(iostreams.G(ctx).Out, "%s\n", logs)
+
+	return nil
+}

--- a/cmd/kraft/cloud/instance/remove/remove.go
+++ b/cmd/kraft/cloud/instance/remove/remove.go
@@ -1,0 +1,107 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2022, Unikraft GmbH and The KraftKit Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+
+package remove
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/MakeNowJust/heredoc"
+	"github.com/spf13/cobra"
+
+	kraftcloud "sdk.kraft.cloud"
+	kcinstance "sdk.kraft.cloud/instance"
+
+	"kraftkit.sh/cmdfactory"
+	"kraftkit.sh/config"
+	"kraftkit.sh/log"
+)
+
+type Remove struct {
+	Output string `long:"output" short:"o" usage:"Set output format" default:"table"`
+	All    bool   `long:"all" usage:"Stop all instances"`
+
+	metro string
+}
+
+func New() *cobra.Command {
+	cmd, err := cmdfactory.New(&Remove{}, cobra.Command{
+		Short:   "Delete an instance",
+		Use:     "delete UUID",
+		Aliases: []string{"del", "delete", "rm"},
+		Args:    cobra.ArbitraryArgs,
+		Long: heredoc.Doc(`
+			Delete a KraftCloud instance.
+		`),
+		Example: heredoc.Doc(`
+			# Delete a KraftCloud instance
+			$ kraft cloud instance delete fd1684ea-7970-4994-92d6-61dcc7905f2b
+	`),
+		Annotations: map[string]string{
+			cmdfactory.AnnotationHelpGroup: "kraftcloud-instance",
+		},
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	return cmd
+}
+
+func (opts *Remove) Pre(cmd *cobra.Command, args []string) error {
+	if !opts.All && len(args) == 0 {
+		return fmt.Errorf("either specify an instance UUID or --all flag")
+	}
+
+	opts.metro = cmd.Flag("metro").Value.String()
+	if opts.metro == "" {
+		opts.metro = os.Getenv("KRAFTCLOUD_METRO")
+	}
+	if opts.metro == "" {
+		return fmt.Errorf("kraftcloud metro is unset")
+	}
+	log.G(cmd.Context()).WithField("metro", opts.metro).Debug("using")
+	return nil
+}
+
+func (opts *Remove) Run(cmd *cobra.Command, args []string) error {
+	ctx := cmd.Context()
+	auth, err := config.GetKraftCloudLoginFromContext(ctx)
+	if err != nil {
+		return fmt.Errorf("could not retrieve credentials: %w", err)
+	}
+
+	client := kcinstance.NewInstancesClient(
+		kraftcloud.WithToken(auth.Token),
+	)
+
+	if opts.All {
+		instances, err := client.WithMetro(opts.metro).List(ctx)
+		if err != nil {
+			return fmt.Errorf("could not get list of all instances: %w", err)
+		}
+
+		for _, instance := range instances {
+			log.G(ctx).Infof("removing %s", instance.UUID)
+
+			if err := client.WithMetro(opts.metro).Delete(ctx, instance.UUID); err != nil {
+				log.G(ctx).Error("could not stop instance: %w", err)
+			}
+		}
+
+		return nil
+	}
+
+	for _, uuid := range args {
+		log.G(ctx).Infof("removing %s", uuid)
+
+		if err := client.WithMetro(opts.metro).Delete(ctx, uuid); err != nil {
+			return fmt.Errorf("could not create instance: %w", err)
+		}
+	}
+
+	return nil
+}

--- a/cmd/kraft/cloud/instance/start/start.go
+++ b/cmd/kraft/cloud/instance/start/start.go
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2023, Unikraft GmbH and The KraftKit Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+package start
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/MakeNowJust/heredoc"
+	"github.com/spf13/cobra"
+
+	kraftcloud "sdk.kraft.cloud"
+	kcinstance "sdk.kraft.cloud/instance"
+
+	"kraftkit.sh/cmdfactory"
+	"kraftkit.sh/config"
+	"kraftkit.sh/log"
+)
+
+type Start struct {
+	WaitTimeoutMS int    `local:"true" long:"wait_timeout_ms" short:"w" usage:"Timeout to wait for the instance to start in milliseconds"`
+	Output        string `long:"output" short:"o" usage:"Set output format" default:"table"`
+
+	metro string
+}
+
+func New() *cobra.Command {
+	cmd, err := cmdfactory.New(&Start{}, cobra.Command{
+		Short: "Start an instance",
+		Use:   "start [FLAGS] [PACKAGE]",
+		Args:  cobra.ExactArgs(1),
+		Example: heredoc.Doc(`
+			# Start a KraftCloud instance
+			$ kraft cloud instance start 77d0316a-fbbe-488d-8618-5bf7a612477a
+		`),
+		Annotations: map[string]string{
+			cmdfactory.AnnotationHelpGroup: "kraftcloud-instance",
+		},
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	return cmd
+}
+
+func (opts *Start) Pre(cmd *cobra.Command, _ []string) error {
+	opts.metro = cmd.Flag("metro").Value.String()
+	if opts.metro == "" {
+		opts.metro = os.Getenv("KRAFTCLOUD_METRO")
+	}
+	if opts.metro == "" {
+		return fmt.Errorf("kraftcloud metro is unset")
+	}
+	log.G(cmd.Context()).WithField("metro", opts.metro).Debug("using")
+	return nil
+}
+
+func (opts *Start) Run(cmd *cobra.Command, args []string) error {
+	ctx := cmd.Context()
+	auth, err := config.GetKraftCloudLoginFromContext(ctx)
+	if err != nil {
+		return fmt.Errorf("could not retrieve credentials: %w", err)
+	}
+
+	client := kcinstance.NewInstancesClient(
+		kraftcloud.WithToken(auth.Token),
+	)
+
+	for _, arg := range args {
+		log.G(ctx).Infof("starting %s", arg)
+
+		_, err := client.WithMetro(opts.metro).Start(ctx, arg, opts.WaitTimeoutMS)
+		if err != nil {
+			log.G(ctx).WithError(err).Error("could not start instance")
+			continue
+		}
+	}
+
+	return nil
+}

--- a/cmd/kraft/cloud/instance/status/status.go
+++ b/cmd/kraft/cloud/instance/status/status.go
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2023, Unikraft GmbH and The KraftKit Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+
+package status
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/MakeNowJust/heredoc"
+	"github.com/spf13/cobra"
+
+	kraftcloud "sdk.kraft.cloud"
+	kcinstance "sdk.kraft.cloud/instance"
+
+	"kraftkit.sh/cmd/kraft/cloud/utils"
+	"kraftkit.sh/cmdfactory"
+	"kraftkit.sh/config"
+	"kraftkit.sh/log"
+)
+
+type Status struct {
+	Output string `long:"output" short:"o" usage:"Set output format" default:"table"`
+
+	metro string
+}
+
+func New() *cobra.Command {
+	cmd, err := cmdfactory.New(&Status{}, cobra.Command{
+		Short:   "Retrieve the status of an instance",
+		Use:     "status [FLAGS] UUID",
+		Args:    cobra.ExactArgs(1),
+		Aliases: []string{"info"},
+		Example: heredoc.Doc(`
+			# Retrieve information about a kraftcloud instance
+			$ kraft cloud instance status fd1684ea-7970-4994-92d6-61dcc7905f2b
+	`),
+		Annotations: map[string]string{
+			cmdfactory.AnnotationHelpGroup: "kraftcloud-instance",
+		},
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	return cmd
+}
+
+func (opts *Status) Pre(cmd *cobra.Command, _ []string) error {
+	opts.metro = cmd.Flag("metro").Value.String()
+	if opts.metro == "" {
+		opts.metro = os.Getenv("KRAFTCLOUD_METRO")
+	}
+	if opts.metro == "" {
+		return fmt.Errorf("kraftcloud metro is unset")
+	}
+	log.G(cmd.Context()).WithField("metro", opts.metro).Debug("using")
+	return nil
+}
+
+func (opts *Status) Run(cmd *cobra.Command, args []string) error {
+	ctx := cmd.Context()
+	auth, err := config.GetKraftCloudLoginFromContext(ctx)
+	if err != nil {
+		return fmt.Errorf("could not retrieve credentials: %w", err)
+	}
+
+	client := kcinstance.NewInstancesClient(
+		kraftcloud.WithToken(auth.Token),
+	)
+
+	instance, err := client.WithMetro(opts.metro).Status(ctx, args[0])
+	if err != nil {
+		return fmt.Errorf("could not create instance: %w", err)
+	}
+
+	return utils.PrintInstances(ctx, opts.Output, *instance)
+}

--- a/cmd/kraft/cloud/instance/stop/stop.go
+++ b/cmd/kraft/cloud/instance/stop/stop.go
@@ -1,0 +1,106 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2023, Unikraft GmbH and The KraftKit Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+
+package stop
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/MakeNowJust/heredoc"
+	"github.com/spf13/cobra"
+
+	kraftcloud "sdk.kraft.cloud"
+	kcinstance "sdk.kraft.cloud/instance"
+
+	"kraftkit.sh/cmdfactory"
+	"kraftkit.sh/config"
+	"kraftkit.sh/log"
+)
+
+type Stop struct {
+	WaitTimeoutMS int64  `local:"true" long:"wait_timeout_ms" short:"w" usage:"Timeout to wait for the instance to start in milliseconds"`
+	Output        string `long:"output" short:"o" usage:"Set output format" default:"table"`
+	All           bool   `long:"all" usage:"Stop all instances"`
+
+	metro string
+}
+
+func New() *cobra.Command {
+	cmd, err := cmdfactory.New(&Stop{}, cobra.Command{
+		Short: "Stop an instance",
+		Use:   "stop [FLAGS] [UUID]",
+		Args:  cobra.ArbitraryArgs,
+		Example: heredoc.Doc(`
+			# Stop a KraftCloud instance
+			$ kraft cloud instance stop 77d0316a-fbbe-488d-8618-5bf7a612477a
+		`),
+		Annotations: map[string]string{
+			cmdfactory.AnnotationHelpGroup: "kraftcloud-instance",
+		},
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	return cmd
+}
+
+func (opts *Stop) Pre(cmd *cobra.Command, args []string) error {
+	if !opts.All && len(args) == 0 {
+		return fmt.Errorf("either specify an instance UUID or --all flag")
+	}
+
+	opts.metro = cmd.Flag("metro").Value.String()
+	if opts.metro == "" {
+		opts.metro = os.Getenv("KRAFTCLOUD_METRO")
+	}
+	if opts.metro == "" {
+		return fmt.Errorf("kraftcloud metro is unset")
+	}
+	log.G(cmd.Context()).WithField("metro", opts.metro).Debug("using")
+	return nil
+}
+
+func (opts *Stop) Run(cmd *cobra.Command, args []string) error {
+	ctx := cmd.Context()
+	auth, err := config.GetKraftCloudLoginFromContext(ctx)
+	if err != nil {
+		return fmt.Errorf("could not retrieve credentials: %w", err)
+	}
+
+	client := kcinstance.NewInstancesClient(
+		kraftcloud.WithToken(auth.Token),
+	)
+
+	if opts.All {
+		instances, err := client.WithMetro(opts.metro).List(ctx)
+		if err != nil {
+			return fmt.Errorf("could not get list of all instances: %w", err)
+		}
+
+		for _, instance := range instances {
+			log.G(ctx).Infof("stopping %s", instance.UUID)
+
+			_, err := client.WithMetro(opts.metro).Stop(ctx, instance.UUID, opts.WaitTimeoutMS)
+			if err != nil {
+				log.G(ctx).Error("could not stop instance: %w", err)
+			}
+		}
+
+		return nil
+	}
+
+	for _, uuid := range args {
+		log.G(ctx).Infof("stopping %s", uuid)
+
+		_, err = client.WithMetro(opts.metro).Stop(ctx, uuid, opts.WaitTimeoutMS)
+		if err != nil {
+			return fmt.Errorf("could not create instance: %w", err)
+		}
+	}
+
+	return nil
+}

--- a/cmd/kraft/cloud/utils/print.go
+++ b/cmd/kraft/cloud/utils/print.go
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2023, Unikraft GmbH and The KraftKit Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+
+package utils
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/dustin/go-humanize"
+	"kraftkit.sh/internal/tableprinter"
+	"kraftkit.sh/iostreams"
+	"kraftkit.sh/log"
+	kcinstance "sdk.kraft.cloud/instance"
+)
+
+// PrintInstances pretty-prints the provided set of instances or returns
+// an error if unable to send to stdout via the provided context.
+func PrintInstances(ctx context.Context, format string, instances ...kcinstance.Instance) error {
+	err := iostreams.G(ctx).StartPager()
+	if err != nil {
+		log.G(ctx).Errorf("error starting pager: %v", err)
+	}
+
+	defer iostreams.G(ctx).StopPager()
+
+	cs := iostreams.G(ctx).ColorScheme()
+	table, err := tableprinter.NewTablePrinter(ctx,
+		tableprinter.WithMaxWidth(iostreams.G(ctx).TerminalWidth()),
+		tableprinter.WithOutputFormatFromString(format),
+	)
+	if err != nil {
+		return err
+	}
+
+	// Header row
+	table.AddField("UUID", cs.Bold)
+	table.AddField("DNS", cs.Bold)
+	table.AddField("PRIVATE IP", cs.Bold)
+	table.AddField("STATUS", cs.Bold)
+	table.AddField("CREATED AT", cs.Bold)
+	table.AddField("IMAGE", cs.Bold)
+	table.AddField("MEMORY", cs.Bold)
+	table.AddField("ARGS", cs.Bold)
+	table.AddField("SERVICE GROUP", cs.Bold)
+	table.AddField("BOOT TIME", cs.Bold)
+	table.EndRow()
+
+	for _, instance := range instances {
+		var createdAt string
+		if len(instance.CreatedAt) > 0 {
+			createdTime, err := time.Parse(time.RFC3339, instance.CreatedAt)
+			if err != nil {
+				return fmt.Errorf("could not parse time for '%s': %w", instance.UUID, err)
+			}
+			createdAt = humanize.Time(createdTime)
+		}
+		table.AddField(instance.UUID, nil)
+		table.AddField(instance.DNS, nil)
+		table.AddField(instance.PrivateIP, nil)
+		table.AddField(string(instance.Status), nil)
+		table.AddField(createdAt, nil)
+		table.AddField(instance.Image, nil)
+		table.AddField(humanize.Bytes(uint64(instance.MemoryMB)*humanize.MiByte), nil)
+		table.AddField(strings.Join(instance.Args, " "), nil)
+		table.AddField(instance.ServiceGroup, nil)
+		table.AddField(fmt.Sprintf("%dus", instance.BootTimeUS), nil)
+		table.EndRow()
+	}
+
+	return table.Render(iostreams.G(ctx).Out)
+}

--- a/cmd/kraft/kraft.go
+++ b/cmd/kraft/kraft.go
@@ -23,6 +23,7 @@ import (
 
 	"kraftkit.sh/cmd/kraft/build"
 	"kraftkit.sh/cmd/kraft/clean"
+	"kraftkit.sh/cmd/kraft/cloud"
 	"kraftkit.sh/cmd/kraft/events"
 	"kraftkit.sh/cmd/kraft/fetch"
 	"kraftkit.sh/cmd/kraft/login"
@@ -56,7 +57,7 @@ func New() *cobra.Command {
       | = |    Version:          %s
      /|/=\|\   Documentation:    https://kraftkit.sh/
     (_:| |:_)  Issues & support: https://github.com/unikraft/kraftkit/issues
-       v v
+       v v     Platform:         https://kraft.cloud/ (Join the beta!)
        ' '`, kitversion.Version()),
 		CompletionOptions: cobra.CompletionOptions{
 			HiddenDefaultCmd: true,
@@ -78,7 +79,7 @@ func New() *cobra.Command {
 	cmd.AddGroup(&cobra.Group{ID: "pkg", Title: "PACKAGING COMMANDS"})
 	cmd.AddCommand(pkg.New())
 
-	cmd.AddGroup(&cobra.Group{ID: "run", Title: "RUNTIME COMMANDS"})
+	cmd.AddGroup(&cobra.Group{ID: "run", Title: "LOCAL RUNTIME COMMANDS"})
 	cmd.AddCommand(events.New())
 	cmd.AddCommand(logs.New())
 	cmd.AddCommand(ps.New())
@@ -88,6 +89,12 @@ func New() *cobra.Command {
 
 	cmd.AddGroup(&cobra.Group{ID: "net", Title: "LOCAL NETWORKING COMMANDS"})
 	cmd.AddCommand(net.New())
+
+	cmd.AddGroup(&cobra.Group{ID: "kraftcloud", Title: "KRAFT CLOUD COMMANDS"})
+	cmd.AddCommand(cloud.New())
+
+	cmd.AddGroup(&cobra.Group{ID: "kraftcloud-img", Title: "KRAFT CLOUD IMAGE COMMANDS"})
+	cmd.AddGroup(&cobra.Group{ID: "kraftcloud-instance", Title: "KRAFT CLOUD INSTANCE COMMANDS"})
 
 	cmd.AddGroup(&cobra.Group{ID: "misc", Title: "MISCELLANEOUS COMMANDS"})
 	cmd.AddCommand(login.New())

--- a/config/kraftcloud.go
+++ b/config/kraftcloud.go
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2023, Unikraft GmbH and The KraftKit Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+
+package config
+
+import (
+	"context"
+	"fmt"
+	"os"
+)
+
+// GetKraftCloudLogin is a utility method which retrieves credentials of a
+// KraftCloud user from the given context which is populated with the
+// current configuration.
+func GetKraftCloudLoginFromContext(ctx context.Context) (*AuthConfig, error) {
+	auth, ok := G[KraftKit](ctx).Auth["index.unikraft.io"]
+	if !ok {
+		return nil, fmt.Errorf("user not logged in to kraftcloud")
+	}
+
+	auth.Endpoint = "index.unikraft.io"
+
+	// Attempt to fallback to environmental variables:
+	if token := os.Getenv("KRAFTCLOUD_TOKEN"); token != "" {
+		auth.Token = token
+	} else {
+		return nil, fmt.Errorf("could not determine kraftcloud user token: try setting `KRAFTCLOUD_TOKEN`")
+	}
+
+	if user := os.Getenv("KRAFTCLOUD_USER"); user != "" {
+		auth.User = user
+	}
+
+	return &auth, nil
+}

--- a/go.mod
+++ b/go.mod
@@ -72,6 +72,7 @@ require (
 	k8s.io/apimachinery v0.27.4
 	k8s.io/apiserver v0.27.3
 	oras.land/oras-go/v2 v2.2.1
+	sdk.kraft.cloud v0.2.4
 	sigs.k8s.io/kustomize/kyaml v0.14.3
 )
 

--- a/go.sum
+++ b/go.sum
@@ -1551,6 +1551,8 @@ oras.land/oras-go/v2 v2.2.1/go.mod h1:GeAwLuC4G/JpNwkd+bSZ6SkDMGaaYglt6YK2WvZP7u
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
 rsc.io/quote/v3 v3.1.0/go.mod h1:yEA65RcK8LyAZtP9Kv3t0HmxON59tX3rD+tICJqUlj0=
 rsc.io/sampler v1.3.0/go.mod h1:T1hPZKmBbMNahiBKFy5HrXp6adAjACjK9JXDnKaTXpA=
+sdk.kraft.cloud v0.2.4 h1:IGpagtVFguvwn2BLumvEfrgFz9Xow6xpAwMZtpVa2TI=
+sdk.kraft.cloud v0.2.4/go.mod h1:8nWpenBQzgMvXDr5iJv2azfDyBfxQhTuG/Lm0OWRG9s=
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.0.14/go.mod h1:LEScyzhFmoF5pso/YSeBstl57mOzx9xlU9n85RGrDQg=
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.0.15/go.mod h1:LEScyzhFmoF5pso/YSeBstl57mOzx9xlU9n85RGrDQg=
 sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd h1:EDPBXCAspyGV4jQlpZSudPeMmr1bNJefnuqLsRAsHZo=


### PR DESCRIPTION
### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [x] Updated relevant documentation.

### Description of changes

This new subcommand gives users the power to exploit the full potential of Unikraft microVMs by helping them to run and manage instances on the millisecond platform, https://kraft.cloud/.

To get started, [sign up for the beta](https://kraft.cloud).  Once you've received your access token, simply export it via:
```
export KRAFTCLOUD_TOKEN=...
```

You can then view available images at individual metros, for example, listing images in Frankfurt:
```
kraft cloud --metro fra0 img ls
```

To deploy a new image, package it using `kraft pkg` and push it to `index.unikraft.io`:
```
kraft pkg --name index.unikraft.io/$KRAFTCLOUD_USER/my-app:latest .
kraft pkg push index.unikraft.io/$KRAFTCLOUD_USER/my-app:latest
```

You can deploy images at any metro via:
```
kraft cloud --metro fra0 instance create \
	--start \
	--port 80:443 \
	unikraft.io/$KRAFTCLOUD_USER/nginx:latest -- nginx -c /usr/local/nginx/conf/nginx.conf
```