### PR TITLE
fix(build): Always initialize project

### DIFF
--- a/internal/cli/kraft/build/build.go
+++ b/internal/cli/kraft/build/build.go
@@ -89,6 +89,11 @@ func (opts *BuildOptions) Pre(cmd *cobra.Command, args []string) error {
 
 	cmd.SetContext(ctx)
 
+	return nil
+}
+
+func (opts *BuildOptions) Run(ctx context.Context, args []string) error {
+	var err error
 	if len(args) == 0 {
 		opts.workdir, err = os.Getwd()
 		if err != nil {
@@ -118,10 +123,6 @@ func (opts *BuildOptions) Pre(cmd *cobra.Command, args []string) error {
 
 	opts.Platform = platform.PlatformByName(opts.Platform).String()
 
-	return nil
-}
-
-func (opts *BuildOptions) Run(ctx context.Context, args []string) error {
 	// Filter project targets by any provided CLI options
 	selected := opts.project.Targets()
 	if len(selected) == 0 {


### PR DESCRIPTION
Move the project initialization to Run instead of Pre. Otherwise, calling Run results in dereferencing a nil pointer.

<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

Calling the ``Run`` method results in a nil pointer exception when there is no project initialized. As a fix, move the project initialization from ``Pre`` to ``Run``

<!--
Please provide a detailed description of the changes made in this new PR.
-->
