### PR TITLE
fix(internal): Fully print `Created At` when not using `-o table`

### DIFF
--- a/internal/cli/kraft/cloud/utils/print.go
+++ b/internal/cli/kraft/cloud/utils/print.go
@@ -100,7 +100,11 @@ func PrintInstances(ctx context.Context, format string, instances ...kraftcloudi
 			if err != nil {
 				return fmt.Errorf("could not parse time for '%s': %w", instance.UUID, err)
 			}
-			createdAt = humanize.Time(createdTime)
+			if format != "table" {
+				createdAt = instance.CreatedAt
+			} else {
+				createdAt = humanize.Time(createdTime)
+			}
 		}
 
 		if format != "table" {
@@ -186,7 +190,11 @@ func PrintVolumes(ctx context.Context, format string, volumes ...kraftcloudvolum
 			if err != nil {
 				return fmt.Errorf("could not parse time for '%s': %w", volume.UUID, err)
 			}
-			createdAt = humanize.Time(createdTime)
+			if format != "table" {
+				createdAt = volume.CreatedAt
+			} else {
+				createdAt = humanize.Time(createdTime)
+			}
 		}
 
 		if format != "table" {
@@ -342,7 +350,11 @@ func PrintServiceGroups(ctx context.Context, format string, serviceGroups ...kra
 			if err != nil {
 				return fmt.Errorf("could not parse time for '%s': %w", sg.UUID, err)
 			}
-			createdAt = humanize.Time(createdTime)
+			if format != "table" {
+				createdAt = sg.CreatedAt
+			} else {
+				createdAt = humanize.Time(createdTime)
+			}
 		}
 
 		table.AddField(createdAt, nil)


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [ ] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [ ] Tested your changes against relevant architectures and platforms;
  - [ ] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->


This was annoying when doing automated parsing as the relative timestamp did not help a lot.