### PR TITLE
fix(actions): Allow public read and write to BuildKit socket

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -112,7 +112,9 @@ runs:
         --privileged \
         --name buildkitd_${GITHUB_RUN_ID} \
         -v /run/buildkit:/run/buildkit:rw \
-        moby/buildkit:v0.12.1
+        moby/buildkit:v0.12.1;
+      sleep 5; # wait for buildkit to start
+      sudo chmod 666 /run/buildkit/buildkitd.sock;
   - name: Set up scripts
     shell: bash
     run: |


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

Simply `chmod` the socket such that the `runner` user can read and write from it.
