### PR TITLE
fix(tui): Do not add parents when requesting children 

### DIFF
--- a/tui/processtree/processtree.go
+++ b/tui/processtree/processtree.go
@@ -191,9 +191,8 @@ func (pt *ProcessTree) Init() tea.Cmd {
 		pt.timer.Init(),
 	}
 
-	// Start all child processes
-	children := pt.getNextReadyChildren(pt.tree)
-	for _, pti := range children {
+	// Start all child processes plus this one
+	for _, pti := range pt.tree {
 		pti := pti
 		pti.timeout = pt.timeout
 
@@ -233,16 +232,6 @@ func (pt ProcessTree) getNextReadyChildren(tree []*ProcessTreeItem) []*ProcessTr
 					completed++
 				}
 			}
-		}
-
-		// Only start the parent process if all children have succeeded or if there
-		// no children and the status is pending
-		if len(subprocesses) == 0 &&
-			failed == 0 &&
-			(pt.parallel || (len(items) == 0 && !pt.parallel)) &&
-			completed == len(item.children) &&
-			(item.status == StatusPending || item.status == StatusRunningChild) {
-			items = append(items, item)
 		}
 	}
 


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

~This enforces the non-parallel way of adding items. It does not decrease the speed of the process tree.~
This was fixed and nothing sequential is done anymore.

Without this what happens is:
* All processes are added and started as requested
* More processes are started and executed until the process tree stops as all X processes have completed. More specifically, the parent is added every time afterwards.
* There is a chance that more processes are started and added between the moment all X processes have completed and the tree is stopped.

~For 4 processes there is around a 50% chance that at least an additional process is started, or, even worse, because the order is not guaranteed, the duplicates take precedence.~
Processes are started until the whole tree is finished so unless you have a quick internet connection, this will fail.

This means that there is no way to ensure order outside of the `processTree` (basically considering it a black box).

An example with the bug in action:
![image](https://github.com/unikraft/kraftkit/assets/46280801/47130f7e-ff0a-4397-8bdf-16838c995355)

I currently do not have any ideas why this did not manifest itself until now.

Later Update:

The bug happened because the function that was supposed to return children also returned the parents. This resulted in infinite cycles that had a hard stop (the process tree finishing).

The fix removed the parent addition and also just inits the parents in `Init`, as the children are picked up by `Update` anyways.