### PR TITLE
feat(internal): Expose `--token` similar to `--metro`

### DIFF
--- a/config/kraftcloud.go
+++ b/config/kraftcloud.go
@@ -14,7 +14,7 @@ import (
 
 // GetKraftCloudLogin is a utility method which retrieves credentials of a
 // KraftCloud user from the given context returning it in AuthConfig format.
-func GetKraftCloudAuthConfigFromContext(ctx context.Context, flagToken string) (*AuthConfig, error) {
+func GetKraftCloudAuthConfig(ctx context.Context, flagToken string) (*AuthConfig, error) {
 	auth := AuthConfig{
 		Endpoint:  "index.unikraft.io",
 		VerifySSL: true,
@@ -54,7 +54,7 @@ func GetKraftCloudTokenAuthConfig(auth AuthConfig) string {
 // HydrateKraftCloudAuthInContext saturates the context with an additional
 // KraftCloud-specific information.
 func HydrateKraftCloudAuthInContext(ctx context.Context) (context.Context, error) {
-	auth, err := GetKraftCloudAuthConfigFromContext(ctx, "")
+	auth, err := GetKraftCloudAuthConfig(ctx, "")
 	if err != nil {
 		return nil, err
 	}

--- a/config/kraftcloud.go
+++ b/config/kraftcloud.go
@@ -9,21 +9,20 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
-	"os"
 	"strings"
 )
 
 // GetKraftCloudLogin is a utility method which retrieves credentials of a
 // KraftCloud user from the given context returning it in AuthConfig format.
-func GetKraftCloudAuthConfigFromContext(ctx context.Context) (*AuthConfig, error) {
+func GetKraftCloudAuthConfigFromContext(ctx context.Context, flagToken string) (*AuthConfig, error) {
 	auth := AuthConfig{
 		Endpoint:  "index.unikraft.io",
 		VerifySSL: true,
 	}
 
 	// Prioritize environmental variables
-	if token := os.Getenv("KRAFTCLOUD_TOKEN"); token != "" {
-		data, err := base64.StdEncoding.DecodeString(token)
+	if flagToken != "" {
+		data, err := base64.StdEncoding.DecodeString(flagToken)
 		if err != nil {
 			return nil, fmt.Errorf("could not decode token: %w", err)
 		}
@@ -55,7 +54,7 @@ func GetKraftCloudTokenAuthConfig(auth AuthConfig) string {
 // HydrateKraftCloudAuthInContext saturates the context with an additional
 // KraftCloud-specific information.
 func HydrateKraftCloudAuthInContext(ctx context.Context) (context.Context, error) {
-	auth, err := GetKraftCloudAuthConfigFromContext(ctx)
+	auth, err := GetKraftCloudAuthConfigFromContext(ctx, "")
 	if err != nil {
 		return nil, err
 	}

--- a/internal/cli/kraft/cloud/cloud.go
+++ b/internal/cli/kraft/cloud/cloud.go
@@ -24,8 +24,8 @@ import (
 )
 
 type CloudOptions struct {
-	Metro string `long:"metro" env:"KRAFTCLOUD_METRO" usage:"Set the KraftCloud metro."`
-	Token string `long:"token" env:"KRAFTCLOUD_TOKEN" usage:"Set the KraftCloud token."`
+	Metro string `long:"metro" env:"KRAFTCLOUD_METRO" usage:"Set the KraftCloud metro"`
+	Token string `long:"token" env:"KRAFTCLOUD_TOKEN" usage:"Set the KraftCloud token"`
 }
 
 func NewCmd() *cobra.Command {

--- a/internal/cli/kraft/cloud/cloud.go
+++ b/internal/cli/kraft/cloud/cloud.go
@@ -25,6 +25,7 @@ import (
 
 type CloudOptions struct {
 	Metro string `long:"metro" env:"KRAFTCLOUD_METRO" usage:"Set the KraftCloud metro."`
+	Token string `long:"token" env:"KRAFTCLOUD_TOKEN" usage:"Set the KraftCloud token."`
 }
 
 func NewCmd() *cobra.Command {

--- a/internal/cli/kraft/cloud/deploy/deploy.go
+++ b/internal/cli/kraft/cloud/deploy/deploy.go
@@ -106,19 +106,10 @@ func NewCmd() *cobra.Command {
 }
 
 func (opts *DeployOptions) Pre(cmd *cobra.Command, _ []string) error {
-	opts.Metro = cmd.Flag("metro").Value.String()
-	if opts.Metro == "" {
-		return fmt.Errorf("kraftcloud metro is unset")
+	err := utils.PopulateMetroToken(cmd, &opts.Metro, &opts.Token)
+	if err != nil {
+		return fmt.Errorf("could not populate metro and token: %w", err)
 	}
-
-	log.G(cmd.Context()).WithField("metro", opts.Metro).Debug("using")
-
-	opts.Token = cmd.Flag("token").Value.String()
-	if opts.Token == "" {
-		return fmt.Errorf("kraftcloud token is unset")
-	}
-
-	log.G(cmd.Context()).WithField("token", opts.Token).Debug("using")
 
 	opts.Strategy = packmanager.MergeStrategy(cmd.Flag("strategy").Value.String())
 

--- a/internal/cli/kraft/cloud/deploy/deploy.go
+++ b/internal/cli/kraft/cloud/deploy/deploy.go
@@ -133,7 +133,7 @@ func (opts *DeployOptions) Pre(cmd *cobra.Command, _ []string) error {
 func (opts *DeployOptions) Run(ctx context.Context, args []string) error {
 	var err error
 
-	opts.Auth, err = config.GetKraftCloudAuthConfigFromContext(ctx, opts.Token)
+	opts.Auth, err = config.GetKraftCloudAuthConfig(ctx, opts.Token)
 	if err != nil {
 		return fmt.Errorf("could not retrieve credentials: %w", err)
 	}

--- a/internal/cli/kraft/cloud/img/list/list.go
+++ b/internal/cli/kraft/cloud/img/list/list.go
@@ -75,7 +75,7 @@ func (opts *ListOptions) Pre(cmd *cobra.Command, _ []string) error {
 }
 
 func (opts *ListOptions) Run(ctx context.Context, args []string) error {
-	auth, err := config.GetKraftCloudAuthConfigFromContext(ctx, opts.token)
+	auth, err := config.GetKraftCloudAuthConfig(ctx, opts.token)
 	if err != nil {
 		return fmt.Errorf("could not retrieve credentials: %w", err)
 	}

--- a/internal/cli/kraft/cloud/img/list/list.go
+++ b/internal/cli/kraft/cloud/img/list/list.go
@@ -21,6 +21,7 @@ import (
 
 	"kraftkit.sh/cmdfactory"
 	"kraftkit.sh/config"
+	"kraftkit.sh/internal/cli/kraft/cloud/utils"
 	"kraftkit.sh/internal/tableprinter"
 	"kraftkit.sh/iostreams"
 	"kraftkit.sh/log"
@@ -65,18 +66,10 @@ func NewCmd() *cobra.Command {
 }
 
 func (opts *ListOptions) Pre(cmd *cobra.Command, _ []string) error {
-	opts.metro = cmd.Flag("metro").Value.String()
-	if opts.metro == "" {
-		return fmt.Errorf("kraftcloud metro is unset")
+	err := utils.PopulateMetroToken(cmd, &opts.metro, &opts.token)
+	if err != nil {
+		return fmt.Errorf("could not populate metro and token: %w", err)
 	}
-	log.G(cmd.Context()).WithField("metro", opts.metro).Debug("using")
-
-	opts.token = cmd.Flag("token").Value.String()
-	if opts.token == "" {
-		return fmt.Errorf("kraftcloud token is unset")
-	}
-
-	log.G(cmd.Context()).WithField("token", opts.token).Debug("using")
 
 	return nil
 }

--- a/internal/cli/kraft/cloud/img/list/list.go
+++ b/internal/cli/kraft/cloud/img/list/list.go
@@ -8,7 +8,6 @@ package list
 import (
 	"context"
 	"fmt"
-	"os"
 	"slices"
 	"sort"
 	"strconv"
@@ -32,6 +31,7 @@ type ListOptions struct {
 	Output string `long:"output" short:"o" usage:"Set output format. Options: table,yaml,json,list" default:"table"`
 
 	metro string
+	token string
 }
 
 func NewCmd() *cobra.Command {
@@ -67,17 +67,22 @@ func NewCmd() *cobra.Command {
 func (opts *ListOptions) Pre(cmd *cobra.Command, _ []string) error {
 	opts.metro = cmd.Flag("metro").Value.String()
 	if opts.metro == "" {
-		opts.metro = os.Getenv("KRAFTCLOUD_METRO")
-	}
-	if opts.metro == "" {
 		return fmt.Errorf("kraftcloud metro is unset")
 	}
 	log.G(cmd.Context()).WithField("metro", opts.metro).Debug("using")
+
+	opts.token = cmd.Flag("token").Value.String()
+	if opts.token == "" {
+		return fmt.Errorf("kraftcloud token is unset")
+	}
+
+	log.G(cmd.Context()).WithField("token", opts.token).Debug("using")
+
 	return nil
 }
 
 func (opts *ListOptions) Run(ctx context.Context, args []string) error {
-	auth, err := config.GetKraftCloudAuthConfigFromContext(ctx)
+	auth, err := config.GetKraftCloudAuthConfigFromContext(ctx, opts.token)
 	if err != nil {
 		return fmt.Errorf("could not retrieve credentials: %w", err)
 	}

--- a/internal/cli/kraft/cloud/img/remove/remove.go
+++ b/internal/cli/kraft/cloud/img/remove/remove.go
@@ -8,7 +8,6 @@ package remove
 import (
 	"context"
 	"fmt"
-	"os"
 	"strings"
 
 	"github.com/MakeNowJust/heredoc"
@@ -27,6 +26,7 @@ type RemoveOptions struct {
 	Auth   *config.AuthConfig             `noattribute:"true"`
 	Client kraftcloudimages.ImagesService `noattribute:"true"`
 	Metro  string                         `noattribute:"true"`
+	Token  string                         `noattribute:"true"`
 }
 
 func NewCmd() *cobra.Command {
@@ -72,13 +72,17 @@ func (opts *RemoveOptions) Pre(cmd *cobra.Command, args []string) error {
 
 	opts.Metro = cmd.Flag("metro").Value.String()
 	if opts.Metro == "" {
-		opts.Metro = os.Getenv("KRAFTCLOUD_METRO")
-	}
-	if opts.Metro == "" {
 		return fmt.Errorf("kraftcloud metro is unset")
 	}
 
 	log.G(cmd.Context()).WithField("metro", opts.Metro).Debug("using")
+
+	opts.Token = cmd.Flag("token").Value.String()
+	if opts.Token == "" {
+		return fmt.Errorf("kraftcloud token is unset")
+	}
+
+	log.G(cmd.Context()).WithField("token", opts.Token).Debug("using")
 
 	return nil
 }
@@ -87,7 +91,7 @@ func (opts *RemoveOptions) Run(ctx context.Context, args []string) error {
 	var err error
 
 	if opts.Auth == nil {
-		opts.Auth, err = config.GetKraftCloudAuthConfigFromContext(ctx)
+		opts.Auth, err = config.GetKraftCloudAuthConfigFromContext(ctx, opts.Token)
 		if err != nil {
 			return fmt.Errorf("could not retrieve credentials: %w", err)
 		}

--- a/internal/cli/kraft/cloud/img/remove/remove.go
+++ b/internal/cli/kraft/cloud/img/remove/remove.go
@@ -18,6 +18,7 @@ import (
 
 	"kraftkit.sh/cmdfactory"
 	"kraftkit.sh/config"
+	"kraftkit.sh/internal/cli/kraft/cloud/utils"
 	"kraftkit.sh/log"
 )
 
@@ -70,19 +71,10 @@ func (opts *RemoveOptions) Pre(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("either specify an image name, or use the --all flag")
 	}
 
-	opts.Metro = cmd.Flag("metro").Value.String()
-	if opts.Metro == "" {
-		return fmt.Errorf("kraftcloud metro is unset")
+	err := utils.PopulateMetroToken(cmd, &opts.Metro, &opts.Token)
+	if err != nil {
+		return fmt.Errorf("could not populate metro and token: %w", err)
 	}
-
-	log.G(cmd.Context()).WithField("metro", opts.Metro).Debug("using")
-
-	opts.Token = cmd.Flag("token").Value.String()
-	if opts.Token == "" {
-		return fmt.Errorf("kraftcloud token is unset")
-	}
-
-	log.G(cmd.Context()).WithField("token", opts.Token).Debug("using")
 
 	return nil
 }

--- a/internal/cli/kraft/cloud/img/remove/remove.go
+++ b/internal/cli/kraft/cloud/img/remove/remove.go
@@ -83,7 +83,7 @@ func (opts *RemoveOptions) Run(ctx context.Context, args []string) error {
 	var err error
 
 	if opts.Auth == nil {
-		opts.Auth, err = config.GetKraftCloudAuthConfigFromContext(ctx, opts.Token)
+		opts.Auth, err = config.GetKraftCloudAuthConfig(ctx, opts.Token)
 		if err != nil {
 			return fmt.Errorf("could not retrieve credentials: %w", err)
 		}

--- a/internal/cli/kraft/cloud/instance/create/create.go
+++ b/internal/cli/kraft/cloud/instance/create/create.go
@@ -56,7 +56,7 @@ func Create(ctx context.Context, opts *CreateOptions, args ...string) (*kraftclo
 	}
 
 	if opts.Auth == nil {
-		opts.Auth, err = config.GetKraftCloudAuthConfigFromContext(ctx, opts.Token)
+		opts.Auth, err = config.GetKraftCloudAuthConfig(ctx, opts.Token)
 		if err != nil {
 			return nil, fmt.Errorf("could not retrieve credentials: %w", err)
 		}
@@ -294,7 +294,7 @@ func NewCmd() *cobra.Command {
 				--port 443:8080/http+tls \
 				--port 80:443/http+redirect \
 				nginx:latest
-			
+
 			# Attach two existing volumes to the vm, one read-write at /data
 			# and another read-only at /config:
 			$ kraft cloud --metro fra0 instance create \

--- a/internal/cli/kraft/cloud/instance/create/create.go
+++ b/internal/cli/kraft/cloud/instance/create/create.go
@@ -324,17 +324,10 @@ func NewCmd() *cobra.Command {
 }
 
 func (opts *CreateOptions) Pre(cmd *cobra.Command, _ []string) error {
-	opts.Metro = cmd.Flag("metro").Value.String()
-	if opts.Metro == "" {
-		return fmt.Errorf("kraftcloud metro is unset")
+	err := utils.PopulateMetroToken(cmd, &opts.Metro, &opts.Token)
+	if err != nil {
+		return fmt.Errorf("could not populate metro and token: %w", err)
 	}
-
-	opts.Token = cmd.Flag("token").Value.String()
-	if opts.Token == "" {
-		return fmt.Errorf("kraftcloud token is unset")
-	}
-
-	log.G(cmd.Context()).WithField("token", opts.Token).Debug("using")
 
 	domain := cmd.Flag("domain").Value.String()
 	if len(domain) > 0 && len(opts.FQDN) > 0 {

--- a/internal/cli/kraft/cloud/instance/get/get.go
+++ b/internal/cli/kraft/cloud/instance/get/get.go
@@ -19,7 +19,6 @@ import (
 	"kraftkit.sh/cmdfactory"
 	"kraftkit.sh/config"
 	"kraftkit.sh/internal/cli/kraft/cloud/utils"
-	"kraftkit.sh/log"
 )
 
 type GetOptions struct {
@@ -66,18 +65,10 @@ func NewCmd() *cobra.Command {
 }
 
 func (opts *GetOptions) Pre(cmd *cobra.Command, _ []string) error {
-	opts.metro = cmd.Flag("metro").Value.String()
-	if opts.metro == "" {
-		return fmt.Errorf("kraftcloud metro is unset")
+	err := utils.PopulateMetroToken(cmd, &opts.metro, &opts.token)
+	if err != nil {
+		return fmt.Errorf("could not populate metro and token: %w", err)
 	}
-	log.G(cmd.Context()).WithField("metro", opts.metro).Debug("using")
-
-	opts.token = cmd.Flag("token").Value.String()
-	if opts.token == "" {
-		return fmt.Errorf("kraftcloud token is unset")
-	}
-
-	log.G(cmd.Context()).WithField("token", opts.token).Debug("using")
 
 	return nil
 }

--- a/internal/cli/kraft/cloud/instance/get/get.go
+++ b/internal/cli/kraft/cloud/instance/get/get.go
@@ -8,7 +8,6 @@ package get
 import (
 	"context"
 	"fmt"
-	"os"
 
 	"github.com/MakeNowJust/heredoc"
 	"github.com/google/uuid"
@@ -27,6 +26,7 @@ type GetOptions struct {
 	Output string `long:"output" short:"o" usage:"Set output format. Options: table,yaml,json,list" default:"table"`
 
 	metro string
+	token string
 }
 
 // Status of a KraftCloud instance.
@@ -68,17 +68,22 @@ func NewCmd() *cobra.Command {
 func (opts *GetOptions) Pre(cmd *cobra.Command, _ []string) error {
 	opts.metro = cmd.Flag("metro").Value.String()
 	if opts.metro == "" {
-		opts.metro = os.Getenv("KRAFTCLOUD_METRO")
-	}
-	if opts.metro == "" {
 		return fmt.Errorf("kraftcloud metro is unset")
 	}
 	log.G(cmd.Context()).WithField("metro", opts.metro).Debug("using")
+
+	opts.token = cmd.Flag("token").Value.String()
+	if opts.token == "" {
+		return fmt.Errorf("kraftcloud token is unset")
+	}
+
+	log.G(cmd.Context()).WithField("token", opts.token).Debug("using")
+
 	return nil
 }
 
 func (opts *GetOptions) Run(ctx context.Context, args []string) error {
-	auth, err := config.GetKraftCloudAuthConfigFromContext(ctx)
+	auth, err := config.GetKraftCloudAuthConfigFromContext(ctx, opts.token)
 	if err != nil {
 		return fmt.Errorf("could not retrieve credentials: %w", err)
 	}

--- a/internal/cli/kraft/cloud/instance/get/get.go
+++ b/internal/cli/kraft/cloud/instance/get/get.go
@@ -74,7 +74,7 @@ func (opts *GetOptions) Pre(cmd *cobra.Command, _ []string) error {
 }
 
 func (opts *GetOptions) Run(ctx context.Context, args []string) error {
-	auth, err := config.GetKraftCloudAuthConfigFromContext(ctx, opts.token)
+	auth, err := config.GetKraftCloudAuthConfig(ctx, opts.token)
 	if err != nil {
 		return fmt.Errorf("could not retrieve credentials: %w", err)
 	}

--- a/internal/cli/kraft/cloud/instance/list/list.go
+++ b/internal/cli/kraft/cloud/instance/list/list.go
@@ -59,7 +59,7 @@ func (opts *ListOptions) Pre(cmd *cobra.Command, _ []string) error {
 }
 
 func (opts *ListOptions) Run(ctx context.Context, args []string) error {
-	auth, err := config.GetKraftCloudAuthConfigFromContext(ctx, opts.token)
+	auth, err := config.GetKraftCloudAuthConfig(ctx, opts.token)
 	if err != nil {
 		return fmt.Errorf("could not retrieve credentials: %w", err)
 	}

--- a/internal/cli/kraft/cloud/instance/list/list.go
+++ b/internal/cli/kraft/cloud/instance/list/list.go
@@ -16,7 +16,6 @@ import (
 	"kraftkit.sh/cmdfactory"
 	"kraftkit.sh/config"
 	"kraftkit.sh/internal/cli/kraft/cloud/utils"
-	"kraftkit.sh/log"
 )
 
 type ListOptions struct {
@@ -51,18 +50,10 @@ func NewCmd() *cobra.Command {
 }
 
 func (opts *ListOptions) Pre(cmd *cobra.Command, _ []string) error {
-	opts.metro = cmd.Flag("metro").Value.String()
-	if opts.metro == "" {
-		return fmt.Errorf("kraftcloud metro is unset")
+	err := utils.PopulateMetroToken(cmd, &opts.metro, &opts.token)
+	if err != nil {
+		return fmt.Errorf("could not populate metro and token: %w", err)
 	}
-	log.G(cmd.Context()).WithField("metro", opts.metro).Debug("using")
-
-	opts.token = cmd.Flag("token").Value.String()
-	if opts.token == "" {
-		return fmt.Errorf("kraftcloud token is unset")
-	}
-
-	log.G(cmd.Context()).WithField("token", opts.token).Debug("using")
 
 	return nil
 }

--- a/internal/cli/kraft/cloud/instance/list/list.go
+++ b/internal/cli/kraft/cloud/instance/list/list.go
@@ -7,7 +7,6 @@ package list
 import (
 	"context"
 	"fmt"
-	"os"
 
 	"github.com/MakeNowJust/heredoc"
 	"github.com/spf13/cobra"
@@ -24,6 +23,7 @@ type ListOptions struct {
 	Output string `long:"output" short:"o" usage:"Set output format. Options: table,yaml,json,list" default:"table"`
 
 	metro string
+	token string
 }
 
 func NewCmd() *cobra.Command {
@@ -53,17 +53,22 @@ func NewCmd() *cobra.Command {
 func (opts *ListOptions) Pre(cmd *cobra.Command, _ []string) error {
 	opts.metro = cmd.Flag("metro").Value.String()
 	if opts.metro == "" {
-		opts.metro = os.Getenv("KRAFTCLOUD_METRO")
-	}
-	if opts.metro == "" {
 		return fmt.Errorf("kraftcloud metro is unset")
 	}
 	log.G(cmd.Context()).WithField("metro", opts.metro).Debug("using")
+
+	opts.token = cmd.Flag("token").Value.String()
+	if opts.token == "" {
+		return fmt.Errorf("kraftcloud token is unset")
+	}
+
+	log.G(cmd.Context()).WithField("token", opts.token).Debug("using")
+
 	return nil
 }
 
 func (opts *ListOptions) Run(ctx context.Context, args []string) error {
-	auth, err := config.GetKraftCloudAuthConfigFromContext(ctx)
+	auth, err := config.GetKraftCloudAuthConfigFromContext(ctx, opts.token)
 	if err != nil {
 		return fmt.Errorf("could not retrieve credentials: %w", err)
 	}

--- a/internal/cli/kraft/cloud/instance/logs/logs.go
+++ b/internal/cli/kraft/cloud/instance/logs/logs.go
@@ -17,7 +17,6 @@ import (
 	"kraftkit.sh/config"
 	"kraftkit.sh/internal/cli/kraft/cloud/utils"
 	"kraftkit.sh/iostreams"
-	"kraftkit.sh/log"
 )
 
 type LogOptions struct {
@@ -64,18 +63,10 @@ func NewCmd() *cobra.Command {
 }
 
 func (opts *LogOptions) Pre(cmd *cobra.Command, _ []string) error {
-	opts.metro = cmd.Flag("metro").Value.String()
-	if opts.metro == "" {
-		return fmt.Errorf("kraftcloud metro is unset")
+	err := utils.PopulateMetroToken(cmd, &opts.metro, &opts.token)
+	if err != nil {
+		return fmt.Errorf("could not populate metro and token: %w", err)
 	}
-	log.G(cmd.Context()).WithField("metro", opts.metro).Debug("using")
-
-	opts.token = cmd.Flag("token").Value.String()
-	if opts.token == "" {
-		return fmt.Errorf("kraftcloud token is unset")
-	}
-
-	log.G(cmd.Context()).WithField("token", opts.token).Debug("using")
 
 	return nil
 }

--- a/internal/cli/kraft/cloud/instance/logs/logs.go
+++ b/internal/cli/kraft/cloud/instance/logs/logs.go
@@ -72,7 +72,7 @@ func (opts *LogOptions) Pre(cmd *cobra.Command, _ []string) error {
 }
 
 func (opts *LogOptions) Run(ctx context.Context, args []string) error {
-	auth, err := config.GetKraftCloudAuthConfigFromContext(ctx, opts.token)
+	auth, err := config.GetKraftCloudAuthConfig(ctx, opts.token)
 	if err != nil {
 		return fmt.Errorf("could not retrieve credentials: %w", err)
 	}

--- a/internal/cli/kraft/cloud/instance/logs/logs.go
+++ b/internal/cli/kraft/cloud/instance/logs/logs.go
@@ -7,7 +7,6 @@ package logs
 import (
 	"context"
 	"fmt"
-	"os"
 
 	"github.com/MakeNowJust/heredoc"
 	"github.com/spf13/cobra"
@@ -25,6 +24,7 @@ type LogOptions struct {
 	Tail int `local:"true" long:"tail" short:"n" usage:"Lines of recent logs to display" default:"-1"`
 
 	metro string
+	token string
 }
 
 // Log retrieves the console output from a KraftCloud instance.
@@ -66,17 +66,22 @@ func NewCmd() *cobra.Command {
 func (opts *LogOptions) Pre(cmd *cobra.Command, _ []string) error {
 	opts.metro = cmd.Flag("metro").Value.String()
 	if opts.metro == "" {
-		opts.metro = os.Getenv("KRAFTCLOUD_METRO")
-	}
-	if opts.metro == "" {
 		return fmt.Errorf("kraftcloud metro is unset")
 	}
 	log.G(cmd.Context()).WithField("metro", opts.metro).Debug("using")
+
+	opts.token = cmd.Flag("token").Value.String()
+	if opts.token == "" {
+		return fmt.Errorf("kraftcloud token is unset")
+	}
+
+	log.G(cmd.Context()).WithField("token", opts.token).Debug("using")
+
 	return nil
 }
 
 func (opts *LogOptions) Run(ctx context.Context, args []string) error {
-	auth, err := config.GetKraftCloudAuthConfigFromContext(ctx)
+	auth, err := config.GetKraftCloudAuthConfigFromContext(ctx, opts.token)
 	if err != nil {
 		return fmt.Errorf("could not retrieve credentials: %w", err)
 	}

--- a/internal/cli/kraft/cloud/instance/remove/remove.go
+++ b/internal/cli/kraft/cloud/instance/remove/remove.go
@@ -81,7 +81,7 @@ func (opts *RemoveOptions) Pre(cmd *cobra.Command, args []string) error {
 }
 
 func (opts *RemoveOptions) Run(ctx context.Context, args []string) error {
-	auth, err := config.GetKraftCloudAuthConfigFromContext(ctx, opts.token)
+	auth, err := config.GetKraftCloudAuthConfig(ctx, opts.token)
 	if err != nil {
 		return fmt.Errorf("could not retrieve credentials: %w", err)
 	}

--- a/internal/cli/kraft/cloud/instance/remove/remove.go
+++ b/internal/cli/kraft/cloud/instance/remove/remove.go
@@ -72,18 +72,10 @@ func (opts *RemoveOptions) Pre(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("either specify an instance name or UUID, or use the --all flag")
 	}
 
-	opts.metro = cmd.Flag("metro").Value.String()
-	if opts.metro == "" {
-		return fmt.Errorf("kraftcloud metro is unset")
+	err := utils.PopulateMetroToken(cmd, &opts.metro, &opts.token)
+	if err != nil {
+		return fmt.Errorf("could not populate metro and token: %w", err)
 	}
-	log.G(cmd.Context()).WithField("metro", opts.metro).Debug("using")
-
-	opts.token = cmd.Flag("token").Value.String()
-	if opts.token == "" {
-		return fmt.Errorf("kraftcloud token is unset")
-	}
-
-	log.G(cmd.Context()).WithField("token", opts.token).Debug("using")
 
 	return nil
 }

--- a/internal/cli/kraft/cloud/instance/remove/remove.go
+++ b/internal/cli/kraft/cloud/instance/remove/remove.go
@@ -8,7 +8,6 @@ package remove
 import (
 	"context"
 	"fmt"
-	"os"
 
 	"github.com/MakeNowJust/heredoc"
 	"github.com/spf13/cobra"
@@ -26,6 +25,7 @@ type RemoveOptions struct {
 	All    bool   `long:"all" usage:"Remove all instances"`
 
 	metro string
+	token string
 }
 
 // Remove a KraftCloud instance.
@@ -74,17 +74,22 @@ func (opts *RemoveOptions) Pre(cmd *cobra.Command, args []string) error {
 
 	opts.metro = cmd.Flag("metro").Value.String()
 	if opts.metro == "" {
-		opts.metro = os.Getenv("KRAFTCLOUD_METRO")
-	}
-	if opts.metro == "" {
 		return fmt.Errorf("kraftcloud metro is unset")
 	}
 	log.G(cmd.Context()).WithField("metro", opts.metro).Debug("using")
+
+	opts.token = cmd.Flag("token").Value.String()
+	if opts.token == "" {
+		return fmt.Errorf("kraftcloud token is unset")
+	}
+
+	log.G(cmd.Context()).WithField("token", opts.token).Debug("using")
+
 	return nil
 }
 
 func (opts *RemoveOptions) Run(ctx context.Context, args []string) error {
-	auth, err := config.GetKraftCloudAuthConfigFromContext(ctx)
+	auth, err := config.GetKraftCloudAuthConfigFromContext(ctx, opts.token)
 	if err != nil {
 		return fmt.Errorf("could not retrieve credentials: %w", err)
 	}

--- a/internal/cli/kraft/cloud/instance/start/start.go
+++ b/internal/cli/kraft/cloud/instance/start/start.go
@@ -64,18 +64,10 @@ func NewCmd() *cobra.Command {
 }
 
 func (opts *StartOptions) Pre(cmd *cobra.Command, _ []string) error {
-	opts.metro = cmd.Flag("metro").Value.String()
-	if opts.metro == "" {
-		return fmt.Errorf("kraftcloud metro is unset")
+	err := utils.PopulateMetroToken(cmd, &opts.metro, &opts.token)
+	if err != nil {
+		return fmt.Errorf("could not populate metro and token: %w", err)
 	}
-	log.G(cmd.Context()).WithField("metro", opts.metro).Debug("using")
-
-	opts.token = cmd.Flag("token").Value.String()
-	if opts.token == "" {
-		return fmt.Errorf("kraftcloud token is unset")
-	}
-
-	log.G(cmd.Context()).WithField("token", opts.token).Debug("using")
 
 	return nil
 }

--- a/internal/cli/kraft/cloud/instance/start/start.go
+++ b/internal/cli/kraft/cloud/instance/start/start.go
@@ -73,7 +73,7 @@ func (opts *StartOptions) Pre(cmd *cobra.Command, _ []string) error {
 }
 
 func (opts *StartOptions) Run(ctx context.Context, args []string) error {
-	auth, err := config.GetKraftCloudAuthConfigFromContext(ctx, opts.token)
+	auth, err := config.GetKraftCloudAuthConfig(ctx, opts.token)
 	if err != nil {
 		return fmt.Errorf("could not retrieve credentials: %w", err)
 	}

--- a/internal/cli/kraft/cloud/instance/start/start.go
+++ b/internal/cli/kraft/cloud/instance/start/start.go
@@ -7,7 +7,6 @@ package start
 import (
 	"context"
 	"fmt"
-	"os"
 
 	"github.com/MakeNowJust/heredoc"
 	"github.com/spf13/cobra"
@@ -25,6 +24,7 @@ type StartOptions struct {
 	Output        string `long:"output" short:"o" usage:"Set output format. Options: table,yaml,json,list" default:"table"`
 
 	metro string
+	token string
 }
 
 // Start a KraftCloud instance.
@@ -66,17 +66,22 @@ func NewCmd() *cobra.Command {
 func (opts *StartOptions) Pre(cmd *cobra.Command, _ []string) error {
 	opts.metro = cmd.Flag("metro").Value.String()
 	if opts.metro == "" {
-		opts.metro = os.Getenv("KRAFTCLOUD_METRO")
-	}
-	if opts.metro == "" {
 		return fmt.Errorf("kraftcloud metro is unset")
 	}
 	log.G(cmd.Context()).WithField("metro", opts.metro).Debug("using")
+
+	opts.token = cmd.Flag("token").Value.String()
+	if opts.token == "" {
+		return fmt.Errorf("kraftcloud token is unset")
+	}
+
+	log.G(cmd.Context()).WithField("token", opts.token).Debug("using")
+
 	return nil
 }
 
 func (opts *StartOptions) Run(ctx context.Context, args []string) error {
-	auth, err := config.GetKraftCloudAuthConfigFromContext(ctx)
+	auth, err := config.GetKraftCloudAuthConfigFromContext(ctx, opts.token)
 	if err != nil {
 		return fmt.Errorf("could not retrieve credentials: %w", err)
 	}

--- a/internal/cli/kraft/cloud/instance/stop/stop.go
+++ b/internal/cli/kraft/cloud/instance/stop/stop.go
@@ -78,7 +78,7 @@ func (opts *StopOptions) Pre(cmd *cobra.Command, args []string) error {
 }
 
 func (opts *StopOptions) Run(ctx context.Context, args []string) error {
-	auth, err := config.GetKraftCloudAuthConfigFromContext(ctx, opts.Token)
+	auth, err := config.GetKraftCloudAuthConfig(ctx, opts.Token)
 	if err != nil {
 		return fmt.Errorf("could not retrieve credentials: %w", err)
 	}

--- a/internal/cli/kraft/cloud/instance/stop/stop.go
+++ b/internal/cli/kraft/cloud/instance/stop/stop.go
@@ -8,7 +8,6 @@ package stop
 import (
 	"context"
 	"fmt"
-	"os"
 
 	"github.com/MakeNowJust/heredoc"
 	"github.com/spf13/cobra"
@@ -26,6 +25,7 @@ type StopOptions struct {
 	Output    string `long:"output" short:"o" usage:"Set output format. Options: table,yaml,json,list" default:"table"`
 	All       bool   `long:"all" usage:"Stop all instances"`
 	Metro     string `noattribute:"true"`
+	Token     string `noattribute:"true"`
 }
 
 // Stop a KraftCloud instance.
@@ -71,17 +71,22 @@ func (opts *StopOptions) Pre(cmd *cobra.Command, args []string) error {
 
 	opts.Metro = cmd.Flag("metro").Value.String()
 	if opts.Metro == "" {
-		opts.Metro = os.Getenv("KRAFTCLOUD_METRO")
-	}
-	if opts.Metro == "" {
 		return fmt.Errorf("kraftcloud metro is unset")
 	}
 	log.G(cmd.Context()).WithField("metro", opts.Metro).Debug("using")
+
+	opts.Token = cmd.Flag("token").Value.String()
+	if opts.Token == "" {
+		return fmt.Errorf("kraftcloud token is unset")
+	}
+
+	log.G(cmd.Context()).WithField("token", opts.Token).Debug("using")
+
 	return nil
 }
 
 func (opts *StopOptions) Run(ctx context.Context, args []string) error {
-	auth, err := config.GetKraftCloudAuthConfigFromContext(ctx)
+	auth, err := config.GetKraftCloudAuthConfigFromContext(ctx, opts.Token)
 	if err != nil {
 		return fmt.Errorf("could not retrieve credentials: %w", err)
 	}

--- a/internal/cli/kraft/cloud/instance/stop/stop.go
+++ b/internal/cli/kraft/cloud/instance/stop/stop.go
@@ -69,18 +69,10 @@ func (opts *StopOptions) Pre(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("either specify an instance UUID or --all flag")
 	}
 
-	opts.Metro = cmd.Flag("metro").Value.String()
-	if opts.Metro == "" {
-		return fmt.Errorf("kraftcloud metro is unset")
+	err := utils.PopulateMetroToken(cmd, &opts.Metro, &opts.Token)
+	if err != nil {
+		return fmt.Errorf("could not populate metro and token: %w", err)
 	}
-	log.G(cmd.Context()).WithField("metro", opts.Metro).Debug("using")
-
-	opts.Token = cmd.Flag("token").Value.String()
-	if opts.Token == "" {
-		return fmt.Errorf("kraftcloud token is unset")
-	}
-
-	log.G(cmd.Context()).WithField("token", opts.Token).Debug("using")
 
 	return nil
 }

--- a/internal/cli/kraft/cloud/quotas/quotas.go
+++ b/internal/cli/kraft/cloud/quotas/quotas.go
@@ -8,7 +8,6 @@ package quotas
 import (
 	"context"
 	"fmt"
-	"os"
 
 	"github.com/MakeNowJust/heredoc"
 	"github.com/spf13/cobra"
@@ -26,6 +25,7 @@ type QuotasOptions struct {
 	Output string `local:"true" long:"output" short:"o" usage:"Set output format. Options: table,yaml,json,list" default:"table"`
 
 	metro string
+	token string
 }
 
 func NewCmd() *cobra.Command {
@@ -58,17 +58,22 @@ func NewCmd() *cobra.Command {
 func (opts *QuotasOptions) Pre(cmd *cobra.Command, _ []string) error {
 	opts.metro = cmd.Flag("metro").Value.String()
 	if opts.metro == "" {
-		opts.metro = os.Getenv("KRAFTCLOUD_METRO")
-	}
-	if opts.metro == "" {
 		return fmt.Errorf("kraftcloud metro is unset")
 	}
 	log.G(cmd.Context()).WithField("metro", opts.metro).Debug("using")
+
+	opts.token = cmd.Flag("token").Value.String()
+	if opts.token == "" {
+		return fmt.Errorf("kraftcloud token is unset")
+	}
+
+	log.G(cmd.Context()).WithField("token", opts.token).Debug("using")
+
 	return nil
 }
 
 func (opts *QuotasOptions) Run(ctx context.Context, _ []string) error {
-	auth, err := config.GetKraftCloudAuthConfigFromContext(ctx)
+	auth, err := config.GetKraftCloudAuthConfigFromContext(ctx, opts.token)
 	if err != nil {
 		return fmt.Errorf("could not retrieve credentials: %w", err)
 	}

--- a/internal/cli/kraft/cloud/quotas/quotas.go
+++ b/internal/cli/kraft/cloud/quotas/quotas.go
@@ -64,7 +64,7 @@ func (opts *QuotasOptions) Pre(cmd *cobra.Command, _ []string) error {
 }
 
 func (opts *QuotasOptions) Run(ctx context.Context, _ []string) error {
-	auth, err := config.GetKraftCloudAuthConfigFromContext(ctx, opts.token)
+	auth, err := config.GetKraftCloudAuthConfig(ctx, opts.token)
 	if err != nil {
 		return fmt.Errorf("could not retrieve credentials: %w", err)
 	}

--- a/internal/cli/kraft/cloud/quotas/quotas.go
+++ b/internal/cli/kraft/cloud/quotas/quotas.go
@@ -15,7 +15,6 @@ import (
 	"kraftkit.sh/cmdfactory"
 	"kraftkit.sh/config"
 	"kraftkit.sh/internal/cli/kraft/cloud/utils"
-	"kraftkit.sh/log"
 
 	kraftcloud "sdk.kraft.cloud"
 )
@@ -56,18 +55,10 @@ func NewCmd() *cobra.Command {
 }
 
 func (opts *QuotasOptions) Pre(cmd *cobra.Command, _ []string) error {
-	opts.metro = cmd.Flag("metro").Value.String()
-	if opts.metro == "" {
-		return fmt.Errorf("kraftcloud metro is unset")
+	err := utils.PopulateMetroToken(cmd, &opts.metro, &opts.token)
+	if err != nil {
+		return fmt.Errorf("could not populate metro and token: %w", err)
 	}
-	log.G(cmd.Context()).WithField("metro", opts.metro).Debug("using")
-
-	opts.token = cmd.Flag("token").Value.String()
-	if opts.token == "" {
-		return fmt.Errorf("kraftcloud token is unset")
-	}
-
-	log.G(cmd.Context()).WithField("token", opts.token).Debug("using")
 
 	return nil
 }

--- a/internal/cli/kraft/cloud/scale/add/add.go
+++ b/internal/cli/kraft/cloud/scale/add/add.go
@@ -19,7 +19,6 @@ import (
 	"kraftkit.sh/cmdfactory"
 	"kraftkit.sh/config"
 	"kraftkit.sh/internal/cli/kraft/cloud/utils"
-	"kraftkit.sh/log"
 )
 
 type AddOptions struct {
@@ -72,19 +71,10 @@ func (opts *AddOptions) Pre(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("specify a configuration UUID or NAME")
 	}
 
-	opts.Metro = cmd.Flag("metro").Value.String()
-	if opts.Metro == "" {
-		return fmt.Errorf("kraftcloud metro is unset")
+	err := utils.PopulateMetroToken(cmd, &opts.Metro, &opts.Token)
+	if err != nil {
+		return fmt.Errorf("could not populate metro and token: %w", err)
 	}
-
-	log.G(cmd.Context()).WithField("metro", opts.Metro).Debug("using")
-
-	opts.Token = cmd.Flag("token").Value.String()
-	if opts.Token == "" {
-		return fmt.Errorf("kraftcloud token is unset")
-	}
-
-	log.G(cmd.Context()).WithField("token", opts.Token).Debug("using")
 
 	return nil
 }

--- a/internal/cli/kraft/cloud/scale/add/add.go
+++ b/internal/cli/kraft/cloud/scale/add/add.go
@@ -8,7 +8,6 @@ package add
 import (
 	"context"
 	"fmt"
-	"os"
 	"sort"
 
 	"github.com/MakeNowJust/heredoc"
@@ -31,6 +30,7 @@ type AddOptions struct {
 	Metro      string                `noattribute:"true"`
 	Name       string                `long:"name" short:"n" usage:"The name of the policy"`
 	Step       []string              `long:"step" short:"s" usage:"The step of the policy in the format 'LOWER_BOUND:UPPER_BOUND/ADJUSTMENT'"`
+	Token      string                `noattribute:"true"`
 }
 
 // stepFormat holds the step format of the policy for parsing.
@@ -74,13 +74,17 @@ func (opts *AddOptions) Pre(cmd *cobra.Command, args []string) error {
 
 	opts.Metro = cmd.Flag("metro").Value.String()
 	if opts.Metro == "" {
-		opts.Metro = os.Getenv("KRAFTCLOUD_METRO")
-	}
-	if opts.Metro == "" {
 		return fmt.Errorf("kraftcloud metro is unset")
 	}
 
 	log.G(cmd.Context()).WithField("metro", opts.Metro).Debug("using")
+
+	opts.Token = cmd.Flag("token").Value.String()
+	if opts.Token == "" {
+		return fmt.Errorf("kraftcloud token is unset")
+	}
+
+	log.G(cmd.Context()).WithField("token", opts.Token).Debug("using")
 
 	return nil
 }
@@ -97,7 +101,7 @@ func (opts *AddOptions) Run(ctx context.Context, args []string) error {
 	}
 
 	if opts.Auth == nil {
-		opts.Auth, err = config.GetKraftCloudAuthConfigFromContext(ctx)
+		opts.Auth, err = config.GetKraftCloudAuthConfigFromContext(ctx, opts.Token)
 		if err != nil {
 			return fmt.Errorf("could not retrieve credentials: %w", err)
 		}

--- a/internal/cli/kraft/cloud/scale/add/add.go
+++ b/internal/cli/kraft/cloud/scale/add/add.go
@@ -91,7 +91,7 @@ func (opts *AddOptions) Run(ctx context.Context, args []string) error {
 	}
 
 	if opts.Auth == nil {
-		opts.Auth, err = config.GetKraftCloudAuthConfigFromContext(ctx, opts.Token)
+		opts.Auth, err = config.GetKraftCloudAuthConfig(ctx, opts.Token)
 		if err != nil {
 			return fmt.Errorf("could not retrieve credentials: %w", err)
 		}

--- a/internal/cli/kraft/cloud/scale/get/get.go
+++ b/internal/cli/kraft/cloud/scale/get/get.go
@@ -70,19 +70,10 @@ func (opts *GetOptions) Pre(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("specify a service group NAME or UUID")
 	}
 
-	opts.Metro = cmd.Flag("metro").Value.String()
-	if opts.Metro == "" {
-		return fmt.Errorf("kraftcloud metro is unset")
+	err := utils.PopulateMetroToken(cmd, &opts.Metro, &opts.Token)
+	if err != nil {
+		return fmt.Errorf("could not populate metro and token: %w", err)
 	}
-
-	log.G(cmd.Context()).WithField("metro", opts.Metro).Debug("using")
-
-	opts.Token = cmd.Flag("token").Value.String()
-	if opts.Token == "" {
-		return fmt.Errorf("kraftcloud token is unset")
-	}
-
-	log.G(cmd.Context()).WithField("token", opts.Token).Debug("using")
 
 	return nil
 }

--- a/internal/cli/kraft/cloud/scale/get/get.go
+++ b/internal/cli/kraft/cloud/scale/get/get.go
@@ -9,7 +9,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"os"
 
 	"github.com/MakeNowJust/heredoc"
 	"github.com/spf13/cobra"
@@ -32,6 +31,7 @@ type GetOptions struct {
 	Metro  string                `noattribute:"true"`
 	Output string                `long:"output" short:"o" usage:"Output format" default:"list"`
 	Policy string                `long:"policy" short:"p" usage:"Get a policy instead of a configuration"`
+	Token  string                `noattribute:"true"`
 }
 
 func NewCmd() *cobra.Command {
@@ -72,13 +72,17 @@ func (opts *GetOptions) Pre(cmd *cobra.Command, args []string) error {
 
 	opts.Metro = cmd.Flag("metro").Value.String()
 	if opts.Metro == "" {
-		opts.Metro = os.Getenv("KRAFTCLOUD_METRO")
-	}
-	if opts.Metro == "" {
 		return fmt.Errorf("kraftcloud metro is unset")
 	}
 
 	log.G(cmd.Context()).WithField("metro", opts.Metro).Debug("using")
+
+	opts.Token = cmd.Flag("token").Value.String()
+	if opts.Token == "" {
+		return fmt.Errorf("kraftcloud token is unset")
+	}
+
+	log.G(cmd.Context()).WithField("token", opts.Token).Debug("using")
 
 	return nil
 }
@@ -87,7 +91,7 @@ func (opts *GetOptions) Run(ctx context.Context, args []string) error {
 	var err error
 
 	if opts.Auth == nil {
-		opts.Auth, err = config.GetKraftCloudAuthConfigFromContext(ctx)
+		opts.Auth, err = config.GetKraftCloudAuthConfigFromContext(ctx, opts.Token)
 		if err != nil {
 			return fmt.Errorf("could not retrieve credentials: %w", err)
 		}

--- a/internal/cli/kraft/cloud/scale/get/get.go
+++ b/internal/cli/kraft/cloud/scale/get/get.go
@@ -82,7 +82,7 @@ func (opts *GetOptions) Run(ctx context.Context, args []string) error {
 	var err error
 
 	if opts.Auth == nil {
-		opts.Auth, err = config.GetKraftCloudAuthConfigFromContext(ctx, opts.Token)
+		opts.Auth, err = config.GetKraftCloudAuthConfig(ctx, opts.Token)
 		if err != nil {
 			return fmt.Errorf("could not retrieve credentials: %w", err)
 		}

--- a/internal/cli/kraft/cloud/scale/initialize/initialize.go
+++ b/internal/cli/kraft/cloud/scale/initialize/initialize.go
@@ -79,7 +79,7 @@ func (opts *InitOptions) Run(ctx context.Context, args []string) error {
 	var err error
 
 	if opts.Auth == nil {
-		opts.Auth, err = config.GetKraftCloudAuthConfigFromContext(ctx, opts.Token)
+		opts.Auth, err = config.GetKraftCloudAuthConfig(ctx, opts.Token)
 		if err != nil {
 			return fmt.Errorf("could not retrieve credentials: %w", err)
 		}

--- a/internal/cli/kraft/cloud/scale/initialize/initialize.go
+++ b/internal/cli/kraft/cloud/scale/initialize/initialize.go
@@ -20,7 +20,6 @@ import (
 	"kraftkit.sh/cmdfactory"
 	"kraftkit.sh/config"
 	"kraftkit.sh/internal/cli/kraft/cloud/utils"
-	"kraftkit.sh/log"
 	"kraftkit.sh/tui/selection"
 )
 
@@ -68,19 +67,10 @@ func (opts *InitOptions) Pre(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("specify a service group name or UUID")
 	}
 
-	opts.Metro = cmd.Flag("metro").Value.String()
-	if opts.Metro == "" {
-		return fmt.Errorf("kraftcloud metro is unset")
+	err := utils.PopulateMetroToken(cmd, &opts.Metro, &opts.Token)
+	if err != nil {
+		return fmt.Errorf("could not populate metro and token: %w", err)
 	}
-
-	log.G(cmd.Context()).WithField("metro", opts.Metro).Debug("using")
-
-	opts.Token = cmd.Flag("token").Value.String()
-	if opts.Token == "" {
-		return fmt.Errorf("kraftcloud token is unset")
-	}
-
-	log.G(cmd.Context()).WithField("token", opts.Token).Debug("using")
 
 	return nil
 }

--- a/internal/cli/kraft/cloud/scale/initialize/initialize.go
+++ b/internal/cli/kraft/cloud/scale/initialize/initialize.go
@@ -8,7 +8,6 @@ package initialize
 import (
 	"context"
 	"fmt"
-	"os"
 	"time"
 
 	"github.com/MakeNowJust/heredoc"
@@ -33,6 +32,7 @@ type InitOptions struct {
 	MaxSize      uint                  `long:"max-size" short:"M" usage:"The maximum size of the configuration" default:"10"`
 	Metro        string                `noattribute:"true"`
 	MinSize      uint                  `long:"min-size" short:"m" usage:"The minimum size of the configuration"`
+	Token        string                `noattribute:"true"`
 	WarmupTime   time.Duration         `long:"warmup-time" short:"w" usage:"The warmup time of the config (ms/s/m/h)" default:"1000000000"`
 }
 
@@ -70,13 +70,17 @@ func (opts *InitOptions) Pre(cmd *cobra.Command, args []string) error {
 
 	opts.Metro = cmd.Flag("metro").Value.String()
 	if opts.Metro == "" {
-		opts.Metro = os.Getenv("KRAFTCLOUD_METRO")
-	}
-	if opts.Metro == "" {
 		return fmt.Errorf("kraftcloud metro is unset")
 	}
 
 	log.G(cmd.Context()).WithField("metro", opts.Metro).Debug("using")
+
+	opts.Token = cmd.Flag("token").Value.String()
+	if opts.Token == "" {
+		return fmt.Errorf("kraftcloud token is unset")
+	}
+
+	log.G(cmd.Context()).WithField("token", opts.Token).Debug("using")
 
 	return nil
 }
@@ -85,7 +89,7 @@ func (opts *InitOptions) Run(ctx context.Context, args []string) error {
 	var err error
 
 	if opts.Auth == nil {
-		opts.Auth, err = config.GetKraftCloudAuthConfigFromContext(ctx)
+		opts.Auth, err = config.GetKraftCloudAuthConfigFromContext(ctx, opts.Token)
 		if err != nil {
 			return fmt.Errorf("could not retrieve credentials: %w", err)
 		}

--- a/internal/cli/kraft/cloud/scale/remove/remove.go
+++ b/internal/cli/kraft/cloud/scale/remove/remove.go
@@ -73,7 +73,7 @@ func (opts *RemoveOptions) Run(ctx context.Context, args []string) error {
 	}
 
 	if opts.Auth == nil {
-		opts.Auth, err = config.GetKraftCloudAuthConfigFromContext(ctx, opts.Token)
+		opts.Auth, err = config.GetKraftCloudAuthConfig(ctx, opts.Token)
 		if err != nil {
 			return fmt.Errorf("could not retrieve credentials: %w", err)
 		}

--- a/internal/cli/kraft/cloud/scale/remove/remove.go
+++ b/internal/cli/kraft/cloud/scale/remove/remove.go
@@ -18,7 +18,6 @@ import (
 	"kraftkit.sh/cmdfactory"
 	"kraftkit.sh/config"
 	"kraftkit.sh/internal/cli/kraft/cloud/utils"
-	"kraftkit.sh/log"
 )
 
 type RemoveOptions struct {
@@ -58,19 +57,10 @@ func (opts *RemoveOptions) Pre(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("specify service group UUID and policy name")
 	}
 
-	opts.Metro = cmd.Flag("metro").Value.String()
-	if opts.Metro == "" {
-		return fmt.Errorf("kraftcloud metro is unset")
+	err := utils.PopulateMetroToken(cmd, &opts.Metro, &opts.Token)
+	if err != nil {
+		return fmt.Errorf("could not populate metro and token: %w", err)
 	}
-
-	log.G(cmd.Context()).WithField("metro", opts.Metro).Debug("using")
-
-	opts.Token = cmd.Flag("token").Value.String()
-	if opts.Token == "" {
-		return fmt.Errorf("kraftcloud token is unset")
-	}
-
-	log.G(cmd.Context()).WithField("token", opts.Token).Debug("using")
 
 	return nil
 }

--- a/internal/cli/kraft/cloud/scale/remove/remove.go
+++ b/internal/cli/kraft/cloud/scale/remove/remove.go
@@ -8,7 +8,6 @@ package remove
 import (
 	"context"
 	"fmt"
-	"os"
 
 	"github.com/MakeNowJust/heredoc"
 	"github.com/spf13/cobra"
@@ -26,6 +25,7 @@ type RemoveOptions struct {
 	Auth   *config.AuthConfig                   `noattribute:"true"`
 	Client kraftcloudautoscale.AutoscaleService `noattribute:"true"`
 	Metro  string                               `noattribute:"true"`
+	Token  string                               `noattribute:"true"`
 }
 
 func NewCmd() *cobra.Command {
@@ -60,13 +60,17 @@ func (opts *RemoveOptions) Pre(cmd *cobra.Command, args []string) error {
 
 	opts.Metro = cmd.Flag("metro").Value.String()
 	if opts.Metro == "" {
-		opts.Metro = os.Getenv("KRAFTCLOUD_METRO")
-	}
-	if opts.Metro == "" {
 		return fmt.Errorf("kraftcloud metro is unset")
 	}
 
 	log.G(cmd.Context()).WithField("metro", opts.Metro).Debug("using")
+
+	opts.Token = cmd.Flag("token").Value.String()
+	if opts.Token == "" {
+		return fmt.Errorf("kraftcloud token is unset")
+	}
+
+	log.G(cmd.Context()).WithField("token", opts.Token).Debug("using")
 
 	return nil
 }
@@ -79,7 +83,7 @@ func (opts *RemoveOptions) Run(ctx context.Context, args []string) error {
 	}
 
 	if opts.Auth == nil {
-		opts.Auth, err = config.GetKraftCloudAuthConfigFromContext(ctx)
+		opts.Auth, err = config.GetKraftCloudAuthConfigFromContext(ctx, opts.Token)
 		if err != nil {
 			return fmt.Errorf("could not retrieve credentials: %w", err)
 		}

--- a/internal/cli/kraft/cloud/scale/reset/reset.go
+++ b/internal/cli/kraft/cloud/scale/reset/reset.go
@@ -18,7 +18,6 @@ import (
 	"kraftkit.sh/cmdfactory"
 	"kraftkit.sh/config"
 	"kraftkit.sh/internal/cli/kraft/cloud/utils"
-	"kraftkit.sh/log"
 )
 
 type ResetOptions struct {
@@ -58,19 +57,10 @@ func (opts *ResetOptions) Pre(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("specify a service group name or UUID")
 	}
 
-	opts.Metro = cmd.Flag("metro").Value.String()
-	if opts.Metro == "" {
-		return fmt.Errorf("kraftcloud metro is unset")
+	err := utils.PopulateMetroToken(cmd, &opts.Metro, &opts.Token)
+	if err != nil {
+		return fmt.Errorf("could not populate metro and token: %w", err)
 	}
-
-	log.G(cmd.Context()).WithField("metro", opts.Metro).Debug("using")
-
-	opts.Token = cmd.Flag("token").Value.String()
-	if opts.Token == "" {
-		return fmt.Errorf("kraftcloud token is unset")
-	}
-
-	log.G(cmd.Context()).WithField("token", opts.Token).Debug("using")
 
 	return nil
 }

--- a/internal/cli/kraft/cloud/scale/reset/reset.go
+++ b/internal/cli/kraft/cloud/scale/reset/reset.go
@@ -69,7 +69,7 @@ func (opts *ResetOptions) Run(ctx context.Context, args []string) error {
 	var err error
 
 	if opts.Auth == nil {
-		opts.Auth, err = config.GetKraftCloudAuthConfigFromContext(ctx, opts.Token)
+		opts.Auth, err = config.GetKraftCloudAuthConfig(ctx, opts.Token)
 		if err != nil {
 			return fmt.Errorf("could not retrieve credentials: %w", err)
 		}

--- a/internal/cli/kraft/cloud/scale/reset/reset.go
+++ b/internal/cli/kraft/cloud/scale/reset/reset.go
@@ -8,7 +8,6 @@ package reset
 import (
 	"context"
 	"fmt"
-	"os"
 
 	"github.com/MakeNowJust/heredoc"
 	"github.com/spf13/cobra"
@@ -26,6 +25,7 @@ type ResetOptions struct {
 	Auth   *config.AuthConfig                   `noattribute:"true"`
 	Client kraftcloudautoscale.AutoscaleService `noattribute:"true"`
 	Metro  string                               `noattribute:"true"`
+	Token  string                               `noattribute:"true"`
 }
 
 func NewCmd() *cobra.Command {
@@ -60,13 +60,17 @@ func (opts *ResetOptions) Pre(cmd *cobra.Command, args []string) error {
 
 	opts.Metro = cmd.Flag("metro").Value.String()
 	if opts.Metro == "" {
-		opts.Metro = os.Getenv("KRAFTCLOUD_METRO")
-	}
-	if opts.Metro == "" {
 		return fmt.Errorf("kraftcloud metro is unset")
 	}
 
 	log.G(cmd.Context()).WithField("metro", opts.Metro).Debug("using")
+
+	opts.Token = cmd.Flag("token").Value.String()
+	if opts.Token == "" {
+		return fmt.Errorf("kraftcloud token is unset")
+	}
+
+	log.G(cmd.Context()).WithField("token", opts.Token).Debug("using")
 
 	return nil
 }
@@ -75,7 +79,7 @@ func (opts *ResetOptions) Run(ctx context.Context, args []string) error {
 	var err error
 
 	if opts.Auth == nil {
-		opts.Auth, err = config.GetKraftCloudAuthConfigFromContext(ctx)
+		opts.Auth, err = config.GetKraftCloudAuthConfigFromContext(ctx, opts.Token)
 		if err != nil {
 			return fmt.Errorf("could not retrieve credentials: %w", err)
 		}

--- a/internal/cli/kraft/cloud/service/create/create.go
+++ b/internal/cli/kraft/cloud/service/create/create.go
@@ -21,7 +21,6 @@ import (
 	"kraftkit.sh/cmdfactory"
 	"kraftkit.sh/config"
 	"kraftkit.sh/internal/cli/kraft/cloud/utils"
-	"kraftkit.sh/log"
 )
 
 type CreateOptions struct {
@@ -190,19 +189,10 @@ func NewCmd() *cobra.Command {
 }
 
 func (opts *CreateOptions) Pre(cmd *cobra.Command, _ []string) error {
-	opts.Metro = cmd.Flag("metro").Value.String()
-
-	if opts.Metro == "" {
-		return fmt.Errorf("kraftcloud metro is unset")
+	err := utils.PopulateMetroToken(cmd, &opts.Metro, &opts.Token)
+	if err != nil {
+		return fmt.Errorf("could not populate metro and token: %w", err)
 	}
-	log.G(cmd.Context()).WithField("metro", opts.Metro).Debug("using")
-
-	opts.Token = cmd.Flag("token").Value.String()
-	if opts.Token == "" {
-		return fmt.Errorf("kraftcloud token is unset")
-	}
-
-	log.G(cmd.Context()).WithField("token", opts.Token).Debug("using")
 
 	domain := cmd.Flag("domain").Value.String()
 	if len(domain) > 0 && len(opts.FQDN) > 0 {

--- a/internal/cli/kraft/cloud/service/create/create.go
+++ b/internal/cli/kraft/cloud/service/create/create.go
@@ -47,7 +47,7 @@ func Create(ctx context.Context, opts *CreateOptions, args ...string) (*kraftclo
 	}
 
 	if opts.Auth == nil {
-		opts.Auth, err = config.GetKraftCloudAuthConfigFromContext(ctx, opts.Token)
+		opts.Auth, err = config.GetKraftCloudAuthConfig(ctx, opts.Token)
 		if err != nil {
 			return nil, fmt.Errorf("could not retrieve credentials: %w", err)
 		}

--- a/internal/cli/kraft/cloud/service/get/get.go
+++ b/internal/cli/kraft/cloud/service/get/get.go
@@ -71,7 +71,7 @@ func (opts *GetOptions) Pre(cmd *cobra.Command, _ []string) error {
 }
 
 func (opts *GetOptions) Run(ctx context.Context, args []string) error {
-	auth, err := config.GetKraftCloudAuthConfigFromContext(ctx, opts.token)
+	auth, err := config.GetKraftCloudAuthConfig(ctx, opts.token)
 	if err != nil {
 		return fmt.Errorf("could not retrieve credentials: %w", err)
 	}

--- a/internal/cli/kraft/cloud/service/get/get.go
+++ b/internal/cli/kraft/cloud/service/get/get.go
@@ -8,7 +8,6 @@ package get
 import (
 	"context"
 	"fmt"
-	"os"
 
 	"github.com/MakeNowJust/heredoc"
 	"github.com/google/uuid"
@@ -27,6 +26,7 @@ type GetOptions struct {
 	Output string `long:"output" short:"o" usage:"Set output format. Options: table,yaml,json,list" default:"table"`
 
 	metro string
+	token string
 }
 
 // State of a KraftCloud instance.
@@ -65,17 +65,22 @@ func NewCmd() *cobra.Command {
 func (opts *GetOptions) Pre(cmd *cobra.Command, _ []string) error {
 	opts.metro = cmd.Flag("metro").Value.String()
 	if opts.metro == "" {
-		opts.metro = os.Getenv("KRAFTCLOUD_METRO")
-	}
-	if opts.metro == "" {
 		return fmt.Errorf("kraftcloud metro is unset")
 	}
 	log.G(cmd.Context()).WithField("metro", opts.metro).Debug("using")
+
+	opts.token = cmd.Flag("token").Value.String()
+	if opts.token == "" {
+		return fmt.Errorf("kraftcloud token is unset")
+	}
+
+	log.G(cmd.Context()).WithField("token", opts.token).Debug("using")
+
 	return nil
 }
 
 func (opts *GetOptions) Run(ctx context.Context, args []string) error {
-	auth, err := config.GetKraftCloudAuthConfigFromContext(ctx)
+	auth, err := config.GetKraftCloudAuthConfigFromContext(ctx, opts.token)
 	if err != nil {
 		return fmt.Errorf("could not retrieve credentials: %w", err)
 	}

--- a/internal/cli/kraft/cloud/service/get/get.go
+++ b/internal/cli/kraft/cloud/service/get/get.go
@@ -19,7 +19,6 @@ import (
 	"kraftkit.sh/cmdfactory"
 	"kraftkit.sh/config"
 	"kraftkit.sh/internal/cli/kraft/cloud/utils"
-	"kraftkit.sh/log"
 )
 
 type GetOptions struct {
@@ -63,18 +62,10 @@ func NewCmd() *cobra.Command {
 }
 
 func (opts *GetOptions) Pre(cmd *cobra.Command, _ []string) error {
-	opts.metro = cmd.Flag("metro").Value.String()
-	if opts.metro == "" {
-		return fmt.Errorf("kraftcloud metro is unset")
+	err := utils.PopulateMetroToken(cmd, &opts.metro, &opts.token)
+	if err != nil {
+		return fmt.Errorf("could not populate metro and token: %w", err)
 	}
-	log.G(cmd.Context()).WithField("metro", opts.metro).Debug("using")
-
-	opts.token = cmd.Flag("token").Value.String()
-	if opts.token == "" {
-		return fmt.Errorf("kraftcloud token is unset")
-	}
-
-	log.G(cmd.Context()).WithField("token", opts.token).Debug("using")
 
 	return nil
 }

--- a/internal/cli/kraft/cloud/service/list/list.go
+++ b/internal/cli/kraft/cloud/service/list/list.go
@@ -8,7 +8,6 @@ package list
 import (
 	"context"
 	"fmt"
-	"os"
 
 	"github.com/MakeNowJust/heredoc"
 	"github.com/spf13/cobra"
@@ -26,6 +25,7 @@ type ListOptions struct {
 	Watch  bool   `long:"watch" short:"w" usage:"After listing watch for changes."`
 
 	metro string
+	token string
 }
 
 func NewCmd() *cobra.Command {
@@ -61,17 +61,22 @@ func NewCmd() *cobra.Command {
 func (opts *ListOptions) Pre(cmd *cobra.Command, _ []string) error {
 	opts.metro = cmd.Flag("metro").Value.String()
 	if opts.metro == "" {
-		opts.metro = os.Getenv("KRAFTCLOUD_METRO")
-	}
-	if opts.metro == "" {
 		return fmt.Errorf("kraftcloud metro is unset")
 	}
 	log.G(cmd.Context()).WithField("metro", opts.metro).Debug("using")
+
+	opts.token = cmd.Flag("token").Value.String()
+	if opts.token == "" {
+		return fmt.Errorf("kraftcloud token is unset")
+	}
+
+	log.G(cmd.Context()).WithField("token", opts.token).Debug("using")
+
 	return nil
 }
 
 func (opts *ListOptions) Run(ctx context.Context, args []string) error {
-	auth, err := config.GetKraftCloudAuthConfigFromContext(ctx)
+	auth, err := config.GetKraftCloudAuthConfigFromContext(ctx, opts.token)
 	if err != nil {
 		return fmt.Errorf("could not retrieve credentials: %w", err)
 	}

--- a/internal/cli/kraft/cloud/service/list/list.go
+++ b/internal/cli/kraft/cloud/service/list/list.go
@@ -67,7 +67,7 @@ func (opts *ListOptions) Pre(cmd *cobra.Command, _ []string) error {
 }
 
 func (opts *ListOptions) Run(ctx context.Context, args []string) error {
-	auth, err := config.GetKraftCloudAuthConfigFromContext(ctx, opts.token)
+	auth, err := config.GetKraftCloudAuthConfig(ctx, opts.token)
 	if err != nil {
 		return fmt.Errorf("could not retrieve credentials: %w", err)
 	}

--- a/internal/cli/kraft/cloud/service/list/list.go
+++ b/internal/cli/kraft/cloud/service/list/list.go
@@ -17,7 +17,6 @@ import (
 	"kraftkit.sh/cmdfactory"
 	"kraftkit.sh/config"
 	"kraftkit.sh/internal/cli/kraft/cloud/utils"
-	"kraftkit.sh/log"
 )
 
 type ListOptions struct {
@@ -59,18 +58,10 @@ func NewCmd() *cobra.Command {
 }
 
 func (opts *ListOptions) Pre(cmd *cobra.Command, _ []string) error {
-	opts.metro = cmd.Flag("metro").Value.String()
-	if opts.metro == "" {
-		return fmt.Errorf("kraftcloud metro is unset")
+	err := utils.PopulateMetroToken(cmd, &opts.metro, &opts.token)
+	if err != nil {
+		return fmt.Errorf("could not populate metro and token: %w", err)
 	}
-	log.G(cmd.Context()).WithField("metro", opts.metro).Debug("using")
-
-	opts.token = cmd.Flag("token").Value.String()
-	if opts.token == "" {
-		return fmt.Errorf("kraftcloud token is unset")
-	}
-
-	log.G(cmd.Context()).WithField("token", opts.token).Debug("using")
 
 	return nil
 }

--- a/internal/cli/kraft/cloud/service/remove/remove.go
+++ b/internal/cli/kraft/cloud/service/remove/remove.go
@@ -8,7 +8,6 @@ package remove
 import (
 	"context"
 	"fmt"
-	"os"
 
 	"github.com/MakeNowJust/heredoc"
 	"github.com/spf13/cobra"
@@ -27,6 +26,7 @@ type RemoveOptions struct {
 	Auth   *config.AuthConfig                 `noattribute:"true"`
 	Client kraftcloudservices.ServicesService `noattribute:"true"`
 	Metro  string                             `noattribute:"true"`
+	Token  string                             `noattribute:"true"`
 }
 
 func NewCmd() *cobra.Command {
@@ -64,9 +64,6 @@ func (opts *RemoveOptions) Pre(cmd *cobra.Command, args []string) error {
 
 	opts.Metro = cmd.Flag("metro").Value.String()
 	if opts.Metro == "" {
-		opts.Metro = os.Getenv("KRAFTCLOUD_METRO")
-	}
-	if opts.Metro == "" {
 		return fmt.Errorf("kraftcloud metro is unset")
 	}
 
@@ -79,7 +76,7 @@ func (opts *RemoveOptions) Run(ctx context.Context, args []string) error {
 	var err error
 
 	if opts.Auth == nil {
-		opts.Auth, err = config.GetKraftCloudAuthConfigFromContext(ctx)
+		opts.Auth, err = config.GetKraftCloudAuthConfigFromContext(ctx, opts.Token)
 		if err != nil {
 			return fmt.Errorf("could not retrieve credentials: %w", err)
 		}

--- a/internal/cli/kraft/cloud/service/remove/remove.go
+++ b/internal/cli/kraft/cloud/service/remove/remove.go
@@ -74,7 +74,7 @@ func (opts *RemoveOptions) Run(ctx context.Context, args []string) error {
 	var err error
 
 	if opts.Auth == nil {
-		opts.Auth, err = config.GetKraftCloudAuthConfigFromContext(ctx, opts.Token)
+		opts.Auth, err = config.GetKraftCloudAuthConfig(ctx, opts.Token)
 		if err != nil {
 			return fmt.Errorf("could not retrieve credentials: %w", err)
 		}

--- a/internal/cli/kraft/cloud/service/remove/remove.go
+++ b/internal/cli/kraft/cloud/service/remove/remove.go
@@ -62,12 +62,10 @@ func (opts *RemoveOptions) Pre(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("either specify an instance name or UUID, or use the --all flag")
 	}
 
-	opts.Metro = cmd.Flag("metro").Value.String()
-	if opts.Metro == "" {
-		return fmt.Errorf("kraftcloud metro is unset")
+	err := utils.PopulateMetroToken(cmd, &opts.Metro, &opts.Token)
+	if err != nil {
+		return fmt.Errorf("could not populate metro and token: %w", err)
 	}
-
-	log.G(cmd.Context()).WithField("metro", opts.Metro).Debug("using")
 
 	return nil
 }

--- a/internal/cli/kraft/cloud/utils/populate_flags.go
+++ b/internal/cli/kraft/cloud/utils/populate_flags.go
@@ -1,0 +1,26 @@
+package utils
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"kraftkit.sh/log"
+)
+
+func PopulateMetroToken(cmd *cobra.Command, metro, token *string) error {
+	*metro = cmd.Flag("metro").Value.String()
+	if *metro == "" {
+		return fmt.Errorf("kraftcloud metro is unset")
+	}
+
+	log.G(cmd.Context()).WithField("metro", *metro).Debug("using")
+
+	*token = cmd.Flag("token").Value.String()
+	if *token == "" {
+		return fmt.Errorf("kraftcloud token is unset")
+	}
+
+	log.G(cmd.Context()).WithField("token", *token).Debug("using")
+
+	return nil
+}

--- a/internal/cli/kraft/cloud/volume/attach/attach.go
+++ b/internal/cli/kraft/cloud/volume/attach/attach.go
@@ -48,7 +48,7 @@ func Attach(ctx context.Context, opts *AttachOptions, args ...string) (*kraftclo
 	}
 
 	if opts.Auth == nil {
-		opts.Auth, err = config.GetKraftCloudAuthConfigFromContext(ctx, opts.token)
+		opts.Auth, err = config.GetKraftCloudAuthConfig(ctx, opts.token)
 		if err != nil {
 			return nil, fmt.Errorf("could not retrieve credentials: %w", err)
 		}

--- a/internal/cli/kraft/cloud/volume/attach/attach.go
+++ b/internal/cli/kraft/cloud/volume/attach/attach.go
@@ -8,7 +8,6 @@ package attach
 import (
 	"context"
 	"fmt"
-	"os"
 
 	"github.com/MakeNowJust/heredoc"
 	"github.com/spf13/cobra"
@@ -30,6 +29,7 @@ type AttachOptions struct {
 	To     string                           `long:"to" usage:"The instance the volume should be attached to"`
 
 	metro string
+	token string
 }
 
 // Attach a KraftCloud persistent volume to an instance.
@@ -49,7 +49,7 @@ func Attach(ctx context.Context, opts *AttachOptions, args ...string) (*kraftclo
 	}
 
 	if opts.Auth == nil {
-		opts.Auth, err = config.GetKraftCloudAuthConfigFromContext(ctx)
+		opts.Auth, err = config.GetKraftCloudAuthConfigFromContext(ctx, opts.token)
 		if err != nil {
 			return nil, fmt.Errorf("could not retrieve credentials: %w", err)
 		}
@@ -96,13 +96,17 @@ func NewCmd() *cobra.Command {
 func (opts *AttachOptions) Pre(cmd *cobra.Command, _ []string) error {
 	opts.metro = cmd.Flag("metro").Value.String()
 	if opts.metro == "" {
-		opts.metro = os.Getenv("KRAFTCLOUD_METRO")
-	}
-	if opts.metro == "" {
 		return fmt.Errorf("kraftcloud metro is unset")
 	}
 
 	log.G(cmd.Context()).WithField("metro", opts.metro).Debug("using")
+
+	opts.token = cmd.Flag("token").Value.String()
+	if opts.token == "" {
+		return fmt.Errorf("kraftcloud token is unset")
+	}
+
+	log.G(cmd.Context()).WithField("token", opts.token).Debug("using")
 	return nil
 }
 

--- a/internal/cli/kraft/cloud/volume/attach/attach.go
+++ b/internal/cli/kraft/cloud/volume/attach/attach.go
@@ -19,7 +19,6 @@ import (
 	"kraftkit.sh/config"
 	"kraftkit.sh/internal/cli/kraft/cloud/utils"
 	"kraftkit.sh/iostreams"
-	"kraftkit.sh/log"
 )
 
 type AttachOptions struct {
@@ -94,19 +93,11 @@ func NewCmd() *cobra.Command {
 }
 
 func (opts *AttachOptions) Pre(cmd *cobra.Command, _ []string) error {
-	opts.metro = cmd.Flag("metro").Value.String()
-	if opts.metro == "" {
-		return fmt.Errorf("kraftcloud metro is unset")
+	err := utils.PopulateMetroToken(cmd, &opts.metro, &opts.token)
+	if err != nil {
+		return fmt.Errorf("could not populate metro and token: %w", err)
 	}
 
-	log.G(cmd.Context()).WithField("metro", opts.metro).Debug("using")
-
-	opts.token = cmd.Flag("token").Value.String()
-	if opts.token == "" {
-		return fmt.Errorf("kraftcloud token is unset")
-	}
-
-	log.G(cmd.Context()).WithField("token", opts.token).Debug("using")
 	return nil
 }
 

--- a/internal/cli/kraft/cloud/volume/create/create.go
+++ b/internal/cli/kraft/cloud/volume/create/create.go
@@ -8,7 +8,6 @@ package create
 import (
 	"context"
 	"fmt"
-	"os"
 
 	"github.com/MakeNowJust/heredoc"
 	"github.com/spf13/cobra"
@@ -28,6 +27,7 @@ type CreateOptions struct {
 	Metro  string                           `noattribute:"true"`
 	Name   string                           `local:"true" size:"name" short:"n"`
 	SizeMB int                              `local:"true" long:"size" short:"s" usage:"Size in MB"`
+	Token  string                           `noattribute:"true"`
 }
 
 // Create a KraftCloud persistent volume.
@@ -39,7 +39,7 @@ func Create(ctx context.Context, opts *CreateOptions, args ...string) (*kraftclo
 	}
 
 	if opts.Auth == nil {
-		opts.Auth, err = config.GetKraftCloudAuthConfigFromContext(ctx)
+		opts.Auth, err = config.GetKraftCloudAuthConfigFromContext(ctx, opts.Token)
 		if err != nil {
 			return nil, fmt.Errorf("could not retrieve credentials: %w", err)
 		}
@@ -85,13 +85,18 @@ func (opts *CreateOptions) Pre(cmd *cobra.Command, _ []string) error {
 
 	opts.Metro = cmd.Flag("metro").Value.String()
 	if opts.Metro == "" {
-		opts.Metro = os.Getenv("KRAFTCLOUD_METRO")
-	}
-	if opts.Metro == "" {
 		return fmt.Errorf("kraftcloud metro is unset")
 	}
 
 	log.G(cmd.Context()).WithField("metro", opts.Metro).Debug("using")
+
+	opts.Token = cmd.Flag("token").Value.String()
+	if opts.Token == "" {
+		return fmt.Errorf("kraftcloud token is unset")
+	}
+
+	log.G(cmd.Context()).WithField("token", opts.Token).Debug("using")
+
 	return nil
 }
 

--- a/internal/cli/kraft/cloud/volume/create/create.go
+++ b/internal/cli/kraft/cloud/volume/create/create.go
@@ -17,8 +17,8 @@ import (
 
 	"kraftkit.sh/cmdfactory"
 	"kraftkit.sh/config"
+	"kraftkit.sh/internal/cli/kraft/cloud/utils"
 	"kraftkit.sh/iostreams"
-	"kraftkit.sh/log"
 )
 
 type CreateOptions struct {
@@ -83,19 +83,10 @@ func (opts *CreateOptions) Pre(cmd *cobra.Command, _ []string) error {
 		return fmt.Errorf("must specify --size flag")
 	}
 
-	opts.Metro = cmd.Flag("metro").Value.String()
-	if opts.Metro == "" {
-		return fmt.Errorf("kraftcloud metro is unset")
+	err := utils.PopulateMetroToken(cmd, &opts.Metro, &opts.Token)
+	if err != nil {
+		return fmt.Errorf("could not populate metro and token: %w", err)
 	}
-
-	log.G(cmd.Context()).WithField("metro", opts.Metro).Debug("using")
-
-	opts.Token = cmd.Flag("token").Value.String()
-	if opts.Token == "" {
-		return fmt.Errorf("kraftcloud token is unset")
-	}
-
-	log.G(cmd.Context()).WithField("token", opts.Token).Debug("using")
 
 	return nil
 }

--- a/internal/cli/kraft/cloud/volume/create/create.go
+++ b/internal/cli/kraft/cloud/volume/create/create.go
@@ -39,7 +39,7 @@ func Create(ctx context.Context, opts *CreateOptions, args ...string) (*kraftclo
 	}
 
 	if opts.Auth == nil {
-		opts.Auth, err = config.GetKraftCloudAuthConfigFromContext(ctx, opts.Token)
+		opts.Auth, err = config.GetKraftCloudAuthConfig(ctx, opts.Token)
 		if err != nil {
 			return nil, fmt.Errorf("could not retrieve credentials: %w", err)
 		}

--- a/internal/cli/kraft/cloud/volume/detach/detach.go
+++ b/internal/cli/kraft/cloud/volume/detach/detach.go
@@ -19,7 +19,6 @@ import (
 	"kraftkit.sh/config"
 	"kraftkit.sh/internal/cli/kraft/cloud/utils"
 	"kraftkit.sh/iostreams"
-	"kraftkit.sh/log"
 )
 
 type DetachOptions struct {
@@ -53,19 +52,11 @@ func NewCmd() *cobra.Command {
 }
 
 func (opts *DetachOptions) Pre(cmd *cobra.Command, _ []string) error {
-	opts.metro = cmd.Flag("metro").Value.String()
-	if opts.metro == "" {
-		return fmt.Errorf("kraftcloud metro is unset")
+	err := utils.PopulateMetroToken(cmd, &opts.metro, &opts.token)
+	if err != nil {
+		return fmt.Errorf("could not populate metro and token: %w", err)
 	}
 
-	opts.token = cmd.Flag("token").Value.String()
-	if opts.token == "" {
-		return fmt.Errorf("kraftcloud token is unset")
-	}
-
-	log.G(cmd.Context()).WithField("token", opts.token).Debug("using")
-
-	log.G(cmd.Context()).WithField("metro", opts.metro).Debug("using")
 	return nil
 }
 

--- a/internal/cli/kraft/cloud/volume/detach/detach.go
+++ b/internal/cli/kraft/cloud/volume/detach/detach.go
@@ -64,7 +64,7 @@ func (opts *DetachOptions) Run(ctx context.Context, args []string) error {
 	var err error
 
 	if opts.Auth == nil {
-		opts.Auth, err = config.GetKraftCloudAuthConfigFromContext(ctx, opts.token)
+		opts.Auth, err = config.GetKraftCloudAuthConfig(ctx, opts.token)
 		if err != nil {
 			return fmt.Errorf("could not retrieve credentials: %w", err)
 		}

--- a/internal/cli/kraft/cloud/volume/detach/detach.go
+++ b/internal/cli/kraft/cloud/volume/detach/detach.go
@@ -8,7 +8,6 @@ package detach
 import (
 	"context"
 	"fmt"
-	"os"
 
 	"github.com/MakeNowJust/heredoc"
 	"github.com/spf13/cobra"
@@ -28,6 +27,7 @@ type DetachOptions struct {
 	Client kraftcloudvolumes.VolumesService `noattribute:"true"`
 
 	metro string
+	token string
 }
 
 func NewCmd() *cobra.Command {
@@ -55,11 +55,15 @@ func NewCmd() *cobra.Command {
 func (opts *DetachOptions) Pre(cmd *cobra.Command, _ []string) error {
 	opts.metro = cmd.Flag("metro").Value.String()
 	if opts.metro == "" {
-		opts.metro = os.Getenv("KRAFTCLOUD_METRO")
-	}
-	if opts.metro == "" {
 		return fmt.Errorf("kraftcloud metro is unset")
 	}
+
+	opts.token = cmd.Flag("token").Value.String()
+	if opts.token == "" {
+		return fmt.Errorf("kraftcloud token is unset")
+	}
+
+	log.G(cmd.Context()).WithField("token", opts.token).Debug("using")
 
 	log.G(cmd.Context()).WithField("metro", opts.metro).Debug("using")
 	return nil
@@ -69,7 +73,7 @@ func (opts *DetachOptions) Run(ctx context.Context, args []string) error {
 	var err error
 
 	if opts.Auth == nil {
-		opts.Auth, err = config.GetKraftCloudAuthConfigFromContext(ctx)
+		opts.Auth, err = config.GetKraftCloudAuthConfigFromContext(ctx, opts.token)
 		if err != nil {
 			return fmt.Errorf("could not retrieve credentials: %w", err)
 		}

--- a/internal/cli/kraft/cloud/volume/get/get.go
+++ b/internal/cli/kraft/cloud/volume/get/get.go
@@ -19,7 +19,6 @@ import (
 	"kraftkit.sh/cmdfactory"
 	"kraftkit.sh/config"
 	"kraftkit.sh/internal/cli/kraft/cloud/utils"
-	"kraftkit.sh/log"
 )
 
 type GetOptions struct {
@@ -66,18 +65,10 @@ func NewCmd() *cobra.Command {
 }
 
 func (opts *GetOptions) Pre(cmd *cobra.Command, _ []string) error {
-	opts.metro = cmd.Flag("metro").Value.String()
-	if opts.metro == "" {
-		return fmt.Errorf("kraftcloud metro is unset")
+	err := utils.PopulateMetroToken(cmd, &opts.metro, &opts.token)
+	if err != nil {
+		return fmt.Errorf("could not populate metro and token: %w", err)
 	}
-	log.G(cmd.Context()).WithField("metro", opts.metro).Debug("using")
-
-	opts.token = cmd.Flag("token").Value.String()
-	if opts.token == "" {
-		return fmt.Errorf("kraftcloud token is unset")
-	}
-
-	log.G(cmd.Context()).WithField("token", opts.token).Debug("using")
 
 	return nil
 }

--- a/internal/cli/kraft/cloud/volume/get/get.go
+++ b/internal/cli/kraft/cloud/volume/get/get.go
@@ -8,7 +8,6 @@ package get
 import (
 	"context"
 	"fmt"
-	"os"
 
 	"github.com/MakeNowJust/heredoc"
 	"github.com/google/uuid"
@@ -27,6 +26,7 @@ type GetOptions struct {
 	Output string `long:"output" short:"o" usage:"Set output format. Options: table,yaml,json,list" default:"table"`
 
 	metro string
+	token string
 }
 
 // Status of a KraftCloud instance.
@@ -68,17 +68,22 @@ func NewCmd() *cobra.Command {
 func (opts *GetOptions) Pre(cmd *cobra.Command, _ []string) error {
 	opts.metro = cmd.Flag("metro").Value.String()
 	if opts.metro == "" {
-		opts.metro = os.Getenv("KRAFTCLOUD_METRO")
-	}
-	if opts.metro == "" {
 		return fmt.Errorf("kraftcloud metro is unset")
 	}
 	log.G(cmd.Context()).WithField("metro", opts.metro).Debug("using")
+
+	opts.token = cmd.Flag("token").Value.String()
+	if opts.token == "" {
+		return fmt.Errorf("kraftcloud token is unset")
+	}
+
+	log.G(cmd.Context()).WithField("token", opts.token).Debug("using")
+
 	return nil
 }
 
 func (opts *GetOptions) Run(ctx context.Context, args []string) error {
-	auth, err := config.GetKraftCloudAuthConfigFromContext(ctx)
+	auth, err := config.GetKraftCloudAuthConfigFromContext(ctx, opts.token)
 	if err != nil {
 		return fmt.Errorf("could not retrieve credentials: %w", err)
 	}

--- a/internal/cli/kraft/cloud/volume/get/get.go
+++ b/internal/cli/kraft/cloud/volume/get/get.go
@@ -74,7 +74,7 @@ func (opts *GetOptions) Pre(cmd *cobra.Command, _ []string) error {
 }
 
 func (opts *GetOptions) Run(ctx context.Context, args []string) error {
-	auth, err := config.GetKraftCloudAuthConfigFromContext(ctx, opts.token)
+	auth, err := config.GetKraftCloudAuthConfig(ctx, opts.token)
 	if err != nil {
 		return fmt.Errorf("could not retrieve credentials: %w", err)
 	}

--- a/internal/cli/kraft/cloud/volume/list/list.go
+++ b/internal/cli/kraft/cloud/volume/list/list.go
@@ -17,7 +17,6 @@ import (
 	"kraftkit.sh/cmdfactory"
 	"kraftkit.sh/config"
 	"kraftkit.sh/internal/cli/kraft/cloud/utils"
-	"kraftkit.sh/log"
 )
 
 type ListOptions struct {
@@ -56,18 +55,10 @@ func NewCmd() *cobra.Command {
 }
 
 func (opts *ListOptions) Pre(cmd *cobra.Command, _ []string) error {
-	opts.metro = cmd.Flag("metro").Value.String()
-	if opts.metro == "" {
-		return fmt.Errorf("kraftcloud metro is unset")
+	err := utils.PopulateMetroToken(cmd, &opts.metro, &opts.token)
+	if err != nil {
+		return fmt.Errorf("could not populate metro and token: %w", err)
 	}
-	log.G(cmd.Context()).WithField("metro", opts.metro).Debug("using")
-
-	opts.token = cmd.Flag("token").Value.String()
-	if opts.token == "" {
-		return fmt.Errorf("kraftcloud token is unset")
-	}
-
-	log.G(cmd.Context()).WithField("token", opts.token).Debug("using")
 
 	return nil
 }

--- a/internal/cli/kraft/cloud/volume/list/list.go
+++ b/internal/cli/kraft/cloud/volume/list/list.go
@@ -64,7 +64,7 @@ func (opts *ListOptions) Pre(cmd *cobra.Command, _ []string) error {
 }
 
 func (opts *ListOptions) Run(ctx context.Context, args []string) error {
-	auth, err := config.GetKraftCloudAuthConfigFromContext(ctx, opts.token)
+	auth, err := config.GetKraftCloudAuthConfig(ctx, opts.token)
 	if err != nil {
 		return fmt.Errorf("could not retrieve credentials: %w", err)
 	}

--- a/internal/cli/kraft/cloud/volume/list/list.go
+++ b/internal/cli/kraft/cloud/volume/list/list.go
@@ -8,7 +8,6 @@ package list
 import (
 	"context"
 	"fmt"
-	"os"
 
 	"github.com/MakeNowJust/heredoc"
 	"github.com/spf13/cobra"
@@ -26,6 +25,7 @@ type ListOptions struct {
 	Watch  bool   `long:"watch" short:"w" usage:"After listing watch for changes."`
 
 	metro string
+	token string
 }
 
 func NewCmd() *cobra.Command {
@@ -58,17 +58,22 @@ func NewCmd() *cobra.Command {
 func (opts *ListOptions) Pre(cmd *cobra.Command, _ []string) error {
 	opts.metro = cmd.Flag("metro").Value.String()
 	if opts.metro == "" {
-		opts.metro = os.Getenv("KRAFTCLOUD_METRO")
-	}
-	if opts.metro == "" {
 		return fmt.Errorf("kraftcloud metro is unset")
 	}
 	log.G(cmd.Context()).WithField("metro", opts.metro).Debug("using")
+
+	opts.token = cmd.Flag("token").Value.String()
+	if opts.token == "" {
+		return fmt.Errorf("kraftcloud token is unset")
+	}
+
+	log.G(cmd.Context()).WithField("token", opts.token).Debug("using")
+
 	return nil
 }
 
 func (opts *ListOptions) Run(ctx context.Context, args []string) error {
-	auth, err := config.GetKraftCloudAuthConfigFromContext(ctx)
+	auth, err := config.GetKraftCloudAuthConfigFromContext(ctx, opts.token)
 	if err != nil {
 		return fmt.Errorf("could not retrieve credentials: %w", err)
 	}

--- a/internal/cli/kraft/cloud/volume/remove/remove.go
+++ b/internal/cli/kraft/cloud/volume/remove/remove.go
@@ -18,7 +18,6 @@ import (
 	"kraftkit.sh/config"
 	"kraftkit.sh/internal/cli/kraft/cloud/utils"
 	"kraftkit.sh/iostreams"
-	"kraftkit.sh/log"
 )
 
 type RemoveOptions struct {
@@ -60,19 +59,10 @@ func NewCmd() *cobra.Command {
 }
 
 func (opts *RemoveOptions) Pre(cmd *cobra.Command, _ []string) error {
-	opts.metro = cmd.Flag("metro").Value.String()
-	if opts.metro == "" {
-		return fmt.Errorf("kraftcloud metro is unset")
+	err := utils.PopulateMetroToken(cmd, &opts.metro, &opts.token)
+	if err != nil {
+		return fmt.Errorf("could not populate metro and token: %w", err)
 	}
-
-	log.G(cmd.Context()).WithField("metro", opts.metro).Debug("using")
-
-	opts.token = cmd.Flag("token").Value.String()
-	if opts.token == "" {
-		return fmt.Errorf("kraftcloud token is unset")
-	}
-
-	log.G(cmd.Context()).WithField("token", opts.token).Debug("using")
 
 	return nil
 }

--- a/internal/cli/kraft/cloud/volume/remove/remove.go
+++ b/internal/cli/kraft/cloud/volume/remove/remove.go
@@ -68,7 +68,7 @@ func (opts *RemoveOptions) Pre(cmd *cobra.Command, _ []string) error {
 }
 
 func (opts *RemoveOptions) Run(ctx context.Context, args []string) error {
-	auth, err := config.GetKraftCloudAuthConfigFromContext(ctx, opts.token)
+	auth, err := config.GetKraftCloudAuthConfig(ctx, opts.token)
 	if err != nil {
 		return fmt.Errorf("could not retrieve credentials: %w", err)
 	}

--- a/internal/cli/kraft/cloud/volume/remove/remove.go
+++ b/internal/cli/kraft/cloud/volume/remove/remove.go
@@ -8,7 +8,6 @@ package remove
 import (
 	"context"
 	"fmt"
-	"os"
 
 	"github.com/MakeNowJust/heredoc"
 	"github.com/spf13/cobra"
@@ -24,6 +23,7 @@ import (
 
 type RemoveOptions struct {
 	metro string
+	token string
 }
 
 // Remove a KraftCloud persistent volume.
@@ -62,18 +62,23 @@ func NewCmd() *cobra.Command {
 func (opts *RemoveOptions) Pre(cmd *cobra.Command, _ []string) error {
 	opts.metro = cmd.Flag("metro").Value.String()
 	if opts.metro == "" {
-		opts.metro = os.Getenv("KRAFTCLOUD_METRO")
-	}
-	if opts.metro == "" {
 		return fmt.Errorf("kraftcloud metro is unset")
 	}
 
 	log.G(cmd.Context()).WithField("metro", opts.metro).Debug("using")
+
+	opts.token = cmd.Flag("token").Value.String()
+	if opts.token == "" {
+		return fmt.Errorf("kraftcloud token is unset")
+	}
+
+	log.G(cmd.Context()).WithField("token", opts.token).Debug("using")
+
 	return nil
 }
 
 func (opts *RemoveOptions) Run(ctx context.Context, args []string) error {
-	auth, err := config.GetKraftCloudAuthConfigFromContext(ctx)
+	auth, err := config.GetKraftCloudAuthConfigFromContext(ctx, opts.token)
 	if err != nil {
 		return fmt.Errorf("could not retrieve credentials: %w", err)
 	}


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [ ] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [ ] Tested your changes against relevant architectures and platforms;
  - [ ] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

Functionality was already present for `KRAFTCLOUD_METRO`. Do this also for `KRAFTCLOUD_TOKEN` and abstract to function.

Github-Fixes: #1246 