### PR TITLE
fix: Improve starting instances and port handling

### DIFF
--- a/internal/cli/kraft/ps/ps.go
+++ b/internal/cli/kraft/ps/ps.go
@@ -179,10 +179,13 @@ func (opts *PsOptions) PsTable(ctx context.Context) ([]PsEntry, error) {
 			State:   machine.Status.State,
 			Mem:     fmt.Sprintf("%dMiB", machine.Spec.Resources.Requests.Memory().Value()/MemoryMiB),
 			Created: humanize.Time(machine.ObjectMeta.CreationTimestamp.Time),
-			Ports:   machine.Spec.Ports.String(),
 			Arch:    machine.Spec.Architecture,
 			Plat:    machine.Spec.Platform,
 			IPs:     []string{},
+		}
+
+		if machine.Status.State == machineapi.MachineStateRunning {
+			entry.Ports = machine.Spec.Ports.String()
 		}
 
 		for _, net := range machine.Spec.Networks {

--- a/internal/cli/kraft/ps/ps.go
+++ b/internal/cli/kraft/ps/ps.go
@@ -87,6 +87,7 @@ type PsEntry struct {
 	State   machineapi.MachineState
 	Mem     string
 	Ports   string
+	Pid     int32
 	Arch    string
 	Plat    string
 	IPs     []string
@@ -180,6 +181,7 @@ func (opts *PsOptions) PsTable(ctx context.Context) ([]PsEntry, error) {
 			Mem:     fmt.Sprintf("%dMiB", machine.Spec.Resources.Requests.Memory().Value()/MemoryMiB),
 			Created: humanize.Time(machine.ObjectMeta.CreationTimestamp.Time),
 			Arch:    machine.Spec.Architecture,
+			Pid:     machine.Status.Pid,
 			Plat:    machine.Spec.Platform,
 			IPs:     []string{},
 		}
@@ -231,9 +233,12 @@ func (opts *PsOptions) PrintPsTable(ctx context.Context, items []PsEntry) error 
 	table.AddField("PORTS", cs.Bold)
 	if opts.Long {
 		table.AddField("IP", cs.Bold)
-		table.AddField("ARCH", cs.Bold)
+		table.AddField("PID", cs.Bold)
 	}
 	table.AddField("PLAT", cs.Bold)
+	if opts.Long {
+		table.AddField("ARCH", cs.Bold)
+	}
 	table.EndRow()
 
 	if config.G[config.KraftKit](ctx).NoColor {
@@ -253,10 +258,13 @@ func (opts *PsOptions) PrintPsTable(ctx context.Context, items []PsEntry) error 
 		table.AddField(item.Ports, nil)
 		if opts.Long {
 			table.AddField(strings.Join(item.IPs, ","), nil)
-			table.AddField(item.Arch, nil)
+			table.AddField(fmt.Sprintf("%d", item.Pid), nil)
 			table.AddField(item.Plat, nil)
 		} else {
 			table.AddField(fmt.Sprintf("%s/%s", item.Plat, item.Arch), nil)
+		}
+		if opts.Long {
+			table.AddField(item.Arch, nil)
 		}
 		table.EndRow()
 	}

--- a/internal/cli/kraft/run/utils.go
+++ b/internal/cli/kraft/run/utils.go
@@ -48,7 +48,7 @@ func (opts *RunOptions) assignPorts(ctx context.Context, machine *machineapi.Mac
 	for _, existingMachine := range existingMachines.Items {
 		for _, existingPort := range existingMachine.Spec.Ports {
 			for _, newPort := range machine.Spec.Ports {
-				if existingPort.HostIP == newPort.HostIP && existingPort.HostPort == newPort.HostPort {
+				if existingPort.HostIP == newPort.HostIP && existingPort.HostPort == newPort.HostPort && existingMachine.Status.State == machineapi.MachineStateRunning {
 					return fmt.Errorf("port %s:%d is already in use by %s", existingPort.HostIP, existingPort.HostPort, existingMachine.Name)
 				}
 			}

--- a/internal/cli/kraft/run/utils.go
+++ b/internal/cli/kraft/run/utils.go
@@ -16,6 +16,7 @@ import (
 	volumeapi "kraftkit.sh/api/volume/v1alpha1"
 	"kraftkit.sh/config"
 	"kraftkit.sh/initrd"
+	"kraftkit.sh/internal/cli/kraft/utils"
 	"kraftkit.sh/log"
 	machinename "kraftkit.sh/machine/name"
 	"kraftkit.sh/machine/network"
@@ -40,22 +41,7 @@ func (opts *RunOptions) assignPorts(ctx context.Context, machine *machineapi.Mac
 		machine.Spec.Ports = append(machine.Spec.Ports, parsed...)
 	}
 
-	existingMachines, err := opts.machineController.List(ctx, &machineapi.MachineList{})
-	if err != nil {
-		return fmt.Errorf("getting list of existing machines: %w", err)
-	}
-
-	for _, existingMachine := range existingMachines.Items {
-		for _, existingPort := range existingMachine.Spec.Ports {
-			for _, newPort := range machine.Spec.Ports {
-				if existingPort.HostIP == newPort.HostIP && existingPort.HostPort == newPort.HostPort && existingMachine.Status.State == machineapi.MachineStateRunning {
-					return fmt.Errorf("port %s:%d is already in use by %s", existingPort.HostIP, existingPort.HostPort, existingMachine.Name)
-				}
-			}
-		}
-	}
-
-	return nil
+	return utils.CheckPorts(ctx, opts.machineController, machine)
 }
 
 // Was a network specified? E.g. --network=kraft0

--- a/internal/cli/kraft/start/start.go
+++ b/internal/cli/kraft/start/start.go
@@ -18,6 +18,7 @@ import (
 	"kraftkit.sh/cmdfactory"
 	"kraftkit.sh/config"
 	"kraftkit.sh/internal/cli/kraft/logs"
+	"kraftkit.sh/internal/cli/kraft/utils"
 	"kraftkit.sh/internal/waitgroup"
 	"kraftkit.sh/iostreams"
 	"kraftkit.sh/log"
@@ -141,6 +142,12 @@ func Start(ctx context.Context, opts *StartOptions, machineNames ...string) erro
 
 	for _, machine := range machines {
 		machine := machine // Go closures
+
+		// Check if the machine's requested ports are not already in use by an
+		// existing running machine.
+		if err := utils.CheckPorts(ctx, machineController, &machine); err != nil {
+			return err
+		}
 
 		log.G(ctx).
 			WithField("machine", machine.Name).

--- a/internal/cli/kraft/utils/ports.go
+++ b/internal/cli/kraft/utils/ports.go
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2024, Unikraft GmbH and The KraftKit Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+
+package utils
+
+import (
+	"context"
+	"fmt"
+
+	machineapi "kraftkit.sh/api/machine/v1alpha1"
+)
+
+// CheckPorts is a utility method used to throw an error if the supplied machine
+// has assigned ports which are already used by an existing, running machine,
+// which is accessible through the supplied machine controller.
+func CheckPorts(ctx context.Context, controller machineapi.MachineService, machine *machineapi.Machine) error {
+	existingMachines, err := controller.List(ctx, &machineapi.MachineList{})
+	if err != nil {
+		return fmt.Errorf("getting list of existing machines: %w", err)
+	}
+
+	for _, existingMachine := range existingMachines.Items {
+		for _, existingPort := range existingMachine.Spec.Ports {
+			for _, newPort := range machine.Spec.Ports {
+				if existingPort.HostIP == newPort.HostIP && existingPort.HostPort == newPort.HostPort && existingMachine.Status.State == machineapi.MachineStateRunning {
+					return fmt.Errorf("port %s:%d is already in use by %s", existingPort.HostIP, existingPort.HostPort, existingMachine.Name)
+				}
+			}
+		}
+	}
+
+	return nil
+}

--- a/machine/qemu/v1alpha1.go
+++ b/machine/qemu/v1alpha1.go
@@ -704,6 +704,13 @@ func (service *machineV1alpha1Service) Watch(ctx context.Context, machine *machi
 // Start implements kraftkit.sh/api/machine/v1alpha1.MachineService
 func (service *machineV1alpha1Service) Start(ctx context.Context, machine *machinev1alpha1.Machine) (*machinev1alpha1.Machine, error) {
 	qmpClient, err := service.QMPClient(ctx, machine)
+	if err != nil && strings.HasSuffix(err.Error(), "connect: no such file or directory") {
+		machine, err = service.Create(ctx, machine)
+		if err != nil {
+			return machine, err
+		}
+		qmpClient, err = service.QMPClient(ctx, machine)
+	}
 	if err != nil {
 		return machine, fmt.Errorf("could not start qemu instance: %v", err)
 	}


### PR DESCRIPTION
This PR fixes issues related to the handling of both starting terminated unikernel virtual machines as well as the handling of assigned ports to the machine.

