### PR TITLE
feat: Handle initrd in fstab entries

### DIFF
--- a/machine/qemu/v1alpha1.go
+++ b/machine/qemu/v1alpha1.go
@@ -358,6 +358,16 @@ func (service *machineV1alpha1Service) Create(ctx context.Context, machine *mach
 				"mkpath",
 			).String())
 
+		case "initrd":
+			fstab = append(fstab, vfscore.NewFstabEntry(
+				"initrd",
+				vol.Spec.Destination,
+				vol.Spec.Driver,
+				"",
+				"",
+				// By default, create the directory if it does not exist when mounting.
+				"mkpath",
+			).String())
 		default:
 			return machine, fmt.Errorf("unsupported QEMU volume driver: %v", vol.Spec.Driver)
 		}

--- a/machine/qemu/v1alpha1.go
+++ b/machine/qemu/v1alpha1.go
@@ -354,6 +354,8 @@ func (service *machineV1alpha1Service) Create(ctx context.Context, machine *mach
 				// Unikraft:
 				"",
 				"",
+				// By default, create the directory if it does not exist when mounting.
+				"mkpath",
 			).String())
 
 		default:

--- a/unikraft/export/v0/ukargparse/params_strslice.go
+++ b/unikraft/export/v0/ukargparse/params_strslice.go
@@ -61,12 +61,12 @@ func (param *ParamStrSlice) String() string {
 	ret.WriteString(param.library)
 	ret.WriteString(".")
 	ret.WriteString(param.name)
-	ret.WriteString("=[")
+	ret.WriteString("=[ ")
 
 	for _, v := range param.values {
 		ret.WriteString("\"")
 		ret.WriteString(v)
-		ret.WriteString("\"")
+		ret.WriteString("\" ")
 	}
 
 	ret.WriteString("]")

--- a/unikraft/export/v0/vfscore/params.go
+++ b/unikraft/export/v0/vfscore/params.go
@@ -25,18 +25,20 @@ type FstabEntry struct {
 	mountTarget  string
 	fsDriver     string
 	flags        string
-	options      string
+	opts         string
+	ukopts       string
 }
 
 // NewFstabEntry generates a structure that is representative of one of
 // Unikraft's vfscore automounts.
-func NewFstabEntry(sourceDevice, mountTarget, fsDriver, flags, options string) FstabEntry {
+func NewFstabEntry(sourceDevice, mountTarget, fsDriver, flags, opts, ukopts string) FstabEntry {
 	return FstabEntry{
 		sourceDevice,
 		mountTarget,
 		fsDriver,
 		flags,
-		options,
+		opts,
+		ukopts,
 	}
 }
 
@@ -48,6 +50,7 @@ func (entry FstabEntry) String() string {
 		entry.mountTarget,
 		entry.fsDriver,
 		entry.flags,
-		entry.options,
+		entry.opts,
+		entry.ukopts,
 	}, ":")
 }


### PR DESCRIPTION

<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [ ] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [ ] Tested your changes against relevant architectures and platforms;
  - [ ] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

This PR provides better handling of the initrd following the recent changes to the Unikraft core ([#1144][0], [#1145][1]).  Essentially this change better facilitates supplementing initializing a QEMU instance with correct command-line arguments when `CONFIG_LIBVFSCORE_FSTAB` is set.  This includes now specifically listing the initrd as a "volume" such that it appears in the fstab list.  Additionally, we must accommodate for new Unikraft-specific fstab options.

- feat: Handle Unikraft-specific options in vfstab arguments
- feat(qemu): Add `initrd` volume vfstab entry
- refactor(ukargparse): Add space around entries
- feat(run): Add a volume entry for initrd

[0]: https://github.com/unikraft/unikraft/pull/1144
[1]: https://github.com/unikraft/unikraft/pull/1145
