### PR TITLE
feat(create): Automatically assign subnet

### DIFF
--- a/machine/network/pool.go
+++ b/machine/network/pool.go
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2024, Unikraft GmbH and The KraftKit Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+
+package network
+
+import (
+	"fmt"
+	"net"
+
+	networkapi "kraftkit.sh/api/network/v1alpha1"
+)
+
+// NetworkPoolEntry describes a network to be used for allocating IP ranges.
+type NetworkPoolEntry struct {
+	// Subnet is the CIDR notation of the network to be sub-divided.
+	Subnet string
+	// Size is the size of the subnets to be allocated, in bits.
+	Size int
+}
+
+type NetworkPool []NetworkPoolEntry
+
+var DefaultNetworkPool = []NetworkPoolEntry{
+	{"172.17.0.0/16", 16},
+	{"172.18.0.0/16", 16},
+	{"172.19.0.0/16", 16},
+	{"172.20.0.0/14", 16},
+	{"172.24.0.0/14", 16},
+	{"172.28.0.0/14", 16},
+	{"192.168.0.0/16", 20},
+}
+
+// FindFreeNetwork finds a free network in the pool.
+func FindFreeNetwork(pool NetworkPool, existingNetworks *networkapi.NetworkList) (*net.IPNet, error) {
+	convertedNetworks := []net.IPNet{}
+
+	for _, network := range existingNetworks.Items {
+		maskBytes := net.ParseIP(network.Spec.Netmask).To4()
+		mask := net.IPv4Mask(maskBytes[0], maskBytes[1], maskBytes[2], maskBytes[3])
+		// Setup IP address for bridge.
+		convertedNetworks = append(convertedNetworks,
+			net.IPNet{
+				IP:   net.ParseIP(network.Spec.Gateway),
+				Mask: mask,
+			})
+	}
+
+	for _, poolEntry := range pool {
+		startingIP, networkToSplit, err := net.ParseCIDR(poolEntry.Subnet)
+		if err != nil {
+			return nil, err
+		}
+
+		startingIP = startingIP.To4()
+
+		// subnetIndex is an unsigned integer that is used to calculate the next
+		var subnetIndex uint32 = 0
+
+		ones, _ := networkToSplit.Mask.Size()
+		numberOfSubnets := 1 << (uint(poolEntry.Size) - uint(ones))
+
+		for range numberOfSubnets {
+			candidateIp := make([]byte, len(startingIP))
+			copy(candidateIp, startingIP)
+
+			offset := subnetIndex
+			for i := 3; i >= 0; i-- {
+				candidateIp[i] |= byte(offset & 0xff)
+				offset >>= 8
+			}
+
+			candidate := net.IPNet{
+				IP:   (net.IP)(candidateIp).To4(),
+				Mask: net.CIDRMask(poolEntry.Size, 32),
+			}
+
+			// Check if the candidate intersects with any existing network
+			intersects := false
+			for _, existing := range convertedNetworks {
+				if NetworksIntersect(existing, candidate) {
+					intersects = true
+					break
+				}
+			}
+
+			if !intersects {
+				// Increment the candidate by 1 to get the first allocatable IP
+				candidate.IP = candidate.IP.To4()
+				candidate.IP[3] = candidate.IP[3] + 1
+
+				return &candidate, nil
+			}
+
+			// Increment the candidate IP by the size of one subnetwork
+			subnetIndex = subnetIndex + (1 << (32 - poolEntry.Size))
+		}
+	}
+
+	return nil, fmt.Errorf("unable to find a free network in the network pool")
+}

--- a/machine/network/utils.go
+++ b/machine/network/utils.go
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2024, Unikraft GmbH and The KraftKit Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+
+package network
+
+import "net"
+
+// NetworksIntersect returns whether two networks have any common IP addresses.
+func NetworksIntersect(a, b net.IPNet) bool {
+	return a.Contains(b.IP) || b.Contains(a.IP)
+}


### PR DESCRIPTION


<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

This `PR` makes the ``--network`` parameter of ``kraft net create`` optional.
Finding a new subnet is achieved by searching through a predefined pool which is also [the one used in Docker](https://github.com/moby/libnetwork/blob/master/ipamutils/utils.go#L18-L20).

Throughout this pool, we search for an "aligned" subnet that does not intersect any existing subnetworks.

This could be further improved by allowing users to define their own default pool within the kraft config.


<!--
Please provide a detailed description of the changes made in this new PR.
-->
