### PR TITLE
fix(workflows): Do not match citations on commit messages 

### DIFF
--- a/.github/workflows/commit-format-check.yaml
+++ b/.github/workflows/commit-format-check.yaml
@@ -20,7 +20,7 @@ jobs:
         if: ${{ github.actor != 'dependabot' && github.actor != 'dependabot[bot]' }}
         uses: gsactions/commit-message-checker@v2
         with:
-          pattern: '^(?!(?:.|\n)*(?:^|\n).{74,}(?:$|\n)(?:.|\n)*)(?:.|\n)*$'
+          pattern: '((^(?=(?:.|\n)*(?:^|\n)\[\d\]: .{69,}(?:$|\n)(?:.|\n)*)(?:.|\n)*$)|(^(?!(?:.|\n)*(?:^|\n).{74,}(?:$|\n)(?:.|\n)*)(?:.|\n)*$))'
           flags: ''
           error: 'The maximum line length of 74 characters is exceeded.'
           excludeDescription: 'true'


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->


This commit adds a fix to the regex pattern to also accept citations
that are longer than 74 characters.

There is still one outstanding issue with this. If a commit contains
lines over 74 characters and also citations longer than 74 characters it
will still match. This case is rare, and probably that commit needs
special attention anyways.
