### PR TITLE
fix(initrd): Add initializers for buildkitd connectors

### DIFF
--- a/initrd/dockerfile.go
+++ b/initrd/dockerfile.go
@@ -20,6 +20,12 @@ import (
 	"github.com/containerd/console"
 	"github.com/moby/buildkit/client"
 	"github.com/moby/buildkit/util/progress/progressui"
+
+	_ "github.com/moby/buildkit/client/connhelper/dockercontainer"
+	_ "github.com/moby/buildkit/client/connhelper/kubepod"
+	_ "github.com/moby/buildkit/client/connhelper/nerdctlcontainer"
+	_ "github.com/moby/buildkit/client/connhelper/podmancontainer"
+	_ "github.com/moby/buildkit/client/connhelper/ssh"
 )
 
 type dockerfile struct {


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

This commit adds initializers to buildkit dial connectors.  It enables users the ability to use buildkit which is being run on alternative systems other than the host UNIX socket or a TCP socket.

These new connectors allow using buildkit over: ssh, Docker container, Dodman container, containerd container and a Kubernetes pod simply by specifying a relevant scheme. See [here][0] for details.

[0]: https://github.com/moby/buildkit#containerizing-buildkit

