### PR TITLE
fix: Correct nix license name

### DIFF
--- a/.goreleaser-stable.yaml
+++ b/.goreleaser-stable.yaml
@@ -121,7 +121,7 @@ nix:
     homepage: https://kraftkit.sh
     description: Build and use highly customized and ultra-lightweight unikernels
     path: pkgs/kraftkit/default.nix
-    license: BSD-3-Clause
+    license: bsd3
     install: |-
       mkdir -p $out/bin
       cp -vr ./dist/kraft $out/bin/kraft


### PR DESCRIPTION
The SDPX identifier is not recognised, use Nix license attribute name.

See: https://github.com/NixOS/nixpkgs/blob/8d165ba9/lib/licenses.nix#L197-L200
See: https://goreleaser.com/customization/nix/?h=nix

Signed-off-by: Alexander Jung <alex@unikraft.io>

<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [ ] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [ ] Tested your changes against relevant architectures and platforms;
  - [ ] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->
