### PR TITLE
fix(qemu): Hide preamble for every machine

### DIFF
--- a/machine/qemu/config.go
+++ b/machine/qemu/config.go
@@ -42,12 +42,16 @@ type QemuConfig struct {
 
 	// Command-line arguments for qemu-system-i386 and qemu-system-x86_64 only
 	NoHPET bool `flag:"-no-hpet" json:"no_hpet,omitempty"`
+
+	ShowSGABiosPreamble bool
 }
 
 type QemuOption func(*QemuConfig) error
 
 func NewQemuConfig(qopts ...QemuOption) (*QemuConfig, error) {
 	qcfg := QemuConfig{}
+
+	qcfg.ShowSGABiosPreamble = qemuShowSgaBiosPreamble
 
 	for _, o := range qopts {
 		if err := o(&qcfg); err != nil {


### PR DESCRIPTION
Introduce a new field inside the qemu config such that we can store whether the qemu preamble
should be skipped on a per-machine basis.

<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->
