### PR TITLE
feat(paraprogress): Add `WithTimeout` option and add ellipsis

### DIFF
--- a/tui/processtree/options.go
+++ b/tui/processtree/options.go
@@ -4,6 +4,8 @@
 // You may not use this file expect in compliance with the License.
 package processtree
 
+import "time"
+
 type ProcessTreeOption func(pt *ProcessTree) error
 
 func WithVerb(verb string) ProcessTreeOption {
@@ -37,6 +39,13 @@ func WithFailFast(failFast bool) ProcessTreeOption {
 func WithHideOnSuccess(hide bool) ProcessTreeOption {
 	return func(pt *ProcessTree) error {
 		pt.hide = hide
+		return nil
+	}
+}
+
+func WithTimeout(timeout time.Duration) ProcessTreeOption {
+	return func(pt *ProcessTree) error {
+		pt.timeout = timeout
 		return nil
 	}
 }

--- a/tui/processtree/processtree.go
+++ b/tui/processtree/processtree.go
@@ -57,6 +57,9 @@ type ProcessTreeItem struct {
 	timer     stopwatch.Model
 	norender  bool
 	ctx       context.Context
+	timeout   time.Duration
+	err       error
+	ellipsis  string
 }
 
 type ProcessTree struct {
@@ -77,6 +80,7 @@ type ProcessTree struct {
 	failFast bool
 	oldOut   iostreams.FileWriter
 	hide     bool
+	timeout  time.Duration
 }
 
 func NewProcessTree(ctx context.Context, opts []ProcessTreeOption, tree ...*ProcessTreeItem) (*ProcessTree, error) {
@@ -105,6 +109,7 @@ func NewProcessTree(ctx context.Context, opts []ProcessTreeOption, tree ...*Proc
 	_ = pt.traverseTreeAndCall(tree, func(item *ProcessTreeItem) error {
 		total++
 		item.norender = pt.norender
+		item.timeout = pt.timeout
 		return nil
 	})
 
@@ -189,6 +194,8 @@ func (pt *ProcessTree) Init() tea.Cmd {
 	children := pt.getNextReadyChildren(pt.tree)
 	for _, pti := range children {
 		pti := pti
+		pti.timeout = pt.timeout
+
 		cmds = append(cmds, pt.waitForProcessCmd(pti))
 		cmds = append(cmds, pti.timer.Init())
 	}

--- a/tui/processtree/update.go
+++ b/tui/processtree/update.go
@@ -6,6 +6,7 @@ package processtree
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/charmbracelet/bubbles/spinner"
 	tea "github.com/charmbracelet/bubbletea"
@@ -47,6 +48,14 @@ func (pt *ProcessTree) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				pti.status = StatusFailed
 			} else {
 				pti.spinner, cmd = pti.spinner.Update(msg)
+			}
+
+			if pti.status == StatusRunning ||
+				pti.status == StatusRunningChild ||
+				pti.status == StatusRunningButAChildHasFailed {
+				pti.ellipsis = strings.Repeat(".", int(pti.timer.Elapsed().Seconds())%4)
+			} else {
+				pti.ellipsis = ""
 			}
 
 			cmds = append(cmds, cmd)

--- a/tui/processtree/update.go
+++ b/tui/processtree/update.go
@@ -42,7 +42,13 @@ func (pt *ProcessTree) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case spinner.TickMsg:
 		_ = pt.traverseTreeAndCall(pt.tree, func(pti *ProcessTreeItem) error {
-			pti.spinner, cmd = pti.spinner.Update(msg)
+			if pti.timeout != 0 && pti.timer.Elapsed() > pti.timeout {
+				pti.err = fmt.Errorf("process timedout after %s", pti.timeout.String())
+				pti.status = StatusFailed
+			} else {
+				pti.spinner, cmd = pti.spinner.Update(msg)
+			}
+
 			cmds = append(cmds, cmd)
 
 			return nil

--- a/tui/processtree/view.go
+++ b/tui/processtree/view.go
@@ -105,6 +105,10 @@ func (stm ProcessTree) printItem(pti *ProcessTreeItem, offset uint) string {
 
 	textLeft += " " + pti.textLeft
 
+	if pti.status == StatusRunning || pti.status == StatusRunningChild {
+		textLeft += pti.ellipsis
+	}
+
 	elapsed := utils.HumanizeDuration(pti.timer.Elapsed())
 	rightTimerWidth := width(elapsed)
 	if rightTimerWidth > stm.rightPad {


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

This PR adds two features to the `processtree` package:

1. Introduces a `WithTimeout` option;
2. Adds a vsual ellipsis (...) to the process title as it works.

