### PR TITLE
fix(bridge): Use user provided network mask

### DIFF
--- a/machine/network/bridge/v1alpha1.go
+++ b/machine/network/bridge/v1alpha1.go
@@ -79,11 +79,13 @@ func (service *v1alpha1Network) Create(ctx context.Context, network *networkv1al
 
 	// br.Promisc = 1 // TODO(nderjung): Should the bridge be promiscuous?
 
+	maskBytes := net.ParseIP(network.Spec.Netmask).To4()
+	mask := net.IPv4Mask(maskBytes[0], maskBytes[1], maskBytes[2], maskBytes[3])
 	// Setup IP address for bridge.
 	addr := &netlink.Addr{
 		IPNet: &net.IPNet{
 			IP:   net.ParseIP(network.Spec.Gateway),
-			Mask: net.ParseIP(network.Spec.Netmask).DefaultMask(),
+			Mask: mask,
 		},
 	}
 	if err := netlink.AddrAdd(br, addr); err != nil {


### PR DESCRIPTION
Previously, the mask assigned to the network would be computed based on the gateway, overriding the mask passed by the user.

<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

The bridge implementation was always overwriting the network mask passed by the user:
```bash
kraft net create some-net --network 172.30.0.1/16

kraft net ls
NAME             NETWORK           DRIVER  STATUS
some-net         172.30.0.1/24     bridge  up
```

This PR fixes this by parsing the actual netmask passed to the bridge implemetation:
```bash
kraft net create some-net --network 172.30.0.1/16

kraft net ls
NAME             NETWORK           DRIVER  STATUS
some-net         172.30.0.1/16     bridge  up
```

<!--
Please provide a detailed description of the changes made in this new PR.
-->
