### PR TITLE
fix(buildenvs): Ensure build environment's target a platform

### DIFF
--- a/buildenvs/Makefile
+++ b/buildenvs/Makefile
@@ -18,6 +18,8 @@ BUILDENVS    ?= gcc \
 
 DOCKER       ?= docker
 
+PLATFORM     ?= linux/x86_64
+
 WITH_CACHE   ?= y
 
 .PHONY: qemu
@@ -32,6 +34,7 @@ qemu: _WITH_CACHE  := --no-cache
 endif
 qemu:
 	$(DOCKER) build \
+		--platform $(PLATFORM) \
 		--build-arg QEMU_VERSION=$(QEMU_VERSION) \
 		--build-arg MAKE_NPROC=$(MAKE_NPROC) \
 		--tag $(IMAGE) \
@@ -51,6 +54,7 @@ myself: _WITH_CACHE := --no-cache
 endif
 myself:
 	$(DOCKER) build \
+		--platform $(PLATFORM) \
 		--build-arg GO_VERSION=$(GO_VERSION) \
 		--tag $(IMAGE) \
 		--target $(TARGET) \
@@ -97,6 +101,7 @@ base-golang: _WITH_CACHE      := --no-cache
 endif
 base-golang:
 	$(DOCKER) build \
+		--platform $(PLATFORM) \
 		--build-arg GO_VERSION=$(GO_VERSION) \
 		--build-arg KRAFTKIT_VERSION=$(KRAFTKIT_VERSION) \
 		--build-arg QEMU_VERSION=$(QEMU_VERSION) \
@@ -117,6 +122,7 @@ github-action: _WITH_CACHE      := --no-cache
 endif
 github-action:
 	$(DOCKER) build \
+		--platform $(PLATFORM) \
 		--build-arg GO_VERSION=$(GO_VERSION) \
 		--tag $(IMAGE) \
 		$(_WITH_CACHE) \


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

To ensure consistency across different hosts which may vary in platform (OS and architecture), ensure that there is a variable that is set to a known default (`linux/x86_64`).  Whilst in the future we may support multi-platform images, for now, this allows building such environments on different platforms and ensuring repeatable outcome of the image itself.
