### PR TITLE
fix(paraprogress): Fix outputs less than `LOGLEN`

### DIFF
--- a/tui/paraprogress/process.go
+++ b/tui/paraprogress/process.go
@@ -296,10 +296,12 @@ func (p Process) View() string {
 		}
 
 		truncate := 0
-		loglen := len(p.logs) - LOGLEN
 
 		if p.Status != StatusFailed {
-			truncate = loglen
+			loglen := len(p.logs) - LOGLEN
+			if loglen > 0 {
+				truncate = loglen
+			}
 		}
 
 		for _, line := range p.logs[truncate:] {


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

This commit fixes an issue where if the output is less than `LOGLEN` an index out of bounds error would be thrown.  Mitigate by performing a check for greater than zero check.
