### PR TITLE
fix(kraft): Remove ellipsis from processtree invocations

### DIFF
--- a/internal/cli/kraft/pkg/list/list.go
+++ b/internal/cli/kraft/pkg/list/list.go
@@ -171,7 +171,7 @@ func (opts *ListOptions) Run(ctx context.Context, args []string) error {
 				processtree.WithHideOnSuccess(true),
 			},
 			processtree.NewProcessTreeItem(
-				"updating index...", "",
+				"updating index", "",
 				func(ctx context.Context) error {
 					found, err = packmanager.G(ctx).Catalog(ctx, qopts...)
 					if err != nil {

--- a/internal/cli/kraft/run/runner_package.go
+++ b/internal/cli/kraft/run/runner_package.go
@@ -113,7 +113,7 @@ func (runner *runnerPackage) Prepare(ctx context.Context, opts *RunOptions, mach
 				processtree.WithHideOnSuccess(true),
 			},
 			processtree.NewProcessTreeItem(
-				"searching...", "",
+				"searching", "",
 				func(ctx context.Context) error {
 					packs, err = runner.pm.Catalog(ctx, qopts...)
 					if err != nil {


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

Following the merge of #962, ellipses are added to the prompt, thus these scenarios would render twice as many (`.....`).
