### PR TITLE
fix: Adds missing cutom created package removal capablity

### DIFF
--- a/manifest/manifest.go
+++ b/manifest/manifest.go
@@ -134,6 +134,13 @@ func (mp *ManifestProvider) DeleteManifest(ctx context.Context) error {
 			if err := os.Remove(resource); err != nil {
 				errs = append(errs, err)
 			}
+		} else if _, err := os.Stat(channel.Resource); err == nil {
+			log.G(ctx).
+				WithField("dir", channel.Resource).
+				Debug("deleting")
+			if err := os.RemoveAll(channel.Resource); err != nil {
+				errs = append(errs, err)
+			}
 		}
 	}
 


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

Adds missing cutom created package removal capablity.

Now, On executing `kraft pkg rm pack_name:default` custom created package/library can be removed from the host machine.
<!--
Please provide a detailed description of the changes made in this new PR.
-->
