### PR TITLE
feat(kraft): Warn if the user has invoked kraft via sudo

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -20,6 +20,7 @@ type KraftKit struct {
 	NoEmojis       bool   `yaml:"no_emojis" env:"KRAFTKIT_NO_EMOJIS" long:"no-emojis" usage:"Do not use emojis in any console output" default:"true"`
 	NoCheckUpdates bool   `yaml:"no_check_updates" env:"KRAFTKIT_NO_CHECK_UPDATES" long:"no-check-updates" usage:"Do not check for updates" default:"false"`
 	NoColor        bool   `yaml:"no_color" env:"KRAFTKIT_NO_COLOR" long:"no-color" usage:"Disable color output"`
+	NoWarnSudo     bool   `yaml:"no_warn_sudo" env:"KRAFTKIT_NO_WARN_SUDO" long:"no-warn-sudo" usage:"Do not warn on running via sudo" default:"false"`
 	Editor         string `yaml:"editor" env:"KRAFTKIT_EDITOR" long:"editor" usage:"Set the text editor to open when prompt to edit a file"`
 	GitProtocol    string `yaml:"git_protocol" env:"KRAFTKIT_GIT_PROTOCOL" long:"git-protocol" usage:"Preferred Git protocol to use" default:"https"`
 	Pager          string `yaml:"pager,omitempty" env:"KRAFTKIT_PAGER" long:"pager" usage:"System pager to pipe output to" default:"cat"`

--- a/internal/cli/kraft/kraft.go
+++ b/internal/cli/kraft/kraft.go
@@ -163,6 +163,20 @@ func Main(args []string) int {
 		ctx = iostreams.WithIOStreams(ctx, copts.IOStreams)
 	}
 
+	if (os.Getenv("SUDO_UID") != "" || os.Getenv("SUDO_GID") != "" || os.Getenv("SUDO_USER") != "") && !config.G[config.KraftKit](ctx).NoWarnSudo {
+		log.G(ctx).Warn("detected invocation via sudo!")
+		log.G(ctx).Warn("")
+		log.G(ctx).Warn("mixing invocations of kraft with sudo can lead to unexpected behavior")
+		log.G(ctx).Warn("read more on how to use kraft without sudo at:")
+		log.G(ctx).Warn("")
+		log.G(ctx).Warn("\thttps://unikraft.org/sudoless")
+		log.G(ctx).Warn("")
+		log.G(ctx).Warn("to hide and ignore this warning message, set the environmental variable:")
+		log.G(ctx).Warn("")
+		log.G(ctx).Warn("\texport KRAFTKIT_NO_WARN_SUDO=1")
+		log.G(ctx).Warn("")
+	}
+
 	// Add the kraftkit version to the debug logs
 	log.G(ctx).Debugf("kraftkit %s", kitversion.Version())
 

--- a/test/e2e/framework/cmd/cmd.go
+++ b/test/e2e/framework/cmd/cmd.go
@@ -65,6 +65,7 @@ func NewKraftPrivileged(stdout, stderr *IOStream, cfgPath string) *Cmd {
 
 	var cmd *exec.Cmd
 	if usr.Uid != "0" {
+		args = append(args, "--no-warn-sudo")
 		cmd = exec.Command("sudo", args...)
 	} else {
 		cmd = exec.Command("kraft", args...)


### PR DESCRIPTION
This PR is dependent on the docs of installation process being updated to incorporate adjustments to allow for sudoless use of `kraft`.
