### PR TITLE
feat(deploy): Introduce `--rollout` flag to aid in deployment strategy

### DIFF
--- a/internal/cli/kraft/cloud/deploy/deployer_image_name.go
+++ b/internal/cli/kraft/cloud/deploy/deployer_image_name.go
@@ -34,6 +34,10 @@ func (deployer *deployerImageName) Deploy(ctx context.Context, opts *DeployOptio
 	var err error
 	var instance *kraftcloudinstances.Instance
 
+	if err := opts.checkExists(ctx); err != nil {
+		return nil, err
+	}
+
 	paramodel, err := processtree.NewProcessTree(
 		ctx,
 		[]processtree.ProcessTreeOption{

--- a/internal/cli/kraft/cloud/deploy/strategy.go
+++ b/internal/cli/kraft/cloud/deploy/strategy.go
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2024, Unikraft GmbH and The KraftKit Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+
+package deploy
+
+import "fmt"
+
+// RolloutStrategy is a method to describe how to approach deployments which
+// have the same canonical name.  This is useful when deciding whether an
+// existing deployment simply needs to be updated.
+type RolloutStrategy string
+
+const (
+	// The 'exit' strategy is used to error-out and indicate that no strategy was
+	// provided and that further operations cannot be completed.
+	StrategyExit = RolloutStrategy("exit")
+
+	// The 'overwrite' strategy removes the existing deployment with the same
+	// canonical name and replaces it with a new deployment entirely.
+	StrategyOverwrite = RolloutStrategy("overwrite")
+
+	// The 'prompt' strategy is an "unlisted" strategy that's used in TTY contexts
+	// where the user is given the opportunity to decide the rollout strategy
+	// before the package operation is performed.  The result of this decision
+	// should yield one of the above rollout strategies.
+	StrategyPrompt = RolloutStrategy("prompt")
+)
+
+var _ fmt.Stringer = (*RolloutStrategy)(nil)
+
+// String implements fmt.Stringer
+func (strategy RolloutStrategy) String() string {
+	return string(strategy)
+}
+
+// RolloutStrategies returns the list of possible package rollout strategies.
+func RolloutStrategies() []RolloutStrategy {
+	return []RolloutStrategy{
+		StrategyExit,
+		StrategyOverwrite,
+	}
+}
+
+// RolloutStrategyNames returns the string representation of all possible
+// package merge strategies.
+func RolloutStrategyNames() []string {
+	strategies := []string{}
+	for _, strategy := range RolloutStrategies() {
+		strategies = append(strategies, strategy.String())
+	}
+
+	return strategies
+}

--- a/internal/cli/kraft/cloud/deploy/utils.go
+++ b/internal/cli/kraft/cloud/deploy/utils.go
@@ -7,7 +7,10 @@ package deploy
 
 import (
 	"context"
+	"fmt"
 
+	"kraftkit.sh/config"
+	"kraftkit.sh/tui/selection"
 	"kraftkit.sh/unikraft/app"
 )
 
@@ -30,6 +33,45 @@ func (opts *DeployOptions) initProject(ctx context.Context) error {
 	opts.Project, err = app.NewProjectFromOptions(ctx, popts...)
 	if err != nil {
 		return err
+	}
+
+	return nil
+}
+
+// checkExists determines if the provided deployment (with the same name)
+// already exists and, if possible, prompts the user for the rollout strategy.
+func (opts *DeployOptions) checkExists(ctx context.Context) error {
+	// Check if the instance with the same name already exists
+	exists, err := opts.Client.Instances().GetByName(ctx, opts.Name)
+	if err == nil && exists != nil {
+		if opts.Rollout == StrategyPrompt {
+			if config.G[config.KraftKit](ctx).NoPrompt {
+				return fmt.Errorf("prompting disabled")
+			}
+
+			strategy, err := selection.Select[RolloutStrategy](
+				fmt.Sprintf("deployment with name '%s' already exists: how would you like to proceed?", opts.Name),
+				RolloutStrategies()...,
+			)
+			if err != nil {
+				return err
+			}
+
+			opts.Rollout = *strategy
+		}
+
+		switch opts.Rollout {
+		case StrategyExit:
+			return fmt.Errorf("deployment already exists and merge strategy set to exit on conflict")
+
+		case StrategyOverwrite:
+			if err := opts.Client.Instances().DeleteByName(ctx, opts.Name); err != nil {
+				return fmt.Errorf("could not delete deployment '%s': %w", opts.Name, err)
+			}
+
+		default:
+			return fmt.Errorf("unsupported rollout strategy '%s'", opts.Rollout.String())
+		}
 	}
 
 	return nil


### PR DESCRIPTION
This initial implementation simply provides the user the ability to
"overwrite" (delete and create new) instances if an instance with the
same name already exists.

Signed-off-by: Alexander Jung <alex@unikraft.io>

<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [ ] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [ ] Tested your changes against relevant architectures and platforms;
  - [ ] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->
