### PR TITLE
refactor!: Upgrade automount KConfig and kernel parameter syntax

### DIFF
--- a/internal/cli/kraft/pkg/packager_kraftfile_unikraft.go
+++ b/internal/cli/kraft/pkg/packager_kraftfile_unikraft.go
@@ -74,7 +74,11 @@ func (p *packagerKraftfileUnikraft) Pack(ctx context.Context, opts *PkgOptions, 
 
 	// Reset the rootfs, such that it is not packaged as an initrd if it is
 	// already embedded inside of the kernel.
-	if val, exists := opts.Project.KConfig().Get("CONFIG_LIBVFSCORE_ROOTFS_EINITRD"); exists && val.Value == "y" {
+	if opts.Project.KConfig().AnyYes(
+		"CONFIG_LIBVFSCORE_ROOTFS_EINITRD", // Deprecated
+		"CONFIG_LIBVFSCORE_AUTOMOUNT_EINITRD",
+		"CONFIG_LIBVFSCORE_AUTOMOUNT_CI_EINITRD",
+	) {
 		opts.Rootfs = ""
 	} else {
 		if opts.Rootfs, err = utils.BuildRootfs(ctx, opts.Workdir, opts.Rootfs, selected...); err != nil {

--- a/internal/cli/kraft/run/runner_kraftfile_runtime.go
+++ b/internal/cli/kraft/run/runner_kraftfile_runtime.go
@@ -14,7 +14,6 @@ import (
 	machineapi "kraftkit.sh/api/machine/v1alpha1"
 	volumeapi "kraftkit.sh/api/volume/v1alpha1"
 	"kraftkit.sh/config"
-	"kraftkit.sh/kconfig"
 	"kraftkit.sh/log"
 	"kraftkit.sh/machine/platform"
 	"kraftkit.sh/pack"
@@ -276,9 +275,12 @@ func (runner *runnerKraftfileRuntime) Prepare(ctx context.Context, opts *RunOpti
 		}
 	}
 
-	// If automounting is disabled, and an initramfs is provided, set it as a
+	// If automounting is enabled, and an initramfs is provided, set it as a
 	// volume if a initram has been provided.
-	if fstab, ok := runtime.KConfig().Get("CONFIG_LIBVFSCORE_FSTAB"); ok && fstab.Value == kconfig.Yes && (len(machine.Status.InitrdPath) > 0 || len(opts.Rootfs) > 0) {
+	if runtime.KConfig().AnyYes(
+		"CONFIG_LIBVFSCORE_FSTAB", // Deprecated
+		"CONFIG_LIBVFSCORE_AUTOMOUNT_UP",
+	) && (len(machine.Status.InitrdPath) > 0 || len(opts.Rootfs) > 0) {
 		machine.Spec.Volumes = append(machine.Spec.Volumes, volumeapi.Volume{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "rootfs",

--- a/internal/cli/kraft/run/runner_kraftfile_unikraft.go
+++ b/internal/cli/kraft/run/runner_kraftfile_unikraft.go
@@ -10,7 +10,10 @@ import (
 	"os"
 	"slices"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	machineapi "kraftkit.sh/api/machine/v1alpha1"
+	volumeapi "kraftkit.sh/api/volume/v1alpha1"
 	"kraftkit.sh/config"
 	"kraftkit.sh/unikraft/app"
 	"kraftkit.sh/unikraft/target"
@@ -135,6 +138,23 @@ func (runner *runnerKraftfileUnikraft) Prepare(ctx context.Context, opts *RunOpt
 
 	if runner.project.Rootfs() != "" && opts.Rootfs == "" {
 		opts.Rootfs = runner.project.Rootfs()
+	}
+
+	// If automounting is enabled, and an initramfs is provided, set it as a
+	// volume if a initram has been provided.
+	if t.KConfig().AnyYes(
+		"CONFIG_LIBVFSCORE_FSTAB", // Deprecated
+		"CONFIG_LIBVFSCORE_AUTOMOUNT_UP",
+	) && (len(machine.Status.InitrdPath) > 0 || len(opts.Rootfs) > 0) {
+		machine.Spec.Volumes = append(machine.Spec.Volumes, volumeapi.Volume{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "rootfs",
+			},
+			Spec: volumeapi.VolumeSpec{
+				Driver:      "initrd",
+				Destination: "/",
+			},
+		})
 	}
 
 	var kernelArgs []string

--- a/internal/cli/kraft/run/utils.go
+++ b/internal/cli/kraft/run/utils.go
@@ -261,24 +261,22 @@ func (opts *RunOptions) prepareRootfs(ctx context.Context, machine *machineapi.M
 		fmt.Sprintf(initrd.DefaultInitramfsArchFileName, machine.Spec.Architecture),
 	)
 
-	if _, err := os.Stat(machine.Status.InitrdPath); err != nil {
-		ramfs, err := initrd.New(ctx,
-			opts.Rootfs,
-			initrd.WithOutput(machine.Status.InitrdPath),
-			initrd.WithCacheDir(filepath.Join(
-				opts.workdir,
-				unikraft.BuildDir,
-				"rootfs-cache",
-			)),
-			initrd.WithArchitecture(machine.Spec.Architecture),
-		)
-		if err != nil {
-			return fmt.Errorf("could not prepare initramfs: %w", err)
-		}
+	ramfs, err := initrd.New(ctx,
+		opts.Rootfs,
+		initrd.WithOutput(machine.Status.InitrdPath),
+		initrd.WithCacheDir(filepath.Join(
+			opts.workdir,
+			unikraft.BuildDir,
+			"rootfs-cache",
+		)),
+		initrd.WithArchitecture(machine.Spec.Architecture),
+	)
+	if err != nil {
+		return fmt.Errorf("could not prepare initramfs: %w", err)
+	}
 
-		if machine.Status.InitrdPath, err = ramfs.Build(ctx); err != nil {
-			return err
-		}
+	if _, err = ramfs.Build(ctx); err != nil {
+		return err
 	}
 
 	if fi, err := os.Stat(machine.Status.InitrdPath); err == nil {

--- a/internal/run/utils.go
+++ b/internal/run/utils.go
@@ -18,9 +18,7 @@ func BootArgsPrepare(args ...string) string {
 			sb.WriteByte('"')
 			sb.WriteByte(' ')
 		} else {
-			sb.WriteByte('\'')
 			sb.Write([]byte(arg))
-			sb.WriteByte('\'')
 			sb.WriteByte(' ')
 		}
 	}

--- a/kconfig/config.go
+++ b/kconfig/config.go
@@ -195,6 +195,19 @@ func (kvm KeyValueMap) Get(key string) (*KeyValue, bool) {
 	return nil, false
 }
 
+// AnyYes accepts an input list of keys which are all checked against the
+// KConfig value for "y" (meaning "yes" or "true").  If any of the keys are set
+// to this value, this method returns true.
+func (kvm KeyValueMap) AnyYes(keys ...string) bool {
+	for _, key := range keys {
+		if val, ok := kvm[key]; ok && val.Value == Yes {
+			return true
+		}
+	}
+
+	return false
+}
+
 // String returns the serialized string representing a .config file
 func (kvm KeyValueMap) String() string {
 	var ret strings.Builder

--- a/machine/firecracker/v1alpha1.go
+++ b/machine/firecracker/v1alpha1.go
@@ -111,13 +111,12 @@ func (service *machineV1alpha1Service) Create(ctx context.Context, machine *mach
 		switch vol.Spec.Driver {
 		case "initrd":
 			fstab = append(fstab, vfscore.NewFstabEntry(
-				"initrd",
+				"initrd0",
 				vol.Spec.Destination,
-				vol.Spec.Driver,
+				"extract",
 				"",
 				"",
-				// By default, create the directory if it does not exist when mounting.
-				"mkmp",
+				"",
 			).String())
 		default:
 			return machine, fmt.Errorf("unsupported Firecracker volume driver: %v", vol.Spec.Driver)

--- a/machine/qemu/v1alpha1.go
+++ b/machine/qemu/v1alpha1.go
@@ -363,13 +363,12 @@ func (service *machineV1alpha1Service) Create(ctx context.Context, machine *mach
 
 		case "initrd":
 			fstab = append(fstab, vfscore.NewFstabEntry(
-				"initrd",
+				"initrd0",
 				vol.Spec.Destination,
-				vol.Spec.Driver,
+				"extract",
 				"",
 				"",
-				// By default, create the directory if it does not exist when mounting.
-				"mkmp",
+				"",
 			).String())
 		default:
 			return machine, fmt.Errorf("unsupported QEMU volume driver: %v", vol.Spec.Driver)

--- a/tools/github-action/build.go
+++ b/tools/github-action/build.go
@@ -50,7 +50,11 @@ func (opts *GithubAction) build(ctx context.Context) error {
 		}
 
 		// Unset the intird path since this is now embedded in the unikernel
-		if val, exists := opts.project.KConfig().Get("CONFIG_LIBVFSCORE_ROOTFS_EINITRD"); exists && val.Value == "y" {
+		if opts.project.KConfig().AnyYes(
+			"CONFIG_LIBVFSCORE_FSTAB", // Deprecated
+			"CONFIG_LIBVFSCORE_AUTOMOUNT_EINITRD",
+			"CONFIG_LIBVFSCORE_AUTOMOUNT_CI_EINITRD",
+		) {
 			opts.initrdPath = ""
 		}
 	}

--- a/unikraft/app/application.go
+++ b/unikraft/app/application.go
@@ -557,11 +557,15 @@ func (app application) Configure(ctx context.Context, tc target.Target, extra kc
 	}
 
 	// Are we embedding an initramfs file into the kernel?
-	if val, exists := values.Get("CONFIG_LIBVFSCORE_ROOTFS_EINITRD"); exists && val.Value == "y" {
+	if values.AnyYes(
+		"CONFIG_LIBVFSCORE_FSTAB", // Deprecated
+		"CONFIG_LIBVFSCORE_AUTOMOUNT_EINITRD",
+		"CONFIG_LIBVFSCORE_AUTOMOUNT_CI_EINITRD",
+	) {
 		// If the user has not specified a path, we set one specifically which
 		// is specific to the target.
-		if val, exists := values.Get("CONFIG_LIBVFSCORE_ROOTFS_EINITRD_PATH"); !exists || val.Value == "" {
-			values.Set("CONFIG_LIBVFSCORE_ROOTFS_EINITRD_PATH",
+		if val, exists := values.Get("CONFIG_LIBVFSCORE_AUTOMOUNT_EINITRD_PATH"); !exists || val.Value == "" {
+			values.Set("CONFIG_LIBVFSCORE_AUTOMOUNT_EINITRD_PATH",
 				filepath.Join(
 					app.outDir,
 					fmt.Sprintf(initrd.DefaultInitramfsArchFileName, tc.Architecture().String()),


### PR DESCRIPTION

<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

This PR refactors the handling of KConfig options and fstab syntax representation the automount procedure.

This change is necessary to continue to be compatible with the latest version of Unikraft following the introduction of [unikraft/unikraft#1262][0].

> [!CAUTION]
> This is a breaking change and this PR should be checked in conjunction with [#1262][0] and merged simultaneously with [#1262][0] to avoid incompatibility issues. Simultaneously, all [catalog](https://github.com/unikraft/catalog) entries should be retriggered against Unikraft's `staging` branch following the merge. Since Unikraft is pre-v1.0, no backwards compatibility is included in this refactor.

[0]: https://github.com/unikraft/unikraft/pull/1262
