### PR TITLE
fix(manifest): Correctly switch to `NewGitHubProvider` based on `path`

### DIFF
--- a/manifest/provider.go
+++ b/manifest/provider.go
@@ -7,6 +7,7 @@ package manifest
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/sirupsen/logrus"
 
@@ -74,7 +75,7 @@ func NewProvider(ctx context.Context, path string, mopts ...ManifestOption) (Pro
 		"path": path,
 	}).Trace("trying git provider")
 	provider, err = NewGitProvider(ctx, path, mopts...)
-	if err == nil {
+	if err == nil || strings.Contains(path, "github.com") {
 		log.G(ctx).WithFields(logrus.Fields{
 			"path": path,
 		}).Trace("trying github provider")


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

Whilst the logic that a provided path is a git repository when it comes from GitHub, it does not take into account the fact that the `NewGitHubProvider` is able to parse gobs (`*`) which will fail when passed to `NewGitProvider`.
