### PR TITLE
fix(run): Improve filter and selection process of potential packages

### DIFF
--- a/internal/cli/kraft/run/runner_kraftfile_runtime.go
+++ b/internal/cli/kraft/run/runner_kraftfile_runtime.go
@@ -112,7 +112,7 @@ func (runner *runnerKraftfileRuntime) Prepare(ctx context.Context, opts *RunOpti
 
 		switch {
 		case len(targets) == 0:
-			return fmt.Errorf("could not detect any project targets based on plat=\"%s\" arch=\"%s\"", opts.platform.String(), opts.Architecture)
+			return fmt.Errorf("could not detect any project targets based on %s/%s", opts.platform.String(), opts.Architecture)
 
 		case len(targets) == 1:
 			targ = targets[0]


### PR DESCRIPTION
This PR partially reworks the filtering of possible runtime packages from the given input for the Kraftfile-with-runtime context.  In this rework;

a). the initial query to the `Catalog` is wrapped in a process tree which hides the search logs from the catalog, reduding the visible output in "fancy-log" mode;
b). uses the provided CLI flags for platform and architecture later in the query process such that the option of selecting a package with alternative platform/architecture is possible.

Ultimately this PR improves the experience of running and selecting a possible runtime following a `kraft run` invocation.

