### PR TITLE
fix(pkg): Correctly set appropriate arguments

### DIFF
--- a/internal/cli/kraft/pkg/packager_kraftfile_unikraft.go
+++ b/internal/cli/kraft/pkg/packager_kraftfile_unikraft.go
@@ -94,6 +94,16 @@ func (p *packagerKraftfileUnikraft) Pack(ctx context.Context, opts *PkgOptions, 
 			opts.Args = targ.Command()
 		}
 
+		// If no arguments have been specified, use the ones which are default and
+		// that have been included in the package.
+		if len(opts.Args) == 0 {
+			if len(opts.Project.Command()) > 0 {
+				opts.Args = opts.Project.Command()
+			} else if len(targ.Command()) > 0 {
+				opts.Args = targ.Command()
+			}
+		}
+
 		cmdShellArgs, err := shellwords.Parse(strings.Join(opts.Args, " "))
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

This PR fixes an issue where if `args` were set in a context where the unikernel had been built from source, the `kraft pkg` would not have picked this up.
