### PR TITLE
fix(github-action): Do not execute if file does not exist

### DIFF
--- a/tools/github-action/main.go
+++ b/tools/github-action/main.go
@@ -64,15 +64,16 @@ type GithubAction struct {
 }
 
 func runScript(ctx context.Context, path string) error {
-	if _, err := os.Stat(path); err == nil {
-		cmd := exec.CommandContext(ctx, path)
-		cmd.Stdout = os.Stdout
-		cmd.Stderr = os.Stderr
-		cmd.Env = os.Environ()
-		return cmd.Run()
+	if _, err := os.Stat(path); err != nil && os.IsNotExist(err) {
+		return nil
 	}
 
-	return fmt.Errorf("could not find script at %s", path)
+	cmd := exec.CommandContext(ctx, path)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	cmd.Env = os.Environ()
+
+	return cmd.Run()
 }
 
 func (opts *GithubAction) Pre(cmd *cobra.Command, args []string) (err error) {

--- a/tools/github-action/main.go
+++ b/tools/github-action/main.go
@@ -87,9 +87,8 @@ func (opts *GithubAction) Pre(cmd *cobra.Command, args []string) (err error) {
 	if workspace == "" {
 		workspace = "/github/workspace"
 	}
-	beforePath := fmt.Sprintf("%s/.kraftkit/before.sh", workspace)
-	err = runScript(ctx, beforePath)
-	if err != nil {
+
+	if err := runScript(ctx, fmt.Sprintf("%s/.kraftkit/before.sh", workspace)); err != nil {
 		log.G(ctx).Errorf("could not run before script: %v", err)
 		os.Exit(1)
 	}
@@ -265,16 +264,13 @@ func (opts *GithubAction) Run(ctx context.Context, args []string) error {
 	if workspace == "" {
 		workspace = "/github/workspace"
 	}
-	afterPath := fmt.Sprintf("%s/.kraftkit/after.sh", workspace)
 
 	// Run the after script even if the context is cancelled
-	err := runScript(context.Background(), afterPath)
-	if err != nil {
-		log.G(ctx).Errorf("could not run after script: %v", err)
-		os.Exit(1)
+	if err := runScript(ctx, fmt.Sprintf("%s/.kraftkit/after.sh", workspace)); err != nil {
+		return fmt.Errorf("could not run after script: %v", err)
 	}
 
-	return err
+	return nil
 }
 
 func main() {


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

This PR fixes an issue where the action would fail (in most usages) if either the before or after scripts did not exist.  If they did not exist, we should simply return gracefully and not continue execution.

Additionally, a small refactor is included which in-lines the `runScript` into a single if-statement.  A correction to the context was also included.
