### PR TITLE
fix: Do not re-package embedded initrd

### DIFF
--- a/tools/github-action/build.go
+++ b/tools/github-action/build.go
@@ -48,6 +48,11 @@ func (opts *GithubAction) build(ctx context.Context) error {
 		if err != nil {
 			return err
 		}
+
+		// Unset the intird path since this is now embedded in the unikernel
+		if val, exists := opts.project.KConfig().Get("CONFIG_LIBVFSCORE_ROOTFS_EINITRD"); exists && val.Value == "y" {
+			opts.initrdPath = ""
+		}
 	}
 
 	if err := opts.project.Configure(


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

This PR fixes an issue where if the user has embedded the initrd within the unikernel binary image, and a packaging step was later performed, it would be part of that package.  Simply unset relevant variables to prevent re-packaging.
