### PR TITLE
refactor(update): Run parallel updates and hide on success

### DIFF
--- a/internal/cli/kraft/pkg/update/update.go
+++ b/internal/cli/kraft/pkg/update/update.go
@@ -108,6 +108,7 @@ func (opts *UpdateOptions) Run(ctx context.Context, args []string) error {
 		[]processtree.ProcessTreeOption{
 			processtree.IsParallel(!config.G[config.KraftKit](ctx).NoParallel),
 			processtree.WithRenderer(log.LoggerTypeFromString(config.G[config.KraftKit](ctx).Log.Type) != log.FANCY),
+			processtree.WithHideOnSuccess(true),
 		},
 		processes...,
 	)

--- a/test/e2e/cli/pkg_update_test.go
+++ b/test/e2e/cli/pkg_update_test.go
@@ -59,7 +59,7 @@ var _ = Describe("kraft pkg", func() {
 					Expect(err).ToNot(HaveOccurred())
 
 					Expect(stderr.String()).To(BeEmpty())
-					Expect(stdout.String()).To(MatchRegexp(`^{"level":"info","msg":"Updating..."}\n$`))
+					Expect(stdout.String()).To(MatchRegexp(`^{"level":"info","msg":"updating"}\n$`))
 
 					Expect(manifestsPath).To(ContainFiles("index.yaml", "unikraft.yaml"))
 					Expect(manifestsPath).To(ContainDirectories("libs"))


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

This refactor makes use of the processtree and parallelization to run an update on all internal package managers if `--manager=all` is set.  Additionally, the result is hidden if the update was successful.  The return code is still `0` on success.
