### PR TITLE
feat: Introduce kraftfile-runtime builder

### DIFF
--- a/internal/cli/kraft/build/build.go
+++ b/internal/cli/kraft/build/build.go
@@ -19,7 +19,6 @@ import (
 	"github.com/spf13/cobra"
 
 	"kraftkit.sh/cmdfactory"
-	"kraftkit.sh/config"
 	"kraftkit.sh/internal/cli/kraft/utils"
 	"kraftkit.sh/internal/fancymap"
 	"kraftkit.sh/iostreams"
@@ -94,36 +93,6 @@ func Build(ctx context.Context, opts *BuildOptions, args ...string) error {
 
 	opts.Platform = platform.PlatformByName(opts.Platform).String()
 	opts.statistics = map[string]string{}
-
-	if opts.Target == nil {
-		// Filter project targets by any provided CLI options
-		selected := opts.project.Targets()
-		if len(selected) == 0 {
-			return fmt.Errorf("no targets to build")
-		}
-		if !opts.All {
-			selected = target.Filter(
-				selected,
-				opts.Architecture,
-				opts.Platform,
-				opts.TargetName,
-			)
-
-			if !config.G[config.KraftKit](ctx).NoPrompt && len(selected) > 1 {
-				res, err := target.Select(selected)
-				if err != nil {
-					return err
-				}
-				selected = []target.Target{res}
-			}
-		}
-
-		if len(selected) == 0 {
-			return fmt.Errorf("no targets selected to build")
-		}
-
-		opts.Target = &selected[0]
-	}
 
 	var build builder
 	builders := builders()

--- a/internal/cli/kraft/build/build.go
+++ b/internal/cli/kraft/build/build.go
@@ -214,11 +214,6 @@ func (opts *BuildOptions) Run(ctx context.Context, args []string) error {
 		return err
 	}
 
-	kernelStat, err := os.Stat((*opts.Target).Kernel())
-	if err != nil {
-		return fmt.Errorf("getting kernel image size: %w", err)
-	}
-
 	workdir, err := filepath.Abs(opts.Workdir)
 	if err != nil {
 		return fmt.Errorf("getting the work directory: %w", err)
@@ -226,17 +221,24 @@ func (opts *BuildOptions) Run(ctx context.Context, args []string) error {
 
 	workdir += "/"
 
-	kernelPath, err := filepath.Abs((*opts.Target).Kernel())
-	if err != nil {
-		return fmt.Errorf("getting kernel absolute path: %w", err)
-	}
+	entries := []fancymap.FancyMapEntry{}
 
-	entries := []fancymap.FancyMapEntry{
-		{
+	if opts.project.Unikraft(ctx) != nil {
+		kernelStat, err := os.Stat((*opts.Target).Kernel())
+		if err != nil {
+			return fmt.Errorf("getting kernel image size: %w", err)
+		}
+
+		kernelPath, err := filepath.Abs((*opts.Target).Kernel())
+		if err != nil {
+			return fmt.Errorf("getting kernel absolute path: %w", err)
+		}
+
+		entries = append(entries, fancymap.FancyMapEntry{
 			Key:   "kernel",
 			Value: strings.TrimPrefix(kernelPath, workdir),
 			Right: fmt.Sprintf("(%s)", humanize.Bytes(uint64(kernelStat.Size()))),
-		},
+		})
 	}
 
 	if opts.Rootfs != "" {

--- a/internal/cli/kraft/build/build.go
+++ b/internal/cli/kraft/build/build.go
@@ -24,6 +24,7 @@ import (
 	"kraftkit.sh/internal/fancymap"
 	"kraftkit.sh/iostreams"
 	"kraftkit.sh/machine/platform"
+	"kraftkit.sh/tui"
 
 	"kraftkit.sh/log"
 	"kraftkit.sh/packmanager"
@@ -284,7 +285,12 @@ func (opts *BuildOptions) Run(ctx context.Context, args []string) error {
 		return nil
 	}
 
-	fancymap.PrintFancyMap(iostreams.G(ctx).Out, "Build completed successfully!", true, entries...)
+	fancymap.PrintFancyMap(
+		iostreams.G(ctx).Out,
+		tui.TextGreen,
+		"Build completed successfully!",
+		entries...,
+	)
 
 	fmt.Fprint(iostreams.G(ctx).Out, "Learn how to package your unikernel with: kraft pkg --help\n")
 

--- a/internal/cli/kraft/build/builder.go
+++ b/internal/cli/kraft/build/builder.go
@@ -40,5 +40,6 @@ type builder interface {
 func builders() []builder {
 	return []builder{
 		&builderKraftfileUnikraft{},
+		&builderKraftfileRuntime{},
 	}
 }

--- a/internal/cli/kraft/build/builder_kraftfile_runtime.go
+++ b/internal/cli/kraft/build/builder_kraftfile_runtime.go
@@ -1,0 +1,137 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2022, Unikraft GmbH and The KraftKit Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+package build
+
+import (
+	"context"
+	"fmt"
+
+	"kraftkit.sh/config"
+	"kraftkit.sh/log"
+	"kraftkit.sh/pack"
+	"kraftkit.sh/packmanager"
+	"kraftkit.sh/tui/processtree"
+	"kraftkit.sh/tui/selection"
+	"kraftkit.sh/unikraft/target"
+)
+
+type builderKraftfileRuntime struct{}
+
+// String implements fmt.Stringer.
+func (build *builderKraftfileRuntime) String() string {
+	return "kraftfile-runtime"
+}
+
+// Buildable implements builder.
+func (build *builderKraftfileRuntime) Buildable(ctx context.Context, opts *BuildOptions, args ...string) (bool, error) {
+	if opts.project == nil {
+		if err := opts.initProject(ctx); err != nil {
+			return false, err
+		}
+	}
+
+	if opts.project.Runtime() == nil {
+		return false, fmt.Errorf("cannot package without unikraft core specification")
+	}
+
+	if opts.project.Rootfs() != "" && opts.Rootfs == "" {
+		opts.Rootfs = opts.project.Rootfs()
+	}
+
+	return true, nil
+}
+
+func (*builderKraftfileRuntime) Prepare(ctx context.Context, opts *BuildOptions, _ ...string) error {
+	var (
+		selected *pack.Package
+		packs    []pack.Package
+		kconfigs []string
+		err      error
+	)
+
+	qopts := []packmanager.QueryOption{
+		packmanager.WithName(opts.project.Runtime().Name()),
+		packmanager.WithVersion(opts.project.Runtime().Version()),
+	}
+
+	treemodel, err := processtree.NewProcessTree(
+		ctx,
+		[]processtree.ProcessTreeOption{
+			processtree.IsParallel(false),
+			processtree.WithRenderer(
+				log.LoggerTypeFromString(config.G[config.KraftKit](ctx).Log.Type) != log.FANCY,
+			),
+			processtree.WithFailFast(true),
+			processtree.WithHideOnSuccess(true),
+		},
+		processtree.NewProcessTreeItem(
+			fmt.Sprintf(
+				"searching for %s:%s",
+				opts.project.Runtime().Name(),
+				opts.project.Runtime().Version(),
+			),
+			"",
+			func(ctx context.Context) error {
+				qopts = append(qopts,
+					packmanager.WithArchitecture(opts.Architecture),
+					packmanager.WithPlatform(opts.Platform),
+					packmanager.WithKConfig(kconfigs),
+				)
+
+				packs, err = packmanager.G(ctx).Catalog(ctx, append(qopts, packmanager.WithRemote(false))...)
+				if err != nil {
+					return fmt.Errorf("could not query catalog: %w", err)
+				} else if len(packs) == 0 {
+					// Try again with a remote update request.  Save this to qopts in case we
+					// need to call `Catalog` again.
+					packs, err = packmanager.G(ctx).Catalog(ctx, append(qopts, packmanager.WithRemote(true))...)
+					if err != nil {
+						return fmt.Errorf("could not query catalog: %w", err)
+					}
+				}
+
+				return nil
+			},
+		),
+	)
+	if err != nil {
+		return err
+	}
+
+	if err := treemodel.Start(); err != nil {
+		return err
+	}
+
+	if len(packs) == 0 {
+		return fmt.Errorf(
+			"could not find runtime '%s:%s'",
+			opts.project.Runtime().Name(),
+			opts.project.Runtime().Version(),
+		)
+	} else if len(packs) == 1 {
+		selected = &packs[0]
+	} else if len(packs) > 1 {
+		// If a target has been previously selected, we can use this to filter the
+		// returned list of packages based on its platform and architecture.
+
+		selected, err = selection.Select("multiple runtimes available", packs...)
+		if err != nil {
+			return err
+		}
+	}
+
+	targ := (*selected).(target.Target)
+	opts.Target = &targ
+
+	return nil
+}
+
+func (*builderKraftfileRuntime) Build(_ context.Context, _ *BuildOptions, _ ...string) error {
+	return nil
+}
+
+func (*builderKraftfileRuntime) Statistics(ctx context.Context, opts *BuildOptions, args ...string) error {
+	return fmt.Errorf("cannot calculate statistics of pre-built unikernel runtime")
+}

--- a/internal/cli/kraft/build/builder_kraftfile_unikraft.go
+++ b/internal/cli/kraft/build/builder_kraftfile_unikraft.go
@@ -35,7 +35,7 @@ type builderKraftfileUnikraft struct {
 
 // String implements fmt.Stringer.
 func (build *builderKraftfileUnikraft) String() string {
-	return "unikraft"
+	return "kraftfile-unikraft"
 }
 
 // Buildable implements builder.

--- a/internal/cli/kraft/build/builder_kraftfile_unikraft.go
+++ b/internal/cli/kraft/build/builder_kraftfile_unikraft.go
@@ -330,6 +330,36 @@ func (build *builderKraftfileUnikraft) Prepare(ctx context.Context, opts *BuildO
 	build.nameWidth = -1
 	norender := log.LoggerTypeFromString(config.G[config.KraftKit](ctx).Log.Type) != log.FANCY
 
+	if opts.Target == nil {
+		// Filter project targets by any provided CLI options
+		selected := opts.project.Targets()
+		if len(selected) == 0 {
+			return fmt.Errorf("no targets to build")
+		}
+		if !opts.All {
+			selected = target.Filter(
+				selected,
+				opts.Architecture,
+				opts.Platform,
+				opts.TargetName,
+			)
+
+			if !config.G[config.KraftKit](ctx).NoPrompt && len(selected) > 1 {
+				res, err := target.Select(selected)
+				if err != nil {
+					return err
+				}
+				selected = []target.Target{res}
+			}
+		}
+
+		if len(selected) == 0 {
+			return fmt.Errorf("no targets selected to build")
+		}
+
+		opts.Target = &selected[0]
+	}
+
 	// Calculate the width of the longest process name so that we can align the
 	// two independent processtrees if we are using "render" mode (aka the fancy
 	// mode is enabled).

--- a/internal/cli/kraft/build/utils.go
+++ b/internal/cli/kraft/build/utils.go
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2023, Unikraft GmbH and The KraftKit Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+
+package build
+
+import (
+	"context"
+
+	"kraftkit.sh/unikraft/app"
+)
+
+// initProject sets up the project based on the provided context and
+// options.
+func (opts *BuildOptions) initProject(ctx context.Context) error {
+	var err error
+
+	popts := []app.ProjectOption{
+		app.WithProjectWorkdir(opts.Workdir),
+	}
+
+	if len(opts.Kraftfile) > 0 {
+		popts = append(popts, app.WithProjectKraftfile(opts.Kraftfile))
+	} else {
+		popts = append(popts, app.WithProjectDefaultKraftfiles())
+	}
+
+	// Interpret the project directory
+	opts.project, err = app.NewProjectFromOptions(ctx, popts...)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/internal/cli/kraft/cloud/utils/print.go
+++ b/internal/cli/kraft/cloud/utils/print.go
@@ -780,8 +780,8 @@ func PrettyPrintInstance(ctx context.Context, instance *kcinstances.GetResponseI
 
 	fancymap.PrintFancyMap(
 		out,
+		color,
 		title,
-		instance.State == "running" || instance.State == "starting",
 		entries...,
 	)
 

--- a/internal/fancymap/print.go
+++ b/internal/fancymap/print.go
@@ -25,7 +25,7 @@ type FancyMapEntry struct {
 // PrintFancyMap uses the provided writer `w` and outputs a pretty printed listed
 // based on the list of `entries`.  A `title` and `success` state can be set
 // which are prepended to the list.
-func PrintFancyMap(w io.Writer, title string, success bool, entries ...FancyMapEntry) {
+func PrintFancyMap(w io.Writer, color func(...string) string, title string, entries ...FancyMapEntry) {
 	keyPad, valPad, bracketPad := 0, 0, 0
 
 	for _, entry := range entries {
@@ -38,13 +38,6 @@ func PrintFancyMap(w io.Writer, title string, success bool, entries ...FancyMapE
 		if newLen := len(entry.Right); newLen > bracketPad {
 			bracketPad = newLen
 		}
-	}
-
-	var color func(...string) string
-	if success {
-		color = tui.TextGreen
-	} else {
-		color = tui.TextRed
 	}
 
 	fmt.Fprintf(w, "\n")


### PR DESCRIPTION
This PR introduces a new build context (builder) to the `kraft build` subcommand which recognizes contexts where a `Kraftfile` has a `runtime` element.

In some cases, the user may still wish to use this command (often out of habit) and expect an action to have occurred.  It is possible in this circumstance to build the rootfs which is traditional considered a build step.  Whilst the rootfs may still be constructed at package-time, this introduction offers a convenient mechanism for performing the same action.

