### PR TITLE
feat(net): Prevent removing networks that are in use

### DIFF
--- a/internal/cli/kraft/net/remove/remove.go
+++ b/internal/cli/kraft/net/remove/remove.go
@@ -11,14 +11,18 @@ import (
 	"github.com/spf13/cobra"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	machineapi "kraftkit.sh/api/machine/v1alpha1"
 	networkapi "kraftkit.sh/api/network/v1alpha1"
 	"kraftkit.sh/cmdfactory"
 	"kraftkit.sh/iostreams"
+	"kraftkit.sh/log"
 	"kraftkit.sh/machine/network"
+	mplatform "kraftkit.sh/machine/platform"
 )
 
 type RemoveOptions struct {
 	Driver string `noattribute:"true"`
+	Force  bool   `long:"force" short:"f" usage:"Force removal of the network" default:"false"`
 }
 
 // Remove a local machine network.
@@ -67,6 +71,42 @@ func (opts *RemoveOptions) Run(ctx context.Context, args []string) error {
 	controller, err := strategy.NewNetworkV1alpha1(ctx)
 	if err != nil {
 		return err
+	}
+
+	machineController, err := mplatform.NewMachineV1alpha1ServiceIterator(ctx)
+	if err != nil {
+		return err
+	}
+
+	machines, err := machineController.List(ctx, &machineapi.MachineList{})
+	if err != nil {
+		return err
+	}
+
+	for _, machine := range machines.Items {
+		if machine.Status.State != machineapi.MachineStateRunning {
+			continue
+		}
+		for _, network := range machine.Spec.Networks {
+			if network.IfName == args[0] {
+				if !opts.Force {
+					return fmt.Errorf("network %s is in use by machine %s. Use --force to remove it anyway", args[0], machine.Name)
+				} else {
+					log.G(ctx).Warnf("network '%s' is in use by machine '%s'", args[0], machine.Name)
+				}
+			}
+		}
+	}
+
+	if opts.Force {
+		// This update ensures that all the interfaces are removed from the NetworkSpec
+		if _, err := controller.Update(ctx, &networkapi.Network{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: args[0],
+			},
+		}); err != nil {
+			return err
+		}
 	}
 
 	if _, err := controller.Delete(ctx, &networkapi.Network{

--- a/internal/cli/kraft/net/remove/remove.go
+++ b/internal/cli/kraft/net/remove/remove.go
@@ -53,6 +53,10 @@ func (opts *RemoveOptions) Pre(cmd *cobra.Command, _ []string) error {
 }
 
 func (opts *RemoveOptions) Run(ctx context.Context, args []string) error {
+	if len(args) != 1 {
+		return fmt.Errorf("expected exactly one network to remove, got %d", len(args))
+	}
+
 	var err error
 
 	strategy, ok := network.Strategies()[opts.Driver]


### PR DESCRIPTION
Check whether there are any running machines that are using the network before removing it. Additionally introduce a force flag that can override this.

<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes
This PR adds a check that prevents a user from removing a network in use, unless forcing it.

<!--
Please provide a detailed description of the changes made in this new PR.
-->
