### PR TITLE
feat: Add netdevip fields and allow multiple networks

### DIFF
--- a/api/network/v1alpha1/interface.zip.go
+++ b/api/network/v1alpha1/interface.zip.go
@@ -25,8 +25,23 @@ type NetworkInterfaceSpec struct {
 	// The name of the interface.
 	IfName string `json:"ifname,omitempty"`
 
-	// IP address of a machine interface.
-	IP string `json:"ip,omitempty"`
+	// IPv4 address in CIDR notation, which includes the subnet.
+	CIDR string
+
+	// Gateway IPv4 address.
+	Gateway string
+
+	// IPv4 address of the primary DNS server.
+	DNS0 string
+
+	// IPv4 address of the secondary DNS server.
+	DNS1 string
+
+	// Hostname of the IPv4 address.
+	Hostname string
+
+	// Domain/Search suffix for IPv4 address.
+	Domain string
 
 	// Hardware address of a machine interface.
 	MacAddress string `json:"mac,omitempty"`

--- a/internal/cli/kraft/ps/ps.go
+++ b/internal/cli/kraft/ps/ps.go
@@ -159,7 +159,7 @@ func (opts *PsOptions) PsTable(ctx context.Context) ([]PsEntry, error) {
 
 		for _, net := range machine.Spec.Networks {
 			for _, iface := range net.Interfaces {
-				entry.IPs = append(entry.IPs, iface.Spec.IP)
+				entry.IPs = append(entry.IPs, iface.Spec.CIDR)
 			}
 		}
 

--- a/internal/cli/kraft/run/run.go
+++ b/internal/cli/kraft/run/run.go
@@ -38,7 +38,7 @@ type RunOptions struct {
 	MacAddress    string   `long:"mac" usage:"Assign the provided MAC address"`
 	Memory        string   `long:"memory" short:"M" usage:"Assign memory to the unikernel (K/Ki, M/Mi, G/Gi)" default:"64Mi"`
 	Name          string   `long:"name" short:"n" usage:"Name of the instance"`
-	Network       string   `long:"network" usage:"Attach instance to the provided network"`
+	Networks      []string `long:"network" usage:"Attach instance to the provided network, in the format <network>[:ip[/mask][:gw[:dns0[:dns1[:hostname[:domain]]]]]], e.g. kraft0:172.100.0.2"`
 	NoStart       bool     `long:"no-start" usage:"Do not start the machine"`
 	Platform      string   `noattribute:"true"`
 	Ports         []string `long:"port" short:"p" usage:"Publish a machine's port(s) to the host" split:"false"`

--- a/internal/cli/kraft/run/utils.go
+++ b/internal/cli/kraft/run/utils.go
@@ -3,6 +3,7 @@ package run
 import (
 	"context"
 	"fmt"
+	"net"
 	"os"
 	"path/filepath"
 	"strings"
@@ -52,6 +53,12 @@ func (opts *RunOptions) parseNetworks(ctx context.Context, machine *machineapi.M
 		return nil
 	}
 
+	// The network is specified in the format
+	// network:[cidr[:gw[:dns0[:dns1[:hostname[:domain]]]]]]
+
+	split := strings.SplitN(opts.Network, ":", 2)
+	networkName := split[0]
+
 	networkServiceIterator, err := network.NewNetworkV1alpha1ServiceIterator(ctx)
 	if err != nil {
 		return err
@@ -60,11 +67,46 @@ func (opts *RunOptions) parseNetworks(ctx context.Context, machine *machineapi.M
 	// Try to discover the user-provided network.
 	found, err := networkServiceIterator.Get(ctx, &networkapi.Network{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: opts.Network,
+			Name: networkName,
 		},
 	})
 	if err != nil {
 		return err
+	}
+
+	var interfaceSpec networkapi.NetworkInterfaceSpec
+
+	if len(split) > 1 {
+		fields := strings.Split(split[1], ":")
+		if len(fields) > 0 {
+			interfaceSpec.CIDR = fields[0]
+			ipMaskSplit := strings.SplitN(interfaceSpec.CIDR, "/", 2)
+			if len(ipMaskSplit) != 2 {
+				sz, _ := net.IPMask(net.ParseIP(found.Spec.Netmask).To4()).Size()
+				interfaceSpec.CIDR = fmt.Sprintf("%s/%d", interfaceSpec.CIDR, sz)
+			}
+			opts.IP = ipMaskSplit[0]
+		}
+
+		if len(fields) > 1 {
+			interfaceSpec.Gateway = fields[1]
+		}
+		if len(fields) > 2 {
+			interfaceSpec.DNS0 = fields[2]
+		}
+		if len(fields) > 3 {
+			interfaceSpec.DNS1 = fields[3]
+		}
+		if len(fields) > 4 {
+			interfaceSpec.Hostname = fields[4]
+		}
+		if len(fields) > 5 {
+			interfaceSpec.Domain = fields[5]
+		}
+	}
+
+	if interfaceSpec.Gateway == "" {
+		interfaceSpec.Gateway = found.Spec.Gateway
 	}
 
 	// Generate the UID pre-emptively so that we can uniquely reference the
@@ -76,10 +118,7 @@ func (opts *RunOptions) parseNetworks(ctx context.Context, machine *machineapi.M
 		ObjectMeta: metav1.ObjectMeta{
 			UID: uuid.NewUUID(),
 		},
-		Spec: networkapi.NetworkInterfaceSpec{
-			IP:         opts.IP,
-			MacAddress: opts.MacAddress,
-		},
+		Spec: interfaceSpec,
 	}
 
 	// Update the list of interfaces

--- a/machine/firecracker/v1alpha1.go
+++ b/machine/firecracker/v1alpha1.go
@@ -8,7 +8,6 @@ import (
 	"context"
 	"fmt"
 	"io/fs"
-	"net"
 	"os"
 	"path/filepath"
 	"time"
@@ -281,12 +280,14 @@ watch:
 				// Assign the first interface statically via command-line arguments, also
 				// checking if the built-in arguments for
 				if !kernelArgs.Contains(uknetdev.ParamIp) && i == 0 {
-					sz, _ := net.IPMask(net.ParseIP(network.Netmask).To4()).Size()
-
 					kernelArgs = append(kernelArgs,
 						uknetdev.ParamIp.WithValue(uknetdev.NetdevIp{
-							CIDR:    fmt.Sprintf("%s/%d", iface.Spec.IP, sz),
-							Gateway: network.Gateway,
+							CIDR:     iface.Spec.CIDR,
+							Gateway:  iface.Spec.Gateway,
+							DNS0:     iface.Spec.DNS0,
+							DNS1:     iface.Spec.DNS1,
+							Hostname: iface.Spec.Hostname,
+							Domain:   iface.Spec.Domain,
 						}),
 					)
 				}

--- a/machine/firecracker/v1alpha1.go
+++ b/machine/firecracker/v1alpha1.go
@@ -277,20 +277,16 @@ watch:
 					return machine, err
 				}
 
-				// Assign the first interface statically via command-line arguments, also
-				// checking if the built-in arguments for
-				if !kernelArgs.Contains(uknetdev.ParamIp) && i == 0 {
-					kernelArgs = append(kernelArgs,
-						uknetdev.ParamIp.WithValue(uknetdev.NetdevIp{
-							CIDR:     iface.Spec.CIDR,
-							Gateway:  iface.Spec.Gateway,
-							DNS0:     iface.Spec.DNS0,
-							DNS1:     iface.Spec.DNS1,
-							Hostname: iface.Spec.Hostname,
-							Domain:   iface.Spec.Domain,
-						}),
-					)
-				}
+				kernelArgs = append(kernelArgs,
+					uknetdev.NewParamIp().WithValue(uknetdev.NetdevIp{
+						CIDR:     iface.Spec.CIDR,
+						Gateway:  iface.Spec.Gateway,
+						DNS0:     iface.Spec.DNS0,
+						DNS1:     iface.Spec.DNS1,
+						Hostname: iface.Spec.Hostname,
+						Domain:   iface.Spec.Domain,
+					}),
+				)
 
 				// Increment the host network ID for additional interfaces.
 				i++

--- a/machine/network/bridge/v1alpha1.go
+++ b/machine/network/bridge/v1alpha1.go
@@ -332,31 +332,6 @@ func (service *v1alpha1Network) Update(ctx context.Context, network *networkv1al
 		network.Spec.Interfaces[i] = iface
 	}
 
-	// Clean up any removed interfaces.  Re-check the link list.
-	links, err := netlink.LinkList()
-	if err != nil {
-		return network, fmt.Errorf("could not gather list of existing links: %v", err)
-	}
-
-	for _, link := range links {
-		tap, ok := link.(*netlink.Tuntap)
-		if !ok {
-			continue // Skip non-tap interfaces
-		}
-
-		if _, ok := inuse[tap.Alias]; ok {
-			continue // Skip in-use interfaces
-		}
-
-		if err = netlink.LinkSetDown(tap); err != nil {
-			return network, fmt.Errorf("could not bring %s link down: %v", tap.Name, err)
-		}
-
-		if err = netlink.LinkDel(tap); err != nil {
-			return network, fmt.Errorf("could not remove %s: %v", tap.Name, err)
-		}
-	}
-
 	return network, nil
 }
 

--- a/machine/network/iterator_v1alpha1.go
+++ b/machine/network/iterator_v1alpha1.go
@@ -13,7 +13,7 @@ import (
 	networkv1alpha1 "kraftkit.sh/api/network/v1alpha1"
 )
 
-type networkV1alpha1ServiceIteartor struct {
+type networkV1alpha1ServiceIterator struct {
 	strategies map[string]networkv1alpha1.NetworkService
 }
 
@@ -24,7 +24,7 @@ type networkV1alpha1ServiceIteartor struct {
 // driver to succeed is returned in all circumstances.
 func NewNetworkV1alpha1ServiceIterator(ctx context.Context) (networkv1alpha1.NetworkService, error) {
 	var err error
-	iterator := networkV1alpha1ServiceIteartor{
+	iterator := networkV1alpha1ServiceIterator{
 		strategies: map[string]networkv1alpha1.NetworkService{},
 	}
 
@@ -39,7 +39,7 @@ func NewNetworkV1alpha1ServiceIterator(ctx context.Context) (networkv1alpha1.Net
 }
 
 // Create implements kraftkit.sh/api/network/v1alpha1.Create
-func (iterator *networkV1alpha1ServiceIteartor) Create(ctx context.Context, network *networkv1alpha1.Network) (*networkv1alpha1.Network, error) {
+func (iterator *networkV1alpha1ServiceIterator) Create(ctx context.Context, network *networkv1alpha1.Network) (*networkv1alpha1.Network, error) {
 	var errs []error
 
 	for _, strategy := range iterator.strategies {
@@ -56,7 +56,7 @@ func (iterator *networkV1alpha1ServiceIteartor) Create(ctx context.Context, netw
 }
 
 // Start implements kraftkit.sh/api/network/v1alpha1.Start
-func (iterator *networkV1alpha1ServiceIteartor) Start(ctx context.Context, network *networkv1alpha1.Network) (*networkv1alpha1.Network, error) {
+func (iterator *networkV1alpha1ServiceIterator) Start(ctx context.Context, network *networkv1alpha1.Network) (*networkv1alpha1.Network, error) {
 	var errs []error
 
 	for _, strategy := range iterator.strategies {
@@ -73,7 +73,7 @@ func (iterator *networkV1alpha1ServiceIteartor) Start(ctx context.Context, netwo
 }
 
 // Stop implements kraftkit.sh/api/network/v1alpha1.Stop
-func (iterator *networkV1alpha1ServiceIteartor) Stop(ctx context.Context, network *networkv1alpha1.Network) (*networkv1alpha1.Network, error) {
+func (iterator *networkV1alpha1ServiceIterator) Stop(ctx context.Context, network *networkv1alpha1.Network) (*networkv1alpha1.Network, error) {
 	var errs []error
 
 	for _, strategy := range iterator.strategies {
@@ -90,7 +90,7 @@ func (iterator *networkV1alpha1ServiceIteartor) Stop(ctx context.Context, networ
 }
 
 // Update implements kraftkit.sh/api/network/v1alpha1.Update.
-func (iterator *networkV1alpha1ServiceIteartor) Update(ctx context.Context, network *networkv1alpha1.Network) (*networkv1alpha1.Network, error) {
+func (iterator *networkV1alpha1ServiceIterator) Update(ctx context.Context, network *networkv1alpha1.Network) (*networkv1alpha1.Network, error) {
 	var errs []error
 
 	for _, strategy := range iterator.strategies {
@@ -107,7 +107,7 @@ func (iterator *networkV1alpha1ServiceIteartor) Update(ctx context.Context, netw
 }
 
 // Delete implements kraftkit.sh/api/network/v1alpha1.Delete
-func (iterator *networkV1alpha1ServiceIteartor) Delete(ctx context.Context, network *networkv1alpha1.Network) (*networkv1alpha1.Network, error) {
+func (iterator *networkV1alpha1ServiceIterator) Delete(ctx context.Context, network *networkv1alpha1.Network) (*networkv1alpha1.Network, error) {
 	var errs []error
 
 	for _, strategy := range iterator.strategies {
@@ -124,7 +124,7 @@ func (iterator *networkV1alpha1ServiceIteartor) Delete(ctx context.Context, netw
 }
 
 // Get implements kraftkit.sh/api/network/v1alpha1.Get
-func (iterator *networkV1alpha1ServiceIteartor) Get(ctx context.Context, network *networkv1alpha1.Network) (*networkv1alpha1.Network, error) {
+func (iterator *networkV1alpha1ServiceIterator) Get(ctx context.Context, network *networkv1alpha1.Network) (*networkv1alpha1.Network, error) {
 	var errs []error
 
 	for _, strategy := range iterator.strategies {
@@ -141,7 +141,7 @@ func (iterator *networkV1alpha1ServiceIteartor) Get(ctx context.Context, network
 }
 
 // List implements kraftkit.sh/api/network/v1alpha1.List
-func (iterator *networkV1alpha1ServiceIteartor) List(ctx context.Context, cached *networkv1alpha1.NetworkList) (*networkv1alpha1.NetworkList, error) {
+func (iterator *networkV1alpha1ServiceIterator) List(ctx context.Context, cached *networkv1alpha1.NetworkList) (*networkv1alpha1.NetworkList, error) {
 	found := []zip.Object[networkv1alpha1.NetworkSpec, networkv1alpha1.NetworkStatus]{}
 
 	for _, strategy := range iterator.strategies {

--- a/machine/network/iterator_v1alpha1.go
+++ b/machine/network/iterator_v1alpha1.go
@@ -60,7 +60,7 @@ func (iterator *networkV1alpha1ServiceIterator) Start(ctx context.Context, netwo
 	var errs []error
 
 	for _, strategy := range iterator.strategies {
-		ret, err := strategy.Create(ctx, network)
+		ret, err := strategy.Start(ctx, network)
 		if err != nil {
 			errs = append(errs, err)
 			continue
@@ -77,7 +77,7 @@ func (iterator *networkV1alpha1ServiceIterator) Stop(ctx context.Context, networ
 	var errs []error
 
 	for _, strategy := range iterator.strategies {
-		ret, err := strategy.Create(ctx, network)
+		ret, err := strategy.Stop(ctx, network)
 		if err != nil {
 			errs = append(errs, err)
 			continue
@@ -94,7 +94,7 @@ func (iterator *networkV1alpha1ServiceIterator) Update(ctx context.Context, netw
 	var errs []error
 
 	for _, strategy := range iterator.strategies {
-		ret, err := strategy.Create(ctx, network)
+		ret, err := strategy.Update(ctx, network)
 		if err != nil {
 			errs = append(errs, err)
 			continue
@@ -111,7 +111,7 @@ func (iterator *networkV1alpha1ServiceIterator) Delete(ctx context.Context, netw
 	var errs []error
 
 	for _, strategy := range iterator.strategies {
-		ret, err := strategy.Create(ctx, network)
+		ret, err := strategy.Delete(ctx, network)
 		if err != nil {
 			errs = append(errs, err)
 			continue
@@ -128,7 +128,7 @@ func (iterator *networkV1alpha1ServiceIterator) Get(ctx context.Context, network
 	var errs []error
 
 	for _, strategy := range iterator.strategies {
-		ret, err := strategy.Create(ctx, network)
+		ret, err := strategy.Get(ctx, network)
 		if err != nil {
 			errs = append(errs, err)
 			continue

--- a/machine/qemu/v1alpha1.go
+++ b/machine/qemu/v1alpha1.go
@@ -314,12 +314,14 @@ func (service *machineV1alpha1Service) Create(ctx context.Context, machine *mach
 				// Assign the first interface statically via command-line arguments, also
 				// checking if the built-in arguments for
 				if !kernelArgs.Contains(uknetdev.ParamIp) && i == 0 {
-					sz, _ := net.IPMask(net.ParseIP(network.Netmask).To4()).Size()
-
 					kernelArgs = append(kernelArgs,
 						uknetdev.ParamIp.WithValue(uknetdev.NetdevIp{
-							CIDR:    fmt.Sprintf("%s/%d", iface.Spec.IP, sz),
-							Gateway: network.Gateway,
+							CIDR:     iface.Spec.CIDR,
+							Gateway:  network.Gateway,
+							DNS0:     iface.Spec.DNS0,
+							DNS1:     iface.Spec.DNS1,
+							Hostname: iface.Spec.Hostname,
+							Domain:   iface.Spec.Domain,
 						}),
 					)
 				}

--- a/machine/qemu/v1alpha1.go
+++ b/machine/qemu/v1alpha1.go
@@ -311,20 +311,16 @@ func (service *machineV1alpha1Service) Create(ctx context.Context, machine *mach
 					}),
 				)
 
-				// Assign the first interface statically via command-line arguments, also
-				// checking if the built-in arguments for
-				if !kernelArgs.Contains(uknetdev.ParamIp) && i == 0 {
-					kernelArgs = append(kernelArgs,
-						uknetdev.ParamIp.WithValue(uknetdev.NetdevIp{
-							CIDR:     iface.Spec.CIDR,
-							Gateway:  network.Gateway,
-							DNS0:     iface.Spec.DNS0,
-							DNS1:     iface.Spec.DNS1,
-							Hostname: iface.Spec.Hostname,
-							Domain:   iface.Spec.Domain,
-						}),
-					)
-				}
+				kernelArgs = append(kernelArgs,
+					uknetdev.NewParamIp().WithValue(uknetdev.NetdevIp{
+						CIDR:     iface.Spec.CIDR,
+						Gateway:  network.Gateway,
+						DNS0:     iface.Spec.DNS0,
+						DNS1:     iface.Spec.DNS1,
+						Hostname: iface.Spec.Hostname,
+						Domain:   iface.Spec.Domain,
+					}),
+				)
 
 				// Increment the host network ID for additional interfaces.
 				i++

--- a/unikraft/export/v0/uknetdev/params.go
+++ b/unikraft/export/v0/uknetdev/params.go
@@ -15,7 +15,9 @@ import (
 // is introduced:
 //
 // cidr[:gw[:dns0[:dns1[:hostname[:domain]]]]]
-var ParamIp = ukargparse.ParamStr("netdev", "ip", nil)
+func NewParamIp() ukargparse.Param {
+	return ukargparse.ParamStr("netdev", "ip", nil)
+}
 
 // NetdevIp represents the attributes of the network device which is understood
 // by uknetdev and uklibparam.
@@ -43,6 +45,6 @@ func (entry NetdevIp) String() string {
 // ExportedParams returns the parameters available by this exported library.
 func ExportedParams() []ukargparse.Param {
 	return []ukargparse.Param{
-		ParamIp,
+		NewParamIp(),
 	}
 }


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

This PR:
- introduces changes to interfaces to accommodate the new `netdev` syntax introduces in [0.16.1](https://unikraft.org/blog/2024-01-18-unikraft-releases-v0.16.1)
- allows specifying multiple networks when running a unikernel
- adds some fixes for `NetworkIterator`
