### PR TITLE
feat: Ability to package kernel directly

### DIFF
--- a/internal/cli/kraft/build/build.go
+++ b/internal/cli/kraft/build/build.go
@@ -178,7 +178,7 @@ func (opts *BuildOptions) Run(ctx context.Context, args []string) error {
 		return fmt.Errorf("could not complete build: %w", err)
 	}
 
-	if err := utils.BuildRootfs(ctx, opts.workdir, opts.Rootfs, selected...); err != nil {
+	if opts.Rootfs, err = utils.BuildRootfs(ctx, opts.workdir, opts.Rootfs, selected...); err != nil {
 		return err
 	}
 

--- a/internal/cli/kraft/pkg/packager.go
+++ b/internal/cli/kraft/pkg/packager.go
@@ -36,5 +36,6 @@ func packagers() []packager {
 	return []packager{
 		&packagerKraftfileUnikraft{},
 		&packagerKraftfileRuntime{},
+		&packagerCliKernel{},
 	}
 }

--- a/internal/cli/kraft/pkg/packager_cli_kernel.go
+++ b/internal/cli/kraft/pkg/packager_cli_kernel.go
@@ -1,0 +1,118 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2023, Unikraft GmbH and The KraftKit Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+
+package pkg
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/mattn/go-shellwords"
+	"kraftkit.sh/config"
+	"kraftkit.sh/internal/cli/kraft/utils"
+	"kraftkit.sh/log"
+	"kraftkit.sh/pack"
+	"kraftkit.sh/packmanager"
+	"kraftkit.sh/tui/processtree"
+	"kraftkit.sh/unikraft/arch"
+	"kraftkit.sh/unikraft/plat"
+	"kraftkit.sh/unikraft/target"
+)
+
+type packagerCliKernel struct{}
+
+// String implements fmt.Stringer.
+func (p *packagerCliKernel) String() string {
+	return "cli-kernel"
+}
+
+// Packagable implements packager.
+func (p *packagerCliKernel) Packagable(ctx context.Context, opts *PkgOptions, args ...string) (bool, error) {
+	if len(opts.Kernel) > 0 && len(opts.Architecture) > 0 && len(opts.Platform) > 0 {
+		return true, nil
+	}
+
+	return false, fmt.Errorf("cannot package without path to -k|-kernel, -m|--arch and -p|--plat")
+}
+
+// Pack implements packager.
+func (p *packagerCliKernel) Pack(ctx context.Context, opts *PkgOptions, args ...string) ([]pack.Package, error) {
+	ac, err := arch.NewArchitectureFromOptions(
+		arch.WithName(opts.Architecture),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("could not prepare architecture: %w", err)
+	}
+
+	pc, err := plat.NewPlatformFromOptions(
+		plat.WithName(opts.Platform),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("could not prepare architecture: %w", err)
+	}
+
+	targ, err := target.NewTargetFromOptions(
+		target.WithArchitecture(ac),
+		target.WithPlatform(pc),
+		target.WithKernel(opts.Kernel),
+		target.WithCommand(opts.Args),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("could not prepare phony target: %w", err)
+	}
+
+	if opts.Rootfs, err = utils.BuildRootfs(ctx, opts.Workdir, opts.Rootfs, targ); err != nil {
+		return nil, fmt.Errorf("could not build rootfs: %w", err)
+	}
+
+	cmdShellArgs, err := shellwords.Parse(strings.Join(opts.Args, " "))
+	if err != nil {
+		return nil, err
+	}
+
+	var result []pack.Package
+	norender := log.LoggerTypeFromString(config.G[config.KraftKit](ctx).Log.Type) != log.FANCY
+
+	model, err := processtree.NewProcessTree(
+		ctx,
+		[]processtree.ProcessTreeOption{
+			processtree.IsParallel(false),
+			processtree.WithRenderer(norender),
+		},
+
+		processtree.NewProcessTreeItem(
+			"packaging "+opts.Name+" ("+opts.Format+")",
+			opts.Platform+"/"+opts.Architecture,
+			func(ctx context.Context) error {
+				popts := append(opts.packopts,
+					packmanager.PackArgs(cmdShellArgs...),
+					packmanager.PackInitrd(opts.Rootfs),
+					packmanager.PackKConfig(!opts.NoKConfig),
+					packmanager.PackName(opts.Name),
+					packmanager.PackOutput(opts.Output),
+				)
+
+				more, err := opts.pm.Pack(ctx, targ, popts...)
+				if err != nil {
+					return err
+				}
+
+				result = append(result, more...)
+
+				return nil
+			},
+		),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := model.Start(); err != nil {
+		return nil, err
+	}
+
+	return result, nil
+}

--- a/internal/cli/kraft/pkg/packager_kraftfile_runtime.go
+++ b/internal/cli/kraft/pkg/packager_kraftfile_runtime.go
@@ -9,12 +9,10 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"path/filepath"
 	"strings"
 
 	"github.com/mattn/go-shellwords"
 	"kraftkit.sh/config"
-	"kraftkit.sh/initrd"
 	"kraftkit.sh/internal/cli/kraft/utils"
 	"kraftkit.sh/log"
 	"kraftkit.sh/machine/platform"
@@ -223,17 +221,8 @@ func (p *packagerKraftfileRuntime) Pack(ctx context.Context, opts *PkgOptions, a
 		return nil, fmt.Errorf("package does not convert to target")
 	}
 
-	if err := utils.BuildRootfs(ctx, opts.Workdir, opts.Rootfs, targ); err != nil {
+	if opts.Rootfs, err = utils.BuildRootfs(ctx, opts.Workdir, opts.Rootfs, targ); err != nil {
 		return nil, fmt.Errorf("could not build rootfs: %w", err)
-	}
-
-	initrdPath := ""
-	if len(opts.Rootfs) > 0 {
-		initrdPath = filepath.Join(
-			opts.Workdir,
-			unikraft.BuildDir,
-			fmt.Sprintf(initrd.DefaultInitramfsArchFileName, targ.Architecture().String()),
-		)
 	}
 
 	// If no arguments have been specified, use the ones which are default and
@@ -267,7 +256,7 @@ func (p *packagerKraftfileRuntime) Pack(ctx context.Context, opts *PkgOptions, a
 			func(ctx context.Context) error {
 				popts := append(opts.packopts,
 					packmanager.PackArgs(cmdShellArgs...),
-					packmanager.PackInitrd(initrdPath),
+					packmanager.PackInitrd(opts.Rootfs),
 					packmanager.PackKConfig(!opts.NoKConfig),
 					packmanager.PackName(opts.Name),
 					packmanager.PackOutput(opts.Output),

--- a/internal/cli/kraft/utils/rootfs.go
+++ b/internal/cli/kraft/utils/rootfs.go
@@ -21,9 +21,9 @@ import (
 
 // BuildRootfs generates a rootfs based on the provided working directory and
 // the rootfs entrypoint for the provided target(s).
-func BuildRootfs(ctx context.Context, workdir, rootfs string, targets ...target.Target) error {
+func BuildRootfs(ctx context.Context, workdir, rootfs string, targets ...target.Target) (string, error) {
 	if rootfs == "" {
-		return nil
+		return "", nil
 	}
 
 	var processes []*processtree.ProcessTreeItem
@@ -51,7 +51,7 @@ func BuildRootfs(ctx context.Context, workdir, rootfs string, targets ...target.
 			initrd.WithArchitecture(arch),
 		)
 		if err != nil {
-			return fmt.Errorf("could not initialize initramfs builder: %w", err)
+			return "", fmt.Errorf("could not initialize initramfs builder: %w", err)
 		}
 
 		processes = append(processes,
@@ -79,12 +79,12 @@ func BuildRootfs(ctx context.Context, workdir, rootfs string, targets ...target.
 		processes...,
 	)
 	if err != nil {
-		return err
+		return "", err
 	}
 
 	if err := model.Start(); err != nil {
-		return err
+		return "", err
 	}
 
-	return nil
+	return rootfs, nil
 }

--- a/unikraft/arch/architecture.go
+++ b/unikraft/arch/architecture.go
@@ -50,6 +50,19 @@ func NewArchitectureFromSchema(value string) (ArchitectureConfig, error) {
 	return architecture, nil
 }
 
+// NewArchitectureFromOptions is a constructor that configures an architecture.
+func NewArchitectureFromOptions(opts ...ArchitectureOption) (Architecture, error) {
+	pc := ArchitectureConfig{}
+
+	for _, opt := range opts {
+		if err := opt(&pc); err != nil {
+			return nil, err
+		}
+	}
+
+	return &pc, nil
+}
+
 func (ac ArchitectureConfig) Name() string {
 	return ac.name
 }

--- a/unikraft/arch/options.go
+++ b/unikraft/arch/options.go
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2022, Unikraft GmbH and The KraftKit Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+package arch
+
+import (
+	"kraftkit.sh/kconfig"
+)
+
+// ArchitectureOption is a function that modifies a ArchitectureConfig.
+type ArchitectureOption func(*ArchitectureConfig) error
+
+// WithName sets the name of the architecture.
+func WithName(name string) ArchitectureOption {
+	return func(ac *ArchitectureConfig) error {
+		ac.name = name
+		return nil
+	}
+}
+
+// WithKConfig sets the kconfig of the architecture.
+func WithKConfig(kconfig kconfig.KeyValueMap) ArchitectureOption {
+	return func(ac *ArchitectureConfig) error {
+		ac.kconfig = kconfig
+		return nil
+	}
+}
+
+// WithVersion sets the version of the architecture.
+func WithVersion(version string) ArchitectureOption {
+	return func(ac *ArchitectureConfig) error {
+		ac.version = version
+		return nil
+	}
+}
+
+// WithSource sets the source of the architecture.
+func WithSource(source string) ArchitectureOption {
+	return func(ac *ArchitectureConfig) error {
+		ac.source = source
+		return nil
+	}
+}
+
+// WithPath sets the path of the architecture.
+func WithPath(path string) ArchitectureOption {
+	return func(ac *ArchitectureConfig) error {
+		ac.path = path
+		return nil
+	}
+}

--- a/unikraft/target/options.go
+++ b/unikraft/target/options.go
@@ -23,7 +23,7 @@ func WithName(name string) TargetOption {
 }
 
 // WithVersion sets the version of the target.
-func WithArchitecture(arch arch.ArchitectureConfig) TargetOption {
+func WithArchitecture(arch arch.Architecture) TargetOption {
 	return func(tc *TargetConfig) error {
 		tc.architecture = arch
 		return nil
@@ -31,7 +31,7 @@ func WithArchitecture(arch arch.ArchitectureConfig) TargetOption {
 }
 
 // WithPlatform sets the platform of the target.
-func WithPlatform(platform plat.PlatformConfig) TargetOption {
+func WithPlatform(platform plat.Platform) TargetOption {
 	return func(tc *TargetConfig) error {
 		tc.platform = platform
 		return nil

--- a/unikraft/target/target.go
+++ b/unikraft/target/target.go
@@ -49,10 +49,10 @@ type TargetConfig struct {
 	name string
 
 	// architecture is the target architecture.
-	architecture arch.ArchitectureConfig
+	architecture arch.Architecture
 
 	// platform is the target platform.
-	platform plat.PlatformConfig
+	platform plat.Platform
 
 	// kconfig list of kconfig key-values specific to this library.
 	kconfig kconfig.KeyValueMap


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

This PR introduces the ability to package a kernel directly, enabling the following workflow:

```console
kraft pkg \
  --name helloworld:latest \
  --kernel path/to/helloworld_qemu-x86_64
  --arch x86_64 \
  --plat qemu
```

GitHub-FIxes: #996