### PR TITLE
feat(deploy): Introduce build deployer and image deployer

### DIFF
--- a/internal/cli/kraft/build/build.go
+++ b/internal/cli/kraft/build/build.go
@@ -41,9 +41,9 @@ type BuildOptions struct {
 	Rootfs       string `long:"rootfs" usage:"Specify a path to use as root file system (can be volume or initramfs)"`
 	SaveBuildLog string `long:"build-log" usage:"Use the specified file to save the output from the build"`
 	Target       string `long:"target" short:"t" usage:"Build a particular known target"`
+	Workdir      string `noattribute:"true"`
 
 	project app.Application
-	workdir string
 }
 
 // Build a Unikraft unikernel.
@@ -96,16 +96,16 @@ func (opts *BuildOptions) Pre(cmd *cobra.Command, args []string) error {
 func (opts *BuildOptions) Run(ctx context.Context, args []string) error {
 	var err error
 	if len(args) == 0 {
-		opts.workdir, err = os.Getwd()
+		opts.Workdir, err = os.Getwd()
 		if err != nil {
 			return err
 		}
-	} else {
-		opts.workdir = args[0]
+	} else if len(opts.Workdir) == 0 {
+		opts.Workdir = args[0]
 	}
 
 	popts := []app.ProjectOption{
-		app.WithProjectWorkdir(opts.workdir),
+		app.WithProjectWorkdir(opts.Workdir),
 	}
 
 	if len(opts.Kraftfile) > 0 {
@@ -178,7 +178,7 @@ func (opts *BuildOptions) Run(ctx context.Context, args []string) error {
 		return fmt.Errorf("could not complete build: %w", err)
 	}
 
-	if opts.Rootfs, err = utils.BuildRootfs(ctx, opts.workdir, opts.Rootfs, selected...); err != nil {
+	if opts.Rootfs, err = utils.BuildRootfs(ctx, opts.Workdir, opts.Rootfs, selected...); err != nil {
 		return err
 	}
 

--- a/internal/cli/kraft/build/builder_kraftfile_unikraft.go
+++ b/internal/cli/kraft/build/builder_kraftfile_unikraft.go
@@ -116,7 +116,7 @@ func (build *builderKraftfileUnikraft) pull(ctx context.Context, opts *BuildOpti
 							return templatePack.Pull(
 								ctx,
 								pack.WithPullProgressFunc(w),
-								pack.WithPullWorkdir(opts.workdir),
+								pack.WithPullWorkdir(opts.Workdir),
 								// pack.WithPullChecksum(!opts.NoChecksum),
 								pack.WithPullCache(!opts.NoCache),
 								pack.WithPullAuthConfig(auths),
@@ -243,7 +243,7 @@ func (build *builderKraftfileUnikraft) pull(ctx context.Context, opts *BuildOpti
 					return p.Pull(
 						ctx,
 						pack.WithPullProgressFunc(w),
-						pack.WithPullWorkdir(opts.workdir),
+						pack.WithPullWorkdir(opts.Workdir),
 						// pack.WithPullChecksum(!opts.NoChecksum),
 						pack.WithPullCache(!opts.NoCache),
 						pack.WithPullAuthConfig(auths),

--- a/internal/cli/kraft/cloud/deploy/deploy.go
+++ b/internal/cli/kraft/cloud/deploy/deploy.go
@@ -66,8 +66,11 @@ func NewCmd() *cobra.Command {
 		},
 		Example: heredoc.Docf(`
 		# Create a new deployment at https://hello-world.fra0.kraft.cloud in Frankfurt
-		# of your current working directory which exposes a port at 8080:
-		kraft cloud --metro fra0 deploy --subdomain hello-world -p 443:8080 .`),
+		# of your current working directory which exposes a port at 8080.
+		kraft cloud --metro fra0 deploy --subdomain hello-world -p 443:8080 .
+		
+		# Alternatively supply an existing image which is available in the catalog:
+		kraft cloud --metro fra0 deploy -p 443:8080 caddy:latest`),
 	})
 	if err != nil {
 		panic(err)

--- a/internal/cli/kraft/cloud/deploy/deploy.go
+++ b/internal/cli/kraft/cloud/deploy/deploy.go
@@ -26,24 +26,34 @@ import (
 )
 
 type DeployOptions struct {
-	Auth      *config.AuthConfig        `noattribute:"true"`
-	Client    kraftcloud.KraftCloud     `noattribute:"true"`
-	Env       []string                  `local:"true" long:"env" short:"e" usage:"Environmental variables"`
-	FQDN      string                    `local:"true" long:"fqdn" short:"d" usage:"Set the fully qualified domain name for the service"`
-	Kraftfile string                    `local:"true" long:"kraftfile" short:"K" usage:"Set the Kraftfile to use"`
-	Memory    int64                     `local:"true" long:"memory" short:"M" usage:"Specify the amount of memory to allocate"`
-	Metro     string                    `noattribute:"true"`
-	Name      string                    `local:"true" long:"name" short:"n" usage:"Name of the deployment"`
-	NoStart   bool                      `local:"true" long:"no-start" short:"S" usage:"Do not start the instance after creation"`
-	Output    string                    `local:"true" long:"output" short:"o" usage:"Set output format"`
-	Ports     []string                  `local:"true" long:"port" short:"p" usage:"Specify the port mapping between external to internal"`
-	Project   app.Application           `noattribute:"true"`
-	Replicas  int                       `local:"true" long:"replicas" short:"R" usage:"Number of replicas of the instance" default:"0"`
-	Rootfs    string                    `local:"true" long:"rootfs" usage:"Specify a path to use as root filesystem"`
-	Strategy  packmanager.MergeStrategy `noattribute:"true"`
-	SubDomain string                    `local:"true" long:"subdomain" short:"s" usage:"Set the name to use when provisioning a subdomain"`
-	Timeout   time.Duration             `local:"true" long:"timeout" usage:"Set the timeout for remote procedure calls"`
-	Workdir   string                    `local:"true" long:"workdir" short:"w" usage:"Set an alternative working directory (default is cwd)"`
+	Auth         *config.AuthConfig        `noattribute:"true"`
+	Client       kraftcloud.KraftCloud     `noattribute:"true"`
+	DotConfig    string                    `long:"config" short:"c" usage:"Override the path to the KConfig .config file"`
+	Env          []string                  `local:"true" long:"env" short:"e" usage:"Environmental variables"`
+	ForcePull    bool                      `long:"force-pull" usage:"Force pulling packages before building"`
+	FQDN         string                    `local:"true" long:"fqdn" short:"d" usage:"Set the fully qualified domain name for the service"`
+	Jobs         int                       `long:"jobs" short:"j" usage:"Allow N jobs at once"`
+	KernelDbg    bool                      `long:"dbg" usage:"Build the debuggable (symbolic) kernel image instead of the stripped image"`
+	Kraftfile    string                    `local:"true" long:"kraftfile" short:"K" usage:"Set the Kraftfile to use"`
+	Memory       int64                     `local:"true" long:"memory" short:"M" usage:"Specify the amount of memory to allocate"`
+	Metro        string                    `noattribute:"true"`
+	Name         string                    `local:"true" long:"name" short:"n" usage:"Name of the deployment"`
+	NoCache      bool                      `long:"no-cache" short:"F" usage:"Force a rebuild even if existing intermediate artifacts already exist"`
+	NoConfigure  bool                      `long:"no-configure" usage:"Do not run Unikraft's configure step before building"`
+	NoFast       bool                      `long:"no-fast" usage:"Do not use maximum parallelization when performing the build"`
+	NoFetch      bool                      `long:"no-fetch" usage:"Do not run Unikraft's fetch step before building"`
+	NoStart      bool                      `local:"true" long:"no-start" short:"S" usage:"Do not start the instance after creation"`
+	NoUpdate     bool                      `long:"no-update" usage:"Do not update package index before running the build"`
+	Output       string                    `local:"true" long:"output" short:"o" usage:"Set output format"`
+	Ports        []string                  `local:"true" long:"port" short:"p" usage:"Specify the port mapping between external to internal"`
+	Project      app.Application           `noattribute:"true"`
+	Replicas     int                       `local:"true" long:"replicas" short:"R" usage:"Number of replicas of the instance" default:"0"`
+	Rootfs       string                    `local:"true" long:"rootfs" usage:"Specify a path to use as root filesystem"`
+	SaveBuildLog string                    `long:"build-log" usage:"Use the specified file to save the output from the build"`
+	Strategy     packmanager.MergeStrategy `noattribute:"true"`
+	SubDomain    string                    `local:"true" long:"subdomain" short:"s" usage:"Set the name to use when provisioning a subdomain"`
+	Timeout      time.Duration             `local:"true" long:"timeout" usage:"Set the timeout for remote procedure calls"`
+	Workdir      string                    `local:"true" long:"workdir" short:"w" usage:"Set an alternative working directory (default is cwd)"`
 }
 
 func NewCmd() *cobra.Command {

--- a/internal/cli/kraft/cloud/deploy/deployer.go
+++ b/internal/cli/kraft/cloud/deploy/deployer.go
@@ -34,6 +34,7 @@ type deployer interface {
 // is used with the controller.
 func deployers() []deployer {
 	return []deployer{
+		&deployerImageName{},
 		&deployerKraftfileRuntime{},
 		&deployerKraftfileUnikraft{},
 	}

--- a/internal/cli/kraft/cloud/deploy/deployer.go
+++ b/internal/cli/kraft/cloud/deploy/deployer.go
@@ -9,7 +9,7 @@ import (
 	"context"
 	"fmt"
 
-	"kraftkit.sh/pack"
+	kraftcloudinstances "sdk.kraft.cloud/instances"
 )
 
 // deployer is an interface for defining different mechanisms to perform a the
@@ -25,8 +25,8 @@ type deployer interface {
 	// current implementation.
 	Deployable(context.Context, *DeployOptions, ...string) (bool, error)
 
-	// Prepare performs the deployment based on the determined implementation.
-	Prepare(context.Context, *DeployOptions, ...string) ([]pack.Package, error)
+	// Deploy performs the deployment based on the determined implementation.
+	Deploy(context.Context, *DeployOptions, ...string) ([]kraftcloudinstances.Instance, error)
 }
 
 // deployers is the list of built-in deployers which are checked

--- a/internal/cli/kraft/cloud/deploy/deployer.go
+++ b/internal/cli/kraft/cloud/deploy/deployer.go
@@ -35,5 +35,6 @@ type deployer interface {
 func deployers() []deployer {
 	return []deployer{
 		&deployerKraftfileRuntime{},
+		&deployerKraftfileUnikraft{},
 	}
 }

--- a/internal/cli/kraft/cloud/deploy/deployer_image_name.go
+++ b/internal/cli/kraft/cloud/deploy/deployer_image_name.go
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2023, Unikraft GmbH and The KraftKit Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+
+package deploy
+
+import (
+	"context"
+	"fmt"
+
+	"kraftkit.sh/config"
+	"kraftkit.sh/internal/cli/kraft/cloud/instance/create"
+	"kraftkit.sh/log"
+	"kraftkit.sh/tui/processtree"
+	kraftcloudinstances "sdk.kraft.cloud/instances"
+)
+
+type deployerImageName struct{}
+
+func (deployer *deployerImageName) String() string {
+	return "image-name"
+}
+
+func (deployer *deployerImageName) Deployable(ctx context.Context, opts *DeployOptions, args ...string) (bool, error) {
+	if err := opts.initProject(ctx); err != nil && len(args) > 0 {
+		return true, nil
+	}
+
+	return false, fmt.Errorf("context contains project")
+}
+
+func (deployer *deployerImageName) Deploy(ctx context.Context, opts *DeployOptions, args ...string) ([]kraftcloudinstances.Instance, error) {
+	var err error
+	var instance *kraftcloudinstances.Instance
+
+	paramodel, err := processtree.NewProcessTree(
+		ctx,
+		[]processtree.ProcessTreeOption{
+			processtree.IsParallel(false),
+			processtree.WithRenderer(
+				log.LoggerTypeFromString(config.G[config.KraftKit](ctx).Log.Type) != log.FANCY,
+			),
+			processtree.WithFailFast(true),
+			processtree.WithHideOnSuccess(true),
+			processtree.WithTimeout(opts.Timeout),
+		},
+		processtree.NewProcessTreeItem(
+			"deploying",
+			"",
+			func(ctx context.Context) error {
+				instance, err = create.Create(ctx, &create.CreateOptions{
+					Env:       opts.Env,
+					FQDN:      opts.FQDN,
+					Memory:    opts.Memory,
+					Metro:     opts.Metro,
+					Name:      opts.Name,
+					Ports:     opts.Ports,
+					Replicas:  opts.Replicas,
+					Start:     !opts.NoStart,
+					SubDomain: opts.SubDomain,
+				}, args[0])
+				if err != nil {
+					return fmt.Errorf("could not create instance: %w", err)
+				}
+
+				return nil
+			},
+		),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := paramodel.Start(); err != nil {
+		return nil, err
+	}
+
+	return []kraftcloudinstances.Instance{*instance}, nil
+}

--- a/internal/cli/kraft/cloud/deploy/deployer_kraftfile_runtime.go
+++ b/internal/cli/kraft/cloud/deploy/deployer_kraftfile_runtime.go
@@ -88,6 +88,9 @@ func (deployer *deployerKraftfileRuntime) Deploy(ctx context.Context, opts *Depl
 		Strategy:     opts.Strategy,
 		Workdir:      opts.Workdir,
 	})
+	if err != nil {
+		return nil, fmt.Errorf("could not package: %w", err)
+	}
 
 	// TODO(nderjung): This is a quirk that will be removed.  Remove the `index.`
 	// from the name.

--- a/internal/cli/kraft/cloud/deploy/deployer_kraftfile_unikraft.go
+++ b/internal/cli/kraft/cloud/deploy/deployer_kraftfile_unikraft.go
@@ -1,0 +1,58 @@
+package deploy
+
+import (
+	"context"
+	"fmt"
+
+	"kraftkit.sh/internal/cli/kraft/build"
+	kraftcloudinstances "sdk.kraft.cloud/instances"
+)
+
+type deployerKraftfileUnikraft struct{}
+
+func (deployer *deployerKraftfileUnikraft) String() string {
+	return "kraftfile-runtime"
+}
+
+func (deployer *deployerKraftfileUnikraft) Deployable(ctx context.Context, opts *DeployOptions, args ...string) (bool, error) {
+	if opts.Project == nil {
+		if err := opts.initProject(ctx); err != nil {
+			return false, err
+		}
+	}
+
+	if opts.Project.Runtime() != nil {
+		return false, nil
+	}
+
+	if opts.Project.Unikraft(ctx) == nil {
+		return false, fmt.Errorf("cannot package without unikraft attribute")
+	}
+
+	return true, nil
+}
+
+func (deployer *deployerKraftfileUnikraft) Deploy(ctx context.Context, opts *DeployOptions, args ...string) ([]kraftcloudinstances.Instance, error) {
+	if err := build.Build(ctx, &build.BuildOptions{
+		Architecture: "x86_64",
+		DotConfig:    opts.DotConfig,
+		ForcePull:    opts.ForcePull,
+		Jobs:         opts.Jobs,
+		KernelDbg:    opts.KernelDbg,
+		NoCache:      opts.NoCache,
+		NoConfigure:  opts.NoConfigure,
+		NoFast:       opts.NoFast,
+		NoFetch:      opts.NoFetch,
+		NoUpdate:     opts.NoUpdate,
+		Platform:     "kraftcloud",
+		Rootfs:       opts.Rootfs,
+		SaveBuildLog: opts.SaveBuildLog,
+		Workdir:      opts.Workdir,
+	}); err != nil {
+		return nil, fmt.Errorf("could not complete build")
+	}
+
+	// Re-use the runtime deployer, which also handles packaging.
+	runtimeDeployer := &deployerKraftfileRuntime{}
+	return runtimeDeployer.Deploy(ctx, opts, args...)
+}


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

This PR introduces two new "`deployer`s" which enrich the `kraft cloud deploy` subcommand.  This command can now be used in two new contexts:

* In a project directory where a Unikraft unikernel image requires construction which is determined by a `Kraftfile` having a `unikraft` element; and,
* An alias where a user provides an input positional command-line argument which represents an image name, making `kraft cloud deploy IMAGE` a possible use and therefore a shortcut.