### PR TITLE
fix(oci): Inject default registry when packaging target

### DIFF
--- a/oci/pack.go
+++ b/oci/pack.go
@@ -93,7 +93,7 @@ func NewPackageFromTarget(ctx context.Context, targ target.Target, opts ...packm
 	}
 	ocipack.ref, err = name.ParseReference(
 		popts.Name(),
-		name.WithDefaultRegistry(""),
+		name.WithDefaultRegistry(DefaultRegistry),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("could not parse image reference: %w", err)


### PR DESCRIPTION
Commit https://github.com/unikraft/kraftkit/commit/eaebb8e4d19c6e8721a8d90232d66c4e24a2e0c2 introduced default registry injection when looking up
image names. Because the registry was not also injected when
packaging, this caused locally packaged images to be unusuable.

<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->
