### PR TITLE
fix(rm): Check all machines regardless of status

### DIFF
--- a/internal/cli/kraft/net/remove/remove.go
+++ b/internal/cli/kraft/net/remove/remove.go
@@ -90,9 +90,6 @@ func (opts *RemoveOptions) Run(ctx context.Context, args []string) error {
 	}
 
 	for _, machine := range machines.Items {
-		if machine.Status.State != machineapi.MachineStateRunning {
-			continue
-		}
 		for _, network := range machine.Spec.Networks {
 			if network.IfName == args[0] {
 				if !opts.Force {


### PR DESCRIPTION


<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes
Machines keep references to their interfaces even in different states. For example, an exited machine maintains its interface DOWN and it is set UP again when using ``kraft start`` on that particular machine. 

Also check for those interfaces when removing network.

<!--
Please provide a detailed description of the changes made in this new PR.
-->
