### PR TITLE
feat(logs): Expose platform field

### DIFF
--- a/internal/cli/kraft/logs/logs.go
+++ b/internal/cli/kraft/logs/logs.go
@@ -23,10 +23,9 @@ import (
 type LogOptions struct {
 	Follow     bool   `long:"follow" short:"f" usage:"Follow log output"`
 	NoColor    bool   `long:"no-color" usage:"Disable color output for prefix"`
+	Platform   string `noattribute:"true"`
 	Prefix     string `long:"prefix" usage:"Prefix each log line with the given string"`
 	PrefixName bool   `long:"prefix-name" usage:"Prefix each log line with the machine name"`
-
-	platform string
 }
 
 type logConsumer interface {
@@ -60,7 +59,7 @@ func NewCmd() *cobra.Command {
 }
 
 func (opts *LogOptions) Pre(cmd *cobra.Command, _ []string) error {
-	opts.platform = cmd.Flag("plat").Value.String()
+	opts.Platform = cmd.Flag("plat").Value.String()
 
 	return nil
 }
@@ -71,19 +70,19 @@ func (opts *LogOptions) Run(ctx context.Context, args []string) error {
 	platform := mplatform.PlatformUnknown
 	var controller machineapi.MachineService
 
-	if opts.platform == "auto" {
+	if opts.Platform == "auto" {
 		controller, err = mplatform.NewMachineV1alpha1ServiceIterator(ctx)
 	} else {
-		if opts.platform == "host" {
+		if opts.Platform == "host" {
 			platform, _, err = mplatform.Detect(ctx)
 			if err != nil {
 				return err
 			}
 		} else {
 			var ok bool
-			platform, ok = mplatform.PlatformsByName()[opts.platform]
+			platform, ok = mplatform.PlatformsByName()[opts.Platform]
 			if !ok {
-				return fmt.Errorf("unknown platform driver: %s", opts.platform)
+				return fmt.Errorf("unknown platform driver: %s", opts.Platform)
 			}
 		}
 


### PR DESCRIPTION
This allows users to set to call Run programatically. Previously, it would result in an error because the platform would never be set.

<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->
