### PR TITLE
fix(paraprogress): Do not quit on receiving 100% progress

### DIFF
--- a/tui/paraprogress/process.go
+++ b/tui/paraprogress/process.go
@@ -206,11 +206,6 @@ func (d *Process) Update(msg tea.Msg) (*Process, tea.Cmd) {
 			return d, nil
 		}
 
-		if msg.progress > 1.0 {
-			msg.progress = 1.0
-			cmds = append(cmds, d.timer.Stop())
-		}
-
 		d.percent = msg.progress
 
 	// TickMsg is sent when the spinner wants to animate itself


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

This may pre-emptively shutdown the process.  Instead, let the process exit "naturally".  If the process is reporting via the onProgress-callback 100%, then this a mistake of the use of the callback itself, and the user will simply have to wait beyond the 100% until the process exits.  There is now also a`WithTimeout` option so we can have both graceful and non-graceful exits with this package.
