### PR TITLE
fix(archive): Revert list split on separator

### DIFF
--- a/archive/unarchive.go
+++ b/archive/unarchive.go
@@ -64,9 +64,7 @@ func Untar(src io.Reader, dst string, opts ...UnarchiveOption) error {
 
 		var path string
 		if uc.stripComponents > 0 {
-			// We don't use the context-(host-)specific filepath.SplitList because
-			// this is a UNIX tarball
-			parts := filepath.SplitList(header.Name)
+			parts := strings.Split(header.Name, string(filepath.Separator))
 			path = strings.Join(parts[uc.stripComponents:], string(filepath.Separator))
 			path = filepath.Join(dst, path)
 		} else {


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

PR #846 introduced a bug in the `archive` package when unpacking because of the list split. This reverts the fix whilst keeping it working on windows.