### PR TITLE
fix(kconfig): Wrap strings with double quotes

### DIFF
--- a/kconfig/config.go
+++ b/kconfig/config.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"os"
 	"regexp"
+	"strconv"
 	"strings"
 )
 
@@ -206,7 +207,15 @@ func (kvm KeyValueMap) String() string {
 		} else {
 			ret.WriteString(v.Key)
 			ret.WriteString("=")
-			ret.WriteString(v.Value)
+			if v.Value == "y" {
+				ret.WriteString(v.Value)
+			} else if _, err := strconv.Atoi(v.Value); err == nil {
+				ret.WriteString(v.Value)
+			} else {
+				ret.WriteString("\"")
+				ret.WriteString(strings.ReplaceAll(v.Value, "\"", "\\\""))
+				ret.WriteString("\"")
+			}
 		}
 		ret.WriteString("\n")
 	}


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

A simple type check is performed to determine whether the value is the boolean `y` value or an integer in which case these are passed explicitly.  Everything else is wrapped with double quotes.  This prevents misparsing for more complex string values by Unikraft's KConfig parser.

