### PR TITLE
fix(workflows): Remove `-n` after echo which adds a newline

### DIFF
--- a/.github/workflows/release-stable.yaml
+++ b/.github/workflows/release-stable.yaml
@@ -30,7 +30,7 @@ jobs:
 
       - name: Write cosign key to file
         run: |
-          echo -n "$COSIGN_KEY" > cosign.key
+          echo "$COSIGN_KEY" > cosign.key
           chmod 600 cosign.key
 
       - name: Run GoReleaser


### PR DESCRIPTION
The current workflow fails because it cannot read the file because
of a newline entry.

Signed-off-by: Alexander Jung <alex@unikraft.io>

<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [ ] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [ ] Tested your changes against relevant architectures and platforms;
  - [ ] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->
