### PR TITLE
fix(oci): Correctly handle "fullrefs" without an identifier

### DIFF
--- a/oci/index.go
+++ b/oci/index.go
@@ -239,7 +239,7 @@ func (index *Index) Save(ctx context.Context, fullref string, onProgress func(fl
 	// save the manifest digest
 	if err := index.handle.SaveDescriptor(
 		ctx,
-		fullref,
+		ref.Name(),
 		*index.desc,
 		bytes.NewReader(indexJson),
 		onProgress,

--- a/oci/manifest.go
+++ b/oci/manifest.go
@@ -360,7 +360,7 @@ func (manifest *Manifest) Save(ctx context.Context, fullref string, onProgress f
 	// save the manifest descriptor
 	if err := manifest.handle.SaveDescriptor(
 		ctx,
-		fullref,
+		ref.Name(),
 		*manifest.desc,
 		bytes.NewReader(manifestJson),
 		onProgress,


### PR DESCRIPTION
This commit fixes an issue wherein a user may pass a "fullref" representing the canonical name of an image WITHOUT an identifier (or tag).  This leads to unexpected behaviour where the image would not be saved correctly.  Ensure the proper reference name.
