### PR TITLE
fix(pkg): Add `--force` flag to sourcing and prevent check on unsourcing

### DIFF
--- a/cmd/kraft/pkg/source/source.go
+++ b/cmd/kraft/pkg/source/source.go
@@ -16,7 +16,9 @@ import (
 	"kraftkit.sh/packmanager"
 )
 
-type Source struct{}
+type Source struct {
+	Force bool `short:"F" long:"force" usage:"Do not run a compatibility test before sourcing."`
+}
 
 func New() *cobra.Command {
 	cmd, err := cmdfactory.New(&Source{}, cobra.Command{
@@ -58,11 +60,13 @@ func (opts *Source) Run(cmd *cobra.Command, args []string) error {
 	ctx := cmd.Context()
 
 	for _, source := range args {
-		_, compatible, err := packmanager.G(ctx).IsCompatible(ctx, source)
-		if err != nil {
-			return err
-		} else if !compatible {
-			return errors.New("incompatible package manager")
+		if !opts.Force {
+			_, compatible, err := packmanager.G(ctx).IsCompatible(ctx, source)
+			if err != nil {
+				return err
+			} else if !compatible {
+				return errors.New("incompatible package manager")
+			}
 		}
 
 		for _, manifest := range config.G[config.KraftKit](ctx).Unikraft.Manifests {

--- a/cmd/kraft/pkg/unsource/unsource.go
+++ b/cmd/kraft/pkg/unsource/unsource.go
@@ -7,8 +7,6 @@
 package unsource
 
 import (
-	"errors"
-
 	"github.com/MakeNowJust/heredoc"
 	"github.com/spf13/cobra"
 
@@ -58,13 +56,6 @@ func (*Unsource) Pre(cmd *cobra.Command, _ []string) error {
 func (opts *Unsource) Run(cmd *cobra.Command, args []string) error {
 	ctx := cmd.Context()
 	for _, source := range args {
-		_, compatible, err := packmanager.G(ctx).IsCompatible(ctx, source)
-		if err != nil {
-			return err
-		} else if !compatible {
-			return errors.New("incompatible package manager")
-		}
-
 		manifests := []string{}
 
 		var manifestRemoved bool

--- a/test/e2e/cli/pkg_source_test.go
+++ b/test/e2e/cli/pkg_source_test.go
@@ -62,6 +62,7 @@ var _ = Describe("kraft pkg", func() {
 					Expect(err).ToNot(HaveOccurred())
 				})
 				It("should create the config file, add the default manifests, and the new link, and print nothing", func() {
+					cmd.Args = append(cmd.Args, "--force")
 					cmd.Args = append(cmd.Args, "https://example.com")
 					err := cmd.Run()
 					if err != nil {
@@ -130,6 +131,7 @@ var _ = Describe("kraft pkg", func() {
 					oldArgs := make([]string, len(cmd.Args))
 					copy(oldArgs, cmd.Args)
 
+					cmd.Args = append(cmd.Args, "--force")
 					cmd.Args = append(cmd.Args, "https://example1.com")
 					err := cmd.Run()
 					if err != nil {
@@ -147,6 +149,7 @@ var _ = Describe("kraft pkg", func() {
 				})
 
 				It("should leave the config file intact, add the new link, and print nothing", func() {
+					cmd.Args = append(cmd.Args, "--force")
 					cmd.Args = append(cmd.Args, "https://example2.com")
 					err := cmd.Run()
 					if err != nil {
@@ -270,6 +273,7 @@ var _ = Describe("kraft pkg", func() {
 		Context("sourcing multiple links in the config file", func() {
 			When("the config file was already present, and all links are unique", func() {
 				It("should add all links and print nothing", func() {
+					cmd.Args = append(cmd.Args, "--force")
 					cmd.Args = append(cmd.Args, "https://example1.com")
 					cmd.Args = append(cmd.Args, "https://example2.com")
 					cmd.Args = append(cmd.Args, "https://example3.com")
@@ -339,6 +343,7 @@ var _ = Describe("kraft pkg", func() {
 
 			When("the config file was already present, and a link is duplicate", func() {
 				It("should add links until the first error is met", func() {
+					cmd.Args = append(cmd.Args, "--force")
 					cmd.Args = append(cmd.Args, "https://example.com")
 					cmd.Args = append(cmd.Args, "https://example.com")
 					cmd.Args = append(cmd.Args, "https://example2.com")

--- a/test/e2e/cli/pkg_unsource_test.go
+++ b/test/e2e/cli/pkg_unsource_test.go
@@ -271,6 +271,8 @@ var _ = Describe("kraft pkg", func() {
 							break
 						}
 					}
+
+					cmd.Args = append(cmd.Args, "--force")
 					cmd.Args = append(cmd.Args, "https://example1.com")
 					cmd.Args = append(cmd.Args, "https://example2.com")
 					cmd.Args = append(cmd.Args, "https://example3.com")
@@ -363,6 +365,8 @@ var _ = Describe("kraft pkg", func() {
 							break
 						}
 					}
+
+					cmd.Args = append(cmd.Args, "--force")
 					cmd.Args = append(cmd.Args, "https://example1.com")
 					cmd.Args = append(cmd.Args, "https://example2.com")
 					cmd.Args = append(cmd.Args, "https://example3.com")


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

This commit fixes an issue whereby the user will have the compatibility of a source checked before the source is saved to config.  To prevent this check, a new `kraft pkg source --force` flag is added which prevents this check.

Inversely, when a source is being removed from `kraft pkg unsource`, its compatibility does not need to be checked because it is being removed, not only is this less computation but if the source was manually added by hand and it was invalid, it would be impossible to remove.

This commit also updates relevant tests which are impacted by this change.  Specifically, tests that use a obviously fake source for testing purposes, the `--force` command is now utilized to ignore what would otherwise error.