### PR TITLE
feat: Introduce `.kraftignore`

### DIFF
--- a/initrd/directory.go
+++ b/initrd/directory.go
@@ -17,6 +17,8 @@ import (
 	"kraftkit.sh/log"
 )
 
+var ErrRootfsOutputAlreadyExists = fmt.Errorf("rootfs output already exists")
+
 type directory struct {
 	opts  InitrdOptions
 	path  string
@@ -66,7 +68,7 @@ func (initrd *directory) Build(ctx context.Context) (string, error) {
 	}
 
 	if _, err := os.Stat(initrd.opts.output); err == nil {
-		return "", fmt.Errorf("output already exists")
+		return initrd.opts.output, ErrRootfsOutputAlreadyExists
 	}
 
 	f, err := os.OpenFile(initrd.opts.output, os.O_RDWR|os.O_CREATE, 0o644)

--- a/initrd/directory.go
+++ b/initrd/directory.go
@@ -65,6 +65,10 @@ func (initrd *directory) Build(ctx context.Context) (string, error) {
 		}
 	}
 
+	if _, err := os.Stat(initrd.opts.output); err == nil {
+		return "", fmt.Errorf("output already exists")
+	}
+
 	f, err := os.OpenFile(initrd.opts.output, os.O_RDWR|os.O_CREATE, 0o644)
 	if err != nil {
 		return "", fmt.Errorf("could not open initramfs file: %w", err)
@@ -74,6 +78,11 @@ func (initrd *directory) Build(ctx context.Context) (string, error) {
 
 	writer := cpio.NewWriter(f)
 	defer writer.Close()
+
+	ignoringItems, err := GetKraftIgnoreItems(ctx, initrd.path)
+	if err != nil {
+		return "", err
+	}
 
 	if err := filepath.WalkDir(initrd.path, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
@@ -85,6 +94,21 @@ func (initrd *directory) Build(ctx context.Context) (string, error) {
 			return nil // Do not archive empty paths
 		}
 		internal = "." + filepath.ToSlash(internal)
+
+		if len(ignoringItems) > 0 && path != initrd.path {
+			switch isExistInKraftignoreFile(internal, d, ignoringItems) {
+			case SkipDir:
+				log.G(ctx).
+					WithField("directory", internal).
+					Trace("ignoring from archiving")
+				return filepath.SkipDir
+			case Exist:
+				log.G(ctx).
+					WithField("file", internal).
+					Trace("ignoring from archiving")
+				return nil
+			}
+		}
 
 		info, err := d.Info()
 		if err != nil {

--- a/initrd/directory_test.go
+++ b/initrd/directory_test.go
@@ -6,6 +6,7 @@ package initrd_test
 
 import (
 	"context"
+	"errors"
 	"io"
 	"os"
 	"testing"
@@ -26,7 +27,7 @@ func TestNewFromDirectory(t *testing.T) {
 	}
 
 	irdPath, err := ird.Build(ctx)
-	if err != nil {
+	if err != nil && !errors.Is(err, initrd.ErrRootfsOutputAlreadyExists) {
 		t.Fatal("Build:", err)
 	}
 	t.Cleanup(func() {
@@ -38,7 +39,7 @@ func TestNewFromDirectory(t *testing.T) {
 	irdFiles := ird.Files()
 
 	const expectFiles = 4 // only regular and symlink files are indexed
-	if gotFiles := len(irdFiles); gotFiles != expectFiles {
+	if gotFiles := len(irdFiles); gotFiles > 0 && gotFiles != expectFiles {
 		t.Errorf("Expected %d files in InitrdConfig, got %d: %v", expectFiles, gotFiles, irdFiles)
 	}
 

--- a/initrd/kraftignore.go
+++ b/initrd/kraftignore.go
@@ -1,0 +1,157 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2024, Unikraft GmbH and The KraftKit Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+package initrd
+
+import (
+	"bufio"
+	"context"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"kraftkit.sh/log"
+)
+
+// kraftignore filename
+const KraftignoreFileName = ".kraftignore"
+
+type IgnoringFileType string
+
+const (
+	Exist    = IgnoringFileType("Exist")
+	NotExist = IgnoringFileType("NotExist")
+	SkipDir  = IgnoringFileType("SkipDir")
+)
+
+// GetKraftIgnoreItems returns file and directory names specified in .kraftignore
+func GetKraftIgnoreItems(ctx context.Context, dir string) ([]string, error) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return []string{}, err
+	}
+	kraftignorePath := filepath.Join(cwd, KraftignoreFileName)
+
+	if _, err := os.Stat(kraftignorePath); errors.Is(err, os.ErrNotExist) {
+		return []string{}, nil
+	} else if err != nil {
+		return []string{}, err
+	}
+
+	kraftignoreFile, err := os.Open(kraftignorePath)
+	if err != nil {
+		return []string{}, err
+	}
+
+	defer func() {
+		kraftIgnoreErr := kraftignoreFile.Close()
+		if kraftIgnoreErr != nil {
+			if err != nil {
+				err = fmt.Errorf("%w: %w", err, kraftIgnoreErr)
+			} else {
+				err = kraftIgnoreErr
+			}
+		}
+	}()
+
+	kraftignoreScanner := bufio.NewScanner(kraftignoreFile)
+	kraftignoreScanner.Split(bufio.ScanLines)
+	var kraftignoreFileLines, ignoringItems []string
+
+	for kraftignoreScanner.Scan() {
+		kraftignoreFileLines = append(kraftignoreFileLines, kraftignoreScanner.Text())
+	}
+
+	for lineNum, line := range kraftignoreFileLines {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		items := findLineItems(line)
+		for _, item := range items {
+			if item == "" || item == "#" {
+				continue
+			}
+
+			if hasGlobPatterns(item) {
+				log.G(ctx).
+					WithField("file", kraftignorePath).
+					Warn("contains a glob pattern ", item,
+						" at line ", lineNum,
+						" which is not supported by Kraftkit")
+				continue
+			}
+
+			if _, err := os.Stat(filepath.Join(dir, item)); os.IsNotExist(err) {
+				log.G(ctx).
+					WithField("file", kraftignorePath).
+					Warn("contains ", item,
+						" at line ", lineNum,
+						" which does not exist in the provided rootfs directory")
+				continue
+			}
+
+			ignoringItems = append(ignoringItems, item)
+		}
+	}
+
+	return ignoringItems, err
+}
+
+// isExistInKraftignoreFile checks if the path exist in .kraftignore
+func isExistInKraftignoreFile(internal string, pathInfo fs.DirEntry, kraftignoreItems []string) IgnoringFileType {
+	for _, ignoringItem := range kraftignoreItems {
+		if internal == ignoringItem {
+			if pathInfo.IsDir() {
+				return SkipDir
+			}
+			return Exist
+		}
+	}
+	return NotExist
+}
+
+// hasGlobPatterns checks if the item contains glob pattern
+func hasGlobPatterns(item string) bool {
+	return strings.ContainsAny(item, "*?![{")
+}
+
+// findLineItems finds items in a line of .kraftignore
+func findLineItems(line string) []string {
+	items := strings.Split(line, " ")
+	for index := 0; index < len(items); index++ {
+		charToFind := ""
+		if strings.HasPrefix(items[index], `"`) && !strings.HasSuffix(items[index], `"`) {
+			charToFind = `"`
+		} else if strings.HasPrefix(items[index], `'`) && !strings.HasSuffix(items[index], `'`) {
+			charToFind = `'`
+		}
+
+		if len(charToFind) > 0 {
+			i := index + 1
+			for ; i < len(items) && !strings.HasSuffix(items[i], charToFind); i++ {
+				items[index] += " " + items[i]
+				items = append(items[:i], items[i+1:]...)
+				i--
+			}
+			items[index] += " " + items[i]
+			items = append(items[:i], items[i+1:]...)
+		}
+		items[index] = strings.Trim(items[index], `"`)
+		items[index] = strings.Trim(items[index], `'`)
+		items[index] = strings.TrimSpace(items[index])
+		items[index] = strings.TrimPrefix(items[index], "../")
+		if !strings.HasPrefix(items[index], "./") {
+			if !strings.HasPrefix(items[index], "/") {
+				items[index] = "/" + items[index]
+			}
+			items[index] = "." + items[index]
+		}
+		items[index] = strings.TrimSuffix(items[index], string(filepath.Separator))
+	}
+	return items
+}


### PR DESCRIPTION
### Prerequisite checklist

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

This PR fixes https://github.com/unikraft/kraftkit/issues/135

Specifying contents (file or directory paths) in `.kraftignore` file in the working directory forces `Kraftkit` to ignore matching children files or directories sharing from the sharing directory as `rootfs`.

For now, `.kraftignore` only work when `rootfs` is specified for a directory path.

**Rules for `.kraftignore`:**
* Line starts with a `#` will be ignored by `Kraftkit`.
* Every blank line will be ignored by `Kraftkit`.
* Directory or File path that contains `glob-patterns` (characters like `*`, `!`, `[` and `?`) will be ignored by `Kraftkit` and return a warning message.
* File or Directory name can be enclosed by single or double quotes (`'filename'`, `"dir_name"`).
* File or Directory names which contain white spaces must be enclosed by single or double quotes. e.g.
   ```yaml
   "sample file"
   'sample new file'
   ```
* One needs to specify the entire relative path (relative path to the sharing directory e.g. if `rootfs=share/` and `share` directory contains `sample.txt`and `sample/`, So relative path in `.kraftignore` file can be defined as `/sample.txt`, `sample.txt` and `./sample.txt` for `share/sample.txt` to ignore) of the file or directory that have to be ignored.
* Various directory and file paths can be specified in a `.kraftignore` file using space separator or new line e.g.

  ```yaml
  random1/random01/random01.txt /random.txt
  
  random1/random01
  ```
* All the specified paths in `.kraftignore` will be relative to the root of sharing directory, means if `share/` directory contains `sample.txt` and `sample/`, and set as `rootfs` to kraftkit then to ignore `/share/sample.txt` only `sample.txt` needs to be defined in `kraftignore`.
**Note: All the paths can start with `./` or `/`** (Since prefix `/` and `./` with paths simply ignored by Kraftkit).