### PR TITLE
fix(internal): Attribute CLI flags after reading config

### DIFF
--- a/config/manager.go
+++ b/config/manager.go
@@ -157,6 +157,28 @@ func AllowedValues(key string) []string {
 	return []string{}
 }
 
+// FetchConfigDirFromArgs returns the path to the alternate config directory
+// that can be set via the --config-dir flag. This needs to be fetched before flags
+// are populated with AttributeFlags to ensure that the function is called only once.
+func FetchConfigDirFromArgs(args []string) (path string) {
+	for idx, arg := range args {
+		if !strings.HasPrefix(arg, "--config-dir") {
+			continue
+		}
+		if strings.Contains(arg, "=") {
+			if split := strings.Split(arg, "="); len(split) == 2 {
+				path = split[1]
+			}
+		} else {
+			if !strings.HasPrefix(args[idx+1], "-") {
+				path = args[idx+1]
+			}
+		}
+		break
+	}
+	return
+}
+
 func Default[C any](key string) string {
 	found, _, def, _, err := findConfigDefault[C](key, "", "", reflect.ValueOf(new([0]C)))
 	if err != nil || found != key {

--- a/internal/cli/options.go
+++ b/internal/cli/options.go
@@ -126,9 +126,7 @@ func WithDefaultConfigManager(cmd *cobra.Command) CliOption {
 		if err != nil {
 			return err
 		}
-		if err := cmdfactory.AttributeFlags(cmd, cfg, args...); err != nil {
-			return err
-		}
+		configDir := config.FetchConfigDirFromArgs(args)
 
 		// Did the user specify a non-standard config directory?  The following
 		// check is possible thanks to the attribution of flags to the config file.
@@ -136,10 +134,10 @@ func WithDefaultConfigManager(cmd *cobra.Command) CliOption {
 		// re-instantiate the ConfigManager with the configuration from that
 		// directory.
 		var cfgm *config.ConfigManager[config.KraftKit]
-		if cpath := cfg.Paths.Config; cpath != "" && cpath != config.ConfigDir() {
+		if configDir != "" && configDir != config.ConfigDir() {
 			cfgm, err = config.NewConfigManager(
 				cfg,
-				config.WithFile[config.KraftKit](filepath.Join(cpath, "config.yaml"), true),
+				config.WithFile[config.KraftKit](filepath.Join(configDir, "config.yaml"), true),
 			)
 			if err != nil {
 				return err
@@ -152,6 +150,10 @@ func WithDefaultConfigManager(cmd *cobra.Command) CliOption {
 			if err != nil {
 				return err
 			}
+		}
+
+		if err := cmdfactory.AttributeFlags(cmd, cfg, args...); err != nil {
+			return err
 		}
 
 		copts.ConfigManager = cfgm


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

Because we read the config file at a path, the previously read CLI flags were overwritten. To fix we attribute the flags again over the newly-read config.