### PR TITLE
fix(ps): Handle ``--all`` flag properly

### DIFF
--- a/internal/cli/kraft/ps/ps.go
+++ b/internal/cli/kraft/ps/ps.go
@@ -120,6 +120,9 @@ func (opts *PsOptions) Run(ctx context.Context, _ []string) error {
 	}
 
 	for _, machine := range machines.Items {
+		if !opts.ShowAll && machine.Status.State != machineapi.MachineStateRunning {
+			continue
+		}
 		entry := psTable{
 			id:      string(machine.UID),
 			name:    machine.Name,


### PR DESCRIPTION
Previously, the ``--all`` option was completely ignored, causing all machines to be listed at all times.

<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->
