### PR TITLE
fix(ci): linter disable-all does not disable all

### DIFF
--- a/.github/workflows/gochecks.yaml
+++ b/.github/workflows/gochecks.yaml
@@ -63,7 +63,7 @@ jobs:
         uses: golangci/golangci-lint-action@v3
         with:
           version: v1.53.3
-          args: --disable-all --enable=gofumpt --out-format=colored-line-number
+          args: --no-config --disable-all --enable=gofumpt --out-format=colored-line-number
           skip-cache: true
 
       - name: golangci-lint


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

`--disable-all` has a counter intuitive behaviour when a golangci-lint config file exists inside the project.
Instead of actually disabling all linters, the configuration from flags is _merged_ with the one from the config, so linters enabled in the config are still being run.