### PR TITLE
fix(machine): Use correct Unikraft vfstap mount option name

### DIFF
--- a/machine/firecracker/v1alpha1.go
+++ b/machine/firecracker/v1alpha1.go
@@ -116,7 +116,7 @@ func (service *machineV1alpha1Service) Create(ctx context.Context, machine *mach
 				"",
 				"",
 				// By default, create the directory if it does not exist when mounting.
-				"mkpath",
+				"mkmp",
 			).String())
 		default:
 			return machine, fmt.Errorf("unsupported Firecracker volume driver: %v", vol.Spec.Driver)

--- a/machine/qemu/v1alpha1.go
+++ b/machine/qemu/v1alpha1.go
@@ -355,7 +355,7 @@ func (service *machineV1alpha1Service) Create(ctx context.Context, machine *mach
 				"",
 				"",
 				// By default, create the directory if it does not exist when mounting.
-				"mkpath",
+				"mkmp",
 			).String())
 
 		case "initrd":
@@ -366,7 +366,7 @@ func (service *machineV1alpha1Service) Create(ctx context.Context, machine *mach
 				"",
 				"",
 				// By default, create the directory if it does not exist when mounting.
-				"mkpath",
+				"mkmp",
 			).String())
 		default:
 			return machine, fmt.Errorf("unsupported QEMU volume driver: %v", vol.Spec.Driver)


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

Following the merge of [unikraft#1145][0], the name of the Unikraft-specific VFSTAB cli option for creating a non-existing directory is called `mkmp` and not `mkpath`.  The latter was the original name which was changed during the review process of [unikraft#1145][0].

[0]: https://github.com/unikraft/unikraft/pull/1145

