### PR TITLE
feat(build): Add option to print build statistics

### DIFF
--- a/internal/cli/kraft/build/builder.go
+++ b/internal/cli/kraft/build/builder.go
@@ -29,6 +29,9 @@ type builder interface {
 	// Build performs the actual construction of the unikernel given the provided
 	// inputs for the given implementation.
 	Build(context.Context, *BuildOptions, ...string) error
+
+	// Statistics returns the statistics for the build.
+	Statistics(context.Context, *BuildOptions, ...string) error
 }
 
 // builders is the list of built-in builders which are checked sequentially for


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

This translates the `make print-loc` into go format and simplifies it quite a bit.
It also adds interface support for adding other statistics.

GitHub-Closes: #854
GitHub-Fixes: #818 