### PR TITLE
fix(initrd): Set the root as positional to the current working directory

### DIFF
--- a/initrd/directory.go
+++ b/initrd/directory.go
@@ -81,10 +81,10 @@ func (initrd *directory) Build(ctx context.Context) (string, error) {
 		}
 
 		internal := strings.TrimPrefix(path, filepath.Clean(initrd.path))
-		internal = filepath.ToSlash(internal)
 		if internal == "" {
 			return nil // Do not archive empty paths
 		}
+		internal = "." + filepath.ToSlash(internal)
 
 		info, err := d.Info()
 		if err != nil {

--- a/initrd/directory_test.go
+++ b/initrd/directory_test.go
@@ -45,25 +45,25 @@ func TestNewFromDirectory(t *testing.T) {
 	r := cpio.NewReader(openFile(t, irdPath))
 
 	expectHeaders := map[string]cpio.Header{
-		"/entrypoint.sh": {
+		"./entrypoint.sh": {
 			Mode: cpio.TypeReg,
 			Size: 25,
 		},
-		"/etc": {
+		"./etc": {
 			Mode: cpio.TypeDir,
 		},
-		"/etc/app.conf": {
+		"./etc/app.conf": {
 			Mode: cpio.TypeReg,
 			Size: 16,
 		},
-		"/lib": {
+		"./lib": {
 			Mode: cpio.TypeDir,
 		},
-		"/lib/libtest.so.1": {
+		"./lib/libtest.so.1": {
 			Mode:     cpio.TypeSymlink,
 			Linkname: "libtest.so.1.0.0",
 		},
-		"/lib/libtest.so.1.0.0": {
+		"./lib/libtest.so.1.0.0": {
 			Mode: cpio.TypeReg,
 			Size: 9,
 		},

--- a/initrd/dockerfile.go
+++ b/initrd/dockerfile.go
@@ -182,6 +182,7 @@ func (initrd *dockerfile) Build(ctx context.Context) (string, error) {
 		if internal == "" {
 			return nil // Do not archive empty paths
 		}
+		internal = "." + filepath.ToSlash(internal)
 
 		info, err := d.Info()
 		if err != nil {


### PR DESCRIPTION

<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

At the present, CPIO archives are built using an absolute path.  For debugging purposes, this makes it difficult to extract locally.  Instead, these archives should be built as relative paths (i.e. ./ instead of /) to the current working directory.

Simultaneously, setting the path as relative does not affect whether the archive is mounted at root, since it is now relative to root.  This also makes it possible to extract archives at subdirectories (relative to that directory).

GitHub-Fixes: #1037
