### PR TITLE
docs(oci): Upgrade `Tracef` log entry to `Warnf`

### DIFF
--- a/oci/manager.go
+++ b/oci/manager.go
@@ -326,7 +326,7 @@ func (manager *ociManager) Catalog(ctx context.Context, qopts ...packmanager.Que
 		v1ImageIndex, err := remote.Index(ref, ropts...)
 		if err != nil {
 			log.G(ctx).
-				Tracef("could not get index: %v", err)
+				Warnf("could not get index: %v", err)
 			goto searchRemoteIndexes
 		}
 


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

This is a remote procedure call which can fail due to network connectivity issues or unauthorization.  Let the user know this by setting this as a warning-level entry as opposed to a hidden trace- level entry.
