### PR TITLE
feat(compose): Add basic networking support

### DIFF
--- a/api/compose/v1/compose.zip.go
+++ b/api/compose/v1/compose.zip.go
@@ -29,6 +29,7 @@ type ComposeSpec struct {
 // ComposeStatus contains the complete status of the compose project.
 type ComposeStatus struct {
 	Machines []v1.ObjectMeta `json:"machines,omitempty"`
+	Networks []v1.ObjectMeta `json:"networks,omitempty"`
 }
 
 // ComposeService is the interface of available methods

--- a/compose/v1.go
+++ b/compose/v1.go
@@ -21,7 +21,7 @@ import (
 	mplatform "kraftkit.sh/machine/platform"
 )
 
-type v1ComposeProject struct{}
+type v1Compose struct{}
 
 func NewComposeProjectV1(ctx context.Context, opts ...any) (composev1.ComposeService, error) {
 	embeddedStore, err := store.NewEmbeddedStore[composev1.ComposeSpec, composev1.ComposeStatus](
@@ -34,7 +34,7 @@ func NewComposeProjectV1(ctx context.Context, opts ...any) (composev1.ComposeSer
 		return nil, err
 	}
 
-	service := &v1ComposeProject{}
+	service := &v1Compose{}
 
 	return composev1.NewComposeServiceHandler(
 		ctx,
@@ -188,12 +188,12 @@ func refreshExistingNetworks(ctx context.Context, embeddedProject *composev1.Com
 }
 
 // Create implements kraftkit.sh/api/compose/v1.ComposeService
-func (p *v1ComposeProject) Create(ctx context.Context, project *composev1.Compose) (*composev1.Compose, error) {
+func (p *v1Compose) Create(ctx context.Context, project *composev1.Compose) (*composev1.Compose, error) {
 	return project, nil
 }
 
 // Delete implements kraftkit.sh/api/compose/v1.ComposeService
-func (p *v1ComposeProject) Delete(ctx context.Context, project *composev1.Compose) (*composev1.Compose, error) {
+func (p *v1Compose) Delete(ctx context.Context, project *composev1.Compose) (*composev1.Compose, error) {
 	if err := refreshRunningServices(ctx, project); err != nil {
 		return project, err
 	}
@@ -206,7 +206,7 @@ func (p *v1ComposeProject) Delete(ctx context.Context, project *composev1.Compos
 }
 
 // List implements kraftkit.sh/api/compose/v1.ComposeService
-func (p *v1ComposeProject) List(ctx context.Context, projects *composev1.ComposeList) (*composev1.ComposeList, error) {
+func (p *v1Compose) List(ctx context.Context, projects *composev1.ComposeList) (*composev1.ComposeList, error) {
 	for i := range projects.Items {
 		if err := refreshRunningServices(ctx, &projects.Items[i]); err != nil {
 			return projects, err
@@ -221,7 +221,7 @@ func (p *v1ComposeProject) List(ctx context.Context, projects *composev1.Compose
 }
 
 // Get implements kraftkit.sh/api/compose/v1.ComposeService
-func (p *v1ComposeProject) Get(ctx context.Context, project *composev1.Compose) (*composev1.Compose, error) {
+func (p *v1Compose) Get(ctx context.Context, project *composev1.Compose) (*composev1.Compose, error) {
 	if err := refreshRunningServices(ctx, project); err != nil {
 		return project, err
 	}
@@ -234,6 +234,6 @@ func (p *v1ComposeProject) Get(ctx context.Context, project *composev1.Compose) 
 }
 
 // Update implements kraftkit.sh/api/compose/v1.ComposeService
-func (p *v1ComposeProject) Update(ctx context.Context, project *composev1.Compose) (*composev1.Compose, error) {
+func (p *v1Compose) Update(ctx context.Context, project *composev1.Compose) (*composev1.Compose, error) {
 	return project, nil
 }

--- a/internal/cli/kraft/compose/up/up.go
+++ b/internal/cli/kraft/compose/up/up.go
@@ -213,15 +213,6 @@ func platArchFromService(service types.ServiceConfig) (string, string, error) {
 		return "", "", fmt.Errorf("invalid platform: %s for service %s", service.Platform, service.Name)
 	}
 
-	// Check that the platform is supported
-	if _, ok := mplatform.PlatformsByName()[parts[0]]; !ok {
-		return "", "", fmt.Errorf("unsupported platform: %s for service %s", parts[0], service.Name)
-	}
-
-	if parts[1] != "x86_64" && parts[1] != "amd64" && parts[1] != "arm32" && parts[1] != "arm64" {
-		return "", "", fmt.Errorf("unsupported architecture: %s for service %s", parts[1], service.Name)
-	}
-
 	return parts[0], parts[1], nil
 }
 

--- a/internal/cli/kraft/compose/up/up.go
+++ b/internal/cli/kraft/compose/up/up.go
@@ -20,17 +20,20 @@ import (
 	"kraftkit.sh/compose"
 	"kraftkit.sh/internal/cli/kraft/build"
 	"kraftkit.sh/internal/cli/kraft/logs"
+	"kraftkit.sh/internal/cli/kraft/net/create"
 	"kraftkit.sh/internal/cli/kraft/pkg"
 	"kraftkit.sh/internal/cli/kraft/pkg/pull"
 	"kraftkit.sh/internal/cli/kraft/remove"
 	"kraftkit.sh/internal/cli/kraft/run"
 	"kraftkit.sh/log"
+	"kraftkit.sh/machine/network"
 	"kraftkit.sh/packmanager"
 	"kraftkit.sh/unikraft"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	composeapi "kraftkit.sh/api/compose/v1"
 	machineapi "kraftkit.sh/api/machine/v1alpha1"
+	networkapi "kraftkit.sh/api/network/v1alpha1"
 	mplatform "kraftkit.sh/machine/platform"
 )
 
@@ -91,6 +94,10 @@ func (opts *UpOptions) Run(ctx context.Context, args []string) error {
 		return err
 	}
 
+	if err := project.AssignIPs(ctx); err != nil {
+		return err
+	}
+
 	composeController, err := compose.NewComposeProjectV1(ctx)
 	if err != nil {
 		return err
@@ -105,6 +112,82 @@ func (opts *UpOptions) Run(ctx context.Context, args []string) error {
 		return err
 	}
 
+	projectNetworks := []metav1.ObjectMeta{}
+	if embeddedProject != nil {
+		projectNetworks = embeddedProject.Status.Networks
+	}
+
+	networkController, err := network.NewNetworkV1alpha1ServiceIterator(ctx)
+	if err != nil {
+		return err
+	}
+
+	networks, err := networkController.List(ctx, &networkapi.NetworkList{})
+	if err != nil {
+		return err
+	}
+
+	// We need to first create the networks with a provided subnet
+	// and then the ones which we will assign IPs to
+	subnetNetworks := []string{}
+	emptyNetworks := []string{}
+	for name, network := range project.Networks {
+		if network.Ipam.Config == nil || len(network.Ipam.Config) == 0 {
+			emptyNetworks = append(emptyNetworks, name)
+		} else {
+			subnetNetworks = append(subnetNetworks, name)
+		}
+	}
+
+	orderedNetworks := append(subnetNetworks, emptyNetworks...)
+
+	for _, networkName := range orderedNetworks {
+		network := project.Networks[networkName]
+		alreadyRunning := false
+		for _, n := range networks.Items {
+			if n.Name == network.Name {
+				alreadyRunning = true
+				break
+			}
+		}
+		if alreadyRunning {
+			continue
+		}
+
+		driver := "bridge"
+		if network.Driver != "" {
+			driver = network.Driver
+		}
+
+		subnet := ""
+		if len(network.Ipam.Config) > 0 {
+			subnet = network.Ipam.Config[0].Subnet
+		}
+		createOptions := create.CreateOptions{
+			Driver:  driver,
+			Network: subnet,
+		}
+
+		log.G(ctx).Infof("creating network %s...", network.Name)
+		if err := createOptions.Run(ctx, []string{network.Name}); err != nil {
+			return err
+		}
+
+		if network, err := networkController.Get(ctx, &networkapi.Network{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: network.Name,
+			},
+		}); err == nil && network.Status.State == networkapi.NetworkStateUp {
+			projectNetworks = append(projectNetworks, network.ObjectMeta)
+		}
+
+	}
+
+	projectMachines := []metav1.ObjectMeta{}
+	if embeddedProject != nil {
+		projectMachines = embeddedProject.Status.Machines
+	}
+
 	// Check that none of the services are already running
 	machineController, err := mplatform.NewMachineV1alpha1ServiceIterator(ctx)
 	if err != nil {
@@ -114,11 +197,6 @@ func (opts *UpOptions) Run(ctx context.Context, args []string) error {
 	machines, err := machineController.List(ctx, &machineapi.MachineList{})
 	if err != nil {
 		return err
-	}
-
-	projectMachines := []metav1.ObjectMeta{}
-	if embeddedProject != nil {
-		projectMachines = embeddedProject.Status.Machines
 	}
 
 	for _, service := range project.Services {
@@ -152,7 +230,7 @@ func (opts *UpOptions) Run(ctx context.Context, args []string) error {
 			}
 		}
 
-		if err := runService(ctx, service); err != nil {
+		if err := runService(ctx, project, service); err != nil {
 			log.G(ctx).WithError(err).Errorf("failed to run service %s", service.Name)
 		}
 
@@ -175,6 +253,7 @@ func (opts *UpOptions) Run(ctx context.Context, args []string) error {
 		},
 		Status: composeapi.ComposeStatus{
 			Machines: projectMachines,
+			Networks: projectNetworks,
 		},
 	}); err != nil {
 		return err
@@ -314,7 +393,7 @@ func pkgService(ctx context.Context, service types.ServiceConfig) error {
 	return pkgOptions.Run(ctx, []string{service.Build.Context})
 }
 
-func runService(ctx context.Context, service types.ServiceConfig) error {
+func runService(ctx context.Context, project *compose.Project, service types.ServiceConfig) error {
 	// The service should be packaged at this point
 	plat, arch, err := platArchFromService(service)
 	if err != nil {
@@ -323,10 +402,17 @@ func runService(ctx context.Context, service types.ServiceConfig) error {
 
 	log.G(ctx).Infof("running service %s...", service.Name)
 
+	networks := []string{}
+	for name, network := range service.Networks {
+		networkArg := fmt.Sprintf("%s:%s", project.Networks[name].Name, network.Ipv4Address)
+		networks = append(networks, networkArg)
+	}
+
 	runOptions := run.RunOptions{
 		Architecture: arch,
 		Detach:       true,
 		Name:         service.Name,
+		Networks:     networks,
 		Platform:     plat,
 	}
 

--- a/internal/cli/kraft/run/utils.go
+++ b/internal/cli/kraft/run/utils.go
@@ -83,7 +83,7 @@ func (opts *RunOptions) parseNetworks(ctx context.Context, machine *machineapi.M
 
 		if len(split) > 1 {
 			fields := strings.Split(split[1], ":")
-			if len(fields) > 0 {
+			if len(fields) > 0 && fields[0] != "" {
 				interfaceSpec.CIDR = fields[0]
 				ipMaskSplit := strings.SplitN(interfaceSpec.CIDR, "/", 2)
 				if len(ipMaskSplit) != 2 {

--- a/machine/network/bridge/utils.go
+++ b/machine/network/bridge/utils.go
@@ -2,52 +2,15 @@ package bridge
 
 import (
 	"context"
-	"encoding/binary"
 	"fmt"
-	"math/big"
 	"net"
 	"time"
 
 	"github.com/erikh/ping"
 	"github.com/vishvananda/netlink"
 	"kraftkit.sh/internal/set"
+	"kraftkit.sh/machine/network/iputils"
 )
-
-// IpToBigInt converts a 4 bytes IP into a 128 bit integer.
-func IPToBigInt(ip net.IP) *big.Int {
-	x := big.NewInt(0)
-	if ip4 := ip.To4(); ip4 != nil {
-		return x.SetBytes(ip4)
-	}
-	if ip6 := ip.To16(); ip6 != nil {
-		return x.SetBytes(ip6)
-	}
-	return nil
-}
-
-// BigIntToIP converts 128 bit integer into a 4 bytes IP address.
-func BigIntToIP(v *big.Int) net.IP {
-	return net.IP(v.Bytes())
-}
-
-// Increases IP address numeric value by 1.
-func IncreaseIP(ip net.IP) net.IP {
-	rawip := IPToBigInt(ip)
-	rawip.Add(rawip, big.NewInt(1))
-	return BigIntToIP(rawip)
-}
-
-// IsUnicastIP returns true if the provided IP address and network mask is a
-// unicast address.
-func IsUnicastIP(ip net.IP, mask net.IPMask) bool {
-	// broadcast v4 ip
-	if len(ip) == net.IPv4len && binary.BigEndian.Uint32(ip)&^binary.BigEndian.Uint32(mask) == ^binary.BigEndian.Uint32(mask) {
-		return false
-	}
-
-	// global unicast
-	return ip.IsGlobalUnicast()
-}
 
 // BridgeIPs returns all the IPs attached to the provided bridge
 func BridgeIPs(bridge *netlink.Bridge) ([]string, error) {
@@ -88,7 +51,7 @@ func AllocateIP(ctx context.Context, ipnet *net.IPNet, iface *net.Interface, bri
 
 search:
 	for {
-		ip = IncreaseIP(ip)
+		ip = iputils.IncreaseIP(ip)
 
 		select {
 		case <-ctx.Done():
@@ -115,7 +78,7 @@ search:
 			continue
 
 		// Skip the broadcast IP address.
-		case !IsUnicastIP(ip, ipnet.Mask):
+		case !iputils.IsUnicastIP(ip, ipnet.Mask):
 			continue
 
 		// Skip allocated IP addresses.

--- a/machine/network/bridge/v1alpha1.go
+++ b/machine/network/bridge/v1alpha1.go
@@ -242,9 +242,11 @@ func (service *v1alpha1Network) Update(ctx context.Context, network *networkv1al
 		return nil, fmt.Errorf("could not get bridge interface: %v", err)
 	}
 
+	maskBytes := net.ParseIP(network.Spec.Netmask).To4()
+	mask := net.IPv4Mask(maskBytes[0], maskBytes[1], maskBytes[2], maskBytes[3])
 	ipnet := &net.IPNet{
 		IP:   net.ParseIP(network.Spec.Gateway),
-		Mask: net.ParseIP(network.Spec.Netmask).DefaultMask(),
+		Mask: mask,
 	}
 
 	// Start MAC addresses iteratively.

--- a/machine/network/iputils/iputils.go
+++ b/machine/network/iputils/iputils.go
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2024, Unikraft GmbH and The KraftKit Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+
+package iputils
+
+import (
+	"encoding/binary"
+	"math/big"
+	"net"
+)
+
+// IpToBigInt converts a 4 bytes IP into a 128 bit integer.
+func IPToBigInt(ip net.IP) *big.Int {
+	x := big.NewInt(0)
+	if ip4 := ip.To4(); ip4 != nil {
+		return x.SetBytes(ip4)
+	}
+	if ip6 := ip.To16(); ip6 != nil {
+		return x.SetBytes(ip6)
+	}
+	return nil
+}
+
+// BigIntToIP converts 128 bit integer into a 4 bytes IP address.
+func BigIntToIP(v *big.Int) net.IP {
+	return net.IP(v.Bytes())
+}
+
+// Increases IP address numeric value by 1.
+func IncreaseIP(ip net.IP) net.IP {
+	rawip := IPToBigInt(ip)
+	rawip.Add(rawip, big.NewInt(1))
+	return BigIntToIP(rawip)
+}
+
+// IsUnicastIP returns true if the provided IP address and network mask is a
+// unicast address.
+func IsUnicastIP(ip net.IP, mask net.IPMask) bool {
+	// broadcast v4 ip
+	if len(ip) == net.IPv4len && binary.BigEndian.Uint32(ip)&^binary.BigEndian.Uint32(mask) == ^binary.BigEndian.Uint32(mask) {
+		return false
+	}
+
+	// global unicast
+	return ip.IsGlobalUnicast()
+}


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes
This PR introduces networking support for compose projects. Currently, because networks have to be "fully" specified, the syntax is quite verbose:

```yaml
services:
  ping:
    build: ./ping
    networks:
     ping-pong-net: # Allocate any IP
  pong:
    build: ./pong
    networks: 
      ping-pong-net:
        ipv4_address: 172.200.0.5

networks:
  ping-pong-net:
    name: ping-pong
    driver: bridge
    ipam:
      config:
        - subnet: 172.200.0.1/24 
      # equivalent to:
      # - subnet: 172.200.0.0/24
      # - gateway: 172.200.0.1
```
This could be improved on by introducing a way to automatically allocate networks.

Additionally, this PR introduces a commit that makes networking thread-safe: running multiple kernels in parallel would result in the network controller not being updated properly.

You can find an example of a working application here:
https://github.com/LucaSeri/kraft-compose-examples/tree/main/ping-pong

Depends on: https://github.com/unikraft/kraftkit/pull/1042, https://github.com/unikraft/kraftkit/pull/1024

<!--
Please provide a detailed description of the changes made in this new PR.
-->
