### PR TITLE
fix(cmdfactory): Fix help output

### DIFF
--- a/cmdfactory/help.go
+++ b/cmdfactory/help.go
@@ -104,12 +104,12 @@ func traverse(cmd *cobra.Command) []*cobra.Command {
 	return cmds
 }
 
-func fullname(cmd *cobra.Command) string {
+func fullname(parent, cmd *cobra.Command) string {
 	name := ""
 
 	for {
 		name = cmd.Name() + " " + name
-		if !cmd.HasParent() || isRootCmd(cmd.Parent()) {
+		if !cmd.HasParent() || cmd.Parent() == parent {
 			break
 		}
 		cmd = cmd.Parent()
@@ -141,7 +141,7 @@ func rootHelpFunc(cmd *cobra.Command, args []string) {
 	}
 	helpEntries = append(helpEntries, helpEntry{"USAGE", cmd.UseLine()})
 
-	if isRootCmd(cmd) {
+	if len(cmd.Groups()) > 0 {
 		maxPad := 0
 		mapping := make(map[string][]*cobra.Command)
 
@@ -158,7 +158,7 @@ func rootHelpFunc(cmd *cobra.Command, args []string) {
 				continue
 			}
 
-			pad := len(fullname(c))
+			pad := len(fullname(cmd, c))
 			if pad > maxPad {
 				maxPad = pad
 			}
@@ -167,11 +167,10 @@ func rootHelpFunc(cmd *cobra.Command, args []string) {
 		}
 
 		for _, group := range cmd.Groups() {
-
 			var usages []string
 
 			for _, c := range mapping[group.ID] {
-				usages = append(usages, rpad(fullname(c), maxPad+2)+c.Short)
+				usages = append(usages, rpad(fullname(cmd, c), maxPad+2)+c.Short)
 			}
 
 			if len(usages) > 0 {


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

This commit fixes two issues in the current help output format:

1. Showing the proper name of the command should be truncated at the parent and not the root.  In circumstances where subcommands themselves wish to display subcommands based on a group, the full name would contain the full command starting from the root and not the parent;
2. Iterate over each command if groups are available and not just if groups are available at the root.  In circumstances where a subcommand has groups, these would not appear.

