### PR TITLE
fix: Fix restoring TUI processtree IOStreams

### DIFF
--- a/internal/cli/kraft/build/builder_kraftfile_unikraft.go
+++ b/internal/cli/kraft/build/builder_kraftfile_unikraft.go
@@ -52,19 +52,6 @@ func (build *builderKraftfileUnikraft) pull(ctx context.Context, opts *BuildOpti
 	parallel := !config.G[config.KraftKit](ctx).NoParallel
 	auths := config.G[config.KraftKit](ctx).Auth
 
-	// FIXME: This is a temporary workaround for incorporating multiple processes in
-	// a command. After calling processtree the original output writer is lost
-	// so writing will no longer work. To fix this we temporarily save it
-	// beforehand.
-
-	// A proper fix would ensure in the tui package that this writer is
-	// preserved. Thankfully, this is the only place where it manifests right
-	// now.
-	oldOut := iostreams.G(ctx).Out
-	defer func() {
-		iostreams.G(ctx).Out = oldOut
-	}()
-
 	if template := opts.project.Template(); template != nil {
 		if stat, err := os.Stat(template.Path()); err != nil || !stat.IsDir() || opts.ForcePull {
 			var templatePack pack.Package

--- a/internal/cli/kraft/fetch/fetch.go
+++ b/internal/cli/kraft/fetch/fetch.go
@@ -129,19 +129,6 @@ func (opts *FetchOptions) pull(ctx context.Context, project app.Application, wor
 	parallel := !config.G[config.KraftKit](ctx).NoParallel
 	auths := config.G[config.KraftKit](ctx).Auth
 
-	// FIXME: This is a temporary workaround for incorporating multiple processes in
-	// a command. After calling processtree the original output writer is lost
-	// so writing will no longer work. To fix this we temporarily save it
-	// beforehand.
-
-	// A proper fix would ensure in the tui package that this writer is
-	// preserved. Thankfully, this is the only place where it manifests right
-	// now.
-	oldOut := iostreams.G(ctx).Out
-	defer func() {
-		iostreams.G(ctx).Out = oldOut
-	}()
-
 	if _, err := opts.project.Components(ctx); err != nil && opts.project.Template().Name() != "" {
 		var packages []pack.Package
 		search := processtree.NewProcessTreeItem(

--- a/internal/cli/kraft/menu/menu.go
+++ b/internal/cli/kraft/menu/menu.go
@@ -117,19 +117,6 @@ func (opts *MenuOptions) pull(ctx context.Context, project app.Application, work
 	parallel := !config.G[config.KraftKit](ctx).NoParallel
 	auths := config.G[config.KraftKit](ctx).Auth
 
-	// FIXME: This is a temporary workaround for incorporating multiple processes in
-	// a command. After calling processtree the original output writer is lost
-	// so writing will no longer work. To fix this we temporarily save it
-	// beforehand.
-
-	// A proper fix would ensure in the tui package that this writer is
-	// preserved. Thankfully, this is the only place where it manifests right
-	// now.
-	oldOut := iostreams.G(ctx).Out
-	defer func() {
-		iostreams.G(ctx).Out = oldOut
-	}()
-
 	if _, err := opts.project.Components(ctx); err != nil && opts.project.Template().Name() != "" {
 		var packages []pack.Package
 		search := processtree.NewProcessTreeItem(

--- a/iostreams/iostreams.go
+++ b/iostreams/iostreams.go
@@ -47,7 +47,7 @@ type ErrClosedPagerPipe struct {
 	error
 }
 
-type fileWriter interface {
+type FileWriter interface {
 	io.Writer
 	Fd() uintptr
 }
@@ -70,7 +70,7 @@ type IOStreams struct {
 	term Terminal
 
 	In     fileReader
-	Out    fileWriter
+	Out    FileWriter
 	ErrOut io.Writer
 
 	terminalTheme string
@@ -154,7 +154,7 @@ func (s *IOStreams) SetColorEnabled(colorEnabled bool) {
 	s.colorEnabled = colorEnabled
 }
 
-func (s *IOStreams) SetOut(out fileWriter) {
+func (s *IOStreams) SetOut(out FileWriter) {
 	s.Out = out
 }
 
@@ -417,7 +417,7 @@ func (s *IOStreams) TempFile(dir, pattern string) (*os.File, error) {
 func System() *IOStreams {
 	terminal := ghTerm.FromEnv()
 
-	var stdout fileWriter = os.Stdout
+	var stdout FileWriter = os.Stdout
 
 	// On Windows with no virtual terminal processing support, translate ANSI escape
 	// sequences to console syscalls
@@ -490,7 +490,7 @@ func (w *fdWriteCloser) Fd() uintptr {
 
 // fdWriter represents a wrapped stdin ReadCloser that preserves the original file descriptor
 type fdReader struct {
-	io.ReadCloser
+	io.Reader
 	fd uintptr
 }
 
@@ -498,7 +498,7 @@ func (r *fdReader) Fd() uintptr {
 	return r.fd
 }
 
-func NewNoTTYWriter(w io.WriteCloser) *fdWriter {
+func NewNoTTYWriter(w io.Writer) *fdWriter {
 	return &fdWriter{w, 0}
 }
 


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

Instead of per-instance usage of restoring the TUI IOstreams, embed the restoration within the processtree.
