### PR TITLE
fix(kraft): Handle tailing logs from fast-exiting kernels

### DIFF
--- a/internal/cli/kraft/run/run.go
+++ b/internal/cli/kraft/run/run.go
@@ -371,10 +371,6 @@ func (opts *RunOptions) Run(ctx context.Context, args []string) error {
 		// Output the name of the instance such that it can be piped
 		fmt.Fprintf(iostreams.G(ctx).Out, "%s\n", machine.Name)
 		return nil
-	} else {
-		if _, err := opts.machineController.Start(ctx, machine); err != nil {
-			return err
-		}
 	}
 
 	return start.Start(ctx, &start.StartOptions{


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

This PR handles an issue where fast-exiting run-to-completion-type unikernels (specifically those emited via the QEMU VMM) would result in the inability to render the available logs since the connectivity to the machine's event stream would be inaccessible (due to the exit).

To remedy this, a pre-emptive static check for the state of the machine is performed if access to the stream is not possible.  This static check determines whether the context is cancelled in all execution paths which would have otherwise prevented the logs from the machine to be properly handled.


