### PR TITLE
fix(buildenvs): Add `runner` user to GitHub Action image

### DIFF
--- a/buildenvs/github-action.Dockerfile
+++ b/buildenvs/github-action.Dockerfile
@@ -93,4 +93,7 @@ RUN ln -s /usr/bin/cpp-12                                   /usr/bin/cc; \
 
 WORKDIR /github/workspace
 
+RUN useradd -rm -d /home/runner -s /bin/bash -g root -G sudo -u 1001 runner
+USER runner
+
 ENTRYPOINT [ "github-action" ]


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

This is the same name and UID as the host of a GitHub Action and prevents bidirectional files between the container and the host from having permission errors.
