### PR TITLE
fix(unikraft): Order external libraries alphabetically

### DIFF
--- a/unikraft/app/application.go
+++ b/unikraft/app/application.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
 	"sort"
 	"strings"
 
@@ -453,13 +454,17 @@ func (app application) MakeArgs(ctx context.Context, tc target.Target) (*core.Ma
 		}
 	}
 
+	orderedLibraries := []string{}
 	for _, library := range unformattedLibraries {
 		if !library.IsUnpacked() {
 			return nil, fmt.Errorf("cannot determine library \"%s\" path without component source", library.Name())
 		}
 
-		libraries = append(libraries, library.Path())
+		orderedLibraries = append(orderedLibraries, library.Path())
 	}
+
+	slices.Sort(orderedLibraries)
+	libraries = append(libraries, orderedLibraries...)
 
 	// TODO: Platforms & architectures
 


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

Right now, if libraries are not ordered in any way, there is a chance that compiling the same, already-compiled, app twice will trigger a full recompilation.

Ordering alphabetically is the simplest option right now and should be fine.
