### PR TITLE
fix: Remove dangling interfaces

### DIFF
--- a/internal/cli/kraft/start/start.go
+++ b/internal/cli/kraft/start/start.go
@@ -233,7 +233,7 @@ func Start(ctx context.Context, opts *StartOptions, machineNames ...string) erro
 
 				// Remove the new network interface
 				for i, iface := range found.Spec.Interfaces {
-					if iface.UID == machine.Spec.Networks[0].Interfaces[0].UID {
+					if iface.UID == network.Interfaces[0].UID {
 						ret := make([]networkapi.NetworkInterfaceTemplateSpec, 0)
 						ret = append(ret, found.Spec.Interfaces[:i]...)
 						found.Spec.Interfaces = append(ret, found.Spec.Interfaces[i+1:]...)

--- a/machine/network/bridge/v1alpha1.go
+++ b/machine/network/bridge/v1alpha1.go
@@ -352,6 +352,16 @@ func (service *v1alpha1Network) Update(ctx context.Context, network *networkv1al
 			continue // Skip in-use interfaces
 		}
 
+		parts := strings.SplitN(tap.Alias, ":", 2)
+
+		if len(parts) != 2 {
+			continue
+		}
+
+		if parts[0] != string(network.ObjectMeta.UID) {
+			continue
+		}
+
 		if err = netlink.LinkSetDown(tap); err != nil {
 			return network, fmt.Errorf("could not bring %s link down: %v", tap.Name, err)
 		}


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

Previously, repeatedly running a unikernel:
```bash
kraft run --rm --network some-net unikraft.org/nginx:1.15
```
would cause interfaces to pile up:

```bash
some-net@if0: <NO-CARRIER,BROADCAST,MULTICAST,UP> mtu 1500 qdisc fq_codel master some-net state DOWN group default qlen 1000
some-net@if1: <NO-CARRIER,BROADCAST,MULTICAST,UP> mtu 1500 qdisc fq_codel master some-net state DOWN 
some-net@if2: <NO-CARRIER,BROADCAST,MULTICAST,UP> mtu 1500 qdisc fq_codel master some-net state DOWN group default qlen 1000
```

This `PR` reverts a previous commit https://github.com/unikraft/kraftkit/pull/1250/commits/49f248ac4f65a54f576b23098d2f82422886d6d3, by instead allowing a network update to only remove the interfaces that belong to that specific network.

Also, it fixes a bug in start that would cause removing interfaces from unikernels with multiple networks to be wrong.
