### PR TITLE
fix(yamlmerger): Update `RecursiveMerge` to support `ScalarNode` kind

### DIFF
--- a/internal/yamlmerger/yamlmerger.go
+++ b/internal/yamlmerger/yamlmerger.go
@@ -54,7 +54,7 @@ func RecursiveMerge(from, into *yaml.Node) error {
 		}
 	case yaml.ScalarNode:
 		// SA4006 these variables represent pointers and are propagated outside of `recursiveMerge`
-		into = from //nolint:staticcheck
+		into.Value = from.Value //nolint:staticcheck
 	case yaml.SequenceNode:
 		for _, fromItem := range from.Content {
 			foundFrom := false


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->
updates RecursiveMerge() for ScalarNode kind.

Currently on adding diffrent version of a pre-existing library in the project directory using cmd `kraft lib add lib_name:version` Kraftfile doesn't get updated for the new version as expected.

But after merging this PR, Kraftkit will be able to update the project `kraftfile` for the new version of the already existing library.

