### PR TITLE
fix(kraft): Handle too many options with selection and better error

### DIFF
--- a/internal/cli/kraft/menu/menu.go
+++ b/internal/cli/kraft/menu/menu.go
@@ -26,6 +26,7 @@ import (
 	"kraftkit.sh/make"
 	"kraftkit.sh/packmanager"
 	"kraftkit.sh/tui/paraprogress"
+	"kraftkit.sh/tui/selection"
 	"kraftkit.sh/unikraft/app"
 	"kraftkit.sh/unikraft/target"
 
@@ -119,6 +120,8 @@ func (opts *MenuOptions) pull(ctx context.Context, project app.Application, work
 
 	if _, err := opts.project.Components(ctx); err != nil && opts.project.Template().Name() != "" {
 		var packages []pack.Package
+		var pullPack pack.Package
+
 		search := processtree.NewProcessTreeItem(
 			fmt.Sprintf("finding %s",
 				unikraft.TypeNameVersion(opts.project.Template()),
@@ -137,10 +140,6 @@ func (opts *MenuOptions) pull(ctx context.Context, project app.Application, work
 
 				if len(packages) == 0 {
 					return fmt.Errorf("could not find: %s",
-						unikraft.TypeNameVersion(opts.project.Template()),
-					)
-				} else if len(packages) > 1 {
-					return fmt.Errorf("too many options for %s",
 						unikraft.TypeNameVersion(opts.project.Template()),
 					)
 				}
@@ -166,12 +165,35 @@ func (opts *MenuOptions) pull(ctx context.Context, project app.Application, work
 			return fmt.Errorf("could not complete search: %v", err)
 		}
 
+		if len(packages) == 1 {
+			pullPack = packages[0]
+		} else if len(packages) > 1 {
+			if config.G[config.KraftKit](ctx).NoPrompt {
+				for _, p := range packages {
+					log.G(ctx).
+						WithField("template", p.String()).
+						Warn("possible")
+				}
+
+				return fmt.Errorf("too many options for %s and prompting has been disabled",
+					opts.project.Template().String(),
+				)
+			}
+
+			selected, err := selection.Select[pack.Package]("select possible template", packages...)
+			if err != nil {
+				return err
+			}
+
+			pullPack = *selected
+		}
+
 		proc := paraprogress.NewProcess(
 			fmt.Sprintf("pulling %s",
-				unikraft.TypeNameVersion(packages[0]),
+				unikraft.TypeNameVersion(pullPack),
 			),
 			func(ctx context.Context, w func(progress float64)) error {
-				return packages[0].Pull(
+				return pullPack.Pull(
 					ctx,
 					pack.WithPullProgressFunc(w),
 					pack.WithPullWorkdir(workdir),


### PR DESCRIPTION

<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

There are several places where multiple packages can be found with the same given input.  In these cases, we can simply prompt the user (as long as prompting/interactivity is enabled) in order to allow the user to progress further.  Not all errors which return this "too many options" are adjusted, only the few where the `Catalog` is used to derive a single package.
