### PR TITLE
fix(cli): Better handling of setting log format & colors

### DIFF
--- a/internal/cli/options.go
+++ b/internal/cli/options.go
@@ -51,8 +51,16 @@ func WithDefaultLogger() CliOption {
 
 		// Set up a default logger based on the internal TextFormatter
 		logger := logrus.New()
+		logType := log.LoggerTypeFromString(copts.ConfigManager.Config.Log.Type)
 
-		switch log.LoggerTypeFromString(copts.ConfigManager.Config.Log.Type) {
+		// Force setting the log type to basic in non-TTY environments when the
+		// log-type has been set to 'fancy' (which is in fact the default).
+		if copts.IOStreams != nil && !copts.IOStreams.IsStdoutTTY() && copts.ConfigManager.Config.Log.Type == "fancy" {
+			logType = log.BASIC
+			copts.ConfigManager.Config.Log.Type = "basic"
+		}
+
+		switch logType {
 		case log.QUIET:
 			formatter := new(logrus.TextFormatter)
 			logger.Formatter = formatter

--- a/internal/cli/options.go
+++ b/internal/cli/options.go
@@ -65,19 +65,6 @@ func WithDefaultLogger() CliOption {
 			formatter := new(logrus.TextFormatter)
 			logger.Formatter = formatter
 
-		case log.BASIC:
-			formatter := new(log.TextFormatter)
-			formatter.FullTimestamp = true
-			formatter.DisableTimestamp = true
-
-			if copts.ConfigManager.Config.Log.Timestamps {
-				formatter.DisableTimestamp = false
-			} else {
-				formatter.TimestampFormat = ">"
-			}
-
-			logger.Formatter = formatter
-
 		case log.FANCY:
 			formatter := new(log.TextFormatter)
 			formatter.FullTimestamp = true
@@ -97,6 +84,19 @@ func WithDefaultLogger() CliOption {
 
 			if copts.ConfigManager.Config.Log.Timestamps {
 				formatter.DisableTimestamp = false
+			}
+
+			logger.Formatter = formatter
+
+		default:
+			formatter := new(log.TextFormatter)
+			formatter.FullTimestamp = true
+			formatter.DisableTimestamp = true
+
+			if copts.ConfigManager.Config.Log.Timestamps {
+				formatter.DisableTimestamp = false
+			} else {
+				formatter.TimestampFormat = ">"
 			}
 
 			logger.Formatter = formatter

--- a/internal/cli/options.go
+++ b/internal/cli/options.go
@@ -76,6 +76,9 @@ func WithDefaultLogger() CliOption {
 				formatter.TimestampFormat = ">"
 			}
 
+			formatter.DisableColors = iostreams.EnvColorDisabled()
+			formatter.ForceColors = iostreams.EnvColorForced()
+
 			logger.Formatter = formatter
 
 		case log.JSON:
@@ -98,6 +101,9 @@ func WithDefaultLogger() CliOption {
 			} else {
 				formatter.TimestampFormat = ">"
 			}
+
+			formatter.DisableColors = iostreams.EnvColorDisabled()
+			formatter.ForceColors = iostreams.EnvColorForced()
 
 			logger.Formatter = formatter
 		}


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

This PR makes a few adjustments to `WithDefaultLogger` which is used during the bootstrapping of KraftKit such that the log-type is appropriately set as well as the use of colors.
