### PR TITLE
refactor(cli): Expose CLI actions as reusable methods

### DIFF
--- a/cmdfactory/builder.go
+++ b/cmdfactory/builder.go
@@ -40,7 +40,7 @@ type PreRunnable interface {
 }
 
 type Runnable interface {
-	Run(cmd *cobra.Command, args []string) error
+	Run(ctx context.Context, args []string) error
 }
 
 type fieldInfo struct {
@@ -361,7 +361,9 @@ func New(obj Runnable, cmd cobra.Command) (*cobra.Command, error) {
 	c.InitDefaultCompletionCmd()
 
 	if obj != nil {
-		c.RunE = obj.Run
+		c.RunE = func(cmd *cobra.Command, args []string) error {
+			return obj.Run(cmd.Context(), args)
+		}
 
 		// Parse the attributes of this object into addressable flags for this command
 		if err := AttributeFlags(&c, obj); err != nil {

--- a/internal/cli/kraft/build/build.go
+++ b/internal/cli/kraft/build/build.go
@@ -44,7 +44,7 @@ type BuildOptions struct {
 	workdir string
 }
 
-func New() *cobra.Command {
+func NewCmd() *cobra.Command {
 	cmd, err := cmdfactory.New(&BuildOptions{}, cobra.Command{
 		Short: "Configure and build Unikraft unikernels",
 		Use:   "build [FLAGS] [SUBCOMMAND|DIR]",

--- a/internal/cli/kraft/build/build.go
+++ b/internal/cli/kraft/build/build.go
@@ -5,6 +5,7 @@
 package build
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"os"
@@ -112,9 +113,7 @@ func (opts *BuildOptions) Pre(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-func (opts *BuildOptions) Run(cmd *cobra.Command, args []string) error {
-	ctx := cmd.Context()
-
+func (opts *BuildOptions) Run(ctx context.Context, args []string) error {
 	// Filter project targets by any provided CLI options
 	selected := opts.project.Targets()
 	if len(selected) == 0 {

--- a/internal/cli/kraft/build/build.go
+++ b/internal/cli/kraft/build/build.go
@@ -45,6 +45,14 @@ type BuildOptions struct {
 	workdir string
 }
 
+// Build a Unikraft unikernel.
+func Build(ctx context.Context, opts *BuildOptions, args ...string) error {
+	if opts == nil {
+		opts = &BuildOptions{}
+	}
+	return opts.Run(ctx, args)
+}
+
 func NewCmd() *cobra.Command {
 	cmd, err := cmdfactory.New(&BuildOptions{}, cobra.Command{
 		Short: "Configure and build Unikraft unikernels",

--- a/internal/cli/kraft/clean/clean.go
+++ b/internal/cli/kraft/clean/clean.go
@@ -51,7 +51,7 @@ type CleanOptions struct {
 	Target       string `long:"target" short:"t" usage:"Filter prepare based on a specific target"`
 }
 
-func New() *cobra.Command {
+func NewCmd() *cobra.Command {
 	cmd, err := cmdfactory.New(&CleanOptions{}, cobra.Command{
 		Short: "Remove the build object files of a Unikraft project",
 		Use:   "clean [DIR]",

--- a/internal/cli/kraft/clean/clean.go
+++ b/internal/cli/kraft/clean/clean.go
@@ -32,6 +32,7 @@
 package clean
 
 import (
+	"context"
 	"os"
 
 	"github.com/MakeNowJust/heredoc"
@@ -88,10 +89,8 @@ func (opts *CleanOptions) Pre(cmd *cobra.Command, _ []string) error {
 	return nil
 }
 
-func (opts *CleanOptions) Run(cmd *cobra.Command, args []string) error {
+func (opts *CleanOptions) Run(ctx context.Context, args []string) error {
 	var err error
-
-	ctx := cmd.Context()
 	workdir := ""
 
 	if len(args) == 0 {

--- a/internal/cli/kraft/clean/clean.go
+++ b/internal/cli/kraft/clean/clean.go
@@ -52,6 +52,14 @@ type CleanOptions struct {
 	Target       string `long:"target" short:"t" usage:"Filter prepare based on a specific target"`
 }
 
+// Clean removes the build object files of a Unikraft project.
+func Clean(ctx context.Context, opts *CleanOptions, args ...string) error {
+	if opts == nil {
+		opts = &CleanOptions{}
+	}
+	return opts.Run(ctx, args)
+}
+
 func NewCmd() *cobra.Command {
 	cmd, err := cmdfactory.New(&CleanOptions{}, cobra.Command{
 		Short: "Remove the build object files of a Unikraft project",

--- a/internal/cli/kraft/cloud/cloud.go
+++ b/internal/cli/kraft/cloud/cloud.go
@@ -6,8 +6,11 @@
 package cloud
 
 import (
+	"context"
+
 	"github.com/MakeNowJust/heredoc"
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 
 	"kraftkit.sh/internal/cli/kraft/cloud/img"
 	"kraftkit.sh/internal/cli/kraft/cloud/instance"
@@ -78,6 +81,6 @@ func NewCmd() *cobra.Command {
 	return cmd
 }
 
-func (opts *CloudOptions) Run(cmd *cobra.Command, args []string) error {
-	return nil
+func (opts *CloudOptions) Run(_ context.Context, args []string) error {
+	return pflag.ErrHelp
 }

--- a/internal/cli/kraft/cloud/cloud.go
+++ b/internal/cli/kraft/cloud/cloud.go
@@ -19,7 +19,7 @@ type CloudOptions struct {
 	Metro string `long:"metro" env:"KRAFTCLOUD_METRO" usage:"Set the KraftCloud metro."`
 }
 
-func New() *cobra.Command {
+func NewCmd() *cobra.Command {
 	cmd, err := cmdfactory.New(&CloudOptions{}, cobra.Command{
 		Short:  "KraftCloud",
 		Use:    "cloud [FLAGS] [SUBCOMMAND|DIR]",
@@ -70,10 +70,10 @@ func New() *cobra.Command {
 	}
 
 	cmd.AddGroup(&cobra.Group{ID: "kraftcloud-img", Title: "IMAGE COMMANDS"})
-	cmd.AddCommand(img.New())
+	cmd.AddCommand(img.NewCmd())
 
 	cmd.AddGroup(&cobra.Group{ID: "kraftcloud-instance", Title: "INSTANCE COMMANDS"})
-	cmd.AddCommand(instance.New())
+	cmd.AddCommand(instance.NewCmd())
 
 	return cmd
 }

--- a/internal/cli/kraft/cloud/img/img.go
+++ b/internal/cli/kraft/cloud/img/img.go
@@ -6,7 +6,10 @@
 package img
 
 import (
+	"context"
+
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 
 	"kraftkit.sh/internal/cli/kraft/cloud/img/list"
 
@@ -34,6 +37,6 @@ func NewCmd() *cobra.Command {
 	return cmd
 }
 
-func (opts *ImgOptions) Run(cmd *cobra.Command, args []string) error {
-	return cmd.Help()
+func (opts *ImgOptions) Run(_ context.Context, _ []string) error {
+	return pflag.ErrHelp
 }

--- a/internal/cli/kraft/cloud/img/img.go
+++ b/internal/cli/kraft/cloud/img/img.go
@@ -15,7 +15,7 @@ import (
 
 type ImgOptions struct{}
 
-func New() *cobra.Command {
+func NewCmd() *cobra.Command {
 	cmd, err := cmdfactory.New(&ImgOptions{}, cobra.Command{
 		Short:   "Manage images on KraftCloud",
 		Use:     "img",
@@ -29,7 +29,7 @@ func New() *cobra.Command {
 		panic(err)
 	}
 
-	cmd.AddCommand(list.New())
+	cmd.AddCommand(list.NewCmd())
 
 	return cmd
 }

--- a/internal/cli/kraft/cloud/img/list/list.go
+++ b/internal/cli/kraft/cloud/img/list/list.go
@@ -6,6 +6,7 @@
 package list
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"strings"
@@ -65,8 +66,7 @@ func (opts *ListOptions) Pre(cmd *cobra.Command, _ []string) error {
 	return nil
 }
 
-func (opts *ListOptions) Run(cmd *cobra.Command, args []string) error {
-	ctx := cmd.Context()
+func (opts *ListOptions) Run(ctx context.Context, args []string) error {
 	auth, err := config.GetKraftCloudLoginFromContext(ctx)
 	if err != nil {
 		return fmt.Errorf("could not retrieve credentials: %w", err)

--- a/internal/cli/kraft/cloud/img/list/list.go
+++ b/internal/cli/kraft/cloud/img/list/list.go
@@ -30,7 +30,7 @@ type ListOptions struct {
 	metro string
 }
 
-func New() *cobra.Command {
+func NewCmd() *cobra.Command {
 	cmd, err := cmdfactory.New(&ListOptions{}, cobra.Command{
 		Short:   "List all images at a metro for your account",
 		Use:     "ls",

--- a/internal/cli/kraft/cloud/instance/create/create.go
+++ b/internal/cli/kraft/cloud/instance/create/create.go
@@ -6,6 +6,7 @@
 package create
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"strconv"
@@ -74,8 +75,7 @@ func (opts *CreateOptions) Pre(cmd *cobra.Command, _ []string) error {
 	return nil
 }
 
-func (opts *CreateOptions) Run(cmd *cobra.Command, args []string) error {
-	ctx := cmd.Context()
+func (opts *CreateOptions) Run(ctx context.Context, args []string) error {
 	image := args[0]
 	auth, err := config.GetKraftCloudLoginFromContext(ctx)
 	if err != nil {

--- a/internal/cli/kraft/cloud/instance/create/create.go
+++ b/internal/cli/kraft/cloud/instance/create/create.go
@@ -36,6 +36,15 @@ type CreateOptions struct {
 	metro string
 }
 
+// Create a KraftCloud instance.
+func Create(ctx context.Context, opts *CreateOptions, args ...string) error {
+	if opts == nil {
+		opts = &CreateOptions{}
+	}
+
+	return opts.Run(ctx, args)
+}
+
 func NewCmd() *cobra.Command {
 	cmd, err := cmdfactory.New(&CreateOptions{}, cobra.Command{
 		Short:   "Create an instance",

--- a/internal/cli/kraft/cloud/instance/create/create.go
+++ b/internal/cli/kraft/cloud/instance/create/create.go
@@ -35,7 +35,7 @@ type CreateOptions struct {
 	metro string
 }
 
-func New() *cobra.Command {
+func NewCmd() *cobra.Command {
 	cmd, err := cmdfactory.New(&CreateOptions{}, cobra.Command{
 		Short:   "Create an instance",
 		Use:     "create [FLAGS] IMAGE [-- ARGS]",

--- a/internal/cli/kraft/cloud/instance/instance.go
+++ b/internal/cli/kraft/cloud/instance/instance.go
@@ -21,7 +21,7 @@ import (
 
 type InstanceOptions struct{}
 
-func New() *cobra.Command {
+func NewCmd() *cobra.Command {
 	cmd, err := cmdfactory.New(&InstanceOptions{}, cobra.Command{
 		Short:   "Manage KraftCloud instances",
 		Use:     "instance SUBCOMMAND",
@@ -35,13 +35,13 @@ func New() *cobra.Command {
 		panic(err)
 	}
 
-	cmd.AddCommand(create.New())
-	cmd.AddCommand(list.New())
-	cmd.AddCommand(logs.New())
-	cmd.AddCommand(remove.New())
-	cmd.AddCommand(start.New())
-	cmd.AddCommand(status.New())
-	cmd.AddCommand(stop.New())
+	cmd.AddCommand(create.NewCmd())
+	cmd.AddCommand(list.NewCmd())
+	cmd.AddCommand(logs.NewCmd())
+	cmd.AddCommand(remove.NewCmd())
+	cmd.AddCommand(start.NewCmd())
+	cmd.AddCommand(status.NewCmd())
+	cmd.AddCommand(stop.NewCmd())
 
 	return cmd
 }

--- a/internal/cli/kraft/cloud/instance/instance.go
+++ b/internal/cli/kraft/cloud/instance/instance.go
@@ -6,7 +6,10 @@
 package instance
 
 import (
+	"context"
+
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 
 	"kraftkit.sh/cmdfactory"
 
@@ -46,6 +49,6 @@ func NewCmd() *cobra.Command {
 	return cmd
 }
 
-func (opts *InstanceOptions) Run(cmd *cobra.Command, _ []string) error {
-	return cmd.Help()
+func (opts *InstanceOptions) Run(_ context.Context, _ []string) error {
+	return pflag.ErrHelp
 }

--- a/internal/cli/kraft/cloud/instance/list/list.go
+++ b/internal/cli/kraft/cloud/instance/list/list.go
@@ -5,6 +5,7 @@
 package list
 
 import (
+	"context"
 	"fmt"
 	"os"
 
@@ -58,8 +59,7 @@ func (opts *ListOptions) Pre(cmd *cobra.Command, _ []string) error {
 	return nil
 }
 
-func (opts *ListOptions) Run(cmd *cobra.Command, args []string) error {
-	ctx := cmd.Context()
+func (opts *ListOptions) Run(ctx context.Context, args []string) error {
 	auth, err := config.GetKraftCloudLoginFromContext(ctx)
 	if err != nil {
 		return fmt.Errorf("could not retrieve credentials: %w", err)

--- a/internal/cli/kraft/cloud/instance/list/list.go
+++ b/internal/cli/kraft/cloud/instance/list/list.go
@@ -26,7 +26,7 @@ type ListOptions struct {
 	metro string
 }
 
-func New() *cobra.Command {
+func NewCmd() *cobra.Command {
 	cmd, err := cmdfactory.New(&ListOptions{}, cobra.Command{
 		Short:   "List instances",
 		Use:     "ls [FLAGS]",

--- a/internal/cli/kraft/cloud/instance/logs/logs.go
+++ b/internal/cli/kraft/cloud/instance/logs/logs.go
@@ -26,7 +26,7 @@ type LogOptions struct {
 	metro string
 }
 
-func New() *cobra.Command {
+func NewCmd() *cobra.Command {
 	cmd, err := cmdfactory.New(&LogOptions{}, cobra.Command{
 		Short: "Get console output of an instance",
 		Use:   "logs [UUID]",

--- a/internal/cli/kraft/cloud/instance/logs/logs.go
+++ b/internal/cli/kraft/cloud/instance/logs/logs.go
@@ -27,6 +27,15 @@ type LogOptions struct {
 	metro string
 }
 
+// Log retrieves the console output from a KraftCloud instance.
+func Log(ctx context.Context, opts *LogOptions, args ...string) error {
+	if opts == nil {
+		opts = &LogOptions{}
+	}
+
+	return opts.Run(ctx, args)
+}
+
 func NewCmd() *cobra.Command {
 	cmd, err := cmdfactory.New(&LogOptions{}, cobra.Command{
 		Short: "Get console output of an instance",

--- a/internal/cli/kraft/cloud/instance/logs/logs.go
+++ b/internal/cli/kraft/cloud/instance/logs/logs.go
@@ -5,6 +5,7 @@
 package logs
 
 import (
+	"context"
 	"fmt"
 	"os"
 
@@ -58,8 +59,7 @@ func (opts *LogOptions) Pre(cmd *cobra.Command, _ []string) error {
 	return nil
 }
 
-func (opts *LogOptions) Run(cmd *cobra.Command, args []string) error {
-	ctx := cmd.Context()
+func (opts *LogOptions) Run(ctx context.Context, args []string) error {
 	auth, err := config.GetKraftCloudLoginFromContext(ctx)
 	if err != nil {
 		return fmt.Errorf("could not retrieve credentials: %w", err)

--- a/internal/cli/kraft/cloud/instance/remove/remove.go
+++ b/internal/cli/kraft/cloud/instance/remove/remove.go
@@ -27,7 +27,7 @@ type RemoveOptions struct {
 	metro string
 }
 
-func New() *cobra.Command {
+func NewCmd() *cobra.Command {
 	cmd, err := cmdfactory.New(&RemoveOptions{}, cobra.Command{
 		Short:   "Delete an instance",
 		Use:     "delete UUID",

--- a/internal/cli/kraft/cloud/instance/remove/remove.go
+++ b/internal/cli/kraft/cloud/instance/remove/remove.go
@@ -28,6 +28,15 @@ type RemoveOptions struct {
 	metro string
 }
 
+// Remove a KraftCloud instance.
+func Remove(ctx context.Context, opts *RemoveOptions, args ...string) error {
+	if opts == nil {
+		opts = &RemoveOptions{}
+	}
+
+	return opts.Run(ctx, args)
+}
+
 func NewCmd() *cobra.Command {
 	cmd, err := cmdfactory.New(&RemoveOptions{}, cobra.Command{
 		Short:   "Delete an instance",

--- a/internal/cli/kraft/cloud/instance/remove/remove.go
+++ b/internal/cli/kraft/cloud/instance/remove/remove.go
@@ -6,6 +6,7 @@
 package remove
 
 import (
+	"context"
 	"fmt"
 	"os"
 
@@ -67,8 +68,7 @@ func (opts *RemoveOptions) Pre(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-func (opts *RemoveOptions) Run(cmd *cobra.Command, args []string) error {
-	ctx := cmd.Context()
+func (opts *RemoveOptions) Run(ctx context.Context, args []string) error {
 	auth, err := config.GetKraftCloudLoginFromContext(ctx)
 	if err != nil {
 		return fmt.Errorf("could not retrieve credentials: %w", err)

--- a/internal/cli/kraft/cloud/instance/start/start.go
+++ b/internal/cli/kraft/cloud/instance/start/start.go
@@ -27,6 +27,15 @@ type StartOptions struct {
 	metro string
 }
 
+// Start a KraftCloud instance.
+func Start(ctx context.Context, opts *StartOptions, args ...string) error {
+	if opts == nil {
+		opts = &StartOptions{}
+	}
+
+	return opts.Run(ctx, args)
+}
+
 func NewCmd() *cobra.Command {
 	cmd, err := cmdfactory.New(&StartOptions{}, cobra.Command{
 		Short: "Start an instance",

--- a/internal/cli/kraft/cloud/instance/start/start.go
+++ b/internal/cli/kraft/cloud/instance/start/start.go
@@ -26,7 +26,7 @@ type StartOptions struct {
 	metro string
 }
 
-func New() *cobra.Command {
+func NewCmd() *cobra.Command {
 	cmd, err := cmdfactory.New(&StartOptions{}, cobra.Command{
 		Short: "Start an instance",
 		Use:   "start [FLAGS] [PACKAGE]",

--- a/internal/cli/kraft/cloud/instance/start/start.go
+++ b/internal/cli/kraft/cloud/instance/start/start.go
@@ -5,6 +5,7 @@
 package start
 
 import (
+	"context"
 	"fmt"
 	"os"
 
@@ -58,8 +59,7 @@ func (opts *StartOptions) Pre(cmd *cobra.Command, _ []string) error {
 	return nil
 }
 
-func (opts *StartOptions) Run(cmd *cobra.Command, args []string) error {
-	ctx := cmd.Context()
+func (opts *StartOptions) Run(ctx context.Context, args []string) error {
 	auth, err := config.GetKraftCloudLoginFromContext(ctx)
 	if err != nil {
 		return fmt.Errorf("could not retrieve credentials: %w", err)

--- a/internal/cli/kraft/cloud/instance/status/status.go
+++ b/internal/cli/kraft/cloud/instance/status/status.go
@@ -6,6 +6,7 @@
 package status
 
 import (
+	"context"
 	"fmt"
 	"os"
 
@@ -60,8 +61,7 @@ func (opts *StatusOptions) Pre(cmd *cobra.Command, _ []string) error {
 	return nil
 }
 
-func (opts *StatusOptions) Run(cmd *cobra.Command, args []string) error {
-	ctx := cmd.Context()
+func (opts *StatusOptions) Run(ctx context.Context, args []string) error {
 	auth, err := config.GetKraftCloudLoginFromContext(ctx)
 	if err != nil {
 		return fmt.Errorf("could not retrieve credentials: %w", err)

--- a/internal/cli/kraft/cloud/instance/status/status.go
+++ b/internal/cli/kraft/cloud/instance/status/status.go
@@ -27,7 +27,7 @@ type StatusOptions struct {
 	metro string
 }
 
-func New() *cobra.Command {
+func NewCmd() *cobra.Command {
 	cmd, err := cmdfactory.New(&StatusOptions{}, cobra.Command{
 		Short:   "Retrieve the status of an instance",
 		Use:     "status [FLAGS] UUID",

--- a/internal/cli/kraft/cloud/instance/status/status.go
+++ b/internal/cli/kraft/cloud/instance/status/status.go
@@ -28,6 +28,15 @@ type StatusOptions struct {
 	metro string
 }
 
+// Status of a KraftCloud instance.
+func Status(ctx context.Context, opts *StatusOptions, args ...string) error {
+	if opts == nil {
+		opts = &StatusOptions{}
+	}
+
+	return opts.Run(ctx, args)
+}
+
 func NewCmd() *cobra.Command {
 	cmd, err := cmdfactory.New(&StatusOptions{}, cobra.Command{
 		Short:   "Retrieve the status of an instance",

--- a/internal/cli/kraft/cloud/instance/stop/stop.go
+++ b/internal/cli/kraft/cloud/instance/stop/stop.go
@@ -28,7 +28,7 @@ type StopOptions struct {
 	metro string
 }
 
-func New() *cobra.Command {
+func NewCmd() *cobra.Command {
 	cmd, err := cmdfactory.New(&StopOptions{}, cobra.Command{
 		Short: "Stop an instance",
 		Use:   "stop [FLAGS] [UUID]",

--- a/internal/cli/kraft/cloud/instance/stop/stop.go
+++ b/internal/cli/kraft/cloud/instance/stop/stop.go
@@ -29,6 +29,15 @@ type StopOptions struct {
 	metro string
 }
 
+// Stop a KraftCloud instance.
+func Stop(ctx context.Context, opts *StopOptions, args ...string) error {
+	if opts == nil {
+		opts = &StopOptions{}
+	}
+
+	return opts.Run(ctx, args)
+}
+
 func NewCmd() *cobra.Command {
 	cmd, err := cmdfactory.New(&StopOptions{}, cobra.Command{
 		Short: "Stop an instance",

--- a/internal/cli/kraft/cloud/instance/stop/stop.go
+++ b/internal/cli/kraft/cloud/instance/stop/stop.go
@@ -6,6 +6,7 @@
 package stop
 
 import (
+	"context"
 	"fmt"
 	"os"
 
@@ -64,8 +65,7 @@ func (opts *StopOptions) Pre(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-func (opts *StopOptions) Run(cmd *cobra.Command, args []string) error {
-	ctx := cmd.Context()
+func (opts *StopOptions) Run(ctx context.Context, args []string) error {
 	auth, err := config.GetKraftCloudLoginFromContext(ctx)
 	if err != nil {
 		return fmt.Errorf("could not retrieve credentials: %w", err)

--- a/internal/cli/kraft/events/events.go
+++ b/internal/cli/kraft/events/events.go
@@ -69,10 +69,10 @@ func (opts *EventOptions) Pre(cmd *cobra.Command, _ []string) error {
 	return nil
 }
 
-func (opts *EventOptions) Run(cmd *cobra.Command, args []string) error {
+func (opts *EventOptions) Run(ctx context.Context, args []string) error {
 	var err error
 
-	ctx, cancel := context.WithCancel(cmd.Context())
+	ctx, cancel := context.WithCancel(ctx)
 	platform := mplatform.PlatformUnknown
 
 	if opts.platform == "" || opts.platform == "auto" {

--- a/internal/cli/kraft/events/events.go
+++ b/internal/cli/kraft/events/events.go
@@ -32,7 +32,7 @@ type EventOptions struct {
 	QuitTogether bool          `long:"quit-together" short:"q" usage:"Exit event loop when machine exits"`
 }
 
-func New() *cobra.Command {
+func NewCmd() *cobra.Command {
 	cmd, err := cmdfactory.New(&EventOptions{}, cobra.Command{
 		Short:   "Follow the events of a unikernel",
 		Hidden:  true,

--- a/internal/cli/kraft/fetch/fetch.go
+++ b/internal/cli/kraft/fetch/fetch.go
@@ -45,6 +45,15 @@ type FetchOptions struct {
 	workdir string
 }
 
+// Fetch Unikraft unikernel dependencies
+func Fetch(ctx context.Context, opts *FetchOptions, args ...string) error {
+	if opts == nil {
+		opts = &FetchOptions{}
+	}
+
+	return opts.Run(ctx, args)
+}
+
 func NewCmd() *cobra.Command {
 	cmd, err := cmdfactory.New(&FetchOptions{}, cobra.Command{
 		Short: "Fetch Unikraft unikernel dependencies",

--- a/internal/cli/kraft/fetch/fetch.go
+++ b/internal/cli/kraft/fetch/fetch.go
@@ -357,9 +357,7 @@ func (opts *FetchOptions) pull(ctx context.Context, project app.Application, wor
 	return nil
 }
 
-func (opts *FetchOptions) Run(cmd *cobra.Command, _ []string) error {
-	ctx := cmd.Context()
-
+func (opts *FetchOptions) Run(ctx context.Context, _ []string) error {
 	// Filter project targets by any provided CLI options
 	selected := opts.project.Targets()
 

--- a/internal/cli/kraft/fetch/fetch.go
+++ b/internal/cli/kraft/fetch/fetch.go
@@ -45,7 +45,7 @@ type FetchOptions struct {
 	workdir string
 }
 
-func New() *cobra.Command {
+func NewCmd() *cobra.Command {
 	cmd, err := cmdfactory.New(&FetchOptions{}, cobra.Command{
 		Short: "Fetch Unikraft unikernel dependencies",
 		Use:   "fetch [FLAGS] [DIR]",

--- a/internal/cli/kraft/kraft.go
+++ b/internal/cli/kraft/kraft.go
@@ -6,12 +6,14 @@
 package kraft
 
 import (
+	"context"
 	"fmt"
 	"os"
 
 	"github.com/MakeNowJust/heredoc"
 	"github.com/rancher/wrangler/pkg/signals"
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 
 	"kraftkit.sh/cmdfactory"
 	"kraftkit.sh/config"
@@ -105,8 +107,8 @@ func NewCmd() *cobra.Command {
 	return cmd
 }
 
-func (k *KraftOptions) Run(cmd *cobra.Command, args []string) error {
-	return cmd.Help()
+func (k *KraftOptions) Run(_ context.Context, args []string) error {
+	return pflag.ErrHelp
 }
 
 func Main(args []string) int {

--- a/internal/cli/kraft/kraft.go
+++ b/internal/cli/kraft/kraft.go
@@ -48,7 +48,7 @@ import (
 
 type KraftOptions struct{}
 
-func New() *cobra.Command {
+func NewCmd() *cobra.Command {
 	cmd, err := cmdfactory.New(&KraftOptions{}, cobra.Command{
 		Short: "Build and use highly customized and ultra-lightweight unikernels",
 		Use:   "kraft [FLAGS] SUBCOMMAND",
@@ -70,37 +70,37 @@ func New() *cobra.Command {
 	}
 
 	cmd.AddGroup(&cobra.Group{ID: "build", Title: "BUILD COMMANDS"})
-	cmd.AddCommand(build.New())
-	cmd.AddCommand(clean.New())
-	cmd.AddCommand(fetch.New())
-	cmd.AddCommand(menu.New())
-	cmd.AddCommand(properclean.New())
-	cmd.AddCommand(set.New())
-	cmd.AddCommand(unset.New())
+	cmd.AddCommand(build.NewCmd())
+	cmd.AddCommand(clean.NewCmd())
+	cmd.AddCommand(fetch.NewCmd())
+	cmd.AddCommand(menu.NewCmd())
+	cmd.AddCommand(properclean.NewCmd())
+	cmd.AddCommand(set.NewCmd())
+	cmd.AddCommand(unset.NewCmd())
 
 	cmd.AddGroup(&cobra.Group{ID: "pkg", Title: "PACKAGING COMMANDS"})
-	cmd.AddCommand(pkg.New())
+	cmd.AddCommand(pkg.NewCmd())
 
 	cmd.AddGroup(&cobra.Group{ID: "run", Title: "LOCAL RUNTIME COMMANDS"})
-	cmd.AddCommand(events.New())
-	cmd.AddCommand(logs.New())
-	cmd.AddCommand(ps.New())
-	cmd.AddCommand(remove.New())
-	cmd.AddCommand(run.New())
-	cmd.AddCommand(stop.New())
+	cmd.AddCommand(events.NewCmd())
+	cmd.AddCommand(logs.NewCmd())
+	cmd.AddCommand(ps.NewCmd())
+	cmd.AddCommand(remove.NewCmd())
+	cmd.AddCommand(run.NewCmd())
+	cmd.AddCommand(stop.NewCmd())
 
 	cmd.AddGroup(&cobra.Group{ID: "net", Title: "LOCAL NETWORKING COMMANDS"})
-	cmd.AddCommand(net.New())
+	cmd.AddCommand(net.NewCmd())
 
 	cmd.AddGroup(&cobra.Group{ID: "kraftcloud", Title: "KRAFT CLOUD COMMANDS"})
-	cmd.AddCommand(cloud.New())
+	cmd.AddCommand(cloud.NewCmd())
 
 	cmd.AddGroup(&cobra.Group{ID: "kraftcloud-img", Title: "KRAFT CLOUD IMAGE COMMANDS"})
 	cmd.AddGroup(&cobra.Group{ID: "kraftcloud-instance", Title: "KRAFT CLOUD INSTANCE COMMANDS"})
 
 	cmd.AddGroup(&cobra.Group{ID: "misc", Title: "MISCELLANEOUS COMMANDS"})
-	cmd.AddCommand(login.New())
-	cmd.AddCommand(version.New())
+	cmd.AddCommand(login.NewCmd())
+	cmd.AddCommand(version.NewCmd())
 
 	return cmd
 }
@@ -110,7 +110,7 @@ func (k *KraftOptions) Run(cmd *cobra.Command, args []string) error {
 }
 
 func Main(args []string) int {
-	cmd := New()
+	cmd := NewCmd()
 	ctx := signals.SetupSignalContext()
 	copts := &cli.CliOptions{}
 

--- a/internal/cli/kraft/kraft.go
+++ b/internal/cli/kraft/kraft.go
@@ -34,7 +34,7 @@ import (
 	"kraftkit.sh/internal/cli/kraft/pkg"
 	"kraftkit.sh/internal/cli/kraft/properclean"
 	"kraftkit.sh/internal/cli/kraft/ps"
-	"kraftkit.sh/internal/cli/kraft/rm"
+	"kraftkit.sh/internal/cli/kraft/remove"
 	"kraftkit.sh/internal/cli/kraft/run"
 	"kraftkit.sh/internal/cli/kraft/set"
 	"kraftkit.sh/internal/cli/kraft/stop"
@@ -85,7 +85,7 @@ func New() *cobra.Command {
 	cmd.AddCommand(events.New())
 	cmd.AddCommand(logs.New())
 	cmd.AddCommand(ps.New())
-	cmd.AddCommand(rm.New())
+	cmd.AddCommand(remove.New())
 	cmd.AddCommand(run.New())
 	cmd.AddCommand(stop.New())
 

--- a/internal/cli/kraft/login/login.go
+++ b/internal/cli/kraft/login/login.go
@@ -23,7 +23,7 @@ type LoginOptions struct {
 	Token string `long:"token" short:"t" usage:"Authentication token" env:"KRAFTKIT_LOGIN_TOKEN"`
 }
 
-func New() *cobra.Command {
+func NewCmd() *cobra.Command {
 	cmd, err := cmdfactory.New(&LoginOptions{}, cobra.Command{
 		Short: "Provide authorization details for a remote service",
 		Use:   "login [FLAGS] HOST",

--- a/internal/cli/kraft/login/login.go
+++ b/internal/cli/kraft/login/login.go
@@ -6,6 +6,7 @@ package login
 
 import (
 	"bufio"
+	"context"
 	"encoding/base64"
 	"fmt"
 	"strings"
@@ -39,10 +40,9 @@ func NewCmd() *cobra.Command {
 	return cmd
 }
 
-func (opts *LoginOptions) Run(cmd *cobra.Command, args []string) error {
+func (opts *LoginOptions) Run(ctx context.Context, args []string) error {
 	var err error
 	host := args[0]
-	ctx := cmd.Context()
 
 	// Prompt the user from stdin for a username if neither a username nor a token
 	// was provided

--- a/internal/cli/kraft/logs/logs.go
+++ b/internal/cli/kraft/logs/logs.go
@@ -24,7 +24,7 @@ type LogOptions struct {
 	Follow   bool `long:"follow" short:"f" usage:"Follow log output"`
 }
 
-func New() *cobra.Command {
+func NewCmd() *cobra.Command {
 	cmd, err := cmdfactory.New(&LogOptions{}, cobra.Command{
 		Short:   "Fetch the logs of a unikernel.",
 		Use:     "logs [FLAGS] MACHINE",

--- a/internal/cli/kraft/logs/logs.go
+++ b/internal/cli/kraft/logs/logs.go
@@ -53,10 +53,9 @@ func (opts *LogOptions) Pre(cmd *cobra.Command, _ []string) error {
 	return nil
 }
 
-func (opts *LogOptions) Run(cmd *cobra.Command, args []string) error {
+func (opts *LogOptions) Run(ctx context.Context, args []string) error {
 	var err error
 
-	ctx := cmd.Context()
 	platform := mplatform.PlatformUnknown
 	var controller machineapi.MachineService
 

--- a/internal/cli/kraft/menu/menu.go
+++ b/internal/cli/kraft/menu/menu.go
@@ -354,9 +354,7 @@ func (opts *MenuOptions) pull(ctx context.Context, project app.Application, work
 	return nil
 }
 
-func (opts *MenuOptions) Run(cmd *cobra.Command, _ []string) error {
-	ctx := cmd.Context()
-
+func (opts *MenuOptions) Run(ctx context.Context, _ []string) error {
 	// Filter project targets by any provided CLI options
 	selected := opts.project.Targets()
 

--- a/internal/cli/kraft/menu/menu.go
+++ b/internal/cli/kraft/menu/menu.go
@@ -46,7 +46,7 @@ type MenuOptions struct {
 	workdir string
 }
 
-func New() *cobra.Command {
+func NewCmd() *cobra.Command {
 	cmd, err := cmdfactory.New(&MenuOptions{}, cobra.Command{
 		Short:   "Open's Unikraft configuration editor TUI",
 		Use:     "menu [FLAGS] [DIR]",

--- a/internal/cli/kraft/net/create/create.go
+++ b/internal/cli/kraft/net/create/create.go
@@ -5,6 +5,7 @@
 package create
 
 import (
+	"context"
 	"fmt"
 	"net"
 
@@ -59,10 +60,8 @@ func (opts *CreateOptions) Pre(cmd *cobra.Command, _ []string) error {
 	return nil
 }
 
-func (opts *CreateOptions) Run(cmd *cobra.Command, args []string) error {
+func (opts *CreateOptions) Run(ctx context.Context, args []string) error {
 	var err error
-
-	ctx := cmd.Context()
 
 	strategy, ok := network.Strategies()[opts.driver]
 	if !ok {

--- a/internal/cli/kraft/net/create/create.go
+++ b/internal/cli/kraft/net/create/create.go
@@ -23,7 +23,7 @@ type CreateOptions struct {
 	Network string `long:"network" short:"n" usage:"Set the gateway IP address and the subnet of the network in CIDR format."`
 }
 
-func New() *cobra.Command {
+func NewCmd() *cobra.Command {
 	cmd, err := cmdfactory.New(&CreateOptions{}, cobra.Command{
 		Short:   "Create a new machine network",
 		Use:     "create [FLAGS] NETWORK",

--- a/internal/cli/kraft/net/create/create.go
+++ b/internal/cli/kraft/net/create/create.go
@@ -24,6 +24,15 @@ type CreateOptions struct {
 	Network string `long:"network" short:"n" usage:"Set the gateway IP address and the subnet of the network in CIDR format."`
 }
 
+// Create a new local machine network.
+func Create(ctx context.Context, opts *CreateOptions, args ...string) error {
+	if opts == nil {
+		opts = &CreateOptions{}
+	}
+
+	return opts.Run(ctx, args)
+}
+
 func NewCmd() *cobra.Command {
 	cmd, err := cmdfactory.New(&CreateOptions{}, cobra.Command{
 		Short:   "Create a new machine network",

--- a/internal/cli/kraft/net/down/down.go
+++ b/internal/cli/kraft/net/down/down.go
@@ -21,6 +21,15 @@ type DownOptions struct {
 	driver string
 }
 
+// Down brings a local machine network offline.
+func Down(ctx context.Context, opts *DownOptions, args ...string) error {
+	if opts == nil {
+		opts = &DownOptions{}
+	}
+
+	return opts.Run(ctx, args)
+}
+
 func NewCmd() *cobra.Command {
 	cmd, err := cmdfactory.New(&DownOptions{}, cobra.Command{
 		Short:   "Bring a network offline",

--- a/internal/cli/kraft/net/down/down.go
+++ b/internal/cli/kraft/net/down/down.go
@@ -20,7 +20,7 @@ type DownOptions struct {
 	driver string
 }
 
-func New() *cobra.Command {
+func NewCmd() *cobra.Command {
 	cmd, err := cmdfactory.New(&DownOptions{}, cobra.Command{
 		Short:   "Bring a network offline",
 		Use:     "down",

--- a/internal/cli/kraft/net/down/down.go
+++ b/internal/cli/kraft/net/down/down.go
@@ -5,6 +5,7 @@
 package down
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/spf13/cobra"
@@ -42,8 +43,7 @@ func (opts *DownOptions) Pre(cmd *cobra.Command, _ []string) error {
 	return nil
 }
 
-func (opts *DownOptions) Run(cmd *cobra.Command, args []string) error {
-	ctx := cmd.Context()
+func (opts *DownOptions) Run(ctx context.Context, args []string) error {
 	strategy, ok := network.Strategies()[opts.driver]
 	if !ok {
 		return fmt.Errorf("unsupported network driver strategy: %v (contributions welcome!)", opts.driver)

--- a/internal/cli/kraft/net/inspect/inspect.go
+++ b/internal/cli/kraft/net/inspect/inspect.go
@@ -5,6 +5,7 @@
 package inspect
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 
@@ -43,10 +44,8 @@ func (opts *InspectOptions) Pre(cmd *cobra.Command, _ []string) error {
 	return nil
 }
 
-func (opts *InspectOptions) Run(cmd *cobra.Command, args []string) error {
+func (opts *InspectOptions) Run(ctx context.Context, args []string) error {
 	var err error
-
-	ctx := cmd.Context()
 
 	strategy, ok := network.Strategies()[opts.Driver]
 	if !ok {

--- a/internal/cli/kraft/net/inspect/inspect.go
+++ b/internal/cli/kraft/net/inspect/inspect.go
@@ -21,7 +21,7 @@ type InspectOptions struct {
 	Driver string `noattribute:"true"`
 }
 
-func New() *cobra.Command {
+func NewCmd() *cobra.Command {
 	cmd, err := cmdfactory.New(&InspectOptions{}, cobra.Command{
 		Short:   "Inspect a machine network",
 		Use:     "inspect NETWORK",

--- a/internal/cli/kraft/net/list/list.go
+++ b/internal/cli/kraft/net/list/list.go
@@ -5,6 +5,7 @@
 package list
 
 import (
+	"context"
 	"fmt"
 	"net"
 
@@ -46,10 +47,8 @@ func (opts *ListOptions) Pre(cmd *cobra.Command, _ []string) error {
 	return nil
 }
 
-func (opts *ListOptions) Run(cmd *cobra.Command, _ []string) error {
+func (opts *ListOptions) Run(ctx context.Context, _ []string) error {
 	var err error
-
-	ctx := cmd.Context()
 
 	strategy, ok := network.Strategies()[opts.driver]
 	if !ok {

--- a/internal/cli/kraft/net/list/list.go
+++ b/internal/cli/kraft/net/list/list.go
@@ -24,7 +24,7 @@ type ListOptions struct {
 	driver string
 }
 
-func New() *cobra.Command {
+func NewCmd() *cobra.Command {
 	cmd, err := cmdfactory.New(&ListOptions{}, cobra.Command{
 		Short:   "List machine networks",
 		Use:     "ls [FLAGS]",

--- a/internal/cli/kraft/net/net.go
+++ b/internal/cli/kraft/net/net.go
@@ -5,9 +5,11 @@
 package net
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 
 	"kraftkit.sh/cmdfactory"
 	"kraftkit.sh/internal/cli/kraft/net/create"
@@ -58,6 +60,6 @@ func (opts *NetOptions) Pre(cmd *cobra.Command, _ []string) error {
 	return nil
 }
 
-func (opts *NetOptions) Run(cmd *cobra.Command, _ []string) error {
-	return cmd.Help()
+func (opts *NetOptions) Run(_ context.Context, _ []string) error {
+	return pflag.ErrHelp
 }

--- a/internal/cli/kraft/net/net.go
+++ b/internal/cli/kraft/net/net.go
@@ -24,7 +24,7 @@ type NetOptions struct {
 	Driver string `local:"false" long:"driver" short:"d" usage:"Set the network driver." default:"bridge"`
 }
 
-func New() *cobra.Command {
+func NewCmd() *cobra.Command {
 	cmd, err := cmdfactory.New(&NetOptions{}, cobra.Command{
 		Short:   "Manage machine networks",
 		Use:     "net SUBCOMMAND",
@@ -38,12 +38,12 @@ func New() *cobra.Command {
 		panic(err)
 	}
 
-	cmd.AddCommand(create.New())
-	cmd.AddCommand(down.New())
-	cmd.AddCommand(inspect.New())
-	cmd.AddCommand(list.New())
-	cmd.AddCommand(remove.New())
-	cmd.AddCommand(up.New())
+	cmd.AddCommand(create.NewCmd())
+	cmd.AddCommand(down.NewCmd())
+	cmd.AddCommand(inspect.NewCmd())
+	cmd.AddCommand(list.NewCmd())
+	cmd.AddCommand(remove.NewCmd())
+	cmd.AddCommand(up.NewCmd())
 
 	return cmd
 }

--- a/internal/cli/kraft/net/remove/remove.go
+++ b/internal/cli/kraft/net/remove/remove.go
@@ -20,7 +20,7 @@ type RemoveOptions struct {
 	driver string
 }
 
-func New() *cobra.Command {
+func NewCmd() *cobra.Command {
 	cmd, err := cmdfactory.New(&RemoveOptions{}, cobra.Command{
 		Short:   "Remove a network",
 		Use:     "rm",

--- a/internal/cli/kraft/net/remove/remove.go
+++ b/internal/cli/kraft/net/remove/remove.go
@@ -5,6 +5,7 @@
 package remove
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/spf13/cobra"
@@ -42,10 +43,8 @@ func (opts *RemoveOptions) Pre(cmd *cobra.Command, _ []string) error {
 	return nil
 }
 
-func (opts *RemoveOptions) Run(cmd *cobra.Command, args []string) error {
+func (opts *RemoveOptions) Run(ctx context.Context, args []string) error {
 	var err error
-
-	ctx := cmd.Context()
 
 	strategy, ok := network.Strategies()[opts.driver]
 	if !ok {

--- a/internal/cli/kraft/net/remove/remove.go
+++ b/internal/cli/kraft/net/remove/remove.go
@@ -21,6 +21,15 @@ type RemoveOptions struct {
 	driver string
 }
 
+// Remove a local machine network.
+func Remove(ctx context.Context, opts *RemoveOptions, args ...string) error {
+	if opts == nil {
+		opts = &RemoveOptions{}
+	}
+
+	return opts.Run(ctx, args)
+}
+
 func NewCmd() *cobra.Command {
 	cmd, err := cmdfactory.New(&RemoveOptions{}, cobra.Command{
 		Short:   "Remove a network",

--- a/internal/cli/kraft/net/up/up.go
+++ b/internal/cli/kraft/net/up/up.go
@@ -21,6 +21,15 @@ type UpOptions struct {
 	driver string
 }
 
+// Up brings a local machine network online.
+func Up(ctx context.Context, opts *UpOptions, args ...string) error {
+	if opts == nil {
+		opts = &UpOptions{}
+	}
+
+	return opts.Run(ctx, args)
+}
+
 func NewCmd() *cobra.Command {
 	cmd, err := cmdfactory.New(&UpOptions{}, cobra.Command{
 		Short:   "Bring a network online",

--- a/internal/cli/kraft/net/up/up.go
+++ b/internal/cli/kraft/net/up/up.go
@@ -20,7 +20,7 @@ type UpOptions struct {
 	driver string
 }
 
-func New() *cobra.Command {
+func NewCmd() *cobra.Command {
 	cmd, err := cmdfactory.New(&UpOptions{}, cobra.Command{
 		Short:   "Bring a network online",
 		Use:     "up",

--- a/internal/cli/kraft/net/up/up.go
+++ b/internal/cli/kraft/net/up/up.go
@@ -5,6 +5,7 @@
 package up
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/spf13/cobra"
@@ -42,8 +43,7 @@ func (opts *UpOptions) Pre(cmd *cobra.Command, _ []string) error {
 	return nil
 }
 
-func (opts *UpOptions) Run(cmd *cobra.Command, args []string) error {
-	ctx := cmd.Context()
+func (opts *UpOptions) Run(ctx context.Context, args []string) error {
 	strategy, ok := network.Strategies()[opts.driver]
 	if !ok {
 		return fmt.Errorf("unsupported network driver strategy: %v (contributions welcome!)", opts.driver)

--- a/internal/cli/kraft/pkg/list/list.go
+++ b/internal/cli/kraft/pkg/list/list.go
@@ -37,7 +37,7 @@ type ListOptions struct {
 	Output    string `long:"output" short:"o" usage:"Set output format" default:"table"`
 }
 
-func New() *cobra.Command {
+func NewCmd() *cobra.Command {
 	cmd, err := cmdfactory.New(&ListOptions{}, cobra.Command{
 		Short:   "List installed Unikraft component packages",
 		Use:     "ls [FLAGS] [DIR]",

--- a/internal/cli/kraft/pkg/list/list.go
+++ b/internal/cli/kraft/pkg/list/list.go
@@ -5,6 +5,7 @@
 package list
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"sort"
@@ -70,10 +71,9 @@ func (*ListOptions) Pre(cmd *cobra.Command, _ []string) error {
 	return nil
 }
 
-func (opts *ListOptions) Run(cmd *cobra.Command, args []string) error {
+func (opts *ListOptions) Run(ctx context.Context, args []string) error {
 	var err error
 
-	ctx := cmd.Context()
 	workdir := ""
 	if len(args) > 0 {
 		workdir = args[0]

--- a/internal/cli/kraft/pkg/pkg.go
+++ b/internal/cli/kraft/pkg/pkg.go
@@ -53,6 +53,15 @@ type PkgOptions struct {
 	pm       packmanager.PackageManager
 }
 
+// Pkg a Unikraft project.
+func Pkg(ctx context.Context, opts *PkgOptions, args ...string) error {
+	if opts == nil {
+		opts = &PkgOptions{}
+	}
+
+	return opts.Run(ctx, args)
+}
+
 func NewCmd() *cobra.Command {
 	cmd, err := cmdfactory.New(&PkgOptions{}, cobra.Command{
 		Short: "Package and distribute Unikraft unikernels and their dependencies",

--- a/internal/cli/kraft/pkg/pkg.go
+++ b/internal/cli/kraft/pkg/pkg.go
@@ -5,6 +5,7 @@
 package pkg
 
 import (
+	"context"
 	"fmt"
 	"os"
 
@@ -144,9 +145,8 @@ func (opts *PkgOptions) Pre(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-func (opts *PkgOptions) Run(cmd *cobra.Command, args []string) error {
+func (opts *PkgOptions) Run(ctx context.Context, args []string) error {
 	var err error
-	ctx := cmd.Context()
 
 	exists, err := opts.pm.Catalog(ctx,
 		packmanager.WithName(opts.Name),

--- a/internal/cli/kraft/pkg/pkg.go
+++ b/internal/cli/kraft/pkg/pkg.go
@@ -52,7 +52,7 @@ type PkgOptions struct {
 	pm       packmanager.PackageManager
 }
 
-func New() *cobra.Command {
+func NewCmd() *cobra.Command {
 	cmd, err := cmdfactory.New(&PkgOptions{}, cobra.Command{
 		Short: "Package and distribute Unikraft unikernels and their dependencies",
 		Use:   "pkg [FLAGS] [SUBCOMMAND|DIR]",
@@ -79,13 +79,13 @@ func New() *cobra.Command {
 		panic(err)
 	}
 
-	cmd.AddCommand(list.New())
-	cmd.AddCommand(pull.New())
-	cmd.AddCommand(push.New())
-	cmd.AddCommand(remove.New())
-	cmd.AddCommand(source.New())
-	cmd.AddCommand(unsource.New())
-	cmd.AddCommand(update.New())
+	cmd.AddCommand(list.NewCmd())
+	cmd.AddCommand(pull.NewCmd())
+	cmd.AddCommand(push.NewCmd())
+	cmd.AddCommand(remove.NewCmd())
+	cmd.AddCommand(source.NewCmd())
+	cmd.AddCommand(unsource.NewCmd())
+	cmd.AddCommand(update.NewCmd())
 
 	cmd.Flags().Var(
 		cmdfactory.NewEnumFlag[packmanager.MergeStrategy](

--- a/internal/cli/kraft/pkg/pull/pull.go
+++ b/internal/cli/kraft/pkg/pull/pull.go
@@ -41,7 +41,7 @@ type PullOptions struct {
 	KConfig      []string `long:"kconfig" short:"k" usage:"Request a package with specific KConfig options."`
 }
 
-func New() *cobra.Command {
+func NewCmd() *cobra.Command {
 	cmd, err := cmdfactory.New(&PullOptions{}, cobra.Command{
 		Short:   "Pull a Unikraft unikernel and/or its dependencies",
 		Use:     "pull [FLAGS] [PACKAGE|DIR]",

--- a/internal/cli/kraft/pkg/pull/pull.go
+++ b/internal/cli/kraft/pkg/pull/pull.go
@@ -41,6 +41,15 @@ type PullOptions struct {
 	KConfig      []string `long:"kconfig" short:"k" usage:"Request a package with specific KConfig options."`
 }
 
+// Pull a Unikraft component.
+func Pull(ctx context.Context, opts *PullOptions, args ...string) error {
+	if opts == nil {
+		opts = &PullOptions{}
+	}
+
+	return opts.Run(ctx, args)
+}
+
 func NewCmd() *cobra.Command {
 	cmd, err := cmdfactory.New(&PullOptions{}, cobra.Command{
 		Short:   "Pull a Unikraft unikernel and/or its dependencies",

--- a/internal/cli/kraft/pkg/pull/pull.go
+++ b/internal/cli/kraft/pkg/pull/pull.go
@@ -102,7 +102,7 @@ func (opts *PullOptions) Pre(cmd *cobra.Command, _ []string) error {
 	)
 }
 
-func (opts *PullOptions) Run(cmd *cobra.Command, args []string) error {
+func (opts *PullOptions) Run(ctx context.Context, args []string) error {
 	var err error
 	var project app.Application
 	var processes []*paraprogress.Process
@@ -119,7 +119,6 @@ func (opts *PullOptions) Run(cmd *cobra.Command, args []string) error {
 		args = []string{workdir}
 	}
 
-	ctx := cmd.Context()
 	pm := packmanager.G(ctx)
 	parallel := !config.G[config.KraftKit](ctx).NoParallel
 	norender := log.LoggerTypeFromString(config.G[config.KraftKit](ctx).Log.Type) != log.FANCY

--- a/internal/cli/kraft/pkg/push/push.go
+++ b/internal/cli/kraft/pkg/push/push.go
@@ -28,7 +28,7 @@ type PushOptions struct {
 	Kraftfile string `long:"kraftfile" short:"K" usage:"Set an alternative path of the Kraftfile"`
 }
 
-func New() *cobra.Command {
+func NewCmd() *cobra.Command {
 	cmd, err := cmdfactory.New(&PushOptions{}, cobra.Command{
 		Short:   "Push a Unikraft unikernel package to registry",
 		Use:     "push [FLAGS] [PACKAGE]",

--- a/internal/cli/kraft/pkg/push/push.go
+++ b/internal/cli/kraft/pkg/push/push.go
@@ -67,7 +67,7 @@ func (opts *PushOptions) Pre(cmd *cobra.Command, _ []string) error {
 	return nil
 }
 
-func (opts *PushOptions) Run(cmd *cobra.Command, args []string) error {
+func (opts *PushOptions) Run(ctx context.Context, args []string) error {
 	var err error
 	var workdir string
 
@@ -82,7 +82,6 @@ func (opts *PushOptions) Run(cmd *cobra.Command, args []string) error {
 		workdir = ""
 	}
 
-	ctx := cmd.Context()
 	norender := log.LoggerTypeFromString(config.G[config.KraftKit](ctx).Log.Type) != log.FANCY
 	ref := ""
 	if workdir != "" {

--- a/internal/cli/kraft/pkg/push/push.go
+++ b/internal/cli/kraft/pkg/push/push.go
@@ -28,6 +28,15 @@ type PushOptions struct {
 	Kraftfile string `long:"kraftfile" short:"K" usage:"Set an alternative path of the Kraftfile"`
 }
 
+// Push a Unikraft component.
+func Push(ctx context.Context, opts *PushOptions, args ...string) error {
+	if opts == nil {
+		opts = &PushOptions{}
+	}
+
+	return opts.Run(ctx, args)
+}
+
 func NewCmd() *cobra.Command {
 	cmd, err := cmdfactory.New(&PushOptions{}, cobra.Command{
 		Short:   "Push a Unikraft unikernel package to registry",

--- a/internal/cli/kraft/pkg/remove/remove.go
+++ b/internal/cli/kraft/pkg/remove/remove.go
@@ -20,7 +20,7 @@ type RemoveOptions struct {
 	Format string `long:"format" short:"f" usage:"Set the package format." default:"any"`
 }
 
-func New() *cobra.Command {
+func NewCmd() *cobra.Command {
 	cmd, err := cmdfactory.New(&RemoveOptions{}, cobra.Command{
 		Short:   "Removes selected local packages",
 		Use:     "rm [FLAGS] [PACKAGE]",

--- a/internal/cli/kraft/pkg/remove/remove.go
+++ b/internal/cli/kraft/pkg/remove/remove.go
@@ -6,6 +6,7 @@
 package remove
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/MakeNowJust/heredoc"
@@ -81,9 +82,7 @@ func (opts *RemoveOptions) Pre(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-func (opts *RemoveOptions) Run(cmd *cobra.Command, args []string) error {
-	ctx := cmd.Context()
-
+func (opts *RemoveOptions) Run(ctx context.Context, args []string) error {
 	umbrella, err := packmanager.PackageManagers()
 	if err != nil {
 		return fmt.Errorf("could not get registered package managers: %w", err)

--- a/internal/cli/kraft/pkg/remove/remove.go
+++ b/internal/cli/kraft/pkg/remove/remove.go
@@ -21,6 +21,15 @@ type RemoveOptions struct {
 	Format string `long:"format" short:"f" usage:"Set the package format." default:"any"`
 }
 
+// Remove a Unikraft component.
+func Remove(ctx context.Context, opts *RemoveOptions, args ...string) error {
+	if opts == nil {
+		opts = &RemoveOptions{}
+	}
+
+	return opts.Run(ctx, args)
+}
+
 func NewCmd() *cobra.Command {
 	cmd, err := cmdfactory.New(&RemoveOptions{}, cobra.Command{
 		Short:   "Removes selected local packages",

--- a/internal/cli/kraft/pkg/source/source.go
+++ b/internal/cli/kraft/pkg/source/source.go
@@ -21,6 +21,16 @@ type SourceOptions struct {
 	Force bool `short:"F" long:"force" usage:"Do not run a compatibility test before sourcing."`
 }
 
+// Source adds a remote location for discovering one-or-many Unikraft
+// components.
+func Source(ctx context.Context, opts *SourceOptions, args ...string) error {
+	if opts == nil {
+		opts = &SourceOptions{}
+	}
+
+	return opts.Run(ctx, args)
+}
+
 func NewCmd() *cobra.Command {
 	cmd, err := cmdfactory.New(&SourceOptions{}, cobra.Command{
 		Short: "Add Unikraft component manifests",

--- a/internal/cli/kraft/pkg/source/source.go
+++ b/internal/cli/kraft/pkg/source/source.go
@@ -20,7 +20,7 @@ type SourceOptions struct {
 	Force bool `short:"F" long:"force" usage:"Do not run a compatibility test before sourcing."`
 }
 
-func New() *cobra.Command {
+func NewCmd() *cobra.Command {
 	cmd, err := cmdfactory.New(&SourceOptions{}, cobra.Command{
 		Short: "Add Unikraft component manifests",
 		Use:   "source [FLAGS] [SOURCE]",

--- a/internal/cli/kraft/pkg/source/source.go
+++ b/internal/cli/kraft/pkg/source/source.go
@@ -5,6 +5,7 @@
 package source
 
 import (
+	"context"
 	"errors"
 
 	"github.com/MakeNowJust/heredoc"
@@ -56,9 +57,7 @@ func (*SourceOptions) Pre(cmd *cobra.Command, _ []string) error {
 	return nil
 }
 
-func (opts *SourceOptions) Run(cmd *cobra.Command, args []string) error {
-	ctx := cmd.Context()
-
+func (opts *SourceOptions) Run(ctx context.Context, args []string) error {
 	for _, source := range args {
 		if !opts.Force {
 			_, compatible, err := packmanager.G(ctx).IsCompatible(ctx,

--- a/internal/cli/kraft/pkg/unsource/unsource.go
+++ b/internal/cli/kraft/pkg/unsource/unsource.go
@@ -42,6 +42,15 @@ func NewCmd() *cobra.Command {
 	return cmd
 }
 
+// Unsource a remote location representing one-or-many Unikraft components.
+func Unsource(ctx context.Context, opts *UnsourceOptions, args ...string) error {
+	if opts == nil {
+		opts = &UnsourceOptions{}
+	}
+
+	return opts.Run(ctx, args)
+}
+
 func (*UnsourceOptions) Pre(cmd *cobra.Command, _ []string) error {
 	ctx, err := packmanager.WithDefaultUmbrellaManagerInContext(cmd.Context())
 	if err != nil {

--- a/internal/cli/kraft/pkg/unsource/unsource.go
+++ b/internal/cli/kraft/pkg/unsource/unsource.go
@@ -18,8 +18,8 @@ import (
 
 type UnsourceOptions struct{}
 
-// New returns a new unsource command
-func New() *cobra.Command {
+// NewCmd returns a new unsource command
+func NewCmd() *cobra.Command {
 	cmd, err := cmdfactory.New(&UnsourceOptions{}, cobra.Command{
 		Short: "Remove Unikraft component manifests",
 		Use:   "unsource [FLAGS] [SOURCE]",

--- a/internal/cli/kraft/pkg/unsource/unsource.go
+++ b/internal/cli/kraft/pkg/unsource/unsource.go
@@ -7,6 +7,8 @@
 package unsource
 
 import (
+	"context"
+
 	"github.com/MakeNowJust/heredoc"
 	"github.com/spf13/cobra"
 
@@ -52,8 +54,7 @@ func (*UnsourceOptions) Pre(cmd *cobra.Command, _ []string) error {
 }
 
 // Run executes the unsource command
-func (opts *UnsourceOptions) Run(cmd *cobra.Command, args []string) error {
-	ctx := cmd.Context()
+func (opts *UnsourceOptions) Run(ctx context.Context, args []string) error {
 	for _, source := range args {
 		manifests := []string{}
 

--- a/internal/cli/kraft/pkg/update/update.go
+++ b/internal/cli/kraft/pkg/update/update.go
@@ -22,7 +22,7 @@ type UpdateOptions struct {
 	Manager string `long:"manager" short:"m" usage:"Force the handler type" default:"manifest" local:"true"`
 }
 
-func New() *cobra.Command {
+func NewCmd() *cobra.Command {
 	cmd, err := cmdfactory.New(&UpdateOptions{}, cobra.Command{
 		Short: "Retrieve new lists of Unikraft components, libraries and packages",
 		Use:   "update [FLAGS]",

--- a/internal/cli/kraft/pkg/update/update.go
+++ b/internal/cli/kraft/pkg/update/update.go
@@ -54,10 +54,9 @@ func (*UpdateOptions) Pre(cmd *cobra.Command, _ []string) error {
 	return nil
 }
 
-func (opts *UpdateOptions) Run(cmd *cobra.Command, args []string) error {
+func (opts *UpdateOptions) Run(ctx context.Context, args []string) error {
 	var err error
 
-	ctx := cmd.Context()
 	pm := packmanager.G(ctx)
 
 	// Force a particular package manager

--- a/internal/cli/kraft/pkg/update/update.go
+++ b/internal/cli/kraft/pkg/update/update.go
@@ -22,6 +22,15 @@ type UpdateOptions struct {
 	Manager string `long:"manager" short:"m" usage:"Force the handler type" default:"manifest" local:"true"`
 }
 
+// Update the local index of known locations for remote Unikraft components.
+func Update(ctx context.Context, opts *UpdateOptions, args ...string) error {
+	if opts == nil {
+		opts = &UpdateOptions{}
+	}
+
+	return opts.Run(ctx, args)
+}
+
 func NewCmd() *cobra.Command {
 	cmd, err := cmdfactory.New(&UpdateOptions{}, cobra.Command{
 		Short: "Retrieve new lists of Unikraft components, libraries and packages",

--- a/internal/cli/kraft/properclean/properclean.go
+++ b/internal/cli/kraft/properclean/properclean.go
@@ -46,7 +46,7 @@ type ProperCleanOptions struct {
 	Kraftfile string `long:"kraftfile" short:"K" usage:"Set an alternative path of the Kraftfile"`
 }
 
-func New() *cobra.Command {
+func NewCmd() *cobra.Command {
 	cmd, err := cmdfactory.New(&ProperCleanOptions{}, cobra.Command{
 		Short:   "Completely remove the build artifacts of a Unikraft project",
 		Use:     "properclean [DIR]",

--- a/internal/cli/kraft/properclean/properclean.go
+++ b/internal/cli/kraft/properclean/properclean.go
@@ -32,6 +32,7 @@
 package properclean
 
 import (
+	"context"
 	"os"
 
 	"github.com/MakeNowJust/heredoc"
@@ -82,10 +83,9 @@ func (*ProperCleanOptions) Pre(cmd *cobra.Command, _ []string) error {
 	return nil
 }
 
-func (opts *ProperCleanOptions) Run(cmd *cobra.Command, args []string) error {
+func (opts *ProperCleanOptions) Run(ctx context.Context, args []string) error {
 	var err error
 
-	ctx := cmd.Context()
 	workdir := ""
 
 	if len(args) == 0 {

--- a/internal/cli/kraft/ps/ps.go
+++ b/internal/cli/kraft/ps/ps.go
@@ -32,7 +32,7 @@ const (
 	MemoryMiB = 1024 * 1024
 )
 
-func New() *cobra.Command {
+func NewCmd() *cobra.Command {
 	cmd, err := cmdfactory.New(&PsOptions{}, cobra.Command{
 		Short: "List running unikernels",
 		Use:   "ps [FLAGS]",

--- a/internal/cli/kraft/ps/ps.go
+++ b/internal/cli/kraft/ps/ps.go
@@ -5,6 +5,7 @@
 package ps
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -64,7 +65,7 @@ func (opts *PsOptions) Pre(cmd *cobra.Command, _ []string) error {
 	return nil
 }
 
-func (opts *PsOptions) Run(cmd *cobra.Command, _ []string) error {
+func (opts *PsOptions) Run(ctx context.Context, _ []string) error {
 	var err error
 
 	type psTable struct {
@@ -83,7 +84,6 @@ func (opts *PsOptions) Run(cmd *cobra.Command, _ []string) error {
 
 	var items []psTable
 
-	ctx := cmd.Context()
 	platform := mplatform.PlatformUnknown
 	var controller machineapi.MachineService
 

--- a/internal/cli/kraft/remove/remove.go
+++ b/internal/cli/kraft/remove/remove.go
@@ -26,6 +26,15 @@ type RemoveOptions struct {
 	platform string
 }
 
+// Remove stops and deletes a local Unikraft virtual machine.
+func Remove(ctx context.Context, opts *RemoveOptions, args ...string) error {
+	if opts == nil {
+		opts = &RemoveOptions{}
+	}
+
+	return opts.Run(ctx, args)
+}
+
 func NewCmd() *cobra.Command {
 	cmd, err := cmdfactory.New(&RemoveOptions{}, cobra.Command{
 		Short:   "Remove one or more running unikernels",

--- a/internal/cli/kraft/remove/remove.go
+++ b/internal/cli/kraft/remove/remove.go
@@ -5,6 +5,7 @@
 package remove
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/MakeNowJust/heredoc"
@@ -59,14 +60,13 @@ func (opts *RemoveOptions) Pre(cmd *cobra.Command, _ []string) error {
 	return nil
 }
 
-func (opts *RemoveOptions) Run(cmd *cobra.Command, args []string) error {
+func (opts *RemoveOptions) Run(ctx context.Context, args []string) error {
 	var err error
 
 	if len(args) == 0 && !opts.All {
 		return fmt.Errorf("no machine(s) specified")
 	}
 
-	ctx := cmd.Context()
 	platform := mplatform.PlatformUnknown
 	var controller machineapi.MachineService
 

--- a/internal/cli/kraft/remove/remove.go
+++ b/internal/cli/kraft/remove/remove.go
@@ -2,7 +2,7 @@
 // Copyright (c) 2022, Unikraft GmbH and The KraftKit Authors.
 // Licensed under the BSD-3-Clause License (the "License").
 // You may not use this file except in compliance with the License.
-package rm
+package remove
 
 import (
 	"fmt"
@@ -20,13 +20,13 @@ import (
 	mplatform "kraftkit.sh/machine/platform"
 )
 
-type Rm struct {
+type Remove struct {
 	All      bool `long:"all" usage:"Remove all machines"`
 	platform string
 }
 
 func New() *cobra.Command {
-	cmd, err := cmdfactory.New(&Rm{}, cobra.Command{
+	cmd, err := cmdfactory.New(&Remove{}, cobra.Command{
 		Short:   "Remove one or more running unikernels",
 		Use:     "rm [FLAGS] MACHINE [MACHINE [...]]",
 		Args:    cobra.MinimumNArgs(0),
@@ -54,12 +54,12 @@ func New() *cobra.Command {
 	return cmd
 }
 
-func (opts *Rm) Pre(cmd *cobra.Command, _ []string) error {
+func (opts *Remove) Pre(cmd *cobra.Command, _ []string) error {
 	opts.platform = cmd.Flag("plat").Value.String()
 	return nil
 }
 
-func (opts *Rm) Run(cmd *cobra.Command, args []string) error {
+func (opts *Remove) Run(cmd *cobra.Command, args []string) error {
 	var err error
 
 	if len(args) == 0 && !opts.All {

--- a/internal/cli/kraft/remove/remove.go
+++ b/internal/cli/kraft/remove/remove.go
@@ -25,7 +25,7 @@ type RemoveOptions struct {
 	platform string
 }
 
-func New() *cobra.Command {
+func NewCmd() *cobra.Command {
 	cmd, err := cmdfactory.New(&RemoveOptions{}, cobra.Command{
 		Short:   "Remove one or more running unikernels",
 		Use:     "rm [FLAGS] MACHINE [MACHINE [...]]",

--- a/internal/cli/kraft/remove/remove.go
+++ b/internal/cli/kraft/remove/remove.go
@@ -20,13 +20,13 @@ import (
 	mplatform "kraftkit.sh/machine/platform"
 )
 
-type Remove struct {
+type RemoveOptions struct {
 	All      bool `long:"all" usage:"Remove all machines"`
 	platform string
 }
 
 func New() *cobra.Command {
-	cmd, err := cmdfactory.New(&Remove{}, cobra.Command{
+	cmd, err := cmdfactory.New(&RemoveOptions{}, cobra.Command{
 		Short:   "Remove one or more running unikernels",
 		Use:     "rm [FLAGS] MACHINE [MACHINE [...]]",
 		Args:    cobra.MinimumNArgs(0),
@@ -54,12 +54,12 @@ func New() *cobra.Command {
 	return cmd
 }
 
-func (opts *Remove) Pre(cmd *cobra.Command, _ []string) error {
+func (opts *RemoveOptions) Pre(cmd *cobra.Command, _ []string) error {
 	opts.platform = cmd.Flag("plat").Value.String()
 	return nil
 }
 
-func (opts *Remove) Run(cmd *cobra.Command, args []string) error {
+func (opts *RemoveOptions) Run(cmd *cobra.Command, args []string) error {
 	var err error
 
 	if len(args) == 0 && !opts.All {

--- a/internal/cli/kraft/run/run.go
+++ b/internal/cli/kraft/run/run.go
@@ -57,7 +57,7 @@ type RunOptions struct {
 	machineController machineapi.MachineService
 }
 
-func New() *cobra.Command {
+func NewCmd() *cobra.Command {
 	cmd, err := cmdfactory.New(&RunOptions{}, cobra.Command{
 		Short:   "Run a unikernel",
 		Use:     "run [FLAGS] PROJECT|PACKAGE|BINARY -- [APP ARGS]",

--- a/internal/cli/kraft/run/run.go
+++ b/internal/cli/kraft/run/run.go
@@ -58,6 +58,15 @@ type RunOptions struct {
 	machineController machineapi.MachineService
 }
 
+// Run a Unikraft unikernel virtual machine locally.
+func Run(ctx context.Context, opts *RunOptions, args ...string) error {
+	if opts == nil {
+		opts = &RunOptions{}
+	}
+
+	return opts.Run(ctx, args)
+}
+
 func NewCmd() *cobra.Command {
 	cmd, err := cmdfactory.New(&RunOptions{}, cobra.Command{
 		Short:   "Run a unikernel",

--- a/internal/cli/kraft/run/run.go
+++ b/internal/cli/kraft/run/run.go
@@ -5,6 +5,7 @@
 package run
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -229,9 +230,8 @@ func (opts *RunOptions) Pre(cmd *cobra.Command, _ []string) error {
 	return nil
 }
 
-func (opts *RunOptions) Run(cmd *cobra.Command, args []string) error {
+func (opts *RunOptions) Run(ctx context.Context, args []string) error {
 	var err error
-	ctx := cmd.Context()
 
 	machine := &machineapi.Machine{
 		ObjectMeta: metav1.ObjectMeta{},

--- a/internal/cli/kraft/set/set.go
+++ b/internal/cli/kraft/set/set.go
@@ -32,6 +32,7 @@
 package set
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"strings"
@@ -85,10 +86,8 @@ func (*SetOptions) Pre(cmd *cobra.Command, _ []string) error {
 	return nil
 }
 
-func (opts *SetOptions) Run(cmd *cobra.Command, args []string) error {
+func (opts *SetOptions) Run(ctx context.Context, args []string) error {
 	var err error
-
-	ctx := cmd.Context()
 
 	workdir := ""
 	confOpts := []string{}

--- a/internal/cli/kraft/set/set.go
+++ b/internal/cli/kraft/set/set.go
@@ -50,6 +50,15 @@ type SetOptions struct {
 	Workdir   string `long:"workdir" short:"w" usage:"Work on a unikernel at a path"`
 }
 
+// Set a KConfig variable in a Unikraft project.
+func Set(ctx context.Context, opts *SetOptions, args ...string) error {
+	if opts == nil {
+		opts = &SetOptions{}
+	}
+
+	return opts.Run(ctx, args)
+}
+
 func NewCmd() *cobra.Command {
 	cmd, err := cmdfactory.New(&SetOptions{}, cobra.Command{
 		Short:   "Set a variable for a Unikraft project",

--- a/internal/cli/kraft/set/set.go
+++ b/internal/cli/kraft/set/set.go
@@ -49,7 +49,7 @@ type SetOptions struct {
 	Workdir   string `long:"workdir" short:"w" usage:"Work on a unikernel at a path"`
 }
 
-func New() *cobra.Command {
+func NewCmd() *cobra.Command {
 	cmd, err := cmdfactory.New(&SetOptions{}, cobra.Command{
 		Short:   "Set a variable for a Unikraft project",
 		Hidden:  true,

--- a/internal/cli/kraft/stop/stop.go
+++ b/internal/cli/kraft/stop/stop.go
@@ -23,6 +23,15 @@ type StopOptions struct {
 	platform string
 }
 
+// Stop a local Unikraft virtual machine.
+func Stop(ctx context.Context, opts *StopOptions, args ...string) error {
+	if opts == nil {
+		opts = &StopOptions{}
+	}
+
+	return opts.Run(ctx, args)
+}
+
 func NewCmd() *cobra.Command {
 	cmd, err := cmdfactory.New(&StopOptions{}, cobra.Command{
 		Short: "Stop one or more running unikernels",

--- a/internal/cli/kraft/stop/stop.go
+++ b/internal/cli/kraft/stop/stop.go
@@ -22,7 +22,7 @@ type StopOptions struct {
 	platform string
 }
 
-func New() *cobra.Command {
+func NewCmd() *cobra.Command {
 	cmd, err := cmdfactory.New(&StopOptions{}, cobra.Command{
 		Short: "Stop one or more running unikernels",
 		Use:   "stop [FLAGS] MACHINE [MACHINE [...]]",

--- a/internal/cli/kraft/stop/stop.go
+++ b/internal/cli/kraft/stop/stop.go
@@ -5,6 +5,7 @@
 package stop
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/MakeNowJust/heredoc"
@@ -58,14 +59,13 @@ func (opts *StopOptions) Pre(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-func (opts *StopOptions) Run(cmd *cobra.Command, args []string) error {
+func (opts *StopOptions) Run(ctx context.Context, args []string) error {
 	if len(args) == 0 && !opts.All {
 		return fmt.Errorf("please supply a machine ID or name or use the --all flag")
 	}
 
 	var err error
 
-	ctx := cmd.Context()
 	platform := mplatform.PlatformUnknown
 	var controller machineapi.MachineService
 

--- a/internal/cli/kraft/unset/unset.go
+++ b/internal/cli/kraft/unset/unset.go
@@ -32,6 +32,7 @@
 package unset
 
 import (
+	"context"
 	"fmt"
 	"os"
 
@@ -83,10 +84,8 @@ func (*UnsetOptions) Pre(cmd *cobra.Command, _ []string) error {
 	return nil
 }
 
-func (opts *UnsetOptions) Run(cmd *cobra.Command, args []string) error {
+func (opts *UnsetOptions) Run(ctx context.Context, args []string) error {
 	var err error
-
-	ctx := cmd.Context()
 
 	workdir := ""
 	confOpts := []string{}

--- a/internal/cli/kraft/unset/unset.go
+++ b/internal/cli/kraft/unset/unset.go
@@ -48,6 +48,15 @@ type UnsetOptions struct {
 	Workdir string `long:"workdir" short:"w" usage:"Work on a unikernel at a path"`
 }
 
+// Unset a KConfig option in a Unikraft project.
+func Unset(ctx context.Context, opts *UnsetOptions, args ...string) error {
+	if opts == nil {
+		opts = &UnsetOptions{}
+	}
+
+	return opts.Run(ctx, args)
+}
+
 func NewCmd() *cobra.Command {
 	cmd, err := cmdfactory.New(&UnsetOptions{}, cobra.Command{
 		Short:   "Unset a variable for a Unikraft project",

--- a/internal/cli/kraft/unset/unset.go
+++ b/internal/cli/kraft/unset/unset.go
@@ -47,7 +47,7 @@ type UnsetOptions struct {
 	Workdir string `long:"workdir" short:"w" usage:"Work on a unikernel at a path"`
 }
 
-func New() *cobra.Command {
+func NewCmd() *cobra.Command {
 	cmd, err := cmdfactory.New(&UnsetOptions{}, cobra.Command{
 		Short:   "Unset a variable for a Unikraft project",
 		Hidden:  true,

--- a/internal/cli/kraft/version/version.go
+++ b/internal/cli/kraft/version/version.go
@@ -16,7 +16,7 @@ import (
 
 type VersionOptions struct{}
 
-func New() *cobra.Command {
+func NewCmd() *cobra.Command {
 	cmd, err := cmdfactory.New(&VersionOptions{}, cobra.Command{
 		Short:   "Show kraft version information",
 		Use:     "version",

--- a/internal/cli/kraft/version/version.go
+++ b/internal/cli/kraft/version/version.go
@@ -5,6 +5,7 @@
 package version
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/spf13/cobra"
@@ -33,7 +34,7 @@ func NewCmd() *cobra.Command {
 	return cmd
 }
 
-func (opts *VersionOptions) Run(cmd *cobra.Command, _ []string) error {
-	fmt.Fprintf(iostreams.G(cmd.Context()).Out, "kraft %s", version.String())
+func (opts *VersionOptions) Run(ctx context.Context, _ []string) error {
+	fmt.Fprintf(iostreams.G(ctx).Out, "kraft %s", version.String())
 	return nil
 }

--- a/internal/cli/runu/create/create.go
+++ b/internal/cli/runu/create/create.go
@@ -44,7 +44,7 @@ type CreateOptions struct {
 	PidFile       string `long:"pid-file" usage:"specify a file where the process ID will be written"`
 }
 
-func New() *cobra.Command {
+func NewCmd() *cobra.Command {
 	cmd, err := cmdfactory.New(&CreateOptions{}, cobra.Command{
 		Short: "Create a new unikernel",
 		Args:  cobra.ExactArgs(1),

--- a/internal/cli/runu/delete/delete.go
+++ b/internal/cli/runu/delete/delete.go
@@ -5,6 +5,7 @@
 package delete
 
 import (
+	"context"
 	"fmt"
 	"time"
 
@@ -23,6 +24,8 @@ const (
 // DeleteOptions implements the OCI "delete" command.
 type DeleteOptions struct {
 	Force bool `long:"force" short:"f" usage:"forcibly delete the unikernel if it is still running"`
+
+	rootDir string
 }
 
 func NewCmd() *cobra.Command {
@@ -39,9 +42,16 @@ func NewCmd() *cobra.Command {
 	return cmd
 }
 
-func (opts *DeleteOptions) Run(cmd *cobra.Command, args []string) (retErr error) {
-	ctx := cmd.Context()
+func (opts *DeleteOptions) Pre(cmd *cobra.Command, args []string) error {
+	opts.rootDir = cmd.Flag(flagRoot).Value.String()
+	if opts.rootDir == "" {
+		return fmt.Errorf("state directory (--%s flag) is not set", flagRoot)
+	}
 
+	return nil
+}
+
+func (opts *DeleteOptions) Run(ctx context.Context, args []string) (retErr error) {
 	defer func() {
 		// Make sure the error is written to the configured log destination, so
 		// that the message gets propagated through the caller (e.g. containerd-shim)
@@ -50,14 +60,9 @@ func (opts *DeleteOptions) Run(cmd *cobra.Command, args []string) (retErr error)
 		}
 	}()
 
-	rootDir := cmd.Flag(flagRoot).Value.String()
-	if rootDir == "" {
-		return fmt.Errorf("state directory (--%s flag) is not set", flagRoot)
-	}
-
 	cID := args[0]
 
-	c, err := libcontainer.Load(rootDir, cID)
+	c, err := libcontainer.Load(opts.rootDir, cID)
 	if err != nil {
 		return fmt.Errorf("loading container from saved state: %w", err)
 	}

--- a/internal/cli/runu/delete/delete.go
+++ b/internal/cli/runu/delete/delete.go
@@ -25,7 +25,7 @@ type DeleteOptions struct {
 	Force bool `long:"force" short:"f" usage:"forcibly delete the unikernel if it is still running"`
 }
 
-func New() *cobra.Command {
+func NewCmd() *cobra.Command {
 	cmd, err := cmdfactory.New(&DeleteOptions{}, cobra.Command{
 		Short: "Delete a unikernel",
 		Args:  cobra.ExactArgs(1),

--- a/internal/cli/runu/kill/kill.go
+++ b/internal/cli/runu/kill/kill.go
@@ -30,7 +30,7 @@ type KillOptions struct {
 	All bool `long:"all" short:"a" usage:"send the specified signal to all processes"`
 }
 
-func New() *cobra.Command {
+func NewCmd() *cobra.Command {
 	cmd, err := cmdfactory.New(&KillOptions{}, cobra.Command{
 		Short: "Send a signal to a unikernel",
 		Args:  cobra.RangeArgs(1, 2),

--- a/internal/cli/runu/ps/ps.go
+++ b/internal/cli/runu/ps/ps.go
@@ -31,7 +31,7 @@ type PsOptions struct {
 	Format string `long:"format" short:"f" usage:"format of the output (table or json)" default:"table"`
 }
 
-func New() *cobra.Command {
+func NewCmd() *cobra.Command {
 	cmd, err := cmdfactory.New(&PsOptions{}, cobra.Command{
 		Short: "Displays the VMM process of a unikernel",
 		Args:  cobra.MinimumNArgs(1),

--- a/internal/cli/runu/runu.go
+++ b/internal/cli/runu/runu.go
@@ -40,7 +40,7 @@ type RunuOptions struct {
 	SystemdCgroup bool   `long:"systemd-cgroup" usage:"enable systemd cgroup support"`
 }
 
-func New() *cobra.Command {
+func NewCmd() *cobra.Command {
 	cmd, err := cmdfactory.New(&RunuOptions{}, cobra.Command{
 		Short: "Run OCI-compatible unikernels",
 		CompletionOptions: cobra.CompletionOptions{
@@ -52,12 +52,12 @@ func New() *cobra.Command {
 		panic(err)
 	}
 
-	cmd.AddCommand(state.New())
-	cmd.AddCommand(create.New())
-	cmd.AddCommand(start.New())
-	cmd.AddCommand(kill.New())
-	cmd.AddCommand(delete.New())
-	cmd.AddCommand(ps.New())
+	cmd.AddCommand(state.NewCmd())
+	cmd.AddCommand(create.NewCmd())
+	cmd.AddCommand(start.NewCmd())
+	cmd.AddCommand(kill.NewCmd())
+	cmd.AddCommand(delete.NewCmd())
+	cmd.AddCommand(ps.NewCmd())
 
 	return cmd
 }
@@ -90,7 +90,7 @@ func (*RunuOptions) Run(cmd *cobra.Command, args []string) error {
 }
 
 func Main(args []string) int {
-	cmd := New()
+	cmd := NewCmd()
 
 	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer cancel()

--- a/internal/cli/runu/runu.go
+++ b/internal/cli/runu/runu.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 
 	"kraftkit.sh/cmdfactory"
 	"kraftkit.sh/config"
@@ -85,8 +86,8 @@ func (opts *RunuOptions) PersistentPre(cmd *cobra.Command, _ []string) error {
 	return nil
 }
 
-func (*RunuOptions) Run(cmd *cobra.Command, args []string) error {
-	return cmd.Help()
+func (*RunuOptions) Run(_ context.Context, args []string) error {
+	return pflag.ErrHelp
 }
 
 func Main(args []string) int {

--- a/internal/cli/runu/start/start.go
+++ b/internal/cli/runu/start/start.go
@@ -5,6 +5,7 @@
 package start
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/spf13/cobra"
@@ -19,7 +20,9 @@ const (
 )
 
 // StartOptions implements the OCI "start" command.
-type StartOptions struct{}
+type StartOptions struct {
+	rootDir string
+}
 
 func NewCmd() *cobra.Command {
 	cmd, err := cmdfactory.New(&StartOptions{}, cobra.Command{
@@ -35,9 +38,16 @@ func NewCmd() *cobra.Command {
 	return cmd
 }
 
-func (opts *StartOptions) Run(cmd *cobra.Command, args []string) (retErr error) {
-	ctx := cmd.Context()
+func (opts *StartOptions) Pre(cmd *cobra.Command, args []string) error {
+	opts.rootDir = cmd.Flag(flagRoot).Value.String()
+	if opts.rootDir == "" {
+		return fmt.Errorf("state directory (--%s flag) is not set", flagRoot)
+	}
 
+	return nil
+}
+
+func (opts *StartOptions) Run(ctx context.Context, args []string) (retErr error) {
 	defer func() {
 		// Make sure the error is written to the configured log destination, so
 		// that the message gets propagated through the caller (e.g. containerd-shim)
@@ -46,14 +56,9 @@ func (opts *StartOptions) Run(cmd *cobra.Command, args []string) (retErr error) 
 		}
 	}()
 
-	rootDir := cmd.Flag(flagRoot).Value.String()
-	if rootDir == "" {
-		return fmt.Errorf("state directory (--%s flag) is not set", flagRoot)
-	}
-
 	cID := args[0]
 
-	c, err := libcontainer.Load(rootDir, cID)
+	c, err := libcontainer.Load(opts.rootDir, cID)
 	if err != nil {
 		return fmt.Errorf("loading container from saved state: %w", err)
 	}

--- a/internal/cli/runu/start/start.go
+++ b/internal/cli/runu/start/start.go
@@ -21,7 +21,7 @@ const (
 // StartOptions implements the OCI "start" command.
 type StartOptions struct{}
 
-func New() *cobra.Command {
+func NewCmd() *cobra.Command {
 	cmd, err := cmdfactory.New(&StartOptions{}, cobra.Command{
 		Short: "Start a unikernel",
 		Args:  cobra.ExactArgs(1),

--- a/internal/cli/runu/state/state.go
+++ b/internal/cli/runu/state/state.go
@@ -25,7 +25,7 @@ const (
 // StateOptions implements the OCI "state" command.
 type StateOptions struct{}
 
-func New() *cobra.Command {
+func NewCmd() *cobra.Command {
 	cmd, err := cmdfactory.New(&StateOptions{}, cobra.Command{
 		Short: "Output the state of a unikernel",
 		Args:  cobra.ExactArgs(1),

--- a/internal/cli/runu/state/state.go
+++ b/internal/cli/runu/state/state.go
@@ -5,6 +5,7 @@
 package state
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -23,7 +24,9 @@ const (
 )
 
 // StateOptions implements the OCI "state" command.
-type StateOptions struct{}
+type StateOptions struct {
+	rootDir string
+}
 
 func NewCmd() *cobra.Command {
 	cmd, err := cmdfactory.New(&StateOptions{}, cobra.Command{
@@ -39,9 +42,16 @@ func NewCmd() *cobra.Command {
 	return cmd
 }
 
-func (opts *StateOptions) Run(cmd *cobra.Command, args []string) (retErr error) {
-	ctx := cmd.Context()
+func (opts *StateOptions) Pre(cmd *cobra.Command, args []string) error {
+	opts.rootDir = cmd.Flag(flagRoot).Value.String()
+	if opts.rootDir == "" {
+		return fmt.Errorf("state directory (--%s flag) is not set", flagRoot)
+	}
 
+	return nil
+}
+
+func (opts *StateOptions) Run(ctx context.Context, args []string) (retErr error) {
 	defer func() {
 		// Make sure the error is written to the configured log destination, so
 		// that the message gets propagated through the caller (e.g. containerd-shim)
@@ -50,14 +60,9 @@ func (opts *StateOptions) Run(cmd *cobra.Command, args []string) (retErr error) 
 		}
 	}()
 
-	rootDir := cmd.Flag(flagRoot).Value.String()
-	if rootDir == "" {
-		return fmt.Errorf("state directory (--%s flag) is not set", flagRoot)
-	}
-
 	cID := args[0]
 
-	c, err := libcontainer.Load(rootDir, cID)
+	c, err := libcontainer.Load(opts.rootDir, cID)
 	if err != nil {
 		return fmt.Errorf("loading container from saved state: %w", err)
 	}


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

This PR enables re-using individual actions from `kraft` subcommands as reusable method actions.  Specifically, actions which are procedural and not informational are exposed (this means all list-type actions are excluded).  To make this change possible, the prototype for `cmdfactory.Run` was updated to use `ctx context.Context` as a positional argument as opposed to `cmd *cobra.Command`.  It turns out in all cases that `cmd` was used to access the command's context.  As a result, simply pass this context instead of the command.  This has the beneficial side-effect of allowing the `Run` method of subcommands to be used independently outside of the `cmdfactory`/subcommand structure as long as the relevant context and options populated.

For example, it is now possible to run a Unikraft build internally by calling:

```go
import "kraftkit.sh/internal/cli/kraft/build"

if err := build.Build(ctx, &build.BuildOptions{...}); err != nil {
  // ...
}
```