### PR TITLE
fix(manifest): Fix JSON marshalling of provider type

### DIFF
--- a/manifest/directory.go
+++ b/manifest/directory.go
@@ -139,3 +139,7 @@ func (dp DirectoryProvider) DeleteManifest(context.Context) error {
 func (dp DirectoryProvider) String() string {
 	return "dir"
 }
+
+func (dp DirectoryProvider) MarshalJSON() ([]byte, error) {
+	return []byte("\"dir\""), nil
+}

--- a/manifest/git.go
+++ b/manifest/git.go
@@ -237,6 +237,10 @@ func (gp *GitProvider) String() string {
 	return "git"
 }
 
+func (gp *GitProvider) MarshalJSON() ([]byte, error) {
+	return []byte("\"git\""), nil
+}
+
 // isSSHURL determines if the provided URL forms an SSH connection
 func isSSHURL(path string) bool {
 	for _, prefix := range []string{

--- a/manifest/github.go
+++ b/manifest/github.go
@@ -148,6 +148,10 @@ func (ghp GitHubProvider) String() string {
 	return "github"
 }
 
+func (ghp GitHubProvider) MarshalJSON() ([]byte, error) {
+	return []byte("\"github\""), nil
+}
+
 // manifestsFromWildcard is an internal method which is called by Manifests to
 // parse a GitHub source with a wildcard repository name, e.g. lib-*
 func (ghp GitHubProvider) manifestsFromWildcard() ([]*Manifest, error) {

--- a/manifest/index.go
+++ b/manifest/index.go
@@ -89,6 +89,10 @@ func (mip *ManifestIndexProvider) String() string {
 	return "index"
 }
 
+func (mip *ManifestIndexProvider) MarshalJSON() ([]byte, error) {
+	return []byte("\"index\""), nil
+}
+
 // NewManifestIndexFromBytes parses a byte array of a YAML representing a
 // manifest index
 func NewManifestIndexFromBytes(raw []byte, opts ...ManifestOption) (*ManifestIndex, error) {

--- a/manifest/manifest.go
+++ b/manifest/manifest.go
@@ -172,6 +172,10 @@ func (mp *ManifestProvider) String() string {
 	return "manifest"
 }
 
+func (mp *ManifestProvider) MarshalJSON() ([]byte, error) {
+	return []byte("\"manifest\""), nil
+}
+
 // NewManifestFromBytes parses a byte array of a YAML representing a manifest
 func NewManifestFromBytes(ctx context.Context, raw []byte, opts ...ManifestOption) (*Manifest, error) {
 	// TODO: This deserialization mechanism is used to encode the provider into the

--- a/manifest/provider.go
+++ b/manifest/provider.go
@@ -6,6 +6,7 @@ package manifest
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 
 	"github.com/sirupsen/logrus"
@@ -27,6 +28,8 @@ type Provider interface {
 
 	// String returns the name of the provider
 	fmt.Stringer
+
+	json.Marshaler
 }
 
 // NewProvider ultimately returns one of the supported manifest providers by


### PR DESCRIPTION
This commit fixes the JSON marshalling of all manifest providers
which allows for saving the provider type in the returned object.

Signed-off-by: Alexander Jung <alex@unikraft.io>

<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [ ] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [ ] Tested your changes against relevant architectures and platforms;
  - [ ] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->
