### PR TITLE
fix(tui): Pass context via `tea.WithContext`

### DIFF
--- a/tui/paraprogress/paraprogress.go
+++ b/tui/paraprogress/paraprogress.go
@@ -101,6 +101,7 @@ func NewParaProgress(ctx context.Context, processes []*Process, opts ...ParaProg
 func (pd *ParaProgress) Start() error {
 	teaOpts := []tea.ProgramOption{
 		tea.WithInput(nil),
+		tea.WithContext(pd.ctx),
 	}
 
 	if pd.norender {

--- a/tui/processtree/processtree.go
+++ b/tui/processtree/processtree.go
@@ -156,6 +156,7 @@ func (pti *ProcessTreeItem) Close() error {
 func (pt *ProcessTree) Start() error {
 	teaOpts := []tea.ProgramOption{
 		tea.WithInput(nil),
+		tea.WithContext(pt.ctx),
 	}
 
 	// Restore the old output for the IOStreams which is manipulated per process.


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

Passing a context helps in situations where a timeout or a cancel is called, helping gracefully exit the tea program.
