### PR TITLE
refactor(pkg): Use `String` over `Name` and format type

### DIFF
--- a/internal/cli/kraft/pkg/pkg.go
+++ b/internal/cli/kraft/pkg/pkg.go
@@ -173,7 +173,7 @@ func Pkg(ctx context.Context, opts *PkgOptions, args ...string) ([]pack.Package,
 			p := p
 
 			processes = append(processes, processtree.NewProcessTreeItem(
-				fmt.Sprintf("pushing %s (%s)", p.Name(), p.Format()),
+				fmt.Sprintf("pushing %s", p.String()),
 				"",
 				func(ctx context.Context) error {
 					return p.Push(ctx)

--- a/internal/cli/kraft/pkg/push/push.go
+++ b/internal/cli/kraft/pkg/push/push.go
@@ -156,7 +156,7 @@ func (opts *PushOptions) Run(ctx context.Context, args []string) error {
 		p := p
 
 		processes = append(processes, processtree.NewProcessTreeItem(
-			fmt.Sprintf("pushing %s (%s)", p.Name(), p.Format()),
+			fmt.Sprintf("pushing %s", p.String()),
 			"",
 			func(ctx context.Context) error {
 				return p.Push(ctx)


### PR DESCRIPTION
This makes the output more consistent.
