### PR TITLE
fix(goreleaser): Remove missing field from brew

### DIFF
--- a/.goreleaser-stable.yaml
+++ b/.goreleaser-stable.yaml
@@ -130,9 +130,6 @@ nix:
       cp -vr ./dist/kraft $out/bin/kraft
 brews:
   - name: kraftkit
-    alternative_names:
-      - kraftkit@{{ .Version }}
-      - kraftkit@{{ .Major }}
     url_template: "https://github.com/unikraft/kraftkit/releases/download/{{ .Tag }}/{{ .ArtifactName }}"
     commit_author:
       name: Unikraft Bot


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

The `alternative_names` field, although present in the docs, shows up as 'not found' by goreleaser.

Remove this and keep only the original name, as we want people to use only the latest version.