### PR TITLE
fix(runu): filter default route for v4 family only

### DIFF
--- a/libmocktainer/unikraft/net_qemu.go
+++ b/libmocktainer/unikraft/net_qemu.go
@@ -121,7 +121,7 @@ func createBridgeMacvtap(name string, parentIdx int) (*netlink.Macvtap, error) {
 // defaultRoute returns the default route for the current namespace.
 func defaultRoute() (*netlink.Route, error) {
 	defaultRouteFilter := &netlink.Route{Dst: nil}
-	routes, err := netlink.RouteListFiltered(netlink.FAMILY_ALL, defaultRouteFilter, netlink.RT_FILTER_DST)
+	routes, err := netlink.RouteListFiltered(netlink.FAMILY_V4, defaultRouteFilter, netlink.RT_FILTER_DST)
 	if err != nil {
 		return nil, fmt.Errorf("listing default net routes: %w", err)
 	}


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

Filtering the default route using `netlink.FAMILY_ALL` yields an empty list of routes on hosts which only have ipv4 enabled. This results in the network setup being silently ignored.

`netlink.FAMILY_ALL` is anyway the wrong choice here because we only return ipv4 addresses inside `netlinkAddress()`:
https://github.com/unikraft/kraftkit/blob/89c0b5c8f888bede5a05fadab9d45c3d68c8daf8/libmocktainer/unikraft/net_qemu.go#L141-L142