### PR TITLE
fix(pkg): Correctly set package arguments

### DIFF
--- a/internal/cli/kraft/pkg/packager_kraftfile_runtime.go
+++ b/internal/cli/kraft/pkg/packager_kraftfile_runtime.go
@@ -219,7 +219,11 @@ func (p *packagerKraftfileRuntime) Pack(ctx context.Context, opts *PkgOptions, a
 	// If no arguments have been specified, use the ones which are default and
 	// that have been included in the package.
 	if len(opts.Args) == 0 {
-		opts.Args = targ.Command()
+		if len(opts.Project.Command()) > 0 {
+			opts.Args = opts.Project.Command()
+		} else if len(targ.Command()) > 0 {
+			opts.Args = targ.Command()
+		}
 	}
 
 	cmdShellArgs, err := shellwords.Parse(strings.Join(opts.Args, " "))


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

This commit fixes an issue where the arguments for the package were not correctly set if the none were specified at the CLI.  Instead, re-use the project's arguments (which take precedence over) or the existing pre-built runtime's arguments.
