### PR TITLE
feat: Introduce `readme` element to `Kraftfile`

### DIFF
--- a/internal/cli/kraft/pkg/packager_kraftfile_runtime.go
+++ b/internal/cli/kraft/pkg/packager_kraftfile_runtime.go
@@ -332,6 +332,14 @@ func (p *packagerKraftfileRuntime) Pack(ctx context.Context, opts *PkgOptions, a
 		return nil, err
 	}
 
+	if len(opts.Readme) == 0 {
+		opts.Readme = opts.Project.Readme()
+	} else {
+		if readmeBytes, err := os.ReadFile(opts.Readme); err == nil {
+			opts.Readme = string(readmeBytes)
+		}
+	}
+
 	var result []pack.Package
 	norender := log.LoggerTypeFromString(config.G[config.KraftKit](ctx).Log.Type) != log.FANCY
 
@@ -352,6 +360,7 @@ func (p *packagerKraftfileRuntime) Pack(ctx context.Context, opts *PkgOptions, a
 					packmanager.PackKConfig(!opts.NoKConfig),
 					packmanager.PackName(opts.Name),
 					packmanager.PackOutput(opts.Output),
+					packmanager.PackReadme(opts.Readme),
 				)
 
 				if ukversion, ok := targ.KConfig().Get(unikraft.UK_FULLVERSION); ok {

--- a/internal/cli/kraft/pkg/packager_kraftfile_unikraft.go
+++ b/internal/cli/kraft/pkg/packager_kraftfile_unikraft.go
@@ -131,6 +131,14 @@ func (p *packagerKraftfileUnikraft) Pack(ctx context.Context, opts *PkgOptions, 
 			return nil, err
 		}
 
+		if len(opts.Readme) == 0 {
+			opts.Readme = opts.Project.Readme()
+		} else {
+			if readmeBytes, err := os.ReadFile(opts.Readme); err == nil {
+				opts.Readme = string(readmeBytes)
+			}
+		}
+
 		// When i > 0, we have already applied the merge strategy.  Now, for all
 		// targets, we actually do wish to merge these because they are part of
 		// the same execution lifecycle.
@@ -150,6 +158,7 @@ func (p *packagerKraftfileUnikraft) Pack(ctx context.Context, opts *PkgOptions, 
 					packmanager.PackKConfig(!opts.NoKConfig),
 					packmanager.PackName(opts.Name),
 					packmanager.PackOutput(opts.Output),
+					packmanager.PackReadme(opts.Readme),
 				)
 
 				if ukversion, ok := targ.KConfig().Get(unikraft.UK_FULLVERSION); ok {

--- a/internal/cli/kraft/pkg/pkg.go
+++ b/internal/cli/kraft/pkg/pkg.go
@@ -48,6 +48,7 @@ type PkgOptions struct {
 	Platform     string                    `local:"true" long:"plat" short:"p" usage:"Filter the creation of the package by platform of known targets"`
 	Project      app.Application           `noattribute:"true"`
 	Push         bool                      `local:"true" long:"push" short:"P" usage:"Push the package on if successfully packaged"`
+	Readme       string                    `local:"true" long:"readme" usage:"Verbatim text or path to a README file to include in the package"`
 	Rootfs       string                    `local:"true" long:"rootfs" usage:"Specify a path to use as root file system (can be volume or initramfs)"`
 	Strategy     packmanager.MergeStrategy `noattribute:"true"`
 	Target       string                    `local:"true" long:"target" short:"t" usage:"Package a particular known target"`

--- a/oci/annotations.go
+++ b/oci/annotations.go
@@ -10,7 +10,7 @@ const (
 	AnnotationVersion              = "org.unikraft.image.version"
 	AnnotationURL                  = "org.unikraft.image.url"
 	AnnotationCreated              = "org.unikraft.image.created"
-	AnnotaitonDescription          = "org.unikraft.image.description"
+	AnnotationDescription          = "org.unikraft.image.description"
 	AnnotationKernelPath           = "org.unikraft.kernel.image"
 	AnnotationKernelVersion        = "org.unikraft.kernel.version"
 	AnnotationKernelInitrdPath     = "org.unikraft.kernel.initrd"

--- a/oci/annotations.go
+++ b/oci/annotations.go
@@ -11,6 +11,7 @@ const (
 	AnnotationURL                  = "org.unikraft.image.url"
 	AnnotationCreated              = "org.unikraft.image.created"
 	AnnotationDescription          = "org.unikraft.image.description"
+	AnnotationReadme               = "org.unikraft.image.readme"
 	AnnotationKernelPath           = "org.unikraft.kernel.image"
 	AnnotationKernelVersion        = "org.unikraft.kernel.version"
 	AnnotationKernelInitrdPath     = "org.unikraft.kernel.initrd"

--- a/packmanager/pack_options.go
+++ b/packmanager/pack_options.go
@@ -17,6 +17,7 @@ type PackOptions struct {
 	kernelSourceFiles                bool
 	kernelVersion                    string
 	name                             string
+	readme                           string
 	output                           string
 	mergeStrategy                    MergeStrategy
 }
@@ -79,6 +80,11 @@ func (popts *PackOptions) KernelVersion() string {
 // Name returns the name of the package.
 func (popts *PackOptions) Name() string {
 	return popts.name
+}
+
+// Readme returns the readme of the package.
+func (popts *PackOptions) Readme() string {
+	return popts.readme
 }
 
 // Output returns the location of the package.
@@ -164,6 +170,13 @@ func PackWithKernelVersion(version string) PackOption {
 func PackName(name string) PackOption {
 	return func(popts *PackOptions) {
 		popts.name = name
+	}
+}
+
+// PackReadme sets the readme of the package.
+func PackReadme(readme string) PackOption {
+	return func(popts *PackOptions) {
+		popts.readme = readme
 	}
 }
 

--- a/schema/v0.6.json
+++ b/schema/v0.6.json
@@ -11,6 +11,8 @@
 
     "/^name$/": { "type": "string" },
 
+    "/^readme$/": { "type": "string" },
+
     "/^outdir$/": { "type": "string" },
 
     "/^template$/": {

--- a/unikraft/app/application.go
+++ b/unikraft/app/application.go
@@ -39,6 +39,9 @@ import (
 type Application interface {
 	component.Component
 
+	// Readme contains the application's README text.
+	Readme() string
+
 	// WorkingDir returns the path to the application's working directory
 	WorkingDir() string
 
@@ -150,6 +153,7 @@ type Application interface {
 
 type application struct {
 	name          string
+	readme        string
 	version       string
 	source        string
 	path          string
@@ -171,6 +175,10 @@ type application struct {
 
 func (app application) Name() string {
 	return app.name
+}
+
+func (app application) Readme() string {
+	return app.readme
 }
 
 func (app application) String() string {

--- a/unikraft/app/application_options.go
+++ b/unikraft/app/application_options.go
@@ -70,6 +70,14 @@ func WithName(name string) ApplicationOption {
 	}
 }
 
+// WithReadme sets the application's readme
+func WithReadme(readme string) ApplicationOption {
+	return func(ac *application) error {
+		ac.readme = readme
+		return nil
+	}
+}
+
 // WithVersion sets the application version
 func WithVersion(version string) ApplicationOption {
 	return func(ac *application) error {

--- a/unikraft/app/loader.go
+++ b/unikraft/app/loader.go
@@ -20,6 +20,7 @@ package app
 import (
 	"context"
 	"fmt"
+	"os"
 	"strings"
 
 	interp "github.com/compose-spec/compose-go/interpolation"
@@ -40,6 +41,17 @@ func NewApplicationFromInterface(ctx context.Context, iface map[string]interface
 		name, ok = n.(string)
 		if !ok {
 			return nil, errors.New("project name must be a string")
+		}
+	}
+
+	if r, ok := iface["readme"]; ok {
+		app.readme, ok = r.(string)
+		if !ok {
+			return nil, errors.New("readme must be a string")
+		}
+
+		if readmeBytes, err := os.ReadFile(app.readme); err == nil {
+			app.readme = string(readmeBytes)
 		}
 	}
 

--- a/unikraft/app/project.go
+++ b/unikraft/app/project.go
@@ -163,6 +163,7 @@ func NewProjectFromOptions(ctx context.Context, opts ...ProjectOption) (Applicat
 
 	project, err := NewApplicationFromOptions(
 		WithName(projectName),
+		WithReadme(app.readme),
 		WithWorkingDir(popts.workdir),
 		WithFilename(app.filename),
 		WithOutDir(app.outDir),


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

This PR introduces the ability to specify either a string or path to a README text file in a `Kraftfile`.  At the same time, this is propagated to the OCI index as an annotation.  In the OCI annotation, the string contents is base64 encoded.

### Example usage

1. As a short-form string:
   ```yaml
   spec: v0.6
   readme: "This unikernel is amazing"
   ```
2. As a long-form string:
   ```yaml
   spec: v0.6
   readme: |
     This unikernel is amazing!
   ```
3. As an external file:
   ```yaml
   spec: v0.6
   readme: ./README.md
   ```

### TODO

This PR is still in draft form, the following additional pieces of work need to occur:
- [ ] Propagate the package's readme into `kraft pkg info`