### PR TITLE
fix(processtree): Correct logic to determine when to show logs

### DIFF
--- a/tui/processtree/view.go
+++ b/tui/processtree/view.go
@@ -157,7 +157,7 @@ func (stm ProcessTree) printItem(pti *ProcessTreeItem, offset uint) string {
 	} else if loglen > 0 {
 		truncate = loglen
 	}
-	if pti.status == StatusRunning || ((pti.status == StatusFailed || pti.status == StatusFailedChild) && pti.hideError) {
+	if pti.status == StatusRunning || ((pti.status == StatusFailed || pti.status == StatusFailedChild) && !pti.hideError) {
 		for i, line := range pti.logs[truncate:] {
 			s += line
 			if i < len(pti.logs[truncate:]) {


### PR DESCRIPTION
The effective if-statement incorrectly hid the logs when `hideError` was set to true.