### PR TITLE
feat: Introduce `kraftcloud` special internal target

### DIFF
--- a/internal/cli/kraft/build/build.go
+++ b/internal/cli/kraft/build/build.go
@@ -174,7 +174,7 @@ func (opts *BuildOptions) Run(ctx context.Context, args []string) error {
 
 	log.G(ctx).WithField("builder", build.String()).Debug("using")
 
-	if err := build.Prepare(ctx, opts, selected, args...); err != nil {
+	if err := build.Prepare(ctx, opts, selected[0], args...); err != nil {
 		return fmt.Errorf("could not complete build: %w", err)
 	}
 
@@ -182,7 +182,7 @@ func (opts *BuildOptions) Run(ctx context.Context, args []string) error {
 		return err
 	}
 
-	if err := build.Build(ctx, opts, selected, args...); err != nil {
+	if err := build.Build(ctx, opts, selected[0], args...); err != nil {
 		return fmt.Errorf("could not complete build: %w", err)
 	}
 

--- a/internal/cli/kraft/build/builder.go
+++ b/internal/cli/kraft/build/builder.go
@@ -26,11 +26,11 @@ type builder interface {
 
 	// Prepare performs any pre-emptive operations that are necessary before
 	// performing the build.
-	Prepare(context.Context, *BuildOptions, []target.Target, ...string) error
+	Prepare(context.Context, *BuildOptions, target.Target, ...string) error
 
 	// Build performs the actual construction of the unikernel given the provided
 	// inputs for the given implementation.
-	Build(context.Context, *BuildOptions, []target.Target, ...string) error
+	Build(context.Context, *BuildOptions, target.Target, ...string) error
 }
 
 // builders is the list of built-in builders which are checked sequentially for

--- a/unikraft/app/application.go
+++ b/unikraft/app/application.go
@@ -128,7 +128,7 @@ type Application interface {
 
 	// Components returns a unique list of Unikraft components which this
 	// applicatiton consists of
-	Components(context.Context) ([]component.Component, error)
+	Components(context.Context, ...target.Target) ([]component.Component, error)
 
 	// WithTarget is a reducer that returns the application with only the provided
 	// target.
@@ -742,7 +742,7 @@ func (app application) TargetNames() []string {
 
 // Components returns a unique list of Unikraft components which this
 // applicatiton consists of
-func (app application) Components(ctx context.Context) ([]component.Component, error) {
+func (app application) Components(ctx context.Context, targets ...target.Target) ([]component.Component, error) {
 	components := []component.Component{}
 
 	if unikraft := app.Unikraft(ctx); unikraft != nil {

--- a/unikraft/plat/platform.go
+++ b/unikraft/plat/platform.go
@@ -97,7 +97,7 @@ func (pc PlatformConfig) KConfig() kconfig.KeyValueMap {
 	// The following are built-in assumptions given the naming conventions used
 	// within the Unikraft core.
 	switch pc.Name() {
-	case "fc", "firecracker":
+	case "fc", "firecracker", "kraftcloud":
 		values.Set("CONFIG_PLAT_KVM", kconfig.Yes)
 		values.Set("CONFIG_KVM_VMM_FIRECRACKER", kconfig.Yes)
 	case "kvm", "qemu":


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

This PR introduces a new special target, `kraftcloud`, which can be used by a user to seamlessly build a kernel designed to be executed on https://kraft.cloud

For now, this implementation focuses on the build process.  To test this change, simply add a new target to your `Kraftfile`:
```yaml
[...]
targets:
- kraftcloud/x84_64
```
And when performing the build, this final kernel binary image will be suitable for execution on the platform.

GitHub-Depends-On: #1027