### PR TITLE
fix(kconfig): Set the value of `No` as `n`

### DIFF
--- a/kconfig/config.go
+++ b/kconfig/config.go
@@ -291,7 +291,7 @@ func (kv *KeyValue) MarshalYAML() (interface{}, error) {
 const (
 	Yes    = "y"
 	Mod    = "m"
-	No     = "---===[[[is not set]]]===---" // to make it more obvious when some code writes it directly
+	No     = "n"
 	Prefix = "CONFIG_"
 )
 


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

This is the real value which is understood by both this KConfig parser and the parser used by Unikraft.  This value is an artifact from the original source which is not fully compatible.
