### PR TITLE
fix: Handle target name shorthand syntax in build

### DIFF
--- a/internal/cli/kraft/build/build.go
+++ b/internal/cli/kraft/build/build.go
@@ -137,7 +137,7 @@ func (opts *BuildOptions) Run(ctx context.Context, args []string) error {
 			opts.Target,
 		)
 
-		if !config.G[config.KraftKit](ctx).NoPrompt {
+		if !config.G[config.KraftKit](ctx).NoPrompt && len(selected) > 1 {
 			res, err := target.Select(selected)
 			if err != nil {
 				return err

--- a/unikraft/target/select.go
+++ b/unikraft/target/select.go
@@ -7,6 +7,7 @@ package target
 import (
 	"fmt"
 	"sort"
+	"strings"
 
 	"github.com/charmbracelet/lipgloss"
 	"github.com/erikgeiser/promptkit/selection"
@@ -71,6 +72,18 @@ func Filter(targets []Target, arch, plat, targ string) []Target {
 		// If only `targ` is supplied and the target name match
 		func(t Target, arch, plat, targ string) bool {
 			return len(targ) > 0 && len(plat) == 0 && len(arch) == 0 && t.Name() == targ
+		},
+
+		// If only `targ` and it represents a split between plat/arch
+		func(t Target, arch, plat, targ string) bool {
+			if !strings.Contains(targ, "/") {
+				return false
+			}
+			split := strings.Split(targ, "/")
+			if len(split) != 2 {
+				return false
+			}
+			return len(targ) > 0 && len(plat) == 0 && len(arch) == 0 && t.Platform().Name() == split[0] && split[1] == t.Architecture().Name()
 		},
 
 		// If only `arch` is supplied and the target's arch matches


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

This PR fixes an issue where short hand syntax could be used when selecting a target.  This enables the workflow:

```console
kraft build --target=linuxu/x86_64
```

Which was previously unhandled.
