### PR TITLE
fix(paraprogress): Fix restoring the IOStreams (stdout) output

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,6 @@ require (
 	github.com/MakeNowJust/heredoc v1.0.0
 	github.com/Masterminds/semver/v3 v3.2.1
 	github.com/acorn-io/baaah v0.0.0-20230522221318-afcc93619e30
-	github.com/barkimedes/go-deepcopy v0.0.0-20220514131651-17c30cfc62df
 	github.com/briandowns/spinner v1.23.0
 	github.com/cavaliergopher/cpio v1.0.1
 	github.com/charmbracelet/bubbles v0.16.1

--- a/go.sum
+++ b/go.sum
@@ -127,8 +127,6 @@ github.com/atotto/clipboard v0.1.4/go.mod h1:ZY9tmq7sm5xIbd9bOK4onWV4S6X0u6GY7Vn
 github.com/aws/aws-sdk-go v1.15.11/go.mod h1:mFuSZ37Z9YOHbQEwBWztmVzqXrEkub65tZoCYDt7FT0=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1 h1:HwpRHbFMcZLEVr42D4p7XBqjyuxQH5SMiErDT4WkJ2k=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1/go.mod h1:uYgXzlJ7ZpABp8OJ+exZzJJhRNQ2ASbcXHWsFqH8hp8=
-github.com/barkimedes/go-deepcopy v0.0.0-20220514131651-17c30cfc62df h1:GSoSVRLoBaFpOOds6QyY1L8AX7uoY+Ln3BHc22W40X0=
-github.com/barkimedes/go-deepcopy v0.0.0-20220514131651-17c30cfc62df/go.mod h1:hiVxq5OP2bUGBRNS3Z/bt/reCLFNbdcST6gISi1fiOM=
 github.com/beorn7/perks v0.0.0-20160804104726-4c0e84591b9a/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=

--- a/tui/paraprogress/paraprogress.go
+++ b/tui/paraprogress/paraprogress.go
@@ -10,11 +10,11 @@ import (
 	"os"
 	"time"
 
-	"github.com/barkimedes/go-deepcopy"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 	"github.com/muesli/termenv"
 	"golang.org/x/term"
+	"kraftkit.sh/iostreams"
 	"kraftkit.sh/log"
 	"kraftkit.sh/tui"
 )
@@ -36,6 +36,7 @@ type ParaProgress struct {
 	failFast      bool
 	nameWidth     int
 	timeout       time.Duration
+	oldOut        iostreams.FileWriter
 }
 
 func NewParaProgress(ctx context.Context, processes []*Process, opts ...ParaProgressOption) (*ParaProgress, error) {
@@ -52,6 +53,7 @@ func NewParaProgress(ctx context.Context, processes []*Process, opts ...ParaProg
 		// process's name's width is checked and the maximum of all
 		// is used.
 		nameWidth: -1,
+		oldOut:    iostreams.G(ctx).Out,
 	}
 
 	for _, opt := range opts {
@@ -75,12 +77,8 @@ func NewParaProgress(ctx context.Context, processes []*Process, opts ...ParaProg
 		processes[i].NameWidth = maxNameLen
 		processes[i].timeout = md.timeout
 
-		pctx, err := deepcopy.Anything(ctx)
-		if err != nil {
-			return nil, err
-		}
-
-		processes[i].ctx = pctx.(context.Context)
+		pctx := ctx
+		processes[i].ctx = pctx
 		log.G(processes[i].ctx).Level = log.G(ctx).Level
 
 		// Update formatter when using KraftKit's TextFormatter.  The
@@ -113,6 +111,12 @@ func (pd *ParaProgress) Start() error {
 	}
 
 	tprog = tea.NewProgram(pd, teaOpts...)
+
+	// Restore the old output for the IOStreams which is manipulated per process.
+	defer func() {
+		iostreams.G(pd.ctx).Out = pd.oldOut
+		log.G(pd.ctx).Out = pd.oldOut
+	}()
 
 	if _, err := tprog.Run(); err != nil {
 		return err


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->


Previously, the context was deeply copied in the attempt to create per-process working versions which could be passed to individual processes with slight modifications (specifically to contextual systems that worked with stdout).  This did not always work which resulted in very occassional malformed or not-fully-copied contexts. Instead, simply perform a shallow copy such that full references can be made per-process and defer a restoration of the iostreams and stdout after the paraprogress exits.  This is much more reliable.
