### PR TITLE
fix(cloud): write to nil Env map

### DIFF
--- a/internal/cli/kraft/cloud/instance/create/create.go
+++ b/internal/cli/kraft/cloud/instance/create/create.go
@@ -266,6 +266,9 @@ func Create(ctx context.Context, opts *CreateOptions, args ...string) (*kcinstan
 		}
 	}
 
+	if len(opts.Env) > 0 && req.Env == nil {
+		req.Env = make(map[string]string, len(opts.Env))
+	}
 	for _, env := range opts.Env {
 		if strings.ContainsRune(env, '=') {
 			split := strings.SplitN(env, "=", 2)


### PR DESCRIPTION
At the time we try to write to `req.Env`, the `map[string]string` is still nil.