### PR TITLE
fix(run): Do not attach initrd when project embeds an initrd

### DIFF
--- a/kconfig/config.go
+++ b/kconfig/config.go
@@ -208,6 +208,19 @@ func (kvm KeyValueMap) AnyYes(keys ...string) bool {
 	return false
 }
 
+// AllNoOrUnset accepts an input list of keys which are all checked against not
+// having the value for "n" (meaning "no" or "false") or whether they are unset.
+// If any of the keys are set to this value, this method returns false.
+func (kvm KeyValueMap) AllNoOrUnset(keys ...string) bool {
+	for _, key := range keys {
+		if val, ok := kvm[key]; ok && val.Value != No {
+			return false
+		}
+	}
+
+	return true
+}
+
 // String returns the serialized string representing a .config file
 func (kvm KeyValueMap) String() string {
 	var ret strings.Builder


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

This PR fixes an issue where a project's `Kraftfile` specifies an embedded filesystem and would otherwise attach the same filesystem as an en external initramfs when after the build it would be executed (i.e. `kraft build` followed by `kraft run`).  In the context of a project, this makes no sense since, even with user-provided (UP) which would a). otherwise overwrite all filesystem entries with the same files and b). these files would not differ since they are part of the same project.

