### PR TITLE
feat(net): Expose driver in all subcommands

### DIFF
--- a/internal/cli/kraft/net/create/create.go
+++ b/internal/cli/kraft/net/create/create.go
@@ -20,7 +20,7 @@ import (
 )
 
 type CreateOptions struct {
-	driver  string
+	Driver  string `noattribute:"true"`
 	Network string `long:"network" short:"n" usage:"Set the gateway IP address and the subnet of the network in CIDR format."`
 }
 
@@ -51,7 +51,7 @@ func NewCmd() *cobra.Command {
 }
 
 func (opts *CreateOptions) Pre(cmd *cobra.Command, _ []string) error {
-	opts.driver = cmd.Flag("driver").Value.String()
+	opts.Driver = cmd.Flag("driver").Value.String()
 
 	// TODO(nderjung): A future implementation can list existing networks and
 	// generate new subnet and gateway appropriately.  Simply calculate a new
@@ -72,9 +72,9 @@ func (opts *CreateOptions) Pre(cmd *cobra.Command, _ []string) error {
 func (opts *CreateOptions) Run(ctx context.Context, args []string) error {
 	var err error
 
-	strategy, ok := network.Strategies()[opts.driver]
+	strategy, ok := network.Strategies()[opts.Driver]
 	if !ok {
-		return fmt.Errorf("unsupported network driver strategy: %v (contributions welcome!)", opts.driver)
+		return fmt.Errorf("unsupported network driver strategy: %v (contributions welcome!)", opts.Driver)
 	}
 
 	controller, err := strategy.NewNetworkV1alpha1(ctx)

--- a/internal/cli/kraft/net/down/down.go
+++ b/internal/cli/kraft/net/down/down.go
@@ -18,7 +18,7 @@ import (
 )
 
 type DownOptions struct {
-	driver string
+	Driver string `noattribute:"true"`
 }
 
 // Down brings a local machine network offline.
@@ -48,14 +48,14 @@ func NewCmd() *cobra.Command {
 }
 
 func (opts *DownOptions) Pre(cmd *cobra.Command, _ []string) error {
-	opts.driver = cmd.Flag("driver").Value.String()
+	opts.Driver = cmd.Flag("driver").Value.String()
 	return nil
 }
 
 func (opts *DownOptions) Run(ctx context.Context, args []string) error {
-	strategy, ok := network.Strategies()[opts.driver]
+	strategy, ok := network.Strategies()[opts.Driver]
 	if !ok {
-		return fmt.Errorf("unsupported network driver strategy: %v (contributions welcome!)", opts.driver)
+		return fmt.Errorf("unsupported network driver strategy: %v (contributions welcome!)", opts.Driver)
 	}
 
 	controller, err := strategy.NewNetworkV1alpha1(ctx)

--- a/internal/cli/kraft/net/list/list.go
+++ b/internal/cli/kraft/net/list/list.go
@@ -20,9 +20,9 @@ import (
 )
 
 type ListOptions struct {
+	Driver string `noattribute:"true"`
 	Long   bool   `long:"long" short:"l" usage:"Show more information"`
 	Output string `long:"output" short:"o" usage:"Set output format" default:"table"`
-	driver string
 }
 
 func NewCmd() *cobra.Command {
@@ -43,16 +43,16 @@ func NewCmd() *cobra.Command {
 }
 
 func (opts *ListOptions) Pre(cmd *cobra.Command, _ []string) error {
-	opts.driver = cmd.Flag("driver").Value.String()
+	opts.Driver = cmd.Flag("driver").Value.String()
 	return nil
 }
 
 func (opts *ListOptions) Run(ctx context.Context, _ []string) error {
 	var err error
 
-	strategy, ok := network.Strategies()[opts.driver]
+	strategy, ok := network.Strategies()[opts.Driver]
 	if !ok {
-		return fmt.Errorf("unsupported network driver strategy: %s", opts.driver)
+		return fmt.Errorf("unsupported network driver strategy: %s", opts.Driver)
 	}
 
 	controller, err := strategy.NewNetworkV1alpha1(ctx)
@@ -84,7 +84,7 @@ func (opts *ListOptions) Run(ctx context.Context, _ []string) error {
 			id:      string(network.UID),
 			name:    network.Name,
 			network: addr.String(),
-			driver:  opts.driver,
+			driver:  opts.Driver,
 			status:  network.Status.State,
 		})
 

--- a/internal/cli/kraft/net/remove/remove.go
+++ b/internal/cli/kraft/net/remove/remove.go
@@ -18,7 +18,7 @@ import (
 )
 
 type RemoveOptions struct {
-	driver string
+	Driver string `noattribute:"true"`
 }
 
 // Remove a local machine network.
@@ -48,16 +48,16 @@ func NewCmd() *cobra.Command {
 }
 
 func (opts *RemoveOptions) Pre(cmd *cobra.Command, _ []string) error {
-	opts.driver = cmd.Flag("driver").Value.String()
+	opts.Driver = cmd.Flag("driver").Value.String()
 	return nil
 }
 
 func (opts *RemoveOptions) Run(ctx context.Context, args []string) error {
 	var err error
 
-	strategy, ok := network.Strategies()[opts.driver]
+	strategy, ok := network.Strategies()[opts.Driver]
 	if !ok {
-		return fmt.Errorf("unsupported network driver strategy: %v (contributions welcome!)", opts.driver)
+		return fmt.Errorf("unsupported network driver strategy: %v (contributions welcome!)", opts.Driver)
 	}
 
 	controller, err := strategy.NewNetworkV1alpha1(ctx)

--- a/internal/cli/kraft/net/up/up.go
+++ b/internal/cli/kraft/net/up/up.go
@@ -18,7 +18,7 @@ import (
 )
 
 type UpOptions struct {
-	driver string
+	Driver string `noattribute:"true"`
 }
 
 // Up brings a local machine network online.
@@ -48,14 +48,14 @@ func NewCmd() *cobra.Command {
 }
 
 func (opts *UpOptions) Pre(cmd *cobra.Command, _ []string) error {
-	opts.driver = cmd.Flag("driver").Value.String()
+	opts.Driver = cmd.Flag("driver").Value.String()
 	return nil
 }
 
 func (opts *UpOptions) Run(ctx context.Context, args []string) error {
-	strategy, ok := network.Strategies()[opts.driver]
+	strategy, ok := network.Strategies()[opts.Driver]
 	if !ok {
-		return fmt.Errorf("unsupported network driver strategy: %v (contributions welcome!)", opts.driver)
+		return fmt.Errorf("unsupported network driver strategy: %v (contributions welcome!)", opts.Driver)
 	}
 
 	controller, err := strategy.NewNetworkV1alpha1(ctx)


### PR DESCRIPTION
This allows the subcommands to be called programatically without generating errors.

<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->
