### PR TITLE
fix(run): Warn early if the requested ports are used by another machine

### DIFF
--- a/internal/cli/kraft/run/run.go
+++ b/internal/cli/kraft/run/run.go
@@ -256,6 +256,12 @@ func (opts *RunOptions) Run(ctx context.Context, args []string) error {
 		},
 	}
 
+	// Preemptively assign ports which can return early with an error if they are
+	// already in use.
+	if err := opts.assignPorts(ctx, machine); err != nil {
+		return err
+	}
+
 	var run runner
 	var errs []error
 	runners, err := runners()
@@ -328,10 +334,6 @@ func (opts *RunOptions) Run(ctx context.Context, args []string) error {
 		}
 
 		machine.Spec.Resources.Requests[corev1.ResourceMemory] = quantity
-	}
-
-	if err := opts.assignPorts(ctx, machine); err != nil {
-		return err
 	}
 
 	if err := opts.parseNetworks(ctx, machine); err != nil {

--- a/internal/cli/kraft/run/run.go
+++ b/internal/cli/kraft/run/run.go
@@ -330,7 +330,7 @@ func (opts *RunOptions) Run(ctx context.Context, args []string) error {
 		machine.Spec.Resources.Requests[corev1.ResourceMemory] = quantity
 	}
 
-	if err := opts.parsePorts(ctx, machine); err != nil {
+	if err := opts.assignPorts(ctx, machine); err != nil {
 		return err
 	}
 

--- a/internal/cli/kraft/run/utils.go
+++ b/internal/cli/kraft/run/utils.go
@@ -27,7 +27,7 @@ import (
 )
 
 // Are we publishing ports? E.g. -p/--ports=127.0.0.1:80:8080/tcp ...
-func (opts *RunOptions) parsePorts(_ context.Context, machine *machineapi.Machine) error {
+func (opts *RunOptions) assignPorts(ctx context.Context, machine *machineapi.Machine) error {
 	if len(opts.Ports) == 0 {
 		return nil
 	}


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->
