### PR TITLE
fix(manifest): Do not return empty repositories

### DIFF
--- a/manifest/git.go
+++ b/manifest/git.go
@@ -92,7 +92,9 @@ func NewGitProvider(ctx context.Context, path string, opts ...ManifestOption) (P
 	// If this is a valid Git repository then let's generate a Manifest based on
 	// what we can read from the remote
 	provider.refs, err = remote.ListContext(ctx, lopts)
-	if err != nil {
+	if err != nil && strings.Contains(err.Error(), "remote repository is empty") {
+		return nil, nil
+	} else if err != nil {
 		return nil, fmt.Errorf("could not list remote git repository: %v", err)
 	}
 

--- a/manifest/github.go
+++ b/manifest/github.go
@@ -120,6 +120,10 @@ func (ghp GitHubProvider) Manifests() ([]*Manifest, error) {
 		return nil, err
 	}
 
+	if manifest == nil {
+		return nil, nil
+	}
+
 	manifest.Provider = ghp
 
 	return []*Manifest{manifest}, nil
@@ -211,6 +215,10 @@ func (ghp GitHubProvider) appendRepositoriesToManifestInParallel(repos []*github
 				return
 			}
 
+			if manifest == nil {
+				return
+			}
+
 			// Populate with GitHub API-centric information
 			if repo.Description != nil {
 				manifest.Description = *repo.Description
@@ -252,6 +260,10 @@ func gitProviderFromGitHub(ctx context.Context, repo string, opts ...ManifestOpt
 	provider, err := NewGitProvider(ctx, repo, opts...)
 	if err != nil {
 		return nil, err
+	}
+
+	if provider == nil {
+		return nil, nil
 	}
 
 	manifests, err := provider.Manifests()


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

Ultimately this commit fixes an issue where empty repositories were resulting in the entire manifest list not being saved.
