### PR TITLE
fix(oci): Seed the index's digest in `NewPackageFromOCIManifestDigest`

### DIFF
--- a/oci/pack.go
+++ b/oci/pack.go
@@ -7,6 +7,7 @@ package oci
 import (
 	"context"
 	"crypto/tls"
+	"encoding/json"
 	"fmt"
 	"io/fs"
 	"net/http"
@@ -22,6 +23,7 @@ import (
 	"github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/sirupsen/logrus"
+	"oras.land/oras-go/v2/content"
 
 	"kraftkit.sh/config"
 	"kraftkit.sh/initrd"
@@ -423,6 +425,18 @@ func NewPackageFromOCIManifestDigest(ctx context.Context, handle handler.Handler
 		if err != nil {
 			return nil, fmt.Errorf("could not convert index manifest: %w", err)
 		}
+
+		indexJson, err := json.Marshal(index)
+		if err != nil {
+			return nil, fmt.Errorf("failed to marshal manifest: %w", err)
+		}
+
+		indexDesc := content.NewDescriptorFromBytes(
+			ocispec.MediaTypeImageIndex,
+			indexJson,
+		)
+
+		ocipack.index.desc = &indexDesc
 
 		for _, descriptor := range index.Manifests {
 			descriptor := descriptor


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

This information is necessary when instantiating the index structure.  When unhandled, this can result in nil-pointer exceptions when attempting to read the digest, such is the case when using:

```consoel
kraft pkg ls --apps --update
```
