### PR TITLE
fix(tui): Correctly handle new `ctx` with custom log and iostreams out

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.21
 require (
 	api.zip v0.1.5
 	github.com/AlecAivazis/survey/v2 v2.3.7
+	github.com/LastPossum/kamino v0.0.1
 	github.com/MakeNowJust/heredoc v1.0.0
 	github.com/Masterminds/semver/v3 v3.2.1
 	github.com/acorn-io/baaah v0.0.0-20230522221318-afcc93619e30

--- a/go.sum
+++ b/go.sum
@@ -62,6 +62,8 @@ github.com/Azure/go-autorest/tracing v0.6.0/go.mod h1:+vhtPC754Xsa23ID7GlGsrdKBp
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/toml v1.2.1/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
+github.com/LastPossum/kamino v0.0.1 h1:ewKozCZpQkwmz6/x02jgC5hPigQJEa/xu50bVec7B6s=
+github.com/LastPossum/kamino v0.0.1/go.mod h1:13HlWhK7QIXYR2/9uyOnaLBMAyDsx5PxxAoVC7An8OY=
 github.com/MakeNowJust/heredoc v1.0.0 h1:cXCdzVdstXyiTqTvfqk9SDHpKNjxuom+DOlyEeQ4pzQ=
 github.com/MakeNowJust/heredoc v1.0.0/go.mod h1:mG5amYoWBHf8vpLOuehzbGGw0EHxpZZ6lCpQ4fNJ8LE=
 github.com/Masterminds/semver/v3 v3.2.1 h1:RN9w6+7QoMeJVGyfmbcgs28Br8cvmnucEXnY0rYXWg0=

--- a/iostreams/iostreams.go
+++ b/iostreams/iostreams.go
@@ -498,10 +498,10 @@ func (r *fdReader) Fd() uintptr {
 	return r.fd
 }
 
-func NewNoTTYWriter(w io.Writer) *fdWriter {
-	return &fdWriter{w, 0}
+func NewNoTTYWriter(w io.Writer, ptr uintptr) *fdWriter {
+	return &fdWriter{w, ptr}
 }
 
-func NewNoTTYReader(r io.ReadCloser) *fdReader {
-	return &fdReader{r, 0}
+func NewNoTTYReader(r io.ReadCloser, ptr uintptr) *fdReader {
+	return &fdReader{r, ptr}
 }

--- a/tui/paraprogress/process.go
+++ b/tui/paraprogress/process.go
@@ -18,7 +18,6 @@ import (
 	"github.com/charmbracelet/lipgloss"
 	"github.com/muesli/reflow/indent"
 
-	"kraftkit.sh/iostreams"
 	"kraftkit.sh/log"
 	"kraftkit.sh/tui"
 	"kraftkit.sh/utils"
@@ -130,11 +129,6 @@ func (p *Process) Start() tea.Cmd {
 
 		if p.norender {
 			log.G(p.ctx).Info(p.Name)
-		} else {
-			// Set the output to the process Writer such that we can hijack logs and
-			// print them in a per-process isolated view.
-			iostreams.G(p.ctx).Out = iostreams.NewNoTTYWriter(p)
-			log.G(p.ctx).Out = p
 		}
 
 		err := p.processFunc(p.ctx, p.onProgress)


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->


This PR fixes an issue where the "stdout" of both the general logger and the iostreams was incorrectly set for all "subprocesses" of `paraprogress` and `processtree`.  Since the `context.Context` object was not unique per process, all subprocesses would output to the last process (becauase of the iteration process which attempted to set the output writer).

To make it so that each context is unique, perform a deepcopy of only the log and iostreams context objects and modify appropriately with new values.  The rest of the context is re-used as-is, allowing subprocesses to continue to access values as necessary.
