### PR TITLE
fix(webinstall): Correct path to release tarball

### DIFF
--- a/tools/webinstall/install.sh
+++ b/tools/webinstall/install.sh
@@ -1145,7 +1145,7 @@ install_linux_manual() {
 
     _ill_url=$(printf "%s%s%s%s"                \
         "https://github.com/unikraft/kraftkit"  \
-        "/releases/latest/download/kraftkit_"   \
+        "/releases/latest/download/kraft_"      \
         "$("$CAT" $_ill_version_file)"          \
         "_linux_amd64.tar.gz"
     )
@@ -1177,7 +1177,7 @@ install_linux_manual() {
     fi
 
     _ill_binary="kraft"
-    _ill_archive="kraftkit.tar.gz"
+    _ill_archive="kraft.tar.gz"
     downloader "$_ill_url" "$_ill_archive" "$_ill_arch"
     _CLEANUP_ARCHIVE="$_ill_archive"
 


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

Following the merge of #1076 the name of the tarball representing the binary has changed.