### PR TITLE
feat: Introduce compose logs subcommand

### DIFF
--- a/internal/cli/kraft/compose/compose.go
+++ b/internal/cli/kraft/compose/compose.go
@@ -15,6 +15,7 @@ import (
 	"kraftkit.sh/cmdfactory"
 	"kraftkit.sh/internal/cli/kraft/compose/build"
 	"kraftkit.sh/internal/cli/kraft/compose/down"
+	"kraftkit.sh/internal/cli/kraft/compose/logs"
 	"kraftkit.sh/internal/cli/kraft/compose/ls"
 	"kraftkit.sh/internal/cli/kraft/compose/ps"
 	"kraftkit.sh/internal/cli/kraft/compose/up"
@@ -47,6 +48,7 @@ func NewCmd() *cobra.Command {
 
 	cmd.AddCommand(build.NewCmd())
 	cmd.AddCommand(down.NewCmd())
+	cmd.AddCommand(logs.NewCmd())
 	cmd.AddCommand(ls.NewCmd())
 	cmd.AddCommand(ps.NewCmd())
 	cmd.AddCommand(up.NewCmd())

--- a/internal/cli/kraft/compose/logs/logs.go
+++ b/internal/cli/kraft/compose/logs/logs.go
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2024, Unikraft GmbH and The KraftKit Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+
+package logs
+
+import (
+	"context"
+	"os"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	machineapi "kraftkit.sh/api/machine/v1alpha1"
+
+	"github.com/spf13/cobra"
+
+	"kraftkit.sh/cmdfactory"
+	"kraftkit.sh/compose"
+	kernellogs "kraftkit.sh/internal/cli/kraft/logs"
+	"kraftkit.sh/log"
+
+	mplatform "kraftkit.sh/machine/platform"
+
+	"kraftkit.sh/packmanager"
+)
+
+type LogsOptions struct {
+	Follow bool `long:"follow" usage:"Follow log output"`
+
+	composefile string
+}
+
+func NewCmd() *cobra.Command {
+	cmd, err := cmdfactory.New(&LogsOptions{}, cobra.Command{
+		Short: "Print the logs of services in a project",
+		Use:   "logs",
+		Annotations: map[string]string{
+			cmdfactory.AnnotationHelpGroup: "compose",
+		},
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	return cmd
+}
+
+func (opts *LogsOptions) Pre(cmd *cobra.Command, _ []string) error {
+	ctx, err := packmanager.WithDefaultUmbrellaManagerInContext(cmd.Context())
+	if err != nil {
+		return err
+	}
+
+	cmd.SetContext(ctx)
+
+	if cmd.Flag("file").Changed {
+		opts.composefile = cmd.Flag("file").Value.String()
+	}
+
+	log.G(cmd.Context()).WithField("composefile", opts.composefile).Debug("using")
+
+	return nil
+}
+
+func (opts *LogsOptions) Run(ctx context.Context, args []string) error {
+	workdir, err := os.Getwd()
+	if err != nil {
+		return err
+	}
+
+	project, err := compose.NewProjectFromComposeFile(ctx, workdir, opts.composefile)
+	if err != nil {
+		return err
+	}
+
+	if err := project.Validate(ctx); err != nil {
+		return err
+	}
+
+	controller, err := mplatform.NewMachineV1alpha1ServiceIterator(ctx)
+	if err != nil {
+		return err
+	}
+
+	machinesToLog := []string{}
+	for _, service := range project.Services {
+		machine, _ := controller.Get(ctx, &machineapi.Machine{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: service.Name,
+			},
+		})
+		if machine != nil {
+			machinesToLog = append(machinesToLog, machine.Name)
+		}
+	}
+
+	logOptions := kernellogs.LogOptions{
+		Follow:   opts.Follow,
+		Platform: "auto",
+	}
+
+	return logOptions.Run(ctx, machinesToLog)
+}


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes
Introduce the ``kraft compose logs`` subcommand that allows users to print existing logs or follow them.

E.g:

```bash
kraft compose up -d

kraft compose logs --follow

ping-pong-pong  | Received: ping
ping-pong-ping  | Received: pong
ping-pong-pong  | Received: ping
```

<!--
Please provide a detailed description of the changes made in this new PR.
-->
