### PR TITLE
refactor: Use dependency injection for configuration passing

### DIFF
--- a/cmd/kraft/clean/clean.go
+++ b/cmd/kraft/clean/clean.go
@@ -38,6 +38,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"kraftkit.sh/cmdfactory"
+	"kraftkit.sh/config"
 	"kraftkit.sh/machine/platform"
 	"kraftkit.sh/packmanager"
 	"kraftkit.sh/unikraft/app"
@@ -51,7 +52,7 @@ type Clean struct {
 	Target       string `long:"target" short:"t" usage:"Filter prepare based on a specific target"`
 }
 
-func New() *cobra.Command {
+func New(cfg *config.ConfigManager[config.KraftKit]) *cobra.Command {
 	cmd, err := cmdfactory.New(&Clean{}, cobra.Command{
 		Short: "Remove the build object files of a Unikraft project",
 		Use:   "clean [DIR]",
@@ -67,7 +68,7 @@ func New() *cobra.Command {
 		Annotations: map[string]string{
 			cmdfactory.AnnotationHelpGroup: "build",
 		},
-	})
+	}, cfg)
 	if err != nil {
 		panic(err)
 	}
@@ -75,7 +76,7 @@ func New() *cobra.Command {
 	return cmd
 }
 
-func (opts *Clean) Pre(cmd *cobra.Command, _ []string) error {
+func (opts *Clean) Pre(cmd *cobra.Command, _ []string, cfg *config.ConfigManager[config.KraftKit]) error {
 	ctx, err := packmanager.WithDefaultUmbrellaManagerInContext(cmd.Context())
 	if err != nil {
 		return err
@@ -88,7 +89,7 @@ func (opts *Clean) Pre(cmd *cobra.Command, _ []string) error {
 	return nil
 }
 
-func (opts *Clean) Run(cmd *cobra.Command, args []string) error {
+func (opts *Clean) Run(cmd *cobra.Command, args []string, cfg *config.ConfigManager[config.KraftKit]) error {
 	var err error
 
 	ctx := cmd.Context()

--- a/cmd/kraft/fetch/fetch.go
+++ b/cmd/kraft/fetch/fetch.go
@@ -45,7 +45,7 @@ type Fetch struct {
 	workdir string
 }
 
-func New() *cobra.Command {
+func New(cfg *config.ConfigManager[config.KraftKit]) *cobra.Command {
 	cmd, err := cmdfactory.New(&Fetch{}, cobra.Command{
 		Short: "Fetch Unikraft unikernel dependencies",
 		Use:   "fetch [FLAGS] [DIR]",
@@ -65,7 +65,7 @@ func New() *cobra.Command {
 		Annotations: map[string]string{
 			cmdfactory.AnnotationHelpGroup: "build",
 		},
-	})
+	}, cfg)
 	if err != nil {
 		panic(err)
 	}
@@ -73,7 +73,7 @@ func New() *cobra.Command {
 	return cmd
 }
 
-func (opts *Fetch) Pre(cmd *cobra.Command, args []string) error {
+func (opts *Fetch) Pre(cmd *cobra.Command, args []string, cfg *config.ConfigManager[config.KraftKit]) error {
 	ctx, err := packmanager.WithDefaultUmbrellaManagerInContext(cmd.Context())
 	if err != nil {
 		return err
@@ -113,12 +113,12 @@ func (opts *Fetch) Pre(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-func (opts *Fetch) pull(ctx context.Context, project app.Application, workdir string, norender bool, nameWidth int) error {
+func (opts *Fetch) pull(ctx context.Context, project app.Application, workdir string, norender bool, nameWidth int, cfg *config.KraftKit) error {
 	var missingPacks []pack.Package
 	var processes []*paraprogress.Process
 	var searches []*processtree.ProcessTreeItem
-	parallel := !config.G[config.KraftKit](ctx).NoParallel
-	auths := config.G[config.KraftKit](ctx).Auth
+	parallel := !cfg.NoParallel
+	auths := cfg.Auth
 
 	// FIXME: This is a temporary workaround for incorporating multiple processes in
 	// a command. After calling processtree the original output writer is lost
@@ -141,11 +141,12 @@ func (opts *Fetch) pull(ctx context.Context, project app.Application, workdir st
 			), "",
 			func(ctx context.Context) error {
 				packages, err = packmanager.G(ctx).Catalog(ctx,
+					cfg,
 					packmanager.WithName(opts.project.Template().Name()),
 					packmanager.WithTypes(unikraft.ComponentTypeApp),
 					packmanager.WithVersion(opts.project.Template().Version()),
 					packmanager.WithCache(!opts.NoCache),
-					packmanager.WithAuthConfig(config.G[config.KraftKit](ctx).Auth),
+					packmanager.WithAuthConfig(cfg.Auth),
 				)
 				if err != nil {
 					return err
@@ -270,6 +271,7 @@ func (opts *Fetch) pull(ctx context.Context, project app.Application, workdir st
 			), "",
 			func(ctx context.Context) error {
 				p, err := packmanager.G(ctx).Catalog(ctx,
+					cfg,
 					packmanager.WithName(component.Name()),
 					packmanager.WithTypes(component.Type()),
 					packmanager.WithVersion(component.Version()),
@@ -357,8 +359,9 @@ func (opts *Fetch) pull(ctx context.Context, project app.Application, workdir st
 	return nil
 }
 
-func (opts *Fetch) Run(cmd *cobra.Command, _ []string) error {
+func (opts *Fetch) Run(cmd *cobra.Command, _ []string, cfgMgr *config.ConfigManager[config.KraftKit]) error {
 	ctx := cmd.Context()
+	cfg := cfgMgr.Config
 
 	// Filter project targets by any provided CLI options
 	selected := opts.project.Targets()
@@ -367,7 +370,7 @@ func (opts *Fetch) Run(cmd *cobra.Command, _ []string) error {
 		return fmt.Errorf("no targets selected to fetch")
 	}
 
-	norender := log.LoggerTypeFromString(config.G[config.KraftKit](ctx).Log.Type) != log.FANCY
+	norender := log.LoggerTypeFromString(cfg.Log.Type) != log.FANCY
 	nameWidth := -1
 
 	// Calculate the width of the longest process name so that we can align the
@@ -386,7 +389,7 @@ func (opts *Fetch) Run(cmd *cobra.Command, _ []string) error {
 	}
 
 	if !opts.NoPull {
-		if err := opts.pull(ctx, opts.project, opts.workdir, norender, nameWidth); err != nil {
+		if err := opts.pull(ctx, opts.project, opts.workdir, norender, nameWidth, cfg); err != nil {
 			return err
 		}
 	}

--- a/cmd/kraft/login/login.go
+++ b/cmd/kraft/login/login.go
@@ -23,7 +23,7 @@ type Login struct {
 	Token string `long:"token" short:"t" usage:"Authentication token" env:"KRAFTKIT_LOGIN_TOKEN"`
 }
 
-func New() *cobra.Command {
+func New(cfg *config.ConfigManager[config.KraftKit]) *cobra.Command {
 	cmd, err := cmdfactory.New(&Login{}, cobra.Command{
 		Short: "Provide authorization details for a remote service",
 		Use:   "login [FLAGS] HOST",
@@ -31,7 +31,7 @@ func New() *cobra.Command {
 		Annotations: map[string]string{
 			cmdfactory.AnnotationHelpGroup: "misc",
 		},
-	})
+	}, cfg)
 	if err != nil {
 		panic(err)
 	}
@@ -39,10 +39,11 @@ func New() *cobra.Command {
 	return cmd
 }
 
-func (opts *Login) Run(cmd *cobra.Command, args []string) error {
+func (opts *Login) Run(cmd *cobra.Command, args []string, cfgMgr *config.ConfigManager[config.KraftKit]) error {
 	var err error
 	host := args[0]
 	ctx := cmd.Context()
+	cfg := cfgMgr.Config
 
 	// Prompt the user from stdin for a username if neither a username nor a token
 	// was provided
@@ -99,10 +100,10 @@ func (opts *Login) Run(cmd *cobra.Command, args []string) error {
 		authConfig.Token = opts.Token
 	}
 
-	if config.G[config.KraftKit](ctx).Auth == nil {
-		config.G[config.KraftKit](ctx).Auth = make(map[string]config.AuthConfig)
+	if cfg.Auth == nil {
+		cfg.Auth = make(map[string]config.AuthConfig)
 	}
-	config.G[config.KraftKit](ctx).Auth[host] = authConfig
+	cfg.Auth[host] = authConfig
 
-	return config.M[config.KraftKit](ctx).Write(true)
+	return cfgMgr.Write(true)
 }

--- a/cmd/kraft/net/create/create.go
+++ b/cmd/kraft/net/create/create.go
@@ -14,6 +14,7 @@ import (
 
 	networkapi "kraftkit.sh/api/network/v1alpha1"
 	"kraftkit.sh/cmdfactory"
+	"kraftkit.sh/config"
 	"kraftkit.sh/iostreams"
 	"kraftkit.sh/machine/network"
 )
@@ -23,7 +24,7 @@ type Create struct {
 	Network string `long:"network" short:"n" usage:"Set the gateway IP address and the subnet of the network in CIDR format."`
 }
 
-func New() *cobra.Command {
+func New(cfg *config.ConfigManager[config.KraftKit]) *cobra.Command {
 	cmd, err := cmdfactory.New(&Create{}, cobra.Command{
 		Short:   "Create a new machine network",
 		Use:     "create [FLAGS] NETWORK",
@@ -32,7 +33,7 @@ func New() *cobra.Command {
 		Annotations: map[string]string{
 			cmdfactory.AnnotationHelpGroup: "net",
 		},
-	})
+	}, cfg)
 	if err != nil {
 		panic(err)
 	}
@@ -40,7 +41,7 @@ func New() *cobra.Command {
 	return cmd
 }
 
-func (opts *Create) Pre(cmd *cobra.Command, _ []string) error {
+func (opts *Create) Pre(cmd *cobra.Command, _ []string, cfg *config.ConfigManager[config.KraftKit]) error {
 	opts.driver = cmd.Flag("driver").Value.String()
 
 	// TODO(nderjung): A future implementation can list existing networks and
@@ -59,12 +60,12 @@ func (opts *Create) Pre(cmd *cobra.Command, _ []string) error {
 	return nil
 }
 
-func (opts *Create) Run(cmd *cobra.Command, args []string) error {
+func (opts *Create) Run(cmd *cobra.Command, args []string, cfgMgr *config.ConfigManager[config.KraftKit]) error {
 	var err error
 
 	ctx := cmd.Context()
 
-	strategy, ok := network.Strategies()[opts.driver]
+	strategy, ok := network.Strategies(cfgMgr.Config)[opts.driver]
 	if !ok {
 		return fmt.Errorf("unsupported network driver strategy: %v (contributions welcome!)", opts.driver)
 	}

--- a/cmd/kraft/net/down/down.go
+++ b/cmd/kraft/net/down/down.go
@@ -12,6 +12,7 @@ import (
 
 	networkapi "kraftkit.sh/api/network/v1alpha1"
 	"kraftkit.sh/cmdfactory"
+	"kraftkit.sh/config"
 	"kraftkit.sh/iostreams"
 	"kraftkit.sh/machine/network"
 )
@@ -20,7 +21,7 @@ type Down struct {
 	driver string
 }
 
-func New() *cobra.Command {
+func New(cfg *config.ConfigManager[config.KraftKit]) *cobra.Command {
 	cmd, err := cmdfactory.New(&Down{}, cobra.Command{
 		Short:   "Bring a network offline",
 		Use:     "down",
@@ -29,7 +30,7 @@ func New() *cobra.Command {
 		Annotations: map[string]string{
 			cmdfactory.AnnotationHelpGroup: "net",
 		},
-	})
+	}, cfg)
 	if err != nil {
 		panic(err)
 	}
@@ -37,14 +38,14 @@ func New() *cobra.Command {
 	return cmd
 }
 
-func (opts *Down) Pre(cmd *cobra.Command, _ []string) error {
+func (opts *Down) Pre(cmd *cobra.Command, _ []string, cfg *config.ConfigManager[config.KraftKit]) error {
 	opts.driver = cmd.Flag("driver").Value.String()
 	return nil
 }
 
-func (opts *Down) Run(cmd *cobra.Command, args []string) error {
+func (opts *Down) Run(cmd *cobra.Command, args []string, cfgMgr *config.ConfigManager[config.KraftKit]) error {
 	ctx := cmd.Context()
-	strategy, ok := network.Strategies()[opts.driver]
+	strategy, ok := network.Strategies(cfgMgr.Config)[opts.driver]
 	if !ok {
 		return fmt.Errorf("unsupported network driver strategy: %v (contributions welcome!)", opts.driver)
 	}

--- a/cmd/kraft/net/inspect/inspect.go
+++ b/cmd/kraft/net/inspect/inspect.go
@@ -13,6 +13,7 @@ import (
 
 	networkapi "kraftkit.sh/api/network/v1alpha1"
 	"kraftkit.sh/cmdfactory"
+	"kraftkit.sh/config"
 	"kraftkit.sh/iostreams"
 	"kraftkit.sh/machine/network"
 )
@@ -21,7 +22,7 @@ type Inspect struct {
 	Driver string `noattribute:"true"`
 }
 
-func New() *cobra.Command {
+func New(cfg *config.ConfigManager[config.KraftKit]) *cobra.Command {
 	cmd, err := cmdfactory.New(&Inspect{}, cobra.Command{
 		Short:   "Inspect a machine network",
 		Use:     "inspect NETWORK",
@@ -30,7 +31,7 @@ func New() *cobra.Command {
 		Annotations: map[string]string{
 			cmdfactory.AnnotationHelpGroup: "net",
 		},
-	})
+	}, cfg)
 	if err != nil {
 		panic(err)
 	}
@@ -38,17 +39,17 @@ func New() *cobra.Command {
 	return cmd
 }
 
-func (opts *Inspect) Pre(cmd *cobra.Command, _ []string) error {
+func (opts *Inspect) Pre(cmd *cobra.Command, _ []string, cfg *config.ConfigManager[config.KraftKit]) error {
 	opts.Driver = cmd.Flag("driver").Value.String()
 	return nil
 }
 
-func (opts *Inspect) Run(cmd *cobra.Command, args []string) error {
+func (opts *Inspect) Run(cmd *cobra.Command, args []string, cfgMgr *config.ConfigManager[config.KraftKit]) error {
 	var err error
 
 	ctx := cmd.Context()
 
-	strategy, ok := network.Strategies()[opts.Driver]
+	strategy, ok := network.Strategies(cfgMgr.Config)[opts.Driver]
 	if !ok {
 		return fmt.Errorf("unsupported network driver strategy: %v (contributions welcome!)", opts.Driver)
 	}

--- a/cmd/kraft/net/list/list.go
+++ b/cmd/kraft/net/list/list.go
@@ -12,6 +12,7 @@ import (
 
 	networkapi "kraftkit.sh/api/network/v1alpha1"
 	"kraftkit.sh/cmdfactory"
+	"kraftkit.sh/config"
 	"kraftkit.sh/internal/tableprinter"
 	"kraftkit.sh/iostreams"
 	"kraftkit.sh/log"
@@ -24,7 +25,7 @@ type List struct {
 	driver string
 }
 
-func New() *cobra.Command {
+func New(cfg *config.ConfigManager[config.KraftKit]) *cobra.Command {
 	cmd, err := cmdfactory.New(&List{}, cobra.Command{
 		Short:   "List machine networks",
 		Use:     "ls [FLAGS]",
@@ -33,7 +34,7 @@ func New() *cobra.Command {
 		Annotations: map[string]string{
 			cmdfactory.AnnotationHelpGroup: "net",
 		},
-	})
+	}, cfg)
 	if err != nil {
 		panic(err)
 	}
@@ -41,17 +42,17 @@ func New() *cobra.Command {
 	return cmd
 }
 
-func (opts *List) Pre(cmd *cobra.Command, _ []string) error {
+func (opts *List) Pre(cmd *cobra.Command, _ []string, cfg *config.ConfigManager[config.KraftKit]) error {
 	opts.driver = cmd.Flag("driver").Value.String()
 	return nil
 }
 
-func (opts *List) Run(cmd *cobra.Command, _ []string) error {
+func (opts *List) Run(cmd *cobra.Command, _ []string, cfgMgr *config.ConfigManager[config.KraftKit]) error {
 	var err error
 
 	ctx := cmd.Context()
 
-	strategy, ok := network.Strategies()[opts.driver]
+	strategy, ok := network.Strategies(cfgMgr.Config)[opts.driver]
 	if !ok {
 		return fmt.Errorf("unsupported network driver strategy: %s", opts.driver)
 	}

--- a/cmd/kraft/net/net.go
+++ b/cmd/kraft/net/net.go
@@ -16,6 +16,7 @@ import (
 	"kraftkit.sh/cmd/kraft/net/remove"
 	"kraftkit.sh/cmd/kraft/net/up"
 	"kraftkit.sh/cmdfactory"
+	"kraftkit.sh/config"
 	"kraftkit.sh/internal/set"
 	"kraftkit.sh/machine/network"
 )
@@ -24,7 +25,7 @@ type Net struct {
 	Driver string `local:"false" long:"driver" short:"d" usage:"Set the network driver." default:"bridge"`
 }
 
-func New() *cobra.Command {
+func New(cfg *config.ConfigManager[config.KraftKit]) *cobra.Command {
 	cmd, err := cmdfactory.New(&Net{}, cobra.Command{
 		Short:   "Manage machine networks",
 		Use:     "net SUBCOMMAND",
@@ -33,31 +34,31 @@ func New() *cobra.Command {
 		Annotations: map[string]string{
 			cmdfactory.AnnotationHelpGroup: "net",
 		},
-	})
+	}, cfg)
 	if err != nil {
 		panic(err)
 	}
 
-	cmd.AddCommand(create.New())
-	cmd.AddCommand(down.New())
-	cmd.AddCommand(inspect.New())
-	cmd.AddCommand(list.New())
-	cmd.AddCommand(remove.New())
-	cmd.AddCommand(up.New())
+	cmd.AddCommand(create.New(cfg))
+	cmd.AddCommand(down.New(cfg))
+	cmd.AddCommand(inspect.New(cfg))
+	cmd.AddCommand(list.New(cfg))
+	cmd.AddCommand(remove.New(cfg))
+	cmd.AddCommand(up.New(cfg))
 
 	return cmd
 }
 
-func (opts *Net) Pre(cmd *cobra.Command, _ []string) error {
+func (opts *Net) Pre(cmd *cobra.Command, _ []string, cfgMgr *config.ConfigManager[config.KraftKit]) error {
 	if opts.Driver == "" {
 		return fmt.Errorf("network driver must be set")
-	} else if !set.NewStringSet(network.DriverNames()...).Contains(opts.Driver) {
+	} else if !set.NewStringSet(network.DriverNames(cfgMgr.Config)...).Contains(opts.Driver) {
 		return fmt.Errorf("unsupported network driver strategy: %s", opts.Driver)
 	}
 
 	return nil
 }
 
-func (opts *Net) Run(cmd *cobra.Command, _ []string) error {
+func (opts *Net) Run(cmd *cobra.Command, _ []string, cfgMgr *config.ConfigManager[config.KraftKit]) error {
 	return cmd.Help()
 }

--- a/cmd/kraft/net/remove/remove.go
+++ b/cmd/kraft/net/remove/remove.go
@@ -12,6 +12,7 @@ import (
 
 	networkapi "kraftkit.sh/api/network/v1alpha1"
 	"kraftkit.sh/cmdfactory"
+	"kraftkit.sh/config"
 	"kraftkit.sh/iostreams"
 	"kraftkit.sh/machine/network"
 )
@@ -20,7 +21,7 @@ type Rm struct {
 	driver string
 }
 
-func New() *cobra.Command {
+func New(cfg *config.ConfigManager[config.KraftKit]) *cobra.Command {
 	cmd, err := cmdfactory.New(&Rm{}, cobra.Command{
 		Short:   "Remove a network",
 		Use:     "rm",
@@ -29,7 +30,7 @@ func New() *cobra.Command {
 		Annotations: map[string]string{
 			cmdfactory.AnnotationHelpGroup: "net",
 		},
-	})
+	}, cfg)
 	if err != nil {
 		panic(err)
 	}
@@ -37,17 +38,17 @@ func New() *cobra.Command {
 	return cmd
 }
 
-func (opts *Rm) Pre(cmd *cobra.Command, _ []string) error {
+func (opts *Rm) Pre(cmd *cobra.Command, _ []string, cfg *config.ConfigManager[config.KraftKit]) error {
 	opts.driver = cmd.Flag("driver").Value.String()
 	return nil
 }
 
-func (opts *Rm) Run(cmd *cobra.Command, args []string) error {
+func (opts *Rm) Run(cmd *cobra.Command, args []string, cfgMgr *config.ConfigManager[config.KraftKit]) error {
 	var err error
 
 	ctx := cmd.Context()
 
-	strategy, ok := network.Strategies()[opts.driver]
+	strategy, ok := network.Strategies(cfgMgr.Config)[opts.driver]
 	if !ok {
 		return fmt.Errorf("unsupported network driver strategy: %v (contributions welcome!)", opts.driver)
 	}

--- a/cmd/kraft/net/up/up.go
+++ b/cmd/kraft/net/up/up.go
@@ -12,6 +12,7 @@ import (
 
 	networkapi "kraftkit.sh/api/network/v1alpha1"
 	"kraftkit.sh/cmdfactory"
+	"kraftkit.sh/config"
 	"kraftkit.sh/iostreams"
 	"kraftkit.sh/machine/network"
 )
@@ -20,7 +21,7 @@ type Up struct {
 	driver string
 }
 
-func New() *cobra.Command {
+func New(cfg *config.ConfigManager[config.KraftKit]) *cobra.Command {
 	cmd, err := cmdfactory.New(&Up{}, cobra.Command{
 		Short:   "Bring a network online",
 		Use:     "up",
@@ -29,7 +30,7 @@ func New() *cobra.Command {
 		Annotations: map[string]string{
 			cmdfactory.AnnotationHelpGroup: "net",
 		},
-	})
+	}, cfg)
 	if err != nil {
 		panic(err)
 	}
@@ -37,14 +38,14 @@ func New() *cobra.Command {
 	return cmd
 }
 
-func (opts *Up) Pre(cmd *cobra.Command, _ []string) error {
+func (opts *Up) Pre(cmd *cobra.Command, _ []string, cfg *config.ConfigManager[config.KraftKit]) error {
 	opts.driver = cmd.Flag("driver").Value.String()
 	return nil
 }
 
-func (opts *Up) Run(cmd *cobra.Command, args []string) error {
+func (opts *Up) Run(cmd *cobra.Command, args []string, cfgMgr *config.ConfigManager[config.KraftKit]) error {
 	ctx := cmd.Context()
-	strategy, ok := network.Strategies()[opts.driver]
+	strategy, ok := network.Strategies(cfgMgr.Config)[opts.driver]
 	if !ok {
 		return fmt.Errorf("unsupported network driver strategy: %v (contributions welcome!)", opts.driver)
 	}

--- a/cmd/kraft/pkg/list/list.go
+++ b/cmd/kraft/pkg/list/list.go
@@ -11,6 +11,7 @@ import (
 	"github.com/MakeNowJust/heredoc"
 	"github.com/spf13/cobra"
 
+	"kraftkit.sh/config"
 	"kraftkit.sh/unikraft/app"
 
 	"kraftkit.sh/cmdfactory"
@@ -35,7 +36,7 @@ type List struct {
 	Output    string `long:"output" short:"o" usage:"Set output format" default:"table"`
 }
 
-func New() *cobra.Command {
+func New(cfg *config.ConfigManager[config.KraftKit]) *cobra.Command {
 	cmd, err := cmdfactory.New(&List{}, cobra.Command{
 		Short:   "List installed Unikraft component packages",
 		Use:     "ls [FLAGS] [DIR]",
@@ -49,7 +50,7 @@ func New() *cobra.Command {
 		Annotations: map[string]string{
 			cmdfactory.AnnotationHelpGroup: "pkg",
 		},
-	})
+	}, cfg)
 	if err != nil {
 		panic(err)
 	}
@@ -57,7 +58,7 @@ func New() *cobra.Command {
 	return cmd
 }
 
-func (*List) Pre(cmd *cobra.Command, _ []string) error {
+func (*List) Pre(cmd *cobra.Command, _ []string, cfg *config.ConfigManager[config.KraftKit]) error {
 	ctx, err := packmanager.WithDefaultUmbrellaManagerInContext(cmd.Context())
 	if err != nil {
 		return err
@@ -68,7 +69,7 @@ func (*List) Pre(cmd *cobra.Command, _ []string) error {
 	return nil
 }
 
-func (opts *List) Run(cmd *cobra.Command, args []string) error {
+func (opts *List) Run(cmd *cobra.Command, args []string, cfgMgr *config.ConfigManager[config.KraftKit]) error {
 	var err error
 
 	ctx := cmd.Context()
@@ -121,6 +122,7 @@ func (opts *List) Run(cmd *cobra.Command, args []string) error {
 
 	} else {
 		packages, err = packmanager.G(ctx).Catalog(ctx,
+			cfgMgr.Config,
 			packmanager.WithCache(!opts.Update),
 			packmanager.WithTypes(types...),
 		)

--- a/cmd/kraft/properclean/properclean.go
+++ b/cmd/kraft/properclean/properclean.go
@@ -38,6 +38,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"kraftkit.sh/cmdfactory"
+	"kraftkit.sh/config"
 	"kraftkit.sh/packmanager"
 	"kraftkit.sh/unikraft/app"
 )
@@ -46,7 +47,7 @@ type ProperClean struct {
 	Kraftfile string `long:"kraftfile" short:"K" usage:"Set an alternative path of the Kraftfile"`
 }
 
-func New() *cobra.Command {
+func New(cfg *config.ConfigManager[config.KraftKit]) *cobra.Command {
 	cmd, err := cmdfactory.New(&ProperClean{}, cobra.Command{
 		Short:   "Completely remove the build artifacts of a Unikraft project",
 		Use:     "properclean [DIR]",
@@ -63,7 +64,7 @@ func New() *cobra.Command {
 		Annotations: map[string]string{
 			cmdfactory.AnnotationHelpGroup: "build",
 		},
-	})
+	}, cfg)
 	if err != nil {
 		panic(err)
 	}
@@ -71,7 +72,7 @@ func New() *cobra.Command {
 	return cmd
 }
 
-func (*ProperClean) Pre(cmd *cobra.Command, _ []string) error {
+func (*ProperClean) Pre(cmd *cobra.Command, _ []string, cfg *config.ConfigManager[config.KraftKit]) error {
 	ctx, err := packmanager.WithDefaultUmbrellaManagerInContext(cmd.Context())
 	if err != nil {
 		return err
@@ -82,7 +83,7 @@ func (*ProperClean) Pre(cmd *cobra.Command, _ []string) error {
 	return nil
 }
 
-func (opts *ProperClean) Run(cmd *cobra.Command, args []string) error {
+func (opts *ProperClean) Run(cmd *cobra.Command, args []string, cfgMgr *config.ConfigManager[config.KraftKit]) error {
 	var err error
 
 	ctx := cmd.Context()

--- a/cmd/kraft/run/runner.go
+++ b/cmd/kraft/run/runner.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 
 	machineapi "kraftkit.sh/api/machine/v1alpha1"
+	"kraftkit.sh/config"
 	"kraftkit.sh/packmanager"
 )
 
@@ -22,11 +23,11 @@ type runner interface {
 	fmt.Stringer
 
 	// Runnable checks whether the provided configuration is runnable.
-	Runnable(context.Context, *Run, ...string) (bool, error)
+	Runnable(context.Context, *Run, *config.KraftKit, ...string) (bool, error)
 
 	// Prepare the provided configuration into a machine specification ready for
 	// execution by the controller.
-	Prepare(context.Context, *Run, *machineapi.Machine, ...string) error
+	Prepare(context.Context, *Run, *machineapi.Machine, *config.KraftKit, ...string) error
 }
 
 // runners is the list of built-in runners which are checked sequentially for

--- a/cmd/kraft/run/runner_kernel.go
+++ b/cmd/kraft/run/runner_kernel.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 
 	machineapi "kraftkit.sh/api/machine/v1alpha1"
+	"kraftkit.sh/config"
 	"kraftkit.sh/unikraft"
 )
 
@@ -29,7 +30,7 @@ func (runner *runnerKernel) String() string {
 }
 
 // Runnable implements Runner.
-func (runner *runnerKernel) Runnable(ctx context.Context, opts *Run, args ...string) (bool, error) {
+func (runner *runnerKernel) Runnable(ctx context.Context, opts *Run, cfg *config.KraftKit, args ...string) (bool, error) {
 	if len(args) == 0 {
 		return false, fmt.Errorf("no arguments supplied")
 	}
@@ -45,7 +46,7 @@ func (runner *runnerKernel) Runnable(ctx context.Context, opts *Run, args ...str
 }
 
 // Prepare implements Runner.
-func (runner *runnerKernel) Prepare(ctx context.Context, opts *Run, machine *machineapi.Machine, args ...string) error {
+func (runner *runnerKernel) Prepare(ctx context.Context, opts *Run, machine *machineapi.Machine, cfg *config.KraftKit, args ...string) error {
 	filename := filepath.Base(runner.kernelPath)
 	machine.Spec.Platform = opts.platform.String()
 	machine.Spec.Kernel = "kernel://" + filename

--- a/cmd/kraft/run/runner_linuxu.go
+++ b/cmd/kraft/run/runner_linuxu.go
@@ -39,7 +39,7 @@ func (runner *runnerLinuxu) String() string {
 }
 
 // Runnable implements Runner.
-func (runner *runnerLinuxu) Runnable(ctx context.Context, opts *Run, args ...string) (bool, error) {
+func (runner *runnerLinuxu) Runnable(ctx context.Context, opts *Run, cfg *config.KraftKit, args ...string) (bool, error) {
 	if len(args) == 0 {
 		return false, fmt.Errorf("no arguments supplied")
 	}
@@ -115,8 +115,8 @@ func (runner *runnerLinuxu) Runnable(ctx context.Context, opts *Run, args ...str
 }
 
 // Prepare implements Runner.
-func (runner *runnerLinuxu) Prepare(ctx context.Context, opts *Run, machine *machineapi.Machine, args ...string) error {
-	loader, err := elfloader.NewELFLoaderFromPrebuilt(ctx, runner.exePath)
+func (runner *runnerLinuxu) Prepare(ctx context.Context, opts *Run, machine *machineapi.Machine, cfg *config.KraftKit, args ...string) error {
+	loader, err := elfloader.NewELFLoaderFromPrebuilt(ctx, runner.exePath, cfg)
 	if err != nil {
 		return err
 	}
@@ -144,7 +144,7 @@ func (runner *runnerLinuxu) Prepare(ctx context.Context, opts *Run, machine *mac
 					pack.WithPullWorkdir(dir),
 					pack.WithPullPlatform(opts.platform.String()),
 				}
-				if log.LoggerTypeFromString(config.G[config.KraftKit](ctx).Log.Type) == log.FANCY {
+				if log.LoggerTypeFromString(cfg.Log.Type) == log.FANCY {
 					popts = append(popts, pack.WithPullProgressFunc(w))
 				}
 
@@ -156,7 +156,7 @@ func (runner *runnerLinuxu) Prepare(ctx context.Context, opts *Run, machine *mac
 		)},
 		paraprogress.IsParallel(false),
 		paraprogress.WithRenderer(
-			log.LoggerTypeFromString(config.G[config.KraftKit](ctx).Log.Type) != log.FANCY,
+			log.LoggerTypeFromString(cfg.Log.Type) != log.FANCY,
 		),
 		paraprogress.WithFailFast(true),
 	)

--- a/cmd/kraft/run/runner_project.go
+++ b/cmd/kraft/run/runner_project.go
@@ -34,7 +34,7 @@ func (runner *runnerProject) String() string {
 }
 
 // Runnable implements Runner.
-func (runner *runnerProject) Runnable(ctx context.Context, opts *Run, args ...string) (bool, error) {
+func (runner *runnerProject) Runnable(ctx context.Context, opts *Run, cfg *config.KraftKit, args ...string) (bool, error) {
 	var err error
 
 	cwd, err := os.Getwd()
@@ -61,7 +61,7 @@ func (runner *runnerProject) Runnable(ctx context.Context, opts *Run, args ...st
 }
 
 // Prepare implements Runner.
-func (runner *runnerProject) Prepare(ctx context.Context, opts *Run, machine *machineapi.Machine, args ...string) error {
+func (runner *runnerProject) Prepare(ctx context.Context, opts *Run, machine *machineapi.Machine, cfg *config.KraftKit, args ...string) error {
 	popts := []app.ProjectOption{
 		app.WithProjectWorkdir(runner.workdir),
 	}
@@ -94,7 +94,7 @@ func (runner *runnerProject) Prepare(ctx context.Context, opts *Run, machine *ma
 	case len(targets) == 1:
 		t = targets[0]
 
-	case config.G[config.KraftKit](ctx).NoPrompt && len(targets) > 1:
+	case cfg.NoPrompt && len(targets) > 1:
 		return fmt.Errorf("could not determine what to run based on provided CLI arguments")
 
 	default:

--- a/cmd/kraft/run/utils.go
+++ b/cmd/kraft/run/utils.go
@@ -11,6 +11,7 @@ import (
 	machineapi "kraftkit.sh/api/machine/v1alpha1"
 	networkapi "kraftkit.sh/api/network/v1alpha1"
 	volumeapi "kraftkit.sh/api/volume/v1alpha1"
+	"kraftkit.sh/config"
 	machinename "kraftkit.sh/machine/name"
 	"kraftkit.sh/machine/volume"
 )
@@ -117,7 +118,7 @@ func (opts *Run) assignName(ctx context.Context, machine *machineapi.Machine) er
 }
 
 // Was a volume specified? E.g. --volume=path:path
-func (opts *Run) parseVolumes(ctx context.Context, machine *machineapi.Machine) error {
+func (opts *Run) parseVolumes(ctx context.Context, machine *machineapi.Machine, cfg *config.KraftKit) error {
 	if len(opts.Volumes) == 0 {
 		return nil
 	}
@@ -138,7 +139,7 @@ func (opts *Run) parseVolumes(ctx context.Context, machine *machineapi.Machine) 
 
 		var driver string
 
-		for sname, strategy := range volume.Strategies() {
+		for sname, strategy := range volume.Strategies(cfg) {
 			if ok, _ := strategy.IsCompatible(hostPath, nil); !ok || err != nil {
 				continue
 			}

--- a/cmd/kraft/set/set.go
+++ b/cmd/kraft/set/set.go
@@ -40,6 +40,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"kraftkit.sh/cmdfactory"
+	"kraftkit.sh/config"
 	"kraftkit.sh/packmanager"
 	"kraftkit.sh/unikraft/app"
 )
@@ -49,7 +50,7 @@ type Set struct {
 	Workdir   string `long:"workdir" short:"w" usage:"Work on a unikernel at a path"`
 }
 
-func New() *cobra.Command {
+func New(cfg *config.ConfigManager[config.KraftKit]) *cobra.Command {
 	cmd, err := cmdfactory.New(&Set{}, cobra.Command{
 		Short:   "Set a variable for a Unikraft project",
 		Hidden:  true,
@@ -66,7 +67,7 @@ func New() *cobra.Command {
 		Annotations: map[string]string{
 			cmdfactory.AnnotationHelpGroup: "build",
 		},
-	})
+	}, cfg)
 	if err != nil {
 		panic(err)
 	}
@@ -74,7 +75,7 @@ func New() *cobra.Command {
 	return cmd
 }
 
-func (*Set) Pre(cmd *cobra.Command, _ []string) error {
+func (*Set) Pre(cmd *cobra.Command, _ []string, cfg *config.ConfigManager[config.KraftKit]) error {
 	ctx, err := packmanager.WithDefaultUmbrellaManagerInContext(cmd.Context())
 	if err != nil {
 		return err
@@ -85,7 +86,7 @@ func (*Set) Pre(cmd *cobra.Command, _ []string) error {
 	return nil
 }
 
-func (opts *Set) Run(cmd *cobra.Command, args []string) error {
+func (opts *Set) Run(cmd *cobra.Command, args []string, cfgMgr *config.ConfigManager[config.KraftKit]) error {
 	var err error
 
 	ctx := cmd.Context()

--- a/cmd/kraft/unset/unset.go
+++ b/cmd/kraft/unset/unset.go
@@ -39,6 +39,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"kraftkit.sh/cmdfactory"
+	"kraftkit.sh/config"
 	"kraftkit.sh/packmanager"
 	"kraftkit.sh/unikraft/app"
 )
@@ -47,7 +48,7 @@ type Unset struct {
 	Workdir string `long:"workdir" short:"w" usage:"Work on a unikernel at a path"`
 }
 
-func New() *cobra.Command {
+func New(cfg *config.ConfigManager[config.KraftKit]) *cobra.Command {
 	cmd, err := cmdfactory.New(&Unset{}, cobra.Command{
 		Short:   "Unset a variable for a Unikraft project",
 		Hidden:  true,
@@ -64,7 +65,7 @@ func New() *cobra.Command {
 		Annotations: map[string]string{
 			cmdfactory.AnnotationHelpGroup: "build",
 		},
-	})
+	}, cfg)
 	if err != nil {
 		panic(err)
 	}
@@ -72,7 +73,7 @@ func New() *cobra.Command {
 	return cmd
 }
 
-func (*Unset) Pre(cmd *cobra.Command, _ []string) error {
+func (*Unset) Pre(cmd *cobra.Command, _ []string, cfg *config.ConfigManager[config.KraftKit]) error {
 	ctx, err := packmanager.WithDefaultUmbrellaManagerInContext(cmd.Context())
 	if err != nil {
 		return err
@@ -83,7 +84,7 @@ func (*Unset) Pre(cmd *cobra.Command, _ []string) error {
 	return nil
 }
 
-func (opts *Unset) Run(cmd *cobra.Command, args []string) error {
+func (opts *Unset) Run(cmd *cobra.Command, args []string, cfgMgr *config.ConfigManager[config.KraftKit]) error {
 	var err error
 
 	ctx := cmd.Context()

--- a/cmd/kraft/version/version.go
+++ b/cmd/kraft/version/version.go
@@ -10,13 +10,14 @@ import (
 	"github.com/spf13/cobra"
 
 	"kraftkit.sh/cmdfactory"
+	"kraftkit.sh/config"
 	"kraftkit.sh/internal/version"
 	"kraftkit.sh/iostreams"
 )
 
 type Version struct{}
 
-func New() *cobra.Command {
+func New(cfg *config.ConfigManager[config.KraftKit]) *cobra.Command {
 	cmd, err := cmdfactory.New(&Version{}, cobra.Command{
 		Short:   "Show kraft version information",
 		Use:     "version",
@@ -25,7 +26,7 @@ func New() *cobra.Command {
 		Annotations: map[string]string{
 			cmdfactory.AnnotationHelpGroup: "misc",
 		},
-	})
+	}, cfg)
 	if err != nil {
 		panic(err)
 	}
@@ -33,7 +34,7 @@ func New() *cobra.Command {
 	return cmd
 }
 
-func (opts *Version) Run(cmd *cobra.Command, _ []string) error {
+func (opts *Version) Run(cmd *cobra.Command, _ []string, cfgMgr *config.ConfigManager[config.KraftKit]) error {
 	fmt.Fprintf(iostreams.G(cmd.Context()).Out, "kraft %s", version.String())
 	return nil
 }

--- a/cmd/runu/delete/delete.go
+++ b/cmd/runu/delete/delete.go
@@ -12,6 +12,7 @@ import (
 	"golang.org/x/sys/unix"
 
 	"kraftkit.sh/cmdfactory"
+	"kraftkit.sh/config"
 	libcontainer "kraftkit.sh/libmocktainer"
 	"kraftkit.sh/log"
 )
@@ -25,13 +26,13 @@ type Delete struct {
 	Force bool `long:"force" short:"f" usage:"forcibly delete the unikernel if it is still running"`
 }
 
-func New() *cobra.Command {
+func New(cfg *config.ConfigManager[config.KraftKit]) *cobra.Command {
 	cmd, err := cmdfactory.New(&Delete{}, cobra.Command{
 		Short: "Delete a unikernel",
 		Args:  cobra.ExactArgs(1),
 		Use:   "delete <unikernel-id>",
 		Long:  "The delete command deletes any resources held by a unikernel.",
-	})
+	}, cfg)
 	if err != nil {
 		panic(err)
 	}
@@ -39,7 +40,7 @@ func New() *cobra.Command {
 	return cmd
 }
 
-func (opts *Delete) Run(cmd *cobra.Command, args []string) (retErr error) {
+func (opts *Delete) Run(cmd *cobra.Command, args []string, cfgMgr *config.ConfigManager[config.KraftKit]) (retErr error) {
 	ctx := cmd.Context()
 
 	defer func() {

--- a/cmd/runu/kill/kill.go
+++ b/cmd/runu/kill/kill.go
@@ -14,6 +14,7 @@ import (
 	"golang.org/x/sys/unix"
 
 	"kraftkit.sh/cmdfactory"
+	"kraftkit.sh/config"
 	libcontainer "kraftkit.sh/libmocktainer"
 	"kraftkit.sh/log"
 )
@@ -30,13 +31,13 @@ type Kill struct {
 	All bool `long:"all" short:"a" usage:"send the specified signal to all processes"`
 }
 
-func New() *cobra.Command {
+func New(cfg *config.ConfigManager[config.KraftKit]) *cobra.Command {
 	cmd, err := cmdfactory.New(&Kill{}, cobra.Command{
 		Short: "Send a signal to a unikernel",
 		Args:  cobra.RangeArgs(1, 2),
 		Use:   "kill <unikernel-id> [signal]",
 		Long:  "The kill command sends a signal to a unikernel.  If the signal is not specified, SIGTERM is sent.",
-	})
+	}, cfg)
 	if err != nil {
 		panic(err)
 	}
@@ -44,7 +45,7 @@ func New() *cobra.Command {
 	return cmd
 }
 
-func (opts *Kill) Run(cmd *cobra.Command, args []string) (retErr error) {
+func (opts *Kill) Run(cmd *cobra.Command, args []string, cfgMgr *config.ConfigManager[config.KraftKit]) (retErr error) {
 	ctx := cmd.Context()
 
 	defer func() {

--- a/cmd/runu/ps/ps.go
+++ b/cmd/runu/ps/ps.go
@@ -16,6 +16,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"kraftkit.sh/cmdfactory"
+	"kraftkit.sh/config"
 	libcontainer "kraftkit.sh/libmocktainer"
 	"kraftkit.sh/log"
 )
@@ -31,13 +32,13 @@ type Ps struct {
 	Format string `long:"format" short:"f" usage:"format of the output (table or json)" default:"table"`
 }
 
-func New() *cobra.Command {
+func New(cfg *config.ConfigManager[config.KraftKit]) *cobra.Command {
 	cmd, err := cmdfactory.New(&Ps{}, cobra.Command{
 		Short: "Displays the VMM process of a unikernel",
 		Args:  cobra.MinimumNArgs(1),
 		Use:   "ps <unikernel-id> [ps options]",
 		Long:  "The ps command displays the VMM process that runs a unikernel.",
-	})
+	}, cfg)
 	if err != nil {
 		panic(err)
 	}
@@ -45,7 +46,7 @@ func New() *cobra.Command {
 	return cmd
 }
 
-func (opts *Ps) Run(cmd *cobra.Command, args []string) (retErr error) {
+func (opts *Ps) Run(cmd *cobra.Command, args []string, cfgMgr *config.ConfigManager[config.KraftKit]) (retErr error) {
 	ctx := cmd.Context()
 
 	defer func() {

--- a/cmd/runu/start/start.go
+++ b/cmd/runu/start/start.go
@@ -10,6 +10,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"kraftkit.sh/cmdfactory"
+	"kraftkit.sh/config"
 	libcontainer "kraftkit.sh/libmocktainer"
 	"kraftkit.sh/log"
 )
@@ -21,13 +22,13 @@ const (
 // Start implements the OCI "start" command.
 type Start struct{}
 
-func New() *cobra.Command {
+func New(cfg *config.ConfigManager[config.KraftKit]) *cobra.Command {
 	cmd, err := cmdfactory.New(&Start{}, cobra.Command{
 		Short: "Start a unikernel",
 		Args:  cobra.ExactArgs(1),
 		Use:   "start <unikernel-id>",
 		Long:  "The start command starts a created unikernel.",
-	})
+	}, cfg)
 	if err != nil {
 		panic(err)
 	}
@@ -35,7 +36,7 @@ func New() *cobra.Command {
 	return cmd
 }
 
-func (opts *Start) Run(cmd *cobra.Command, args []string) (retErr error) {
+func (opts *Start) Run(cmd *cobra.Command, args []string, cfgMgr *config.ConfigManager[config.KraftKit]) (retErr error) {
 	ctx := cmd.Context()
 
 	defer func() {

--- a/cmd/runu/state/state.go
+++ b/cmd/runu/state/state.go
@@ -14,6 +14,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"kraftkit.sh/cmdfactory"
+	"kraftkit.sh/config"
 	libcontainer "kraftkit.sh/libmocktainer"
 	"kraftkit.sh/log"
 )
@@ -25,13 +26,13 @@ const (
 // State implements the OCI "state" command.
 type State struct{}
 
-func New() *cobra.Command {
+func New(cfg *config.ConfigManager[config.KraftKit]) *cobra.Command {
 	cmd, err := cmdfactory.New(&State{}, cobra.Command{
 		Short: "Output the state of a unikernel",
 		Args:  cobra.ExactArgs(1),
 		Use:   "state <unikernel-id>",
 		Long:  "The state command outputs current state information for a unikernel.",
-	})
+	}, cfg)
 	if err != nil {
 		panic(err)
 	}
@@ -39,7 +40,7 @@ func New() *cobra.Command {
 	return cmd
 }
 
-func (opts *State) Run(cmd *cobra.Command, args []string) (retErr error) {
+func (opts *State) Run(cmd *cobra.Command, args []string, cfgMgr *config.ConfigManager[config.KraftKit]) (retErr error) {
 	ctx := cmd.Context()
 
 	defer func() {

--- a/internal/bootstrap/init.go
+++ b/internal/bootstrap/init.go
@@ -10,6 +10,7 @@ import (
 	"context"
 
 	"kraftkit.sh/api"
+	"kraftkit.sh/config"
 	"kraftkit.sh/machine/qemu"
 	"kraftkit.sh/manifest"
 	"kraftkit.sh/oci"
@@ -20,14 +21,14 @@ import (
 // InitKraftkit performs a set of kraftkit setup steps.
 // It allows us to move away from in-package init() magic.
 // It also allows us to propagate initialization errors easily.
-func InitKraftkit(ctx context.Context) error {
+func InitKraftkit(ctx context.Context, cfg *config.KraftKit) error {
 	registerAdditionalFlags()
 
 	if err := registerSchemes(); err != nil {
 		return err
 	}
 
-	return registerPackageManagers(ctx)
+	return registerPackageManagers(ctx, cfg)
 }
 
 func registerAdditionalFlags() {
@@ -40,11 +41,11 @@ func registerSchemes() error {
 	return api.RegisterSchemes()
 }
 
-func registerPackageManagers(ctx context.Context) error {
+func registerPackageManagers(ctx context.Context, cfg *config.KraftKit) error {
 	managerConstructors := []func(u *packmanager.UmbrellaManager) error{
-		oci.RegisterPackageManager(),
+		oci.RegisterPackageManager(cfg),
 		manifest.RegisterPackageManager(),
 	}
 
-	return packmanager.InitUmbrellaManager(ctx, managerConstructors)
+	return packmanager.InitUmbrellaManager(ctx, cfg, managerConstructors)
 }

--- a/machine/firecracker/v1alpha1.go
+++ b/machine/firecracker/v1alpha1.go
@@ -70,7 +70,7 @@ func NewMachineV1alpha1Service(ctx context.Context, opts ...any) (machinev1alpha
 }
 
 // Create implements kraftkit.sh/api/machine/v1alpha1.MachineService.Create
-func (service *machineV1alpha1Service) Create(ctx context.Context, machine *machinev1alpha1.Machine) (*machinev1alpha1.Machine, error) {
+func (service *machineV1alpha1Service) Create(ctx context.Context, cfg *config.KraftKit, machine *machinev1alpha1.Machine) (*machinev1alpha1.Machine, error) {
 	// Start with fail-safe checks for unsupported specification declarations.
 	if len(machine.Spec.Ports) > 0 {
 		return machine, fmt.Errorf("kraftkit does not yet support port forwarding to firecracker (contributions welcome): please use a network instead")
@@ -91,7 +91,7 @@ func (service *machineV1alpha1Service) Create(ctx context.Context, machine *mach
 	machine.Status.State = machinev1alpha1.MachineStateUnknown
 
 	if len(machine.Status.StateDir) == 0 {
-		machine.Status.StateDir = filepath.Join(config.G[config.KraftKit](ctx).RuntimeDir, string(machine.ObjectMeta.UID))
+		machine.Status.StateDir = filepath.Join(cfg.RuntimeDir, string(machine.ObjectMeta.UID))
 	}
 
 	if err := os.MkdirAll(machine.Status.StateDir, fs.ModeSetgid|0o775); err != nil {

--- a/machine/network/register_linux.go
+++ b/machine/network/register_linux.go
@@ -18,7 +18,7 @@ import (
 
 // hostSupportedStrategies returns the map of known supported drivers for the
 // given host.
-func hostSupportedStrategies() map[string]*Strategy {
+func hostSupportedStrategies(cfg *config.KraftKit) map[string]*Strategy {
 	return map[string]*Strategy{
 		"bridge": {
 			NewNetworkV1alpha1: func(ctx context.Context, opts ...any) (networkv1alpha1.NetworkService, error) {
@@ -29,7 +29,7 @@ func hostSupportedStrategies() map[string]*Strategy {
 
 				embeddedStore, err := store.NewEmbeddedStore[networkv1alpha1.NetworkSpec, networkv1alpha1.NetworkStatus](
 					filepath.Join(
-						config.G[config.KraftKit](ctx).RuntimeDir,
+						cfg.RuntimeDir,
 						"networkv1alpha1",
 					),
 				)

--- a/machine/network/service.go
+++ b/machine/network/service.go
@@ -8,6 +8,7 @@ import (
 	"context"
 
 	networkv1alpha1 "kraftkit.sh/api/network/v1alpha1"
+	"kraftkit.sh/config"
 )
 
 // NewStrategyConstructor is a prototype for the instantiation function of a
@@ -27,8 +28,8 @@ type Strategy struct {
 }
 
 // Strategies returns the list of registered platform implementations.
-func Strategies() map[string]*Strategy {
-	base := hostSupportedStrategies()
+func Strategies(cfg *config.KraftKit) map[string]*Strategy {
+	base := hostSupportedStrategies(cfg)
 	for name, driverInfo := range strategies {
 		base[name] = driverInfo
 	}
@@ -38,9 +39,9 @@ func Strategies() map[string]*Strategy {
 
 // DriverNames returns the list of registered platform driver implementation
 // names.
-func DriverNames() []string {
+func DriverNames(cfg *config.KraftKit) []string {
 	ret := []string{}
-	for plat := range Strategies() {
+	for plat := range Strategies(cfg) {
 		ret = append(ret, plat)
 	}
 

--- a/machine/platform/iterator_v1alpha1.go
+++ b/machine/platform/iterator_v1alpha1.go
@@ -12,6 +12,7 @@ import (
 	"github.com/acorn-io/baaah/pkg/merr"
 
 	machinev1alpha1 "kraftkit.sh/api/machine/v1alpha1"
+	"kraftkit.sh/config"
 )
 
 type machineV1alpha1ServiceIterator struct {
@@ -23,14 +24,14 @@ type machineV1alpha1ServiceIterator struct {
 // each supported host platform and calls the representing method.  This is
 // useful in circumstances where the platform is not supplied.  The first
 // platform strategy to succeed is returned in all circumstances.
-func NewMachineV1alpha1ServiceIterator(ctx context.Context) (machinev1alpha1.MachineService, error) {
+func NewMachineV1alpha1ServiceIterator(ctx context.Context, cfg *config.KraftKit) (machinev1alpha1.MachineService, error) {
 	var err error
 	iterator := machineV1alpha1ServiceIterator{
 		strategies: map[Platform]machinev1alpha1.MachineService{},
 	}
 
 	for platform, strategy := range hostSupportedStrategies() {
-		iterator.strategies[platform], err = strategy.NewMachineV1alpha1(ctx)
+		iterator.strategies[platform], err = strategy.NewMachineV1alpha1(ctx, cfg)
 		if err != nil {
 			return nil, err
 		}
@@ -40,11 +41,11 @@ func NewMachineV1alpha1ServiceIterator(ctx context.Context) (machinev1alpha1.Mac
 }
 
 // Create implements kraftkit.sh/api/machine/v1alpha1.MachineService
-func (iterator *machineV1alpha1ServiceIterator) Create(ctx context.Context, machine *machinev1alpha1.Machine) (*machinev1alpha1.Machine, error) {
+func (iterator *machineV1alpha1ServiceIterator) Create(ctx context.Context, cfg *config.KraftKit, machine *machinev1alpha1.Machine) (*machinev1alpha1.Machine, error) {
 	var errs []error
 
 	for _, strategy := range iterator.strategies {
-		ret, err := strategy.Create(ctx, machine)
+		ret, err := strategy.Create(ctx, cfg, machine)
 		if err != nil {
 			errs = append(errs, err)
 			continue

--- a/machine/platform/register_unix.go
+++ b/machine/platform/register_unix.go
@@ -19,7 +19,7 @@ import (
 	"kraftkit.sh/machine/store"
 )
 
-var qemuV1alpha1Driver = func(ctx context.Context, opts ...any) (machinev1alpha1.MachineService, error) {
+var qemuV1alpha1Driver = func(ctx context.Context, cfg *config.KraftKit, opts ...any) (machinev1alpha1.MachineService, error) {
 	service, err := qemu.NewMachineV1alpha1Service(ctx, opts...)
 	if err != nil {
 		return nil, err
@@ -27,7 +27,7 @@ var qemuV1alpha1Driver = func(ctx context.Context, opts ...any) (machinev1alpha1
 
 	embeddedStore, err := store.NewEmbeddedStore[machinev1alpha1.MachineSpec, machinev1alpha1.MachineStatus](
 		filepath.Join(
-			config.G[config.KraftKit](ctx).RuntimeDir,
+			cfg.RuntimeDir,
 			"machinev1alpha1",
 		),
 	)
@@ -38,6 +38,7 @@ var qemuV1alpha1Driver = func(ctx context.Context, opts ...any) (machinev1alpha1
 	return machinev1alpha1.NewMachineServiceHandler(
 		ctx,
 		service,
+		cfg,
 		zip.WithStore[machinev1alpha1.MachineSpec, machinev1alpha1.MachineStatus](embeddedStore, zip.StoreRehydrationSpecNil),
 		zip.WithBefore(storePlatformFilter(PlatformQEMU)),
 	)

--- a/machine/platform/strategy.go
+++ b/machine/platform/strategy.go
@@ -9,6 +9,7 @@ import (
 
 	_ "kraftkit.sh/api"
 	machinev1alpha1 "kraftkit.sh/api/machine/v1alpha1"
+	"kraftkit.sh/config"
 )
 
 // strategies contains the map of registered strategies, whether provided as
@@ -18,7 +19,7 @@ var strategies = make(map[Platform]*Strategy)
 
 // NewStrategyConstructor is a prototype for the instantiation function of a
 // platform driver implementation.
-type NewStrategyConstructor[T any] func(context.Context, ...any) (T, error)
+type NewStrategyConstructor[T any] func(context.Context, *config.KraftKit, ...any) (T, error)
 
 // Strategy represents canonical reference of a machine driver and their
 // platform.

--- a/machine/qemu/v1alpha1.go
+++ b/machine/qemu/v1alpha1.go
@@ -64,7 +64,7 @@ func NewMachineV1alpha1Service(ctx context.Context, opts ...any) (machinev1alpha
 }
 
 // Create implements kraftkit.sh/api/machine/v1alpha1.MachineService.Create
-func (service *machineV1alpha1Service) Create(ctx context.Context, machine *machinev1alpha1.Machine) (*machinev1alpha1.Machine, error) {
+func (service *machineV1alpha1Service) Create(ctx context.Context, cfg *config.KraftKit, machine *machinev1alpha1.Machine) (*machinev1alpha1.Machine, error) {
 	if machine.Status.KernelPath == "" {
 		return machine, fmt.Errorf("empty kernel path")
 	}
@@ -136,7 +136,7 @@ func (service *machineV1alpha1Service) Create(ctx context.Context, machine *mach
 	machine.Status.State = machinev1alpha1.MachineStateUnknown
 
 	if len(machine.Status.StateDir) == 0 {
-		machine.Status.StateDir = filepath.Join(config.G[config.KraftKit](ctx).RuntimeDir, string(machine.ObjectMeta.UID))
+		machine.Status.StateDir = filepath.Join(cfg.RuntimeDir, string(machine.ObjectMeta.UID))
 	}
 
 	if err := os.MkdirAll(machine.Status.StateDir, fs.ModeSetgid|0o775); err != nil {

--- a/machine/volume/register_unix.go
+++ b/machine/volume/register_unix.go
@@ -19,7 +19,7 @@ import (
 
 // hostSupportedStrategies returns the map of known supported drivers for the
 // given host.
-func hostSupportedStrategies() map[string]*Strategy {
+func hostSupportedStrategies(cfg *config.KraftKit) map[string]*Strategy {
 	return map[string]*Strategy{
 		"9pfs": {
 			IsCompatible: func(source string, _ kconfig.KeyValueMap) (bool, error) {
@@ -38,7 +38,7 @@ func hostSupportedStrategies() map[string]*Strategy {
 
 				embeddedStore, err := store.NewEmbeddedStore[volumev1alpha1.VolumeSpec, volumev1alpha1.VolumeStatus](
 					filepath.Join(
-						config.G[config.KraftKit](ctx).RuntimeDir,
+						cfg.RuntimeDir,
 						"volumev1alpha1",
 					),
 				)

--- a/machine/volume/strategy.go
+++ b/machine/volume/strategy.go
@@ -8,6 +8,7 @@ import (
 	"context"
 
 	volumev1alpha1 "kraftkit.sh/api/volume/v1alpha1"
+	"kraftkit.sh/config"
 	"kraftkit.sh/kconfig"
 )
 
@@ -28,8 +29,8 @@ type Strategy struct {
 }
 
 // Strategies returns the list of registered platform implementations.
-func Strategies() map[string]*Strategy {
-	base := hostSupportedStrategies()
+func Strategies(cfg *config.KraftKit) map[string]*Strategy {
+	base := hostSupportedStrategies(cfg)
 	for name, driverInfo := range strategies {
 		base[name] = driverInfo
 	}
@@ -39,9 +40,9 @@ func Strategies() map[string]*Strategy {
 
 // DriverNames returns the list of registered platform driver implementation
 // names.
-func DriverNames() []string {
+func DriverNames(cfg *config.KraftKit) []string {
 	ret := []string{}
-	for plat := range Strategies() {
+	for plat := range Strategies(cfg) {
 		ret = append(ret, plat)
 	}
 

--- a/manifest/pack.go
+++ b/manifest/pack.go
@@ -12,6 +12,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"kraftkit.sh/config"
 	"kraftkit.sh/log"
 	"kraftkit.sh/pack"
 	"kraftkit.sh/unikraft"
@@ -102,7 +103,7 @@ func (mp mpack) Pull(ctx context.Context, opts ...pack.PullOption) error {
 }
 
 // Delete deletes the manifest package from host machine.
-func (mp mpack) Delete(ctx context.Context, version string) error {
+func (mp mpack) Delete(ctx context.Context, version string, cfg *config.KraftKit) error {
 	for _, channel := range mp.manifest.Channels {
 		if channel.Name == version && !strings.HasPrefix(channel.Resource, "http") {
 			err := os.RemoveAll(channel.Resource)

--- a/oci/init.go
+++ b/oci/init.go
@@ -5,17 +5,18 @@
 package oci
 
 import (
+	"kraftkit.sh/config"
 	"kraftkit.sh/packmanager"
 )
 
-func RegisterPackageManager() func(u *packmanager.UmbrellaManager) error {
+func RegisterPackageManager(cfg *config.KraftKit) func(u *packmanager.UmbrellaManager) error {
 	return func(u *packmanager.UmbrellaManager) error {
 		return u.RegisterPackageManager(
 			OCIFormat,
 			NewOCIManager,
-			WithDefaultAuth(),
-			WithDefaultRegistries(),
-			WithDetectHandler(),
+			WithDefaultAuth(cfg),
+			WithDefaultRegistries(cfg),
+			WithDetectHandler(cfg),
 		)
 	}
 }

--- a/pack/package.go
+++ b/pack/package.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"fmt"
 
+	"kraftkit.sh/config"
 	"kraftkit.sh/unikraft"
 )
 
@@ -32,7 +33,7 @@ type Package interface {
 	Pull(context.Context, ...PullOption) error
 
 	// Deletes package available locally.
-	Delete(context.Context, string) error
+	Delete(context.Context, string, *config.KraftKit) error
 
 	// Format returns the name of the implementation.
 	Format() PackageFormat

--- a/packmanager/manager.go
+++ b/packmanager/manager.go
@@ -7,6 +7,7 @@ package packmanager
 import (
 	"context"
 
+	"kraftkit.sh/config"
 	"kraftkit.sh/pack"
 	"kraftkit.sh/unikraft/component"
 )
@@ -16,17 +17,17 @@ import (
 // and output during "construction", particularly providing access to a
 // referenceable context with which they can access (within the context of
 // KraftKit) the logging, IOStreams and Config subsystems.
-type NewManagerConstructor func(context.Context, ...any) (PackageManager, error)
+type NewManagerConstructor func(context.Context, *config.KraftKit, ...any) (PackageManager, error)
 
 type PackageManager interface {
 	// Update retrieves and stores locally a cache of the upstream registry.
-	Update(context.Context) error
+	Update(context.Context, *config.KraftKit) error
 
 	// Pack turns the provided component into the distributable package.  Since
 	// components can comprise of other components, it is possible to return more
 	// than one package.  It is possible to disable this and "flatten" a component
 	// into a single package by setting a relevant `pack.PackOption`.
-	Pack(context.Context, component.Component, ...PackOption) ([]pack.Package, error)
+	Pack(context.Context, component.Component, *config.KraftKit, ...PackOption) ([]pack.Package, error)
 
 	// Unpack turns a given package into a usable component.  Since a package can
 	// compromise of a multiple components, it is possible to return multiple
@@ -34,7 +35,7 @@ type PackageManager interface {
 	Unpack(context.Context, pack.Package, ...UnpackOption) ([]component.Component, error)
 
 	// Catalog returns all packages known to the manager via given query
-	Catalog(context.Context, ...QueryOption) ([]pack.Package, error)
+	Catalog(context.Context, *config.KraftKit, ...QueryOption) ([]pack.Package, error)
 
 	// Set the list of sources for the package manager
 	SetSources(context.Context, ...string) error
@@ -43,14 +44,14 @@ type PackageManager interface {
 	AddSource(context.Context, string) error
 
 	// Prune packages from the host machine
-	Prune(context.Context, ...QueryOption) error
+	Prune(context.Context, *config.KraftKit, ...QueryOption) error
 
 	// Remove a source from the package manager
 	RemoveSource(context.Context, string) error
 
 	// IsCompatible checks whether the provided source is compatible with the
 	// package manager
-	IsCompatible(context.Context, string, ...QueryOption) (PackageManager, bool, error)
+	IsCompatible(context.Context, string, *config.KraftKit, ...QueryOption) (PackageManager, bool, error)
 
 	// From is used to retrieve a sub-package manager.  For now, this is a small
 	// hack used for the umbrella.

--- a/tools/github-action/execute.go
+++ b/tools/github-action/execute.go
@@ -26,7 +26,7 @@ import (
 	mplatform "kraftkit.sh/machine/platform"
 )
 
-func (opts *GithubAction) execute(ctx context.Context) error {
+func (opts *GithubAction) execute(ctx context.Context, cfg *config.KraftKit) error {
 	var err error
 
 	if opts.Timeout == 0 {
@@ -43,7 +43,7 @@ func (opts *GithubAction) execute(ctx context.Context) error {
 		return fmt.Errorf("unsupported platform driver: %s (contributions welcome!)", opts.Plat)
 	}
 
-	controller, err := machineStrategy.NewMachineV1alpha1(ctx)
+	controller, err := machineStrategy.NewMachineV1alpha1(ctx, cfg)
 	if err != nil {
 		return err
 	}
@@ -99,7 +99,7 @@ func (opts *GithubAction) execute(ctx context.Context) error {
 		}
 
 		if len(machine.Status.StateDir) == 0 {
-			machine.Status.StateDir = filepath.Join(config.G[config.KraftKit](ctx).RuntimeDir, string(machine.ObjectMeta.UID))
+			machine.Status.StateDir = filepath.Join(cfg.RuntimeDir, string(machine.ObjectMeta.UID))
 		}
 
 		if err := os.MkdirAll(machine.Status.StateDir, 0o755); err != nil {
@@ -145,7 +145,7 @@ func (opts *GithubAction) execute(ctx context.Context) error {
 	}
 
 	// Create the machine
-	machine, err = controller.Create(ctx, machine)
+	machine, err = controller.Create(ctx, cfg, machine)
 	if err != nil {
 		return err
 	}

--- a/tools/github-action/pack.go
+++ b/tools/github-action/pack.go
@@ -8,13 +8,14 @@ import (
 	"context"
 	"strings"
 
+	"kraftkit.sh/config"
 	"kraftkit.sh/pack"
 	"kraftkit.sh/packmanager"
 	"kraftkit.sh/unikraft"
 )
 
 // pack
-func (opts *GithubAction) packAndPush(ctx context.Context) error {
+func (opts *GithubAction) packAndPush(ctx context.Context, cfg *config.KraftKit) error {
 	output := opts.Output
 	var format pack.PackageFormat
 	if strings.Contains(opts.Output, "://") {
@@ -48,7 +49,7 @@ func (opts *GithubAction) packAndPush(ctx context.Context) error {
 		)
 	}
 
-	packs, err := pm.Pack(ctx, opts.target, popts...)
+	packs, err := pm.Pack(ctx, opts.target, cfg, popts...)
 	if err != nil {
 		return err
 	}

--- a/tools/github-action/pull.go
+++ b/tools/github-action/pull.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"os"
 
+	"kraftkit.sh/config"
 	"kraftkit.sh/iostreams"
 	"kraftkit.sh/pack"
 	"kraftkit.sh/packmanager"
@@ -17,8 +18,8 @@ import (
 
 // pull updates the package index and retrieves missing components necessary for
 // performing the build.
-func (opts *GithubAction) pull(ctx context.Context) error {
-	if err := packmanager.G(ctx).Update(ctx); err != nil {
+func (opts *GithubAction) pull(ctx context.Context, cfg *config.KraftKit) error {
+	if err := packmanager.G(ctx).Update(ctx, cfg); err != nil {
 		return fmt.Errorf("could not update package index: %w", err)
 	}
 
@@ -56,6 +57,7 @@ func (opts *GithubAction) pull(ctx context.Context) error {
 		}
 
 		p, err := packmanager.G(ctx).Catalog(ctx,
+			cfg,
 			packmanager.WithName(component.Name()),
 			packmanager.WithTypes(component.Type()),
 			packmanager.WithVersion(component.Version()),


### PR DESCRIPTION
### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [x] Updated relevant documentation.

### Description of changes

Switch from using the context based config accessor towards dependency injection.

Changes the architecture a bit so that config data flow is more explicit.

Left a few todo's, but overall this makes reasoning about config handling a bit easier. Should make unit/integration testing easier. Improves clarity when debugging.

The generic stuff is still around, but we can think whether the added abstractions are worth it and whether using a simpler way would be better.

Another architecture decision point is on what type of the param shall we inject. Perhaps an interface would be better.

The test suite results are equivalent to 2828af22. The app-helloworld target builds and runs.
