### PR TITLE
fix(workflows): Rerun only on releases

### DIFF
--- a/.github/workflows/expire-caches.yml
+++ b/.github/workflows/expire-caches.yml
@@ -2,7 +2,7 @@ name: Expire Action Caches
 
 on:
   push:
-    branches: [staging]
+    branches: [stable]
 
 jobs:
 

--- a/.github/workflows/gobuild-qemu-devices.yaml
+++ b/.github/workflows/gobuild-qemu-devices.yaml
@@ -2,7 +2,7 @@ name: tools/go-generate-qemu-device
 
 on:
   push:
-    branches: [staging]
+    branches: [stable]
   pull_request:
     types: [opened, synchronize, reopened]
     branches: [staging]

--- a/.github/workflows/gochecks.yaml
+++ b/.github/workflows/gochecks.yaml
@@ -2,7 +2,7 @@ name: Go static checks
 
 on:
   push:
-    branches: [staging]
+    branches: [stable]
   pull_request:
     types: [opened, synchronize, reopened]
     branches: [staging]

--- a/.github/workflows/gotests.yaml
+++ b/.github/workflows/gotests.yaml
@@ -1,8 +1,6 @@
 name: Tests
 
 on:
-  push:
-    branches: [staging]
   pull_request:
     types: [opened, synchronize, reopened]
     branches: [staging]

--- a/.github/workflows/myself-full.yaml
+++ b/.github/workflows/myself-full.yaml
@@ -3,9 +3,7 @@ name: buildenvs/myself-full
 # Build only on changes to the build environment itself
 on:
   push:
-    branches:
-      - stable
-      - staging
+    branches: [stable]
     paths:
       - 'buildenvs/myself.Dockerfile'
       - '.github/workflows/myself-full.yaml'

--- a/.github/workflows/release-staging.yaml
+++ b/.github/workflows/release-staging.yaml
@@ -2,8 +2,7 @@ name: pre-release-staging
 
 on:
   push:
-    branches:
-      - staging
+    branches: [staging]
 
 permissions:
   contents: write


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

Right now, many of the workflows run on pull requests and also on staging afterwards. This is more or less useless because AFAIK the action result from the PR is transferred to the merge commit.

This moves everything to stable pushes, to still ensure everything works on releases, but also not use workflow minutes aimlessly.