### PR TITLE
fix(pkg): Correctly seed the `Kraftfile`'s rootfs if flag is unused

### DIFF
--- a/internal/cli/kraft/pkg/packager_kraftfile_runtime.go
+++ b/internal/cli/kraft/pkg/packager_kraftfile_runtime.go
@@ -46,6 +46,10 @@ func (p *packagerKraftfileRuntime) Packagable(ctx context.Context, opts *PkgOpti
 		return false, fmt.Errorf("cannot package without unikraft core specification")
 	}
 
+	if opts.Project.Rootfs() != "" && opts.Rootfs == "" {
+		opts.Rootfs = opts.Project.Rootfs()
+	}
+
 	return true, nil
 }
 

--- a/internal/cli/kraft/pkg/packager_kraftfile_unikraft.go
+++ b/internal/cli/kraft/pkg/packager_kraftfile_unikraft.go
@@ -43,6 +43,10 @@ func (p *packagerKraftfileUnikraft) Packagable(ctx context.Context, opts *PkgOpt
 		return false, fmt.Errorf("cannot package without unikraft core specification")
 	}
 
+	if opts.Project.Rootfs() != "" && opts.Rootfs == "" {
+		opts.Rootfs = opts.Project.Rootfs()
+	}
+
 	return true, nil
 }
 


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

Following the merge of #1011 and the introduction and unification of the construction of the root filesystem, the `Kraftfile`'s `rootfs` element attribute was missed during this rework.  In this commit, use the `Kraftfile`'s `rootfs` element if the equivilent flag is unset.

