### PR TITLE
feat(e2e): Add common method for outputting command error

### DIFF
--- a/test/e2e/cli/net_create_test.go
+++ b/test/e2e/cli/net_create_test.go
@@ -56,7 +56,7 @@ var _ = Describe("kraft net create", func() {
 		It("should print the command's help", func() {
 			err := cmd.Run()
 			if err != nil {
-				fmt.Printf("Error running command, dumping output:\n%s\n%s\n%s\n", err, stderr, stdout)
+				fmt.Print(cmd.DumpError(stdout, stderr, err))
 			}
 			Expect(err).ToNot(HaveOccurred())
 
@@ -172,7 +172,7 @@ var _ = Describe("kraft net create", func() {
 
 			err := cmdRm.Run()
 			if err != nil {
-				fmt.Printf("Error running command, dumping output:\n%s\n%s\n%s\n", err, stderr, stdout)
+				fmt.Print(cmd.DumpError(stdout, stderr, err))
 			}
 			Expect(err).ToNot(HaveOccurred())
 		})
@@ -180,7 +180,7 @@ var _ = Describe("kraft net create", func() {
 		It("should create the network, print the network name, and exit", func() {
 			err := cmd.Run()
 			if err != nil {
-				fmt.Printf("Error running command, dumping output:\n%s\n%s\n%s\n", err, stderr, stdout)
+				fmt.Print(cmd.DumpError(stdout, stderr, err))
 			}
 			Expect(err).ToNot(HaveOccurred())
 			Expect(stderr.String()).To(BeEmpty())
@@ -194,7 +194,7 @@ var _ = Describe("kraft net create", func() {
 			err = cmdLs.Run()
 
 			if err != nil {
-				fmt.Printf("Error running command, dumping output:\n%s\n%s\n%s\n", err, stderr, stdout)
+				fmt.Print(cmd.DumpError(stdout, stderr, err))
 			}
 			Expect(err).ToNot(HaveOccurred())
 			Expect(stderrLs.String()).To(BeEmpty())

--- a/test/e2e/cli/net_down_test.go
+++ b/test/e2e/cli/net_down_test.go
@@ -78,7 +78,7 @@ var _ = Describe("kraft net down", func() {
 
 			err := cmdCreate.Run()
 			if err != nil {
-				fmt.Printf("Error running command, dumping output:\n%s\n%s\n%s\n", err, stderr, stdout)
+				fmt.Print(cmd.DumpError(stdout, stderr, err))
 			}
 			Expect(err).ToNot(HaveOccurred())
 			Expect(stderrCreate.String()).To(BeEmpty())
@@ -95,7 +95,7 @@ var _ = Describe("kraft net down", func() {
 
 			err := cmdRm.Run()
 			if err != nil {
-				fmt.Printf("Error running command, dumping output:\n%s\n%s\n%s\n", err, stderr, stdout)
+				fmt.Print(cmd.DumpError(stdout, stderr, err))
 			}
 			Expect(err).ToNot(HaveOccurred())
 		})
@@ -103,7 +103,7 @@ var _ = Describe("kraft net down", func() {
 		It("should bring the network down and print its name", func() {
 			err := cmd.Run()
 			if err != nil {
-				fmt.Printf("Error running command, dumping output:\n%s\n%s\n%s\n", err, stderr, stdout)
+				fmt.Print(cmd.DumpError(stdout, stderr, err))
 			}
 			Expect(err).ToNot(HaveOccurred())
 			Expect(stderr.String()).To(BeEmpty())
@@ -118,7 +118,7 @@ var _ = Describe("kraft net down", func() {
 			err = cmdLs.Run()
 
 			if err != nil {
-				fmt.Printf("Error running command, dumping output:\n%s\n%s\n%s\n", err, stderr, stdout)
+				fmt.Print(cmd.DumpError(stdout, stderr, err))
 			}
 			Expect(err).ToNot(HaveOccurred())
 			Expect(stderrLs.String()).To(BeEmpty())
@@ -135,7 +135,7 @@ var _ = Describe("kraft net down", func() {
 		It("should print the command's help", func() {
 			err := cmd.Run()
 			if err != nil {
-				fmt.Printf("Error running command, dumping output:\n%s\n%s\n%s\n", err, stderr, stdout)
+				fmt.Print(cmd.DumpError(stdout, stderr, err))
 			}
 			Expect(err).ToNot(HaveOccurred())
 

--- a/test/e2e/cli/net_inspect_test.go
+++ b/test/e2e/cli/net_inspect_test.go
@@ -79,7 +79,7 @@ var _ = Describe("kraft net inspect", func() {
 
 			err := cmdCreate.Run()
 			if err != nil {
-				fmt.Printf("Error running command, dumping output:\n%s\n%s\n%s\n", err, stderr, stdout)
+				fmt.Print(cmd.DumpError(stdout, stderr, err))
 			}
 			Expect(err).ToNot(HaveOccurred())
 			Expect(stderrCreate.String()).To(BeEmpty())
@@ -96,7 +96,7 @@ var _ = Describe("kraft net inspect", func() {
 			cmdRm.Args = append(cmdRm.Args, "net", "rm", "test-inspect-1")
 			err := cmdRm.Run()
 			if err != nil {
-				fmt.Printf("Error running command, dumping output:\n%s\n%s\n%s\n", err, stderr, stdout)
+				fmt.Print(cmd.DumpError(stdout, stderr, err))
 			}
 			Expect(err).ToNot(HaveOccurred())
 		})
@@ -104,7 +104,7 @@ var _ = Describe("kraft net inspect", func() {
 		It("should print a detailed, valid, json for the interface", func() {
 			err := cmd.Run()
 			if err != nil {
-				fmt.Printf("Error running command, dumping output:\n%s\n%s\n%s\n", err, stderr, stdout)
+				fmt.Print(cmd.DumpError(stdout, stderr, err))
 			}
 			Expect(err).ToNot(HaveOccurred())
 			Expect(stderr.String()).To(BeEmpty())
@@ -113,7 +113,7 @@ var _ = Describe("kraft net inspect", func() {
 			inspectData := make(map[string]interface{})
 			err = json.Unmarshal([]byte(stdout.String()), &inspectData)
 			if err != nil {
-				fmt.Printf("Error running command, dumping output:\n%s\n%s\n%s\n", err, stderr, stdout)
+				fmt.Print(cmd.DumpError(stdout, stderr, err))
 			}
 			Expect(err).ToNot(HaveOccurred())
 
@@ -132,7 +132,7 @@ var _ = Describe("kraft net inspect", func() {
 		It("should print the command's help", func() {
 			err := cmd.Run()
 			if err != nil {
-				fmt.Printf("Error running command, dumping output:\n%s\n%s\n%s\n", err, stderr, stdout)
+				fmt.Print(cmd.DumpError(stdout, stderr, err))
 			}
 			Expect(err).ToNot(HaveOccurred())
 

--- a/test/e2e/cli/net_ls_test.go
+++ b/test/e2e/cli/net_ls_test.go
@@ -65,7 +65,7 @@ var _ = Describe("kraft net ls", func() {
 
 			err := cmdCreate.Run()
 			if err != nil {
-				fmt.Printf("Error running command, dumping output:\n%s\n%s\n%s\n", err, stderr, stdout)
+				fmt.Print(cmd.DumpError(stdout, stderr, err))
 			}
 			Expect(err).ToNot(HaveOccurred())
 			Expect(stderr.String()).To(BeEmpty())
@@ -83,7 +83,7 @@ var _ = Describe("kraft net ls", func() {
 
 			err := cmdRm.Run()
 			if err != nil {
-				fmt.Printf("Error running command, dumping output:\n%s\n%s\n%s\n", err, stderr, stdout)
+				fmt.Print(cmd.DumpError(stdout, stderr, err))
 			}
 			Expect(err).ToNot(HaveOccurred())
 			Expect(stderrRm.String()).To(BeEmpty())
@@ -92,7 +92,7 @@ var _ = Describe("kraft net ls", func() {
 		It("should print a table of networks and exit", func() {
 			err := cmd.Run()
 			if err != nil {
-				fmt.Printf("Error running command, dumping output:\n%s\n%s\n%s\n", err, stderr, stdout)
+				fmt.Print(cmd.DumpError(stdout, stderr, err))
 			}
 			Expect(err).ToNot(HaveOccurred())
 			Expect(stderr.String()).To(BeEmpty())
@@ -109,7 +109,7 @@ var _ = Describe("kraft net ls", func() {
 		It("should print the command's help", func() {
 			err := cmd.Run()
 			if err != nil {
-				fmt.Printf("Error running command, dumping output:\n%s\n%s\n%s\n", err, stderr, stdout)
+				fmt.Print(cmd.DumpError(stdout, stderr, err))
 			}
 			Expect(err).ToNot(HaveOccurred())
 

--- a/test/e2e/cli/net_rm_test.go
+++ b/test/e2e/cli/net_rm_test.go
@@ -71,7 +71,7 @@ var _ = Describe("kraft net rm", func() {
 		It("should print the command's help", func() {
 			err := cmd.Run()
 			if err != nil {
-				fmt.Printf("Error running command, dumping output:\n%s\n%s\n%s\n", err, stderr, stdout)
+				fmt.Print(cmd.DumpError(stdout, stderr, err))
 			}
 			Expect(err).ToNot(HaveOccurred())
 
@@ -93,7 +93,7 @@ var _ = Describe("kraft net rm", func() {
 
 			err := cmdCreate.Run()
 			if err != nil {
-				fmt.Printf("Error running command, dumping output:\n%s\n%s\n%s\n", err, stderr, stdout)
+				fmt.Print(cmd.DumpError(stdout, stderr, err))
 			}
 			Expect(err).ToNot(HaveOccurred())
 			Expect(stderr.String()).To(BeEmpty())
@@ -105,7 +105,7 @@ var _ = Describe("kraft net rm", func() {
 		It("should delete the network, print the network name, and exit", func() {
 			err := cmd.Run()
 			if err != nil {
-				fmt.Printf("Error running command, dumping output:\n%s\n%s\n%s\n", err, stderr, stdout)
+				fmt.Print(cmd.DumpError(stdout, stderr, err))
 			}
 			Expect(err).ToNot(HaveOccurred())
 			Expect(stderr.String()).To(BeEmpty())
@@ -120,7 +120,7 @@ var _ = Describe("kraft net rm", func() {
 			err = cmdLs.Run()
 
 			if err != nil {
-				fmt.Printf("Error running command, dumping output:\n%s\n%s\n%s\n", err, stderr, stdout)
+				fmt.Print(cmd.DumpError(stdout, stderr, err))
 			}
 			Expect(err).ToNot(HaveOccurred())
 			Expect(stderrLs.String()).To(BeEmpty())

--- a/test/e2e/cli/net_up_test.go
+++ b/test/e2e/cli/net_up_test.go
@@ -78,7 +78,7 @@ var _ = Describe("kraft net up", func() {
 
 			err := cmdCreate.Run()
 			if err != nil {
-				fmt.Printf("Error running command, dumping output:\n%s\n%s\n%s\n", err, stderr, stdout)
+				fmt.Print(cmd.DumpError(stdout, stderr, err))
 			}
 			Expect(err).ToNot(HaveOccurred())
 			Expect(stderrCreate.String()).To(BeEmpty())
@@ -94,7 +94,7 @@ var _ = Describe("kraft net up", func() {
 			cmdRm.Args = append(cmdRm.Args, "net", "rm", "test-up-1")
 			err := cmdRm.Run()
 			if err != nil {
-				fmt.Printf("Error running command, dumping output:\n%s\n%s\n%s\n", err, stderr, stdout)
+				fmt.Print(cmd.DumpError(stdout, stderr, err))
 			}
 			Expect(err).ToNot(HaveOccurred())
 		})
@@ -110,7 +110,7 @@ var _ = Describe("kraft net up", func() {
 
 			err := cmdDown.Run()
 			if err != nil {
-				fmt.Printf("Error running command, dumping output:\n%s\n%s\n%s\n", err, stderr, stdout)
+				fmt.Print(cmd.DumpError(stdout, stderr, err))
 			}
 			Expect(err).ToNot(HaveOccurred())
 			Expect(stderrDown.String()).To(BeEmpty())
@@ -125,7 +125,7 @@ var _ = Describe("kraft net up", func() {
 			err = cmdLs.Run()
 
 			if err != nil {
-				fmt.Printf("Error running command, dumping output:\n%s\n%s\n%s\n", err, stderr, stdout)
+				fmt.Print(cmd.DumpError(stdout, stderr, err))
 			}
 			Expect(err).ToNot(HaveOccurred())
 			Expect(stderrLs.String()).To(BeEmpty())
@@ -136,7 +136,7 @@ var _ = Describe("kraft net up", func() {
 			err = cmd.Run()
 
 			if err != nil {
-				fmt.Printf("Error running command, dumping output:\n%s\n%s\n%s\n", err, stderr, stdout)
+				fmt.Print(cmd.DumpError(stdout, stderr, err))
 			}
 			Expect(err).ToNot(HaveOccurred())
 			Expect(stderr.String()).To(BeEmpty())
@@ -150,7 +150,7 @@ var _ = Describe("kraft net up", func() {
 			err = cmdLs.Run()
 
 			if err != nil {
-				fmt.Printf("Error running command, dumping output:\n%s\n%s\n%s\n", err, stderr, stdout)
+				fmt.Print(cmd.DumpError(stdout, stderr, err))
 			}
 			Expect(err).ToNot(HaveOccurred())
 			Expect(stderrLs.String()).To(BeEmpty())
@@ -167,7 +167,7 @@ var _ = Describe("kraft net up", func() {
 		It("should print the command's help", func() {
 			err := cmd.Run()
 			if err != nil {
-				fmt.Printf("Error running command, dumping output:\n%s\n%s\n%s\n", err, stderr, stdout)
+				fmt.Print(cmd.DumpError(stdout, stderr, err))
 			}
 			Expect(err).ToNot(HaveOccurred())
 

--- a/test/e2e/cli/pkg_source_test.go
+++ b/test/e2e/cli/pkg_source_test.go
@@ -48,7 +48,7 @@ var _ = Describe("kraft pkg", func() {
 					// Save the config file by moving it to a temporary location
 					err := os.Rename(cfg.Path(), cfg.Path()+".tmp")
 					if err != nil {
-						fmt.Printf("Error running command, dumping output:\n%s\n%s\n%s\n", err, stderr, stdout)
+						fmt.Print(cmd.DumpError(stdout, stderr, err))
 					}
 					Expect(err).ToNot(HaveOccurred())
 				})
@@ -57,7 +57,7 @@ var _ = Describe("kraft pkg", func() {
 					// Restore the config file
 					err := os.Rename(cfg.Path()+".tmp", cfg.Path())
 					if err != nil {
-						fmt.Printf("Error running command, dumping output:\n%s\n%s\n%s\n", err, stderr, stdout)
+						fmt.Print(cmd.DumpError(stdout, stderr, err))
 					}
 					Expect(err).ToNot(HaveOccurred())
 				})
@@ -65,7 +65,7 @@ var _ = Describe("kraft pkg", func() {
 					cmd.Args = append(cmd.Args, "https://example.com")
 					err := cmd.Run()
 					if err != nil {
-						fmt.Printf("Error running command, dumping output:\n%s\n%s\n%s\n", err, stderr, stdout)
+						fmt.Print(cmd.DumpError(stdout, stderr, err))
 					}
 					Expect(err).ToNot(HaveOccurred())
 					Expect(stderr.String()).To(BeEmpty())
@@ -73,14 +73,14 @@ var _ = Describe("kraft pkg", func() {
 					// Read the config file
 					osFile, err := os.Open(cfg.Path())
 					if err != nil {
-						fmt.Printf("Error running command, dumping output:\n%s\n%s\n%s\n", err, stderr, stdout)
+						fmt.Print(cmd.DumpError(stdout, stderr, err))
 					}
 					Expect(err).ToNot(HaveOccurred())
 					defer osFile.Close()
 
 					osFileInfo, err := osFile.Stat()
 					if err != nil {
-						fmt.Printf("Error running command, dumping output:\n%s\n%s\n%s\n", err, stderr, stdout)
+						fmt.Print(cmd.DumpError(stdout, stderr, err))
 					}
 					Expect(err).ToNot(HaveOccurred())
 
@@ -93,7 +93,7 @@ var _ = Describe("kraft pkg", func() {
 					// Read file content
 					readBytes, err := os.ReadFile(cfg.Path())
 					if err != nil {
-						fmt.Printf("Error running command, dumping output:\n%s\n%s\n%s\n", err, stderr, stdout)
+						fmt.Print(cmd.DumpError(stdout, stderr, err))
 					}
 					Expect(err).ToNot(HaveOccurred())
 
@@ -101,7 +101,7 @@ var _ = Describe("kraft pkg", func() {
 					var cfgMap map[string]interface{}
 					err = yaml.Unmarshal([]byte(readBytes), &cfgMap)
 					if err != nil {
-						fmt.Printf("Error running command, dumping output:\n%s\n%s\n%s\n", err, stderr, stdout)
+						fmt.Print(cmd.DumpError(stdout, stderr, err))
 					}
 					Expect(err).ToNot(HaveOccurred())
 
@@ -133,7 +133,7 @@ var _ = Describe("kraft pkg", func() {
 					cmd.Args = append(cmd.Args, "https://example1.com")
 					err := cmd.Run()
 					if err != nil {
-						fmt.Printf("Error running command, dumping output:\n%s\n%s\n%s\n", err, stderr, stdout)
+						fmt.Print(cmd.DumpError(stdout, stderr, err))
 					}
 					Expect(err).ToNot(HaveOccurred())
 					Expect(stderr.String()).To(BeEmpty())
@@ -150,7 +150,7 @@ var _ = Describe("kraft pkg", func() {
 					cmd.Args = append(cmd.Args, "https://example2.com")
 					err := cmd.Run()
 					if err != nil {
-						fmt.Printf("Error running command, dumping output:\n%s\n%s\n%s\n", err, stderr, stdout)
+						fmt.Print(cmd.DumpError(stdout, stderr, err))
 					}
 					Expect(err).ToNot(HaveOccurred())
 					Expect(stderr.String()).To(BeEmpty())
@@ -158,14 +158,14 @@ var _ = Describe("kraft pkg", func() {
 					// Read the config file
 					osFile, err := os.Open(cfg.Path())
 					if err != nil {
-						fmt.Printf("Error running command, dumping output:\n%s\n%s\n%s\n", err, stderr, stdout)
+						fmt.Print(cmd.DumpError(stdout, stderr, err))
 					}
 					Expect(err).ToNot(HaveOccurred())
 					defer osFile.Close()
 
 					osFileInfo, err := osFile.Stat()
 					if err != nil {
-						fmt.Printf("Error running command, dumping output:\n%s\n%s\n%s\n", err, stderr, stdout)
+						fmt.Print(cmd.DumpError(stdout, stderr, err))
 					}
 					Expect(err).ToNot(HaveOccurred())
 
@@ -178,7 +178,7 @@ var _ = Describe("kraft pkg", func() {
 					// Read file content
 					readBytes, err := os.ReadFile(cfg.Path())
 					if err != nil {
-						fmt.Printf("Error running command, dumping output:\n%s\n%s\n%s\n", err, stderr, stdout)
+						fmt.Print(cmd.DumpError(stdout, stderr, err))
 					}
 					Expect(err).ToNot(HaveOccurred())
 
@@ -186,7 +186,7 @@ var _ = Describe("kraft pkg", func() {
 					var cfgMap map[string]interface{}
 					err = yaml.Unmarshal([]byte(readBytes), &cfgMap)
 					if err != nil {
-						fmt.Printf("Error running command, dumping output:\n%s\n%s\n%s\n", err, stderr, stdout)
+						fmt.Print(cmd.DumpError(stdout, stderr, err))
 					}
 					Expect(err).ToNot(HaveOccurred())
 
@@ -220,7 +220,7 @@ var _ = Describe("kraft pkg", func() {
 					cmd.Args = append(cmd.Args, "https://manifests.kraftkit.sh/index.yaml")
 					err := cmd.Run()
 					if err != nil {
-						fmt.Printf("Error running command, dumping output:\n%s\n%s\n%s\n", err, stderr, stdout)
+						fmt.Print(cmd.DumpError(stdout, stderr, err))
 					}
 					Expect(err).ToNot(HaveOccurred())
 					Expect(stderr.String()).To(BeEmpty())
@@ -228,7 +228,7 @@ var _ = Describe("kraft pkg", func() {
 					// Calculate config file hash
 					bytes, err := os.ReadFile(cfg.Path())
 					if err != nil {
-						fmt.Printf("Error running command, dumping output:\n%s\n%s\n%s\n", err, stderr, stdout)
+						fmt.Print(cmd.DumpError(stdout, stderr, err))
 					}
 					Expect(err).ToNot(HaveOccurred())
 
@@ -246,7 +246,7 @@ var _ = Describe("kraft pkg", func() {
 					err = cmd.Run()
 
 					if err != nil {
-						fmt.Printf("Error running command, dumping output:\n%s\n%s\n%s\n", err, stderr, stdout)
+						fmt.Print(cmd.DumpError(stdout, stderr, err))
 					}
 					Expect(err).ToNot(HaveOccurred())
 					Expect(stderr.String()).To(BeEmpty())
@@ -257,7 +257,7 @@ var _ = Describe("kraft pkg", func() {
 					// Check if the config file was not modified
 					newBytes, err := os.ReadFile(cfg.Path())
 					if err != nil {
-						fmt.Printf("Error running command, dumping output:\n%s\n%s\n%s\n", err, stderr, stdout)
+						fmt.Print(cmd.DumpError(stdout, stderr, err))
 					}
 					Expect(err).ToNot(HaveOccurred())
 
@@ -275,7 +275,7 @@ var _ = Describe("kraft pkg", func() {
 					cmd.Args = append(cmd.Args, "https://example3.com")
 					err := cmd.Run()
 					if err != nil {
-						fmt.Printf("Error running command, dumping output:\n%s\n%s\n%s\n", err, stderr, stdout)
+						fmt.Print(cmd.DumpError(stdout, stderr, err))
 					}
 					Expect(err).ToNot(HaveOccurred())
 					Expect(stderr.String()).To(BeEmpty())
@@ -283,14 +283,14 @@ var _ = Describe("kraft pkg", func() {
 					// Read the config file
 					osFile, err := os.Open(cfg.Path())
 					if err != nil {
-						fmt.Printf("Error running command, dumping output:\n%s\n%s\n%s\n", err, stderr, stdout)
+						fmt.Print(cmd.DumpError(stdout, stderr, err))
 					}
 					Expect(err).ToNot(HaveOccurred())
 					defer osFile.Close()
 
 					osFileInfo, err := osFile.Stat()
 					if err != nil {
-						fmt.Printf("Error running command, dumping output:\n%s\n%s\n%s\n", err, stderr, stdout)
+						fmt.Print(cmd.DumpError(stdout, stderr, err))
 					}
 					Expect(err).ToNot(HaveOccurred())
 
@@ -303,7 +303,7 @@ var _ = Describe("kraft pkg", func() {
 					// Read file content
 					readBytes, err := os.ReadFile(cfg.Path())
 					if err != nil {
-						fmt.Printf("Error running command, dumping output:\n%s\n%s\n%s\n", err, stderr, stdout)
+						fmt.Print(cmd.DumpError(stdout, stderr, err))
 					}
 					Expect(err).ToNot(HaveOccurred())
 
@@ -311,7 +311,7 @@ var _ = Describe("kraft pkg", func() {
 					var cfgMap map[string]interface{}
 					err = yaml.Unmarshal([]byte(readBytes), &cfgMap)
 					if err != nil {
-						fmt.Printf("Error running command, dumping output:\n%s\n%s\n%s\n", err, stderr, stdout)
+						fmt.Print(cmd.DumpError(stdout, stderr, err))
 					}
 					Expect(err).ToNot(HaveOccurred())
 
@@ -344,7 +344,7 @@ var _ = Describe("kraft pkg", func() {
 					cmd.Args = append(cmd.Args, "https://example2.com")
 					err := cmd.Run()
 					if err != nil {
-						fmt.Printf("Error running command, dumping output:\n%s\n%s\n%s\n", err, stderr, stdout)
+						fmt.Print(cmd.DumpError(stdout, stderr, err))
 					}
 					Expect(err).ToNot(HaveOccurred())
 					Expect(stderr.String()).To(BeEmpty())
@@ -352,14 +352,14 @@ var _ = Describe("kraft pkg", func() {
 					// Read the config file
 					osFile, err := os.Open(cfg.Path())
 					if err != nil {
-						fmt.Printf("Error running command, dumping output:\n%s\n%s\n%s\n", err, stderr, stdout)
+						fmt.Print(cmd.DumpError(stdout, stderr, err))
 					}
 					Expect(err).ToNot(HaveOccurred())
 					defer osFile.Close()
 
 					osFileInfo, err := osFile.Stat()
 					if err != nil {
-						fmt.Printf("Error running command, dumping output:\n%s\n%s\n%s\n", err, stderr, stdout)
+						fmt.Print(cmd.DumpError(stdout, stderr, err))
 					}
 					Expect(err).ToNot(HaveOccurred())
 
@@ -372,7 +372,7 @@ var _ = Describe("kraft pkg", func() {
 					// Read file content
 					readBytes, err := os.ReadFile(cfg.Path())
 					if err != nil {
-						fmt.Printf("Error running command, dumping output:\n%s\n%s\n%s\n", err, stderr, stdout)
+						fmt.Print(cmd.DumpError(stdout, stderr, err))
 					}
 					Expect(err).ToNot(HaveOccurred())
 
@@ -380,7 +380,7 @@ var _ = Describe("kraft pkg", func() {
 					var cfgMap map[string]interface{}
 					err = yaml.Unmarshal([]byte(readBytes), &cfgMap)
 					if err != nil {
-						fmt.Printf("Error running command, dumping output:\n%s\n%s\n%s\n", err, stderr, stdout)
+						fmt.Print(cmd.DumpError(stdout, stderr, err))
 					}
 					Expect(err).ToNot(HaveOccurred())
 

--- a/test/e2e/cli/pkg_unsource_test.go
+++ b/test/e2e/cli/pkg_unsource_test.go
@@ -47,7 +47,7 @@ var _ = Describe("kraft pkg", func() {
 					cmd.Args = append(cmd.Args, "https://manifests.kraftkit.sh/index.yaml")
 					err := cmd.Run()
 					if err != nil {
-						fmt.Printf("Error running command, dumping output:\n%s\n%s\n%s\n", err, stderr, stdout)
+						fmt.Print(cmd.DumpError(stdout, stderr, err))
 					}
 					Expect(err).ToNot(HaveOccurred())
 					Expect(stderr.String()).To(BeEmpty())
@@ -55,14 +55,14 @@ var _ = Describe("kraft pkg", func() {
 					// Read the config file
 					osFile, err := os.Open(cfg.Path())
 					if err != nil {
-						fmt.Printf("Error running command, dumping output:\n%s\n%s\n%s\n", err, stderr, stdout)
+						fmt.Print(cmd.DumpError(stdout, stderr, err))
 					}
 					Expect(err).ToNot(HaveOccurred())
 					defer osFile.Close()
 
 					osFileInfo, err := osFile.Stat()
 					if err != nil {
-						fmt.Printf("Error running command, dumping output:\n%s\n%s\n%s\n", err, stderr, stdout)
+						fmt.Print(cmd.DumpError(stdout, stderr, err))
 					}
 					Expect(err).ToNot(HaveOccurred())
 
@@ -75,7 +75,7 @@ var _ = Describe("kraft pkg", func() {
 					// Read file content
 					readBytes, err := os.ReadFile(cfg.Path())
 					if err != nil {
-						fmt.Printf("Error running command, dumping output:\n%s\n%s\n%s\n", err, stderr, stdout)
+						fmt.Print(cmd.DumpError(stdout, stderr, err))
 					}
 					Expect(err).ToNot(HaveOccurred())
 
@@ -83,7 +83,7 @@ var _ = Describe("kraft pkg", func() {
 					var cfgMap map[string]interface{}
 					err = yaml.Unmarshal([]byte(readBytes), &cfgMap)
 					if err != nil {
-						fmt.Printf("Error running command, dumping output:\n%s\n%s\n%s\n", err, stderr, stdout)
+						fmt.Print(cmd.DumpError(stdout, stderr, err))
 					}
 					Expect(err).ToNot(HaveOccurred())
 
@@ -108,7 +108,7 @@ var _ = Describe("kraft pkg", func() {
 					// Save the config file by moving it to a temporary location
 					err := os.Rename(cfg.Path(), cfg.Path()+".tmp")
 					if err != nil {
-						fmt.Printf("Error running command, dumping output:\n%s\n%s\n%s\n", err, stderr, stdout)
+						fmt.Print(cmd.DumpError(stdout, stderr, err))
 					}
 					Expect(err).ToNot(HaveOccurred())
 				})
@@ -116,7 +116,7 @@ var _ = Describe("kraft pkg", func() {
 					// Restore the config file
 					err := os.Rename(cfg.Path()+".tmp", cfg.Path())
 					if err != nil {
-						fmt.Printf("Error running command, dumping output:\n%s\n%s\n%s\n", err, stderr, stdout)
+						fmt.Print(cmd.DumpError(stdout, stderr, err))
 					}
 					Expect(err).ToNot(HaveOccurred())
 				})
@@ -124,7 +124,7 @@ var _ = Describe("kraft pkg", func() {
 					cmd.Args = append(cmd.Args, "https://manifests.kraftkit.sh/index.yaml")
 					err := cmd.Run()
 					if err != nil {
-						fmt.Printf("Error running command, dumping output:\n%s\n%s\n%s\n", err, stderr, stdout)
+						fmt.Print(cmd.DumpError(stdout, stderr, err))
 					}
 					Expect(err).ToNot(HaveOccurred())
 					Expect(stderr.String()).To(BeEmpty())
@@ -132,14 +132,14 @@ var _ = Describe("kraft pkg", func() {
 					// Read the config file
 					osFile, err := os.Open(cfg.Path())
 					if err != nil {
-						fmt.Printf("Error running command, dumping output:\n%s\n%s\n%s\n", err, stderr, stdout)
+						fmt.Print(cmd.DumpError(stdout, stderr, err))
 					}
 					Expect(err).ToNot(HaveOccurred())
 					defer osFile.Close()
 
 					osFileInfo, err := osFile.Stat()
 					if err != nil {
-						fmt.Printf("Error running command, dumping output:\n%s\n%s\n%s\n", err, stderr, stdout)
+						fmt.Print(cmd.DumpError(stdout, stderr, err))
 					}
 					Expect(err).ToNot(HaveOccurred())
 
@@ -152,7 +152,7 @@ var _ = Describe("kraft pkg", func() {
 					// Read file content
 					readBytes, err := os.ReadFile(cfg.Path())
 					if err != nil {
-						fmt.Printf("Error running command, dumping output:\n%s\n%s\n%s\n", err, stderr, stdout)
+						fmt.Print(cmd.DumpError(stdout, stderr, err))
 					}
 					Expect(err).ToNot(HaveOccurred())
 
@@ -160,7 +160,7 @@ var _ = Describe("kraft pkg", func() {
 					var cfgMap map[string]interface{}
 					err = yaml.Unmarshal([]byte(readBytes), &cfgMap)
 					if err != nil {
-						fmt.Printf("Error running command, dumping output:\n%s\n%s\n%s\n", err, stderr, stdout)
+						fmt.Print(cmd.DumpError(stdout, stderr, err))
 					}
 					Expect(err).ToNot(HaveOccurred())
 
@@ -185,7 +185,7 @@ var _ = Describe("kraft pkg", func() {
 					// Save the config file by moving it to a temporary location
 					err := os.Rename(cfg.Path(), cfg.Path()+".tmp")
 					if err != nil {
-						fmt.Printf("Error running command, dumping output:\n%s\n%s\n%s\n", err, stderr, stdout)
+						fmt.Print(cmd.DumpError(stdout, stderr, err))
 					}
 					Expect(err).ToNot(HaveOccurred())
 				})
@@ -193,7 +193,7 @@ var _ = Describe("kraft pkg", func() {
 					// Restore the config file
 					err := os.Rename(cfg.Path()+".tmp", cfg.Path())
 					if err != nil {
-						fmt.Printf("Error running command, dumping output:\n%s\n%s\n%s\n", err, stderr, stdout)
+						fmt.Print(cmd.DumpError(stdout, stderr, err))
 					}
 					Expect(err).ToNot(HaveOccurred())
 				})
@@ -201,7 +201,7 @@ var _ = Describe("kraft pkg", func() {
 					cmd.Args = append(cmd.Args, "https://example.com")
 					err := cmd.Run()
 					if err != nil {
-						fmt.Printf("Error running command, dumping output:\n%s\n%s\n%s\n", err, stderr, stdout)
+						fmt.Print(cmd.DumpError(stdout, stderr, err))
 					}
 					Expect(err).ToNot(HaveOccurred())
 					Expect(stderr.String()).To(BeEmpty())
@@ -209,14 +209,14 @@ var _ = Describe("kraft pkg", func() {
 					// Read the config file
 					osFile, err := os.Open(cfg.Path())
 					if err != nil {
-						fmt.Printf("Error running command, dumping output:\n%s\n%s\n%s\n", err, stderr, stdout)
+						fmt.Print(cmd.DumpError(stdout, stderr, err))
 					}
 					Expect(err).ToNot(HaveOccurred())
 					defer osFile.Close()
 
 					osFileInfo, err := osFile.Stat()
 					if err != nil {
-						fmt.Printf("Error running command, dumping output:\n%s\n%s\n%s\n", err, stderr, stdout)
+						fmt.Print(cmd.DumpError(stdout, stderr, err))
 					}
 					Expect(err).ToNot(HaveOccurred())
 
@@ -229,7 +229,7 @@ var _ = Describe("kraft pkg", func() {
 					// Read file content
 					readBytes, err := os.ReadFile(cfg.Path())
 					if err != nil {
-						fmt.Printf("Error running command, dumping output:\n%s\n%s\n%s\n", err, stderr, stdout)
+						fmt.Print(cmd.DumpError(stdout, stderr, err))
 					}
 					Expect(err).ToNot(HaveOccurred())
 
@@ -237,7 +237,7 @@ var _ = Describe("kraft pkg", func() {
 					var cfgMap map[string]interface{}
 					err = yaml.Unmarshal([]byte(readBytes), &cfgMap)
 					if err != nil {
-						fmt.Printf("Error running command, dumping output:\n%s\n%s\n%s\n", err, stderr, stdout)
+						fmt.Print(cmd.DumpError(stdout, stderr, err))
 					}
 					Expect(err).ToNot(HaveOccurred())
 
@@ -276,7 +276,7 @@ var _ = Describe("kraft pkg", func() {
 					cmd.Args = append(cmd.Args, "https://example3.com")
 					err := cmd.Run()
 					if err != nil {
-						fmt.Printf("Error running command, dumping output:\n%s\n%s\n%s\n", err, stderr, stdout)
+						fmt.Print(cmd.DumpError(stdout, stderr, err))
 					}
 					Expect(err).ToNot(HaveOccurred())
 					Expect(stderr.String()).To(BeEmpty())
@@ -295,7 +295,7 @@ var _ = Describe("kraft pkg", func() {
 					cmd.Args = append(cmd.Args, "https://example3.com")
 					err := cmd.Run()
 					if err != nil {
-						fmt.Printf("Error running command, dumping output:\n%s\n%s\n%s\n", err, stderr, stdout)
+						fmt.Print(cmd.DumpError(stdout, stderr, err))
 					}
 					Expect(err).ToNot(HaveOccurred())
 					Expect(stderr.String()).To(BeEmpty())
@@ -303,14 +303,14 @@ var _ = Describe("kraft pkg", func() {
 					// Read the config file
 					osFile, err := os.Open(cfg.Path())
 					if err != nil {
-						fmt.Printf("Error running command, dumping output:\n%s\n%s\n%s\n", err, stderr, stdout)
+						fmt.Print(cmd.DumpError(stdout, stderr, err))
 					}
 					Expect(err).ToNot(HaveOccurred())
 					defer osFile.Close()
 
 					osFileInfo, err := osFile.Stat()
 					if err != nil {
-						fmt.Printf("Error running command, dumping output:\n%s\n%s\n%s\n", err, stderr, stdout)
+						fmt.Print(cmd.DumpError(stdout, stderr, err))
 					}
 					Expect(err).ToNot(HaveOccurred())
 
@@ -323,7 +323,7 @@ var _ = Describe("kraft pkg", func() {
 					// Read file content
 					readBytes, err := os.ReadFile(cfg.Path())
 					if err != nil {
-						fmt.Printf("Error running command, dumping output:\n%s\n%s\n%s\n", err, stderr, stdout)
+						fmt.Print(cmd.DumpError(stdout, stderr, err))
 					}
 					Expect(err).ToNot(HaveOccurred())
 
@@ -331,7 +331,7 @@ var _ = Describe("kraft pkg", func() {
 					var cfgMap map[string]interface{}
 					err = yaml.Unmarshal([]byte(readBytes), &cfgMap)
 					if err != nil {
-						fmt.Printf("Error running command, dumping output:\n%s\n%s\n%s\n", err, stderr, stdout)
+						fmt.Print(cmd.DumpError(stdout, stderr, err))
 					}
 					Expect(err).ToNot(HaveOccurred())
 
@@ -368,7 +368,7 @@ var _ = Describe("kraft pkg", func() {
 					cmd.Args = append(cmd.Args, "https://example3.com")
 					err := cmd.Run()
 					if err != nil {
-						fmt.Printf("Error running command, dumping output:\n%s\n%s\n%s\n", err, stderr, stdout)
+						fmt.Print(cmd.DumpError(stdout, stderr, err))
 					}
 					Expect(err).ToNot(HaveOccurred())
 					Expect(stderr.String()).To(BeEmpty())
@@ -387,7 +387,7 @@ var _ = Describe("kraft pkg", func() {
 					cmd.Args = append(cmd.Args, "https://example2.com")
 					err := cmd.Run()
 					if err != nil {
-						fmt.Printf("Error running command, dumping output:\n%s\n%s\n%s\n", err, stderr, stdout)
+						fmt.Print(cmd.DumpError(stdout, stderr, err))
 					}
 					Expect(err).ToNot(HaveOccurred())
 					Expect(stderr.String()).To(BeEmpty())
@@ -395,14 +395,14 @@ var _ = Describe("kraft pkg", func() {
 					// Read the config file
 					osFile, err := os.Open(cfg.Path())
 					if err != nil {
-						fmt.Printf("Error running command, dumping output:\n%s\n%s\n%s\n", err, stderr, stdout)
+						fmt.Print(cmd.DumpError(stdout, stderr, err))
 					}
 					Expect(err).ToNot(HaveOccurred())
 					defer osFile.Close()
 
 					osFileInfo, err := osFile.Stat()
 					if err != nil {
-						fmt.Printf("Error running command, dumping output:\n%s\n%s\n%s\n", err, stderr, stdout)
+						fmt.Print(cmd.DumpError(stdout, stderr, err))
 					}
 					Expect(err).ToNot(HaveOccurred())
 
@@ -415,7 +415,7 @@ var _ = Describe("kraft pkg", func() {
 					// Read file content
 					readBytes, err := os.ReadFile(cfg.Path())
 					if err != nil {
-						fmt.Printf("Error running command, dumping output:\n%s\n%s\n%s\n", err, stderr, stdout)
+						fmt.Print(cmd.DumpError(stdout, stderr, err))
 					}
 					Expect(err).ToNot(HaveOccurred())
 
@@ -423,7 +423,7 @@ var _ = Describe("kraft pkg", func() {
 					var cfgMap map[string]interface{}
 					err = yaml.Unmarshal([]byte(readBytes), &cfgMap)
 					if err != nil {
-						fmt.Printf("Error running command, dumping output:\n%s\n%s\n%s\n", err, stderr, stdout)
+						fmt.Print(cmd.DumpError(stdout, stderr, err))
 					}
 					Expect(err).ToNot(HaveOccurred())
 

--- a/test/e2e/cli/pkg_update_test.go
+++ b/test/e2e/cli/pkg_update_test.go
@@ -54,7 +54,7 @@ var _ = Describe("kraft pkg", func() {
 				It("should retrieve the list of components, libraries and packages", func() {
 					err := cmd.Run()
 					if err != nil {
-						fmt.Printf("Error running command, dumping output:\n%s\n%s\n%s\n", err, stderr, stdout)
+						fmt.Print(cmd.DumpError(stdout, stderr, err))
 					}
 					Expect(err).ToNot(HaveOccurred())
 
@@ -74,7 +74,7 @@ var _ = Describe("kraft pkg", func() {
 				It("should print the command's help", func() {
 					err := cmd.Run()
 					if err != nil {
-						fmt.Printf("Error running command, dumping output:\n%s\n%s\n%s\n", err, stderr, stdout)
+						fmt.Print(cmd.DumpError(stdout, stderr, err))
 					}
 					Expect(err).ToNot(HaveOccurred())
 

--- a/test/e2e/cli/version_test.go
+++ b/test/e2e/cli/version_test.go
@@ -37,7 +37,7 @@ var _ = Describe("kraft version", func() {
 		It("should print the version and exit gracefully", func() {
 			err := cmd.Run()
 			if err != nil {
-				fmt.Printf("Error running command, dumping output:\n%s\n%s\n%s\n", err, stderr, stdout)
+				fmt.Print(cmd.DumpError(stdout, stderr, err))
 			}
 			Expect(err).ToNot(HaveOccurred())
 
@@ -54,7 +54,7 @@ var _ = Describe("kraft version", func() {
 		It("should print the command's help", func() {
 			err := cmd.Run()
 			if err != nil {
-				fmt.Printf("Error running command, dumping output:\n%s\n%s\n%s\n", err, stderr, stdout)
+				fmt.Print(cmd.DumpError(stdout, stderr, err))
 			}
 			Expect(err).ToNot(HaveOccurred())
 

--- a/test/e2e/framework/cmd/cmd.go
+++ b/test/e2e/framework/cmd/cmd.go
@@ -13,6 +13,7 @@ import (
 	"os/exec"
 	"os/user"
 	"path/filepath"
+	"strings"
 
 	gomegafmt "github.com/onsi/gomega/format"
 )
@@ -89,6 +90,39 @@ func (c *Cmd) Run() error {
 	}
 
 	return nil
+}
+
+// DumpError is a common method used across command executions which is
+// used to standardize the output display of the command which was invoked
+// along with the stdout and stderr.
+func (c *Cmd) DumpError(stdoutio, stderrio *IOStream, err error) string {
+	var builder strings.Builder
+
+	builder.WriteString("\n")
+	builder.WriteString(strings.Join(c.Args, " "))
+	builder.WriteString("\n")
+
+	stdout := strings.Split(stdoutio.String(), "\n")
+	if !(len(stdout) == 1 && stdout[0] == "") {
+		for _, line := range stdout {
+			builder.WriteString("stdout > ")
+			builder.WriteString(line)
+			builder.WriteString("\n")
+		}
+	}
+
+	builder.WriteString("\n")
+
+	stderr := strings.Split(stderrio.String(), "\n")
+	if !(len(stdout) == 1 && stdout[0] == "") {
+		for _, line := range stderr {
+			builder.WriteString("stderr > ")
+			builder.WriteString(line)
+			builder.WriteString("\n")
+		}
+	}
+
+	return builder.String()
 }
 
 // IOStream represents an IO stream to be used by OS commands and suitable


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

Previously, a command invocation's error would be output using the same string text.  Firstly, standardize this with a common method `cmd.DumpError` and simultaneously add the command which was invoked which provides the user more information about what was run to help debug why the test failed.
