### PR TITLE
refactor!: Upgrade uknetdev IP parameter handling

### DIFF
--- a/machine/firecracker/v1alpha1.go
+++ b/machine/firecracker/v1alpha1.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"fmt"
 	"io/fs"
+	"net"
 	"os"
 	"path/filepath"
 	"time"
@@ -280,11 +281,14 @@ watch:
 
 				// Assign the first interface statically via command-line arguments, also
 				// checking if the built-in arguments for
-				if !kernelArgs.Contains(uknetdev.ParamIpv4Addr) && i == 0 {
+				if !kernelArgs.Contains(uknetdev.ParamIp) && i == 0 {
+					sz, _ := net.IPMask(net.ParseIP(network.Netmask).To4()).Size()
+
 					kernelArgs = append(kernelArgs,
-						uknetdev.ParamIpv4Addr.WithValue(iface.Spec.IP),
-						uknetdev.ParamIpv4GwAddr.WithValue(network.Gateway),
-						uknetdev.ParamIpv4SubnetMask.WithValue(network.Netmask),
+						uknetdev.ParamIp.WithValue(uknetdev.NetdevIp{
+							CIDR:    fmt.Sprintf("%s/%d", iface.Spec.IP, sz),
+							Gateway: network.Gateway,
+						}),
 					)
 				}
 

--- a/machine/qemu/v1alpha1.go
+++ b/machine/qemu/v1alpha1.go
@@ -313,11 +313,14 @@ func (service *machineV1alpha1Service) Create(ctx context.Context, machine *mach
 
 				// Assign the first interface statically via command-line arguments, also
 				// checking if the built-in arguments for
-				if !kernelArgs.Contains(uknetdev.ParamIpv4Addr) && i == 0 {
+				if !kernelArgs.Contains(uknetdev.ParamIp) && i == 0 {
+					sz, _ := net.IPMask(net.ParseIP(network.Netmask).To4()).Size()
+
 					kernelArgs = append(kernelArgs,
-						uknetdev.ParamIpv4Addr.WithValue(iface.Spec.IP),
-						uknetdev.ParamIpv4GwAddr.WithValue(network.Gateway),
-						uknetdev.ParamIpv4SubnetMask.WithValue(network.Netmask),
+						uknetdev.ParamIp.WithValue(uknetdev.NetdevIp{
+							CIDR:    fmt.Sprintf("%s/%d", iface.Spec.IP, sz),
+							Gateway: network.Gateway,
+						}),
 					)
 				}
 

--- a/unikraft/export/v0/ukargparse/params.go
+++ b/unikraft/export/v0/ukargparse/params.go
@@ -59,6 +59,12 @@ func (param *paramStr) Name() string {
 func (param *paramStr) Set(value any) {
 	v, ok := value.(string)
 	if !ok {
+		v, ok := value.(fmt.Stringer)
+		if !ok {
+			return
+		}
+
+		param.value = v.String()
 		return
 	}
 	param.value = v

--- a/unikraft/export/v0/uknetdev/params.go
+++ b/unikraft/export/v0/uknetdev/params.go
@@ -5,18 +5,44 @@
 package uknetdev
 
 import (
+	"strings"
+
 	"kraftkit.sh/unikraft/export/v0/ukargparse"
 )
 
-var (
-	ParamIpv4Addr       = ukargparse.ParamStr("netdev", "ipv4_addr", nil)
-	ParamIpv4SubnetMask = ukargparse.ParamStr("netdev", "ipv4_subnet_mask", nil)
-	ParamIpv4GwAddr     = ukargparse.ParamStr("netdev", "ipv4_gw_addr", nil)
-)
+// The netdev.ip parameter can be used to override IPv4 address information
+// for multiple devices. For each device the following colon-separated format
+// is introduced:
+//
+// cidr[:gw[:dns0[:dns1[:hostname[:domain]]]]]
+var ParamIp = ukargparse.ParamStr("netdev", "ip", nil)
+
+// NetdevIp represents the attributes of the network device which is understood
+// by uknetdev and uklibparam.
+type NetdevIp struct {
+	CIDR     string
+	Gateway  string
+	DNS0     string
+	DNS1     string
+	Hostname string
+	Domain   string
+}
+
+// String implements fmt.Stringer and returns a valid netdev.ip-formatted entry.
+func (entry NetdevIp) String() string {
+	return strings.Join([]string{
+		entry.CIDR,
+		entry.Gateway,
+		entry.DNS0,
+		entry.DNS1,
+		entry.Hostname,
+		entry.Domain,
+	}, ":")
+}
 
 // ExportedParams returns the parameters available by this exported library.
 func ExportedParams() []ukargparse.Param {
 	return []ukargparse.Param{
-		ParamIpv4Addr,
+		ParamIp,
 	}
 }


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

This PR refactors the syntax for passing static IP addresses, along with other auxiliary network information (DNS, hostname, etc.), to the kernel command-line arguments.

This change is necessary to continue to be compatible with the latest version of Unikraft following the introduction of [unikraft/unikraft#1211][0].

> [!CAUTION]
> This is a breaking change and this PR should be checked in conjunction with [#1211][0] and merged simultaneously with [#1211][0] to avoid incompatibility issues. Simultaneously, all [catalog](https://github.com/unikraft/catalog) entries should be retriggered against Unikraft's `staging` branch following the merge. Since Unikraft is pre-v1.0, no backwards compatibility is included in this refactor.

[0]: https://github.com/unikraft/unikraft/pull/1211

