### PR TITLE
refactor(utils): Reduce output of instance output

### DIFF
--- a/internal/cli/kraft/cloud/utils/print.go
+++ b/internal/cli/kraft/cloud/utils/print.go
@@ -38,15 +38,21 @@ func PrintInstances(ctx context.Context, format string, instances ...kcinstance.
 	}
 
 	// Header row
-	table.AddField("UUID", cs.Bold)
+	if format != "table" {
+		table.AddField("UUID", cs.Bold)
+	}
 	table.AddField("DNS", cs.Bold)
-	table.AddField("PRIVATE IP", cs.Bold)
+	if format != "table" {
+		table.AddField("PRIVATE IP", cs.Bold)
+	}
 	table.AddField("STATUS", cs.Bold)
 	table.AddField("CREATED AT", cs.Bold)
 	table.AddField("IMAGE", cs.Bold)
 	table.AddField("MEMORY", cs.Bold)
 	table.AddField("ARGS", cs.Bold)
-	table.AddField("SERVICE GROUP", cs.Bold)
+	if format != "table" {
+		table.AddField("SERVICE GROUP", cs.Bold)
+	}
 	table.AddField("BOOT TIME", cs.Bold)
 	table.EndRow()
 
@@ -59,15 +65,21 @@ func PrintInstances(ctx context.Context, format string, instances ...kcinstance.
 			}
 			createdAt = humanize.Time(createdTime)
 		}
-		table.AddField(instance.UUID, nil)
+		if format != "table" {
+			table.AddField(instance.UUID, nil)
+		}
 		table.AddField(instance.DNS, nil)
-		table.AddField(instance.PrivateIP, nil)
+		if format != "table" {
+			table.AddField(instance.PrivateIP, nil)
+		}
 		table.AddField(string(instance.Status), nil)
 		table.AddField(createdAt, nil)
 		table.AddField(instance.Image, nil)
 		table.AddField(humanize.Bytes(uint64(instance.MemoryMB)*humanize.MiByte), nil)
 		table.AddField(strings.Join(instance.Args, " "), nil)
-		table.AddField(instance.ServiceGroup, nil)
+		if format != "table" {
+			table.AddField(instance.ServiceGroup, nil)
+		}
 		table.AddField(fmt.Sprintf("%dus", instance.BootTimeUS), nil)
 		table.EndRow()
 	}


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

This commit reduces the verbose output when printing a list of instances.  To show more, a new option `-o wide` is used to show all fields in table mode.  All fields will be shown with JSON or YAML output formats.
