### PR TITLE
feat(compose): Add kraft compose command

### DIFF
--- a/compose/project.go
+++ b/compose/project.go
@@ -93,10 +93,6 @@ func (project *Project) Validate(ctx context.Context) error {
 
 	// Fill in any missing image names and prepend the project name
 	for i, service := range project.Services {
-		if service.Image == "" {
-			project.Services[i].Image = fmt.Sprint(project.Name, "-", service.Name)
-		}
-
 		project.Services[i].Name = fmt.Sprint(project.Name, "-", service.Name)
 	}
 

--- a/internal/cli/kraft/compose/compose.go
+++ b/internal/cli/kraft/compose/compose.go
@@ -14,6 +14,7 @@ import (
 
 	"kraftkit.sh/cmdfactory"
 	"kraftkit.sh/internal/cli/kraft/compose/down"
+	"kraftkit.sh/internal/cli/kraft/compose/ls"
 	"kraftkit.sh/internal/cli/kraft/compose/ps"
 	"kraftkit.sh/internal/cli/kraft/compose/up"
 )
@@ -38,6 +39,7 @@ func NewCmd() *cobra.Command {
 	}
 
 	cmd.AddCommand(down.NewCmd())
+	cmd.AddCommand(ls.NewCmd())
 	cmd.AddCommand(ps.NewCmd())
 	cmd.AddCommand(up.NewCmd())
 

--- a/internal/cli/kraft/compose/compose.go
+++ b/internal/cli/kraft/compose/compose.go
@@ -14,6 +14,7 @@ import (
 
 	"kraftkit.sh/cmdfactory"
 	"kraftkit.sh/internal/cli/kraft/compose/up"
+	"kraftkit.sh/internal/cli/kraft/net/down"
 )
 
 type ComposeOptions struct {
@@ -35,6 +36,7 @@ func NewCmd() *cobra.Command {
 		panic(err)
 	}
 
+	cmd.AddCommand(down.NewCmd())
 	cmd.AddCommand(up.NewCmd())
 
 	return cmd

--- a/internal/cli/kraft/compose/compose.go
+++ b/internal/cli/kraft/compose/compose.go
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2023, Unikraft GmbH and The KraftKit Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+
+package compose
+
+import (
+	"context"
+
+	"github.com/MakeNowJust/heredoc"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+
+	"kraftkit.sh/cmdfactory"
+	"kraftkit.sh/internal/cli/kraft/compose/up"
+)
+
+type ComposeOptions struct {
+	Composefile string `long:"file" short:"f" usage:"Set the Compose file."`
+}
+
+func NewCmd() *cobra.Command {
+	cmd, err := cmdfactory.New(&ComposeOptions{}, cobra.Command{
+		Short:  "compose",
+		Use:    "compose [FLAGS] [SUBCOMMAND|DIR]",
+		Hidden: true,
+		Long: heredoc.Docf(`
+		Build and run compose projects with Unikraft.`),
+		Annotations: map[string]string{
+			cmdfactory.AnnotationHelpGroup: "compose",
+		},
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	cmd.AddCommand(up.NewCmd())
+
+	return cmd
+}
+
+func (opts *ComposeOptions) Pre(cmd *cobra.Command, _ []string) error {
+	return nil
+}
+
+func (opts *ComposeOptions) Run(_ context.Context, _ []string) error {
+	return pflag.ErrHelp
+}

--- a/internal/cli/kraft/compose/compose.go
+++ b/internal/cli/kraft/compose/compose.go
@@ -13,8 +13,9 @@ import (
 	"github.com/spf13/pflag"
 
 	"kraftkit.sh/cmdfactory"
+	"kraftkit.sh/internal/cli/kraft/compose/down"
+	"kraftkit.sh/internal/cli/kraft/compose/ps"
 	"kraftkit.sh/internal/cli/kraft/compose/up"
-	"kraftkit.sh/internal/cli/kraft/net/down"
 )
 
 type ComposeOptions struct {
@@ -37,6 +38,7 @@ func NewCmd() *cobra.Command {
 	}
 
 	cmd.AddCommand(down.NewCmd())
+	cmd.AddCommand(ps.NewCmd())
 	cmd.AddCommand(up.NewCmd())
 
 	return cmd

--- a/internal/cli/kraft/compose/down/down.go
+++ b/internal/cli/kraft/compose/down/down.go
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2024, Unikraft GmbH and The KraftKit Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+
+package down
+
+import (
+	"context"
+	"os"
+
+	"github.com/compose-spec/compose-go/types"
+
+	"github.com/spf13/cobra"
+	"kraftkit.sh/cmdfactory"
+	"kraftkit.sh/compose"
+	"kraftkit.sh/internal/cli/kraft/remove"
+	"kraftkit.sh/log"
+	"kraftkit.sh/packmanager"
+
+	machineapi "kraftkit.sh/api/machine/v1alpha1"
+	mplatform "kraftkit.sh/machine/platform"
+)
+
+type DownOptions struct {
+	composefile string
+}
+
+func NewCmd() *cobra.Command {
+	cmd, err := cmdfactory.New(&DownOptions{}, cobra.Command{
+		Short: "Stop and remove a compose project.",
+		Use:   "down",
+		Annotations: map[string]string{
+			cmdfactory.AnnotationHelpGroup: "compose",
+		},
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	return cmd
+}
+
+func (opts *DownOptions) Pre(cmd *cobra.Command, _ []string) error {
+	ctx, err := packmanager.WithDefaultUmbrellaManagerInContext(cmd.Context())
+	if err != nil {
+		return err
+	}
+
+	cmd.SetContext(ctx)
+
+	if cmd.Flag("file").Changed {
+		opts.composefile = cmd.Flag("file").Value.String()
+	}
+
+	log.G(cmd.Context()).WithField("composefile", opts.composefile).Debug("using")
+	return nil
+}
+
+func (opts *DownOptions) Run(ctx context.Context, args []string) error {
+	workdir, err := os.Getwd()
+	if err != nil {
+		return err
+	}
+	project, err := compose.NewProjectFromComposeFile(ctx, workdir, opts.composefile)
+	if err != nil {
+		return err
+	}
+
+	if err := project.Validate(ctx); err != nil {
+		return err
+	}
+
+	controller, err := mplatform.NewMachineV1alpha1ServiceIterator(ctx)
+	if err != nil {
+		return err
+	}
+
+	machines, err := controller.List(ctx, &machineapi.MachineList{})
+	if err != nil {
+		return err
+	}
+
+	for _, service := range project.Services {
+		for _, machine := range machines.Items {
+			if service.Name == machine.Name {
+				if err := removeService(ctx, service); err != nil {
+					return err
+				}
+			}
+		}
+	}
+
+	return nil
+}
+
+func removeService(ctx context.Context, service types.ServiceConfig) error {
+	log.G(ctx).Infof("removing service %s...", service.Name)
+	removeOptions := remove.RemoveOptions{Platform: "auto"}
+
+	return removeOptions.Run(ctx, []string{service.Name})
+}

--- a/internal/cli/kraft/compose/ls/ls.go
+++ b/internal/cli/kraft/compose/ls/ls.go
@@ -1,0 +1,107 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2024, Unikraft GmbH and The KraftKit Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+
+package ls
+
+import (
+	"context"
+	"path/filepath"
+
+	"github.com/spf13/cobra"
+	"kraftkit.sh/cmdfactory"
+	"kraftkit.sh/compose"
+	"kraftkit.sh/internal/tableprinter"
+	"kraftkit.sh/iostreams"
+	"kraftkit.sh/log"
+
+	composeapi "kraftkit.sh/api/compose/v1"
+	"kraftkit.sh/packmanager"
+)
+
+type LsOptions struct {
+	ShowAll bool   `long:"all" short:"a" usage:"Show all projects (default shows just running)"`
+	Output  string `long:"output" short:"o" usage:"Set output format" default:"table"`
+}
+
+func NewCmd() *cobra.Command {
+	cmd, err := cmdfactory.New(&LsOptions{}, cobra.Command{
+		Short: "List compose projects.",
+		Use:   "ls",
+		Annotations: map[string]string{
+			cmdfactory.AnnotationHelpGroup: "compose",
+		},
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	return cmd
+}
+
+func (opts *LsOptions) Pre(cmd *cobra.Command, _ []string) error {
+	ctx, err := packmanager.WithDefaultUmbrellaManagerInContext(cmd.Context())
+	if err != nil {
+		return err
+	}
+
+	cmd.SetContext(ctx)
+
+	return nil
+}
+
+func (opts *LsOptions) Run(ctx context.Context, args []string) error {
+	controller, err := compose.NewComposeProjectV1(ctx)
+	if err != nil {
+		return err
+	}
+
+	projects, err := controller.List(ctx, &composeapi.ComposeList{})
+	if err != nil {
+		return err
+	}
+
+	err = iostreams.G(ctx).StartPager()
+	if err != nil {
+		log.G(ctx).Errorf("error starting pager: %v", err)
+	}
+
+	defer iostreams.G(ctx).StopPager()
+
+	cs := iostreams.G(ctx).ColorScheme()
+
+	table, err := tableprinter.NewTablePrinter(ctx,
+		tableprinter.WithMaxWidth(iostreams.G(ctx).TerminalWidth()),
+		tableprinter.WithOutputFormatFromString(opts.Output),
+	)
+	if err != nil {
+		return err
+	}
+
+	table.AddField("NAME", cs.Bold)
+	table.AddField("STATUS", cs.Bold)
+	table.AddField("COMPOSEFILE", cs.Bold)
+	table.EndRow()
+
+	for _, project := range projects.Items {
+		var status string
+		if len(project.Status.Machines) == 0 {
+			if !opts.ShowAll {
+				continue
+			}
+			status = "Stopped"
+		} else {
+			status = "Running"
+		}
+
+		table.AddField(project.Name, nil)
+		table.AddField(status, nil)
+
+		composefile := filepath.Join(project.Spec.Workdir, project.Spec.Composefile)
+		table.AddField(composefile, nil)
+		table.EndRow()
+	}
+
+	return table.Render(iostreams.G(ctx).Out)
+}

--- a/internal/cli/kraft/compose/ps/ps.go
+++ b/internal/cli/kraft/compose/ps/ps.go
@@ -1,0 +1,105 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2024, Unikraft GmbH and The KraftKit Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+
+package ps
+
+import (
+	"context"
+	"os"
+
+	"github.com/spf13/cobra"
+	"kraftkit.sh/cmdfactory"
+	"kraftkit.sh/compose"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	composeapi "kraftkit.sh/api/compose/v1"
+	pslist "kraftkit.sh/internal/cli/kraft/ps"
+	"kraftkit.sh/log"
+	"kraftkit.sh/packmanager"
+)
+
+type PsOptions struct {
+	composefile string
+}
+
+func NewCmd() *cobra.Command {
+	cmd, err := cmdfactory.New(&PsOptions{}, cobra.Command{
+		Short: "List running services of current project",
+		Use:   "ps",
+		Annotations: map[string]string{
+			cmdfactory.AnnotationHelpGroup: "compose",
+		},
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	return cmd
+}
+
+func (opts *PsOptions) Pre(cmd *cobra.Command, _ []string) error {
+	ctx, err := packmanager.WithDefaultUmbrellaManagerInContext(cmd.Context())
+	if err != nil {
+		return err
+	}
+
+	cmd.SetContext(ctx)
+
+	if cmd.Flag("file").Changed {
+		opts.composefile = cmd.Flag("file").Value.String()
+	}
+
+	log.G(cmd.Context()).WithField("composefile", opts.composefile).Debug("using")
+	return nil
+}
+
+func (opts *PsOptions) Run(ctx context.Context, args []string) error {
+	workdir, err := os.Getwd()
+	if err != nil {
+		return err
+	}
+	project, err := compose.NewProjectFromComposeFile(ctx, workdir, opts.composefile)
+	if err != nil {
+		return err
+	}
+
+	if err := project.Validate(ctx); err != nil {
+		return err
+	}
+
+	pslistOptions := pslist.PsOptions{
+		Output: "table",
+	}
+
+	psTable, err := pslistOptions.PsTable(ctx)
+	if err != nil {
+		return err
+	}
+
+	controller, err := compose.NewComposeProjectV1(ctx)
+	if err != nil {
+		return err
+	}
+
+	embeddedProject, err := controller.Get(ctx, &composeapi.Compose{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: project.Name,
+		},
+	})
+	if err != nil {
+		return err
+	}
+
+	filteredPsTable := []pslist.PsEntry{}
+	for _, psEntry := range psTable {
+		for _, machine := range embeddedProject.Status.Machines {
+			if psEntry.Name == machine.Name {
+				filteredPsTable = append(filteredPsTable, psEntry)
+			}
+		}
+	}
+
+	return pslistOptions.PrintPsTable(ctx, filteredPsTable)
+}

--- a/internal/cli/kraft/compose/up/up.go
+++ b/internal/cli/kraft/compose/up/up.go
@@ -1,0 +1,358 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2024, Unikraft GmbH and The KraftKit Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+
+package up
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"sync"
+
+	"github.com/compose-spec/compose-go/types"
+	"github.com/spf13/cobra"
+
+	"kraftkit.sh/cmdfactory"
+	"kraftkit.sh/compose"
+	"kraftkit.sh/internal/cli/kraft/build"
+	"kraftkit.sh/internal/cli/kraft/logs"
+	"kraftkit.sh/internal/cli/kraft/pkg"
+	"kraftkit.sh/internal/cli/kraft/pkg/pull"
+	"kraftkit.sh/internal/cli/kraft/remove"
+	"kraftkit.sh/internal/cli/kraft/run"
+	"kraftkit.sh/log"
+	"kraftkit.sh/packmanager"
+	"kraftkit.sh/unikraft"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	composeapi "kraftkit.sh/api/compose/v1"
+	machineapi "kraftkit.sh/api/machine/v1alpha1"
+	mplatform "kraftkit.sh/machine/platform"
+)
+
+type UpOptions struct {
+	composefile string
+}
+
+func NewCmd() *cobra.Command {
+	cmd, err := cmdfactory.New(&UpOptions{}, cobra.Command{
+		Short: "Run a compose project.",
+		Use:   "up",
+		Annotations: map[string]string{
+			cmdfactory.AnnotationHelpGroup: "compose",
+		},
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	return cmd
+}
+
+func (opts *UpOptions) Pre(cmd *cobra.Command, _ []string) error {
+	ctx, err := packmanager.WithDefaultUmbrellaManagerInContext(cmd.Context())
+	if err != nil {
+		return err
+	}
+
+	cmd.SetContext(ctx)
+
+	if cmd.Flag("file").Changed {
+		opts.composefile = cmd.Flag("file").Value.String()
+	}
+
+	log.G(cmd.Context()).WithField("composefile", opts.composefile).Debug("using")
+	return nil
+}
+
+func (opts *UpOptions) Run(ctx context.Context, args []string) error {
+	workdir, err := os.Getwd()
+	if err != nil {
+		return err
+	}
+
+	project, err := compose.NewProjectFromComposeFile(ctx, workdir, opts.composefile)
+	if err != nil {
+		return err
+	}
+
+	if err := project.Validate(ctx); err != nil {
+		return err
+	}
+
+	composeController, err := compose.NewComposeProjectV1(ctx)
+	if err != nil {
+		return err
+	}
+
+	embeddedProject, err := composeController.Get(ctx, &composeapi.Compose{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: project.Name,
+		},
+	})
+	if err != nil {
+		return err
+	}
+
+	// Check that none of the services are already running
+	machineController, err := mplatform.NewMachineV1alpha1ServiceIterator(ctx)
+	if err != nil {
+		return err
+	}
+
+	machines, err := machineController.List(ctx, &machineapi.MachineList{})
+	if err != nil {
+		return err
+	}
+
+	projectMachines := []metav1.ObjectMeta{}
+	if embeddedProject != nil {
+		projectMachines = embeddedProject.Status.Machines
+	}
+
+	for _, service := range project.Services {
+		alreadyRunning := false
+		for _, machine := range machines.Items {
+			if service.Name == machine.Name {
+				if machine.Status.State == machineapi.MachineStateRunning {
+					alreadyRunning = true
+				} else {
+					rmOpts := remove.RemoveOptions{
+						Platform: machine.Spec.Platform,
+					}
+
+					if err := rmOpts.Run(ctx, []string{service.Name}); err != nil {
+						return err
+					}
+				}
+				break
+			}
+		}
+		if alreadyRunning {
+			continue
+		}
+		if service.Image == "" {
+			if err := buildService(ctx, service); err != nil {
+				return err
+			}
+		} else {
+			if err := ensureServiceIsPackaged(ctx, service); err != nil {
+				return err
+			}
+		}
+
+		if err := runService(ctx, service); err != nil {
+			log.G(ctx).WithError(err).Errorf("failed to run service %s", service.Name)
+		}
+
+		if machine, err := machineController.Get(ctx, &machineapi.Machine{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: service.Name,
+			},
+		}); err == nil && machine.Status.State == machineapi.MachineStateRunning {
+			projectMachines = append(projectMachines, machine.ObjectMeta)
+		}
+	}
+
+	if _, err := composeController.Update(ctx, &composeapi.Compose{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: project.Name,
+		},
+		Spec: composeapi.ComposeSpec{
+			Composefile: project.ComposeFiles[0],
+			Workdir:     project.WorkingDir,
+		},
+		Status: composeapi.ComposeStatus{
+			Machines: projectMachines,
+		},
+	}); err != nil {
+		return err
+	}
+
+	var wg sync.WaitGroup
+
+	longestName := 0
+	for _, service := range project.Services {
+		if len(service.Name) > longestName {
+			longestName = len(service.Name)
+		}
+	}
+	for i := range project.Services {
+		wg.Add(1)
+		go func(service types.ServiceConfig) {
+			defer wg.Done()
+
+			if err := logService(ctx, service, longestName); err != nil {
+				log.G(ctx).WithError(err).Errorf("failed to log service %s", service.Name)
+			}
+		}(project.Services[i])
+	}
+
+	wg.Wait()
+
+	return nil
+}
+
+func platArchFromService(service types.ServiceConfig) (string, string, error) {
+	// The service platform should be in the form <platform>/<arch>
+
+	parts := strings.SplitN(service.Platform, "/", 2)
+
+	if len(parts) != 2 {
+		return "", "", fmt.Errorf("invalid platform: %s for service %s", service.Platform, service.Name)
+	}
+
+	// Check that the platform is supported
+	if _, ok := mplatform.PlatformsByName()[parts[0]]; !ok {
+		return "", "", fmt.Errorf("unsupported platform: %s for service %s", parts[0], service.Name)
+	}
+
+	if parts[1] != "x86_64" && parts[1] != "amd64" && parts[1] != "arm32" && parts[1] != "arm64" {
+		return "", "", fmt.Errorf("unsupported architecture: %s for service %s", parts[1], service.Name)
+	}
+
+	return parts[0], parts[1], nil
+}
+
+func ensureServiceIsPackaged(ctx context.Context, service types.ServiceConfig) error {
+	plat, arch, err := platArchFromService(service)
+	if err != nil {
+		return err
+	}
+
+	parts := strings.SplitN(service.Image, ":", 2)
+	imageName := parts[0]
+	imageVersion := "latest"
+	if len(parts) == 2 {
+		imageVersion = parts[1]
+	}
+
+	service.Image = imageName + ":" + imageVersion
+
+	log.G(ctx).Debugf("searching for service %s locally...", service.Name)
+	// Check whether the image is already in the local catalog
+	packages, err := packmanager.G(ctx).Catalog(ctx,
+		packmanager.WithArchitecture(arch),
+		packmanager.WithName(imageName),
+		packmanager.WithPlatform(plat),
+		packmanager.WithTypes(unikraft.ComponentTypeApp),
+		packmanager.WithUpdate(false),
+		packmanager.WithVersion(imageVersion))
+	if err != nil {
+		return err
+	}
+
+	// If we have it locally, we are done
+	if len(packages) != 0 {
+		log.G(ctx).Debugf("found service %s locally", service.Name)
+		return nil
+	}
+
+	log.G(ctx).Debugf("searching for service %s remotely...", service.Name)
+	// Check whether the image is in the remote catalog
+	packages, err = packmanager.G(ctx).Catalog(ctx,
+		packmanager.WithArchitecture(arch),
+		packmanager.WithName(imageName),
+		packmanager.WithPlatform(plat),
+		packmanager.WithTypes(unikraft.ComponentTypeApp),
+		packmanager.WithUpdate(true),
+		packmanager.WithVersion(imageVersion))
+
+	if err != nil {
+		return err
+	}
+
+	// If we have it remotely, we are done
+	if len(packages) != 0 {
+		log.G(ctx).Infof("found service %s remotely, pulling...", service.Name)
+		// We need to pull it locally
+		pullOptions := pull.PullOptions{Platform: plat, Architecture: arch}
+		return pullOptions.Run(ctx, []string{service.Image})
+	}
+
+	// Otherwise, we need to build and package it
+	if err := buildService(ctx, service); err != nil {
+		return err
+	}
+
+	return pkgService(ctx, service)
+}
+
+func buildService(ctx context.Context, service types.ServiceConfig) error {
+	if service.Build == nil {
+		return fmt.Errorf("service %s has no build context", service.Name)
+	}
+
+	plat, arch, err := platArchFromService(service)
+	if err != nil {
+		return err
+	}
+
+	log.G(ctx).Infof("building service %s...", service.Name)
+
+	buildOptions := build.BuildOptions{Platform: plat, Architecture: arch}
+
+	return buildOptions.Run(ctx, []string{service.Build.Context})
+}
+
+func pkgService(ctx context.Context, service types.ServiceConfig) error {
+	plat, arch, err := platArchFromService(service)
+	if err != nil {
+		return err
+	}
+
+	log.G(ctx).Infof("packaging service %s...", service.Name)
+
+	pkgOptions := pkg.PkgOptions{
+		Architecture: arch,
+		Name:         service.Image,
+		Format:       "oci",
+		Platform:     plat,
+		Strategy:     packmanager.StrategyOverwrite,
+	}
+
+	return pkgOptions.Run(ctx, []string{service.Build.Context})
+}
+
+func runService(ctx context.Context, service types.ServiceConfig) error {
+	// The service should be packaged at this point
+	plat, arch, err := platArchFromService(service)
+	if err != nil {
+		return err
+	}
+
+	log.G(ctx).Infof("running service %s...", service.Name)
+
+	runOptions := run.RunOptions{
+		Architecture: arch,
+		Detach:       true,
+		Name:         service.Name,
+		Platform:     plat,
+	}
+
+	if service.Image != "" {
+		return runOptions.Run(ctx, []string{service.Image})
+	}
+
+	return runOptions.Run(ctx, []string{service.Build.Context})
+}
+
+func logService(ctx context.Context, service types.ServiceConfig, prefixLength int) error {
+	prefix := service.Name + strings.Repeat(" ", prefixLength-len(service.Name))
+
+	plat, _, err := platArchFromService(service)
+	if err != nil {
+		return err
+	}
+
+	logOptions := logs.LogOptions{
+		Follow:   true,
+		Platform: plat,
+		Prefix:   prefix,
+	}
+
+	return logOptions.Run(ctx, []string{service.Name})
+}

--- a/internal/cli/kraft/kraft.go
+++ b/internal/cli/kraft/kraft.go
@@ -28,6 +28,7 @@ import (
 	"kraftkit.sh/internal/cli/kraft/build"
 	"kraftkit.sh/internal/cli/kraft/clean"
 	"kraftkit.sh/internal/cli/kraft/cloud"
+	"kraftkit.sh/internal/cli/kraft/compose"
 	"kraftkit.sh/internal/cli/kraft/events"
 	"kraftkit.sh/internal/cli/kraft/fetch"
 	"kraftkit.sh/internal/cli/kraft/login"
@@ -110,6 +111,9 @@ func NewCmd() *cobra.Command {
 	cmd.AddGroup(&cobra.Group{ID: "misc", Title: "MISCELLANEOUS COMMANDS"})
 	cmd.AddCommand(login.NewCmd())
 	cmd.AddCommand(version.NewCmd())
+
+	cmd.AddGroup(&cobra.Group{ID: "compose", Title: "COMPOSE COMMANDS"})
+	cmd.AddCommand(compose.NewCmd())
 
 	cmd.AddCommand(x.NewCmd())
 


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

This commit introduces the ``compose`` command along with the ``up``, ``down``, ``ps`` and ``ls`` sub-commands, based on the internal compose library.  At the moment, they only support services running off an image or a build context.

GitHub-Depends: https://github.com/unikraft/kraftkit/pull/1151

For example, pull the ``app-helloworld`` repository and create the following ``compose.yaml`` file:
```
services:
 helloworld-remote: 
  image: unikraft.org/helloworld:latest # Run a remote image
 helloworld-local:
  build: ../app-helloworld # Run based on a build context
```

Then, you can just invoke ``kraft compose up`` and should soon see an output similar to this (with colors):
```
kraftcompose-helloworld-remote | o.   .o       _ _               __ _
kraftcompose-helloworld-remote | Oo   Oo  ___ (_) | __ __  __ _ ' _) :_
kraftcompose-helloworld-remote | oO   oO ' _ `| | |/ /  _)' _` | |_|  _)
kraftcompose-helloworld-remote | oOo oOO| | | | |   (| | | (_) |  _) :_
kraftcompose-helloworld-remote |  OoOoO ._, ._:_:_,\_._,  .__,_:_, \___)
kraftcompose-helloworld-remote |                  Pandora 0.15.0~46c2059
kraftcompose-helloworld-remote | Hello from Unikraft!
kraftcompose-helloworld-remote | 
kraftcompose-helloworld-remote | This message shows that your installation appears to be working correctly.
kraftcompose-helloworld-remote | 
kraftcompose-helloworld-remote | For more examples and ideas, visit: https://unikraft.org/docs/
kraftcompose-helloworld-local  | o.   .o       _ _               __ _
kraftcompose-helloworld-local  | Oo   Oo  ___ (_) | __ __  __ _ ' _) :_
kraftcompose-helloworld-local  | oO   oO ' _ `| | |/ /  _)' _` | |_|  _)
kraftcompose-helloworld-local  | oOo oOO| | | | |   (| | | (_) |  _) :_
kraftcompose-helloworld-local  |  OoOoO ._, ._:_:_,\_._,  .__,_:_, \___)
kraftcompose-helloworld-local  |                  Pandora 0.15.0~86710f6
kraftcompose-helloworld-local  | Hello world!
kraftcompose-helloworld-local  | Arguments:  "/home/kero/.local/share/kraftkit/runtime/03157fd3-14c0-471e-b694-93978719a26d/unikraft/bin/kernel"
```
You can run ``kraft compose ps`` to see information about the running services and ``kraft compose ls`` to see information about the compose projects.

Then, you can call ``kraft compose down`` to remove the images.
<!--
Please provide a detailed description of the changes made in this new PR.
-->
