### PR TITLE
fix(gendocs): Remove old link prefixes

### DIFF
--- a/tools/gendocs/main.go
+++ b/tools/gendocs/main.go
@@ -83,6 +83,14 @@ func generateMarkdown(cmd *cobra.Command, dir string) error {
 		return err
 	}
 
+	if hasAliases(cmd) {
+		buf.WriteString("## Aliases\n\n")
+		buf.WriteString("The `" + name + "` command can also be run as:\n\n")
+		buf.WriteString("```\n")
+		buf.WriteString(strings.Join(cmd.Aliases, ", ") + "\n")
+		buf.WriteString("```\n\n")
+	}
+
 	if hasSeeAlso(cmd) {
 		buf.WriteString("## See Also\n\n")
 		if cmd.HasParent() {
@@ -162,6 +170,10 @@ func printOptions(buf *bytes.Buffer, cmd *cobra.Command) error {
 	}
 
 	return nil
+}
+
+func hasAliases(cmd *cobra.Command) bool {
+	return len(cmd.Aliases) > 0
 }
 
 // Test to see if we have a reason to print See Also information in docs

--- a/tools/gendocs/main.go
+++ b/tools/gendocs/main.go
@@ -88,7 +88,8 @@ func generateMarkdown(cmd *cobra.Command, dir string) error {
 		if cmd.HasParent() {
 			parent := cmd.Parent()
 			pname := parent.CommandPath()
-			link := "/docs/cli/reference/" + strings.ReplaceAll(pname, " ", "/")
+			link := "/cli/" + strings.ReplaceAll(pname, " ", "/")
+			link = strings.ReplaceAll(link, "/kraft/cloud", "")
 			buf.WriteString(fmt.Sprintf("* [`%s`](%s): %s\n", pname, link, parent.Short))
 			cmd.VisitParents(func(c *cobra.Command) {
 				if c.DisableAutoGenTag {
@@ -106,8 +107,9 @@ func generateMarkdown(cmd *cobra.Command, dir string) error {
 			}
 
 			cname := name + " " + child.Name()
-			link := "/docs/cli/reference/" + cname
+			link := "/cli/" + cname
 			link = strings.ReplaceAll(link, " ", "/")
+			link = strings.ReplaceAll(link, "/kraft/cloud", "")
 			buf.WriteString(fmt.Sprintf("* [`%s`](%s): %s\n", cname, link, child.Short))
 		}
 


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [ ] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [ ] Tested your changes against relevant architectures and platforms;
  - [ ] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

@nderjung this might not be universally correct, but keep it in mind when deploying docs. After an initial scan it looks fine.