### PR TITLE
fix: Prevent needless CLI parsing

### DIFF
--- a/cmdfactory/builder_test.go
+++ b/cmdfactory/builder_test.go
@@ -30,7 +30,7 @@ func TestAttributeFlags_StructFields(t *testing.T) {
 
 		// Execute command to invoke cmd.RunE. This executes all middlewares injected
 		// by bind(), which role is to assign parsed flag values to struct fields.
-		if _, err := executeC(cmd); err != nil {
+		if _, err := cmd.ExecuteC(); err != nil {
 			t.Fatal("Failed to execute command:", err)
 		}
 	}

--- a/internal/cli/options.go
+++ b/internal/cli/options.go
@@ -122,11 +122,7 @@ func WithDefaultConfigManager(cmd *cobra.Command) CliOption {
 		}
 
 		// Attribute all configuration flags and command-line argument values
-		cmd, args, err := cmd.Find(os.Args[1:])
-		if err != nil {
-			return err
-		}
-		configDir := config.FetchConfigDirFromArgs(args)
+		configDir := config.FetchConfigDirFromArgs(os.Args[1:])
 
 		// Did the user specify a non-standard config directory?  The following
 		// check is possible thanks to the attribution of flags to the config file.
@@ -152,8 +148,12 @@ func WithDefaultConfigManager(cmd *cobra.Command) CliOption {
 			}
 		}
 
-		if err := cmdfactory.AttributeFlags(cmd, cfg, args...); err != nil {
+		if err := cmdfactory.AttributeFlags(cmd, cfg, os.Args[1:]...); err != nil {
 			return err
+		}
+
+		if err := cmd.ParseFlags(os.Args[1:]); err == nil {
+			cmd.DisableFlagParsing = true
 		}
 
 		copts.ConfigManager = cfgm


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->


Initially, `cmd.ParseFlags` in the `AttributeFlags` method was used to associate the provided list of command-line arguments with the respectively registered flag.  However, `AttributeFlags` has since been modified to make this association by directly calling `flag.Set`. Furthermore, calling `cmd.ParseFlags` consistently had the unintended side-affect of populating initialized slice structures with duplicate values.

To mitigate against double parsing, which results in duplicate values in, for example, slice types, remove this additional parsing of the flags.

We call `cmd.ParseFlags` only once after the config manager has been attributed as these values are required by subsequent context systems (e.g. logging).  To prevent double parsing on the root command, set `DisableFlagParsing` to true such that cobra's `ExecuteContext` method does not end up calling this again on the root command.

This also has the benefit of greatly simplify the code by removing [the previously imported `execute` and `executeC` to prevent internal parsing](https://github.com/unikraft/kraftkit/commit/1e6c1a4b38b6fa98e823b3bbaabfabf6d3faff2a) and fixing command completion and listing inherited flags.