### PR TITLE
fix(kconfig): Ensure kconfig options have a value

### DIFF
--- a/kconfig/config.go
+++ b/kconfig/config.go
@@ -20,7 +20,7 @@ const DotConfigFileName = ".config"
 type KeyValueMap map[string]*KeyValue
 
 // NewKeyValueMapFromSlice build a new Mapping from a set of KEY=VALUE strings
-func NewKeyValueMapFromSlice(values ...interface{}) KeyValueMap {
+func NewKeyValueMapFromSlice(values ...interface{}) (KeyValueMap, error) {
 	mapping := KeyValueMap{}
 
 	for _, value := range values {
@@ -32,26 +32,29 @@ func NewKeyValueMapFromSlice(values ...interface{}) KeyValueMap {
 			str = fmt.Sprintf("%d", t)
 		}
 		tokens := strings.SplitN(str, "=", 2)
-		if len(tokens) > 1 {
+		if len(tokens) > 1 && tokens[1] != "" {
 			mapping[tokens[0]] = &KeyValue{
 				Key:   tokens[0],
 				Value: tokens[1],
 			}
 		} else {
-			mapping[str] = nil
+			return nil, fmt.Errorf("kconfig option must be a key-value pair(key=value), found: %v", str)
 		}
 	}
 
-	return mapping
+	return mapping, nil
 }
 
 // NewKeyValueMapFromMap build a new Mapping from a set of KEY=VALUE strings
-func NewKeyValueMapFromMap(values map[string]interface{}) KeyValueMap {
+func NewKeyValueMapFromMap(values map[string]interface{}) (KeyValueMap, error) {
 	mapping := KeyValueMap{}
-
 	for key, value := range values {
 		mapping[key] = &KeyValue{
 			Key: key,
+		}
+
+		if value == nil {
+			return nil, fmt.Errorf("kconfig option must have a value, on key: %v", key)
 		}
 
 		switch casting := value.(type) {
@@ -70,7 +73,7 @@ func NewKeyValueMapFromMap(values map[string]interface{}) KeyValueMap {
 		}
 	}
 
-	return mapping
+	return mapping, nil
 }
 
 // Override accepts a list of key value pairs and overrides the key in the map

--- a/unikraft/component/component.go
+++ b/unikraft/component/component.go
@@ -50,6 +50,7 @@ func NameAndVersion(component Component) string {
 // primarily used by other components internally which follow a similar format
 // of specifying a version, source and list of KConfig options.
 func TranslateFromSchema(props interface{}) (map[string]interface{}, error) {
+	var err error
 	component := make(map[string]interface{})
 
 	switch entry := props.(type) {
@@ -79,9 +80,12 @@ func TranslateFromSchema(props interface{}) (map[string]interface{}, error) {
 			case "kconfig":
 				switch tprop := prop.(type) {
 				case map[string]interface{}:
-					component["kconfig"] = kconfig.NewKeyValueMapFromMap(tprop)
+					component["kconfig"], err = kconfig.NewKeyValueMapFromMap(tprop)
 				case []interface{}:
-					component["kconfig"] = kconfig.NewKeyValueMapFromSlice(tprop...)
+					component["kconfig"], err = kconfig.NewKeyValueMapFromSlice(tprop...)
+				}
+				if err != nil {
+					return nil, err
 				}
 			}
 		}

--- a/unikraft/target/transform.go
+++ b/unikraft/target/transform.go
@@ -16,6 +16,7 @@ import (
 )
 
 func TransformFromSchema(ctx context.Context, data interface{}) (interface{}, error) {
+	var err error
 	switch value := data.(type) {
 	case map[string]interface{}:
 		uk := unikraft.FromContext(ctx)
@@ -52,9 +53,12 @@ func TransformFromSchema(ctx context.Context, data interface{}) (interface{}, er
 			case "kconfig":
 				switch tprop := prop.(type) {
 				case map[string]interface{}:
-					t.kconfig = kconfig.NewKeyValueMapFromMap(tprop)
+					t.kconfig, err = kconfig.NewKeyValueMapFromMap(tprop)
 				case []interface{}:
-					t.kconfig = kconfig.NewKeyValueMapFromSlice(tprop...)
+					t.kconfig, err = kconfig.NewKeyValueMapFromSlice(tprop...)
+				}
+				if err != nil {
+					return nil, err
 				}
 			}
 		}


### PR DESCRIPTION

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [x] Updated relevant documentation.

### Description of changes

Kconfig values from `kraftfile` were not checked against nil, causing the panic in the issue. Now the functions return an error when the value of a KV pair is nil.

Fixes #858 