### PR TITLE
fix(oci): Correct order of plat/arch in name

### DIFF
--- a/oci/pack.go
+++ b/oci/pack.go
@@ -664,7 +664,7 @@ func (ocipack *ociPackage) Name() string {
 
 // Name implements fmt.Stringer
 func (ocipack *ociPackage) String() string {
-	return fmt.Sprintf("%s (%s/%s)", ocipack.imageRef(), ocipack.Architecture().Name(), ocipack.Platform().Name())
+	return fmt.Sprintf("%s (%s/%s)", ocipack.imageRef(), ocipack.Platform().Name(), ocipack.Architecture().Name())
 }
 
 // Version implements unikraft.Nameable


### PR DESCRIPTION
The two are expressed, throughout the project, in this order. Ensure consistency by switching.
