### PR TITLE
fix: Better handling of package runtimes

### DIFF
--- a/internal/cli/kraft/run/run.go
+++ b/internal/cli/kraft/run/run.go
@@ -27,6 +27,7 @@ import (
 	"kraftkit.sh/packmanager"
 	"kraftkit.sh/tui/selection"
 	"kraftkit.sh/unikraft/arch"
+	ukarch "kraftkit.sh/unikraft/arch"
 )
 
 type RunOptions struct {
@@ -198,11 +199,19 @@ func (opts *RunOptions) discoverMachineController(ctx context.Context) error {
 
 	if opts.Platform == "" || opts.Platform == "auto" || opts.Platform == defaultPlatform.String() {
 		opts.platform = defaultPlatform
+		opts.Platform = defaultPlatform.String()
 	} else {
 		var ok bool
 		opts.platform, ok = mplatform.PlatformsByName()[opts.Platform]
 		if !ok {
 			return fmt.Errorf("unknown platform driver '%s', however your system supports '%s'", opts.Platform, defaultPlatform.String())
+		}
+	}
+
+	if opts.Architecture == "" {
+		opts.Architecture, err = ukarch.HostArchitecture()
+		if err != nil {
+			return fmt.Errorf("could not get host architecture: %w", err)
 		}
 	}
 

--- a/oci/manager.go
+++ b/oci/manager.go
@@ -80,8 +80,8 @@ func (manager *ociManager) Update(ctx context.Context) error {
 
 		log.G(ctx).Infof("saving %s", pack.String())
 
-		if _, err := pack.index.Save(ctx, pack.String(), nil); err != nil {
-			return fmt.Errorf("error saving %s: %w", pack.Name(), err)
+		if _, err := pack.index.Save(ctx, pack.imageRef(), nil); err != nil {
+			return fmt.Errorf("error saving %s: %w", pack.String(), err)
 		}
 	}
 

--- a/oci/manager.go
+++ b/oci/manager.go
@@ -564,7 +564,7 @@ searchLocalIndexes:
 
 		for oref, index := range indexes {
 			ref, err := name.ParseReference(oref,
-				name.WithDefaultRegistry(DefaultRegistry),
+				name.WithDefaultRegistry(""),
 				name.WithDefaultTag(DefaultTag),
 			)
 			if err != nil {

--- a/oci/manager.go
+++ b/oci/manager.go
@@ -385,7 +385,7 @@ func (manager *ociManager) Catalog(ctx context.Context, qopts ...packmanager.Que
 	// Adjust for the version being suffixed in a prototypical OCI reference
 	// format.
 	ref, refErr := name.ParseReference(qname,
-		name.WithDefaultRegistry(DefaultRegistry),
+		name.WithDefaultRegistry(""),
 		name.WithDefaultTag(DefaultTag),
 	)
 	if refErr == nil {
@@ -400,7 +400,7 @@ func (manager *ociManager) Catalog(ctx context.Context, qopts ...packmanager.Que
 	unsetRegistry := false
 
 	// No default registry found, re-parse with
-	if ref != nil && ref.Context().Registry.String() == "" {
+	if ref != nil && ref.Context().RegistryStr() == "" {
 		unsetRegistry = true
 		ref, refErr = name.ParseReference(qname,
 			name.WithDefaultRegistry(DefaultRegistry),

--- a/oci/manager.go
+++ b/oci/manager.go
@@ -428,7 +428,7 @@ func (manager *ociManager) Catalog(ctx context.Context, qopts ...packmanager.Que
 	}
 
 	// If a direct reference can be made, attempt to generate a package from it.
-	if query.Remote() && refErr == nil {
+	if query.Remote() && refErr == nil && !unsetRegistry {
 		authConfig := &authn.AuthConfig{}
 
 		ropts := []remote.Option{
@@ -487,9 +487,7 @@ func (manager *ociManager) Catalog(ctx context.Context, qopts ...packmanager.Que
 
 		// No need to search remote indexes by registry if the registry has been
 		// included as part of the ref.
-		if !unsetRegistry {
-			goto searchLocalIndexes
-		}
+		goto searchLocalIndexes
 	}
 
 	if query.Remote() {
@@ -549,7 +547,11 @@ resolveLocalIndex:
 			packs[checksum] = pack
 		}
 
-		goto returnPacks
+		// If the register was set, then an exact local index lookup was expected so
+		// we can return here.
+		if !unsetRegistry {
+			goto returnPacks
+		}
 	}
 
 searchLocalIndexes:

--- a/oci/pack.go
+++ b/oci/pack.go
@@ -585,7 +585,7 @@ func NewPackageFromOCIManifestDigest(ctx context.Context, handle handler.Handler
 	}
 
 	ocipack.ref, err = name.ParseReference(ref,
-		name.WithDefaultRegistry(DefaultRegistry),
+		name.WithDefaultRegistry(""),
 		name.WithDefaultTag(DefaultTag),
 	)
 	if err != nil {

--- a/oci/pack.go
+++ b/oci/pack.go
@@ -661,7 +661,7 @@ func (ocipack *ociPackage) Name() string {
 
 // Name implements fmt.Stringer
 func (ocipack *ociPackage) String() string {
-	return ocipack.imageRef()
+	return fmt.Sprintf("%s (%s/%s)", ocipack.imageRef(), ocipack.Architecture().Name(), ocipack.Platform().Name())
 }
 
 // Version implements unikraft.Nameable

--- a/oci/pack.go
+++ b/oci/pack.go
@@ -363,6 +363,9 @@ func NewPackageFromTarget(ctx context.Context, targ target.Target, opts ...packm
 		log.G(ctx).
 			Debug("including list of kconfig as features")
 
+		// Reset the list of features.
+		ocipack.manifest.config.OSFeatures = make([]string, 0)
+
 		// TODO(nderjung): Not sure if these filters are best placed here or
 		// elsewhere.
 		skippable := set.NewStringSet(


### PR DESCRIPTION
- feat(oci): Return architecture and platform as part of `String`
- fix(oci): Do not set default registry as it is used in check
- fix(oci): If a registry has been set make a direct index request
- fix(oci): The index's canonical name should be parsed as-is
- fix(oci): Include registry only when registry is part of query
- fix(oci): Reset the list of OS features if we are including new ones
- fix(oci): Instantiating digests will have correct canonical ref
- fix(run): Better handling of searching and selecting existing packages
- fix(pkg): Introduce additional resilience and user prompts

<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [ ] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [ ] Tested your changes against relevant architectures and platforms;
  - [ ] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->
