### PR TITLE
feat(compose): Add compose build subommand

### DIFF
--- a/internal/cli/kraft/compose/build/build.go
+++ b/internal/cli/kraft/compose/build/build.go
@@ -1,0 +1,151 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2024, Unikraft GmbH and The KraftKit Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+
+package build
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/compose-spec/compose-go/types"
+	"github.com/spf13/cobra"
+
+	"kraftkit.sh/cmdfactory"
+	"kraftkit.sh/compose"
+	"kraftkit.sh/internal/cli/kraft/build"
+	"kraftkit.sh/internal/cli/kraft/pkg"
+	"kraftkit.sh/log"
+	"kraftkit.sh/packmanager"
+
+	mplatform "kraftkit.sh/machine/platform"
+)
+
+type BuildOptions struct {
+	composefile string
+}
+
+func NewCmd() *cobra.Command {
+	cmd, err := cmdfactory.New(&BuildOptions{}, cobra.Command{
+		Short: "Build or rebuild services",
+		Use:   "build",
+		Annotations: map[string]string{
+			cmdfactory.AnnotationHelpGroup: "compose",
+		},
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	return cmd
+}
+
+func (opts *BuildOptions) Pre(cmd *cobra.Command, _ []string) error {
+	ctx, err := packmanager.WithDefaultUmbrellaManagerInContext(cmd.Context())
+	if err != nil {
+		return err
+	}
+
+	cmd.SetContext(ctx)
+
+	if cmd.Flag("file").Changed {
+		opts.composefile = cmd.Flag("file").Value.String()
+	}
+
+	log.G(cmd.Context()).WithField("composefile", opts.composefile).Debug("using")
+	return nil
+}
+
+func (opts *BuildOptions) Run(ctx context.Context, args []string) error {
+	workdir, err := os.Getwd()
+	if err != nil {
+		return err
+	}
+
+	project, err := compose.NewProjectFromComposeFile(ctx, workdir, opts.composefile)
+	if err != nil {
+		return err
+	}
+
+	if err := project.Validate(ctx); err != nil {
+		return err
+	}
+
+	for _, service := range project.Services {
+		if service.Build == nil {
+			continue
+		}
+
+		if err := buildService(ctx, service); err != nil {
+			return err
+		}
+
+		if service.Image != "" {
+			if err := pkgService(ctx, service); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+func platArchFromService(service types.ServiceConfig) (string, string, error) {
+	// The service platform should be in the form <platform>/<arch>
+
+	parts := strings.SplitN(service.Platform, "/", 2)
+
+	if len(parts) != 2 {
+		return "", "", fmt.Errorf("invalid platform: %s for service %s", service.Platform, service.Name)
+	}
+
+	// Check that the platform is supported
+	if _, ok := mplatform.PlatformsByName()[parts[0]]; !ok {
+		return "", "", fmt.Errorf("unsupported platform: %s for service %s", parts[0], service.Name)
+	}
+
+	if parts[1] != "x86_64" && parts[1] != "amd64" && parts[1] != "arm32" && parts[1] != "arm64" {
+		return "", "", fmt.Errorf("unsupported architecture: %s for service %s", parts[1], service.Name)
+	}
+
+	return parts[0], parts[1], nil
+}
+
+func buildService(ctx context.Context, service types.ServiceConfig) error {
+	if service.Build == nil {
+		return fmt.Errorf("service %s has no build context", service.Name)
+	}
+
+	plat, arch, err := platArchFromService(service)
+	if err != nil {
+		return err
+	}
+
+	log.G(ctx).Infof("Building service %s...", service.Name)
+
+	buildOptions := build.BuildOptions{Platform: plat, Architecture: arch}
+
+	return buildOptions.Run(ctx, []string{service.Build.Context})
+}
+
+func pkgService(ctx context.Context, service types.ServiceConfig) error {
+	plat, arch, err := platArchFromService(service)
+	if err != nil {
+		return err
+	}
+
+	log.G(ctx).Infof("packaging service %s...", service.Name)
+
+	pkgOptions := pkg.PkgOptions{
+		Architecture: arch,
+		Name:         service.Image,
+		Format:       "oci",
+		Platform:     plat,
+		Strategy:     packmanager.StrategyOverwrite,
+	}
+
+	return pkgOptions.Run(ctx, []string{service.Build.Context})
+}

--- a/internal/cli/kraft/compose/compose.go
+++ b/internal/cli/kraft/compose/compose.go
@@ -13,6 +13,7 @@ import (
 	"github.com/spf13/pflag"
 
 	"kraftkit.sh/cmdfactory"
+	"kraftkit.sh/internal/cli/kraft/compose/build"
 	"kraftkit.sh/internal/cli/kraft/compose/down"
 	"kraftkit.sh/internal/cli/kraft/compose/ls"
 	"kraftkit.sh/internal/cli/kraft/compose/ps"
@@ -38,6 +39,7 @@ func NewCmd() *cobra.Command {
 		panic(err)
 	}
 
+	cmd.AddCommand(build.NewCmd())
 	cmd.AddCommand(down.NewCmd())
 	cmd.AddCommand(ls.NewCmd())
 	cmd.AddCommand(ps.NewCmd())


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

The `kraft compose build` subcommand build all the services and repackages them in order to be ready for running.

Given some `compose.yml`:
```
services:
 helloworld-local:
  build: ../../app-helloworld/
 helloworld-local2:
  image: custom-name
  build: ../../app-helloworld2/
```
Run:
```
$ kraft compose build
```

Then, you will see the packaged images:
```
$ kraft pkg ls --apps
$ TYPE  NAME                          VERSION  FORMAT  MANIFEST  INDEX    PLAT
$ app   .playground-helloworld-local  latest   oci     752afc6   b3e99ba  qemu/x86_64
$ app   custom-name                   latest   oci     af38c6e   e395a6f  qemu/x86_64
```

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->
