### PR TITLE
feat(cloud): default to listing only user-owned images

### DIFF
--- a/internal/cli/kraft/cloud/img/list/list.go
+++ b/internal/cli/kraft/cloud/img/list/list.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/MakeNowJust/heredoc"
 	"github.com/dustin/go-humanize"
+	gcrname "github.com/google/go-containerregistry/pkg/name"
 	"github.com/spf13/cobra"
 
 	kraftcloud "sdk.kraft.cloud"
@@ -27,7 +28,7 @@ import (
 )
 
 type ListOptions struct {
-	All    bool   `long:"all" usage:"Show all images by their digest"`
+	All    bool   `long:"all" usage:"Also show available official images"`
 	Output string `long:"output" short:"o" usage:"Set output format. Options: table,yaml,json,list" default:"table"`
 
 	metro string
@@ -47,7 +48,7 @@ func NewCmd() *cobra.Command {
 			# List images in your account.
 			$ kraft cloud image list
 
-			# List all images in your account.
+			# List images in your account along with available official images.
 			$ kraft cloud image list --all
 
 			# List all images in your account in JSON format.
@@ -120,26 +121,27 @@ func (opts *ListOptions) Run(ctx context.Context, args []string) error {
 	table.AddField("SIZE", cs.Bold)
 	table.EndRow()
 
+imgloop:
 	for _, image := range images {
-		if len(image.Tags) == 0 && !opts.All {
+		if len(image.Tags) == 0 {
 			continue
 		}
 
 		var name string
-		var versions []string
+		versions := make([]string, 0, len(image.Tags))
 
-		if opts.All {
-			split := strings.Split(image.Digest, "@sha256:")
-			name = split[0]
-			versions = append(versions, split[1])
-		}
-
-		if len(image.Tags) > 0 {
-			for _, tag := range image.Tags {
-				split := strings.Split(tag, ":")
-				name = split[0]
-				versions = append(versions, split[1])
+		for _, taggedImgRef := range image.Tags {
+			tag, err := parseTagReference(taggedImgRef)
+			if err != nil {
+				log.G(ctx).Warn("Invalid tagged image reference: ", err)
+				continue
 			}
+
+			if name = tag.RepositoryStr(); isOfficial(name) && !opts.All {
+				continue imgloop
+			}
+
+			versions = append(versions, tag.TagStr())
 		}
 
 		slices.Sort[[]string](versions)
@@ -158,4 +160,45 @@ func (opts *ListOptions) Run(ctx context.Context, args []string) error {
 	}
 
 	return table.Render(iostreams.G(ctx).Out)
+}
+
+// parseTagReference parses the given tagged image reference into a name.Tage.
+// The input is expected to be in the format "[namespace/]image:tag" without
+// the registry host.
+func parseTagReference(tref string) (gcrname.Tag, error) {
+	// Shortest possible string that can be parseable as a registry domain.
+	// https://github.com/google/go-containerregistry/blob/v0.19.0/pkg/name/repository.go#L81-L91
+	const sentinelRegHost = "::"
+
+	t, err := gcrname.NewTag(tref, gcrname.WithDefaultRegistry(sentinelRegHost))
+	if err != nil {
+		return gcrname.Tag{}, fmt.Errorf("parsing image reference: %w", err)
+	}
+
+	// Special case: the ref string is namespaced with a valid hostname,
+	// resulting in that namespace being parsed as the image's registry.
+	//
+	// Example:
+	//
+	//	(no registry/)user.unikraft.io/myapp      -> {reg:user.unikraft.io, img:myapp}
+	//	              │             └── image
+	//	              └── image namespace
+	//
+	if t.RegistryStr() != sentinelRegHost {
+		return parseTagReference(sentinelRegHost + "/" + tref)
+	}
+
+	return t, nil
+}
+
+// isOfficial naively differentiates between official and non-official images.
+func isOfficial(repo string) bool {
+	return !isNamespacedRepository(repo)
+}
+
+// isNamespacedRepository returns whether the given image repository is
+// namespaced.
+func isNamespacedRepository(repo string) bool {
+	const regNsDelimiter = '/'
+	return strings.ContainsRune(repo, regNsDelimiter)
 }


### PR DESCRIPTION
Closes #1326

```console
% kraft cloud image list --metro=fra0
NAME                                         VERSION        SIZE
felipe.unikraft.io/traefik                   latest         215 MB
felipe.unikraft.io/wasmtime-go121            latest         56 MB
felipe.unikraft.io/wazero-import-go          latest         13 MB
```
```console
% kraft cloud image list --metro=fra0 --all
NAME                                         VERSION        SIZE
felipe.unikraft.io/traefik                   latest         215 MB
felipe.unikraft.io/wasmtime-go121            latest         56 MB
felipe.unikraft.io/wazero-import-go          latest         13 MB
findtime                                     latest         22 MB
grafana                                      10.2, latest   421 MB
haproxy                                      2.8, latest    30 MB
hugo                                         0.122, latest  136 MB
imaginary                                    1.2, latest    112 MB
...
```