### PR TITLE
fix(oci): Initialize the index's descriptor

### DIFF
--- a/oci/index.go
+++ b/oci/index.go
@@ -53,6 +53,18 @@ func NewIndexFromSpec(ctx context.Context, handle handler.Handler, spec *ocispec
 
 	index.index = spec
 
+	indexJson, err := json.Marshal(spec)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal manifest: %w", err)
+	}
+
+	indexDesc := content.NewDescriptorFromBytes(
+		ocispec.MediaTypeImageIndex,
+		indexJson,
+	)
+
+	index.desc = &indexDesc
+
 	for _, desc := range spec.Manifests {
 		manifest, err := NewManifestFromDigest(ctx, handle, desc.Digest)
 		if err != nil {


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

Initializing an index via `NewIndexFromSpec` did not previously initialize the already well-known descriptor (and therefore digest). Which could be used later on.
