### PR TITLE
feat(cloud): certificates subcommands

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -75,7 +75,7 @@ require (
 	k8s.io/apimachinery v0.29.2
 	k8s.io/apiserver v0.29.2
 	oras.land/oras-go/v2 v2.4.0
-	sdk.kraft.cloud v0.5.1
+	sdk.kraft.cloud v0.5.2
 	sigs.k8s.io/kustomize/kyaml v0.14.3
 )
 
@@ -139,6 +139,7 @@ require (
 	github.com/gofrs/flock v0.8.1 // indirect
 	github.com/gogo/googleapis v1.4.1 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
+	github.com/goharbor/go-client v0.28.2 // indirect
 	github.com/golang/glog v1.1.2 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/golang/protobuf v1.5.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -541,6 +541,8 @@ github.com/gogo/protobuf v1.3.0/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXP
 github.com/gogo/protobuf v1.3.1/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXPKa29o=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
+github.com/goharbor/go-client v0.28.2 h1:qD4wNqVSyuJm4Q2qZkTD3TC+ZcFxQ7f+MU4rtKdMZjs=
+github.com/goharbor/go-client v0.28.2/go.mod h1:XMWHucuHU9VTRx6U6wYwbRuyCVhE6ffJGRjaeo0nvwo=
 github.com/golang-jwt/jwt/v4 v4.5.0 h1:7cYmW1XlMY7h7ii7UhUyChSgS5wUJEnm9uZVTGqOWzg=
 github.com/golang-jwt/jwt/v4 v4.5.0/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
@@ -1671,8 +1673,8 @@ oras.land/oras-go/v2 v2.4.0/go.mod h1:osvtg0/ClRq1KkydMAEu/IxFieyjItcsQ4ut4PPF+f
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
 rsc.io/quote/v3 v3.1.0/go.mod h1:yEA65RcK8LyAZtP9Kv3t0HmxON59tX3rD+tICJqUlj0=
 rsc.io/sampler v1.3.0/go.mod h1:T1hPZKmBbMNahiBKFy5HrXp6adAjACjK9JXDnKaTXpA=
-sdk.kraft.cloud v0.5.1 h1:rzTdQua4Jg76w6O+25B8IzkUrB9WcBrall060d4y9BY=
-sdk.kraft.cloud v0.5.1/go.mod h1:noR5Nb90RW7Cyzj3ym53+Z1geyTC3d4ou0ltR0VTqlU=
+sdk.kraft.cloud v0.5.2 h1:Yy7uDRQgMWmMIa5GZr1sQ9fhIj1dSyv2uim6FPGFhD4=
+sdk.kraft.cloud v0.5.2/go.mod h1:lgGLp9jSBwSdeQkwrcQZHuejQbkgE3AqbIN+mnaKDkg=
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.0.14/go.mod h1:LEScyzhFmoF5pso/YSeBstl57mOzx9xlU9n85RGrDQg=
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.0.15/go.mod h1:LEScyzhFmoF5pso/YSeBstl57mOzx9xlU9n85RGrDQg=
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.28.0 h1:TgtAeesdhpm2SGwkQasmbeqDo8th5wOBA5h/AjTKA4I=

--- a/internal/cli/kraft/cloud/certificate/certificate.go
+++ b/internal/cli/kraft/cloud/certificate/certificate.go
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2024, Unikraft GmbH and The KraftKit Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+
+package certificate
+
+import (
+	"context"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+
+	"kraftkit.sh/cmdfactory"
+
+	"kraftkit.sh/internal/cli/kraft/cloud/certificate/get"
+	"kraftkit.sh/internal/cli/kraft/cloud/certificate/list"
+	"kraftkit.sh/internal/cli/kraft/cloud/certificate/remove"
+)
+
+type CertificateOptions struct{}
+
+func NewCmd() *cobra.Command {
+	cmd, err := cmdfactory.New(&CertificateOptions{}, cobra.Command{
+		Short:   "Manage KraftCloud TLS certificates",
+		Use:     "certificate SUBCOMMAND",
+		Aliases: []string{"certificates", "cert", "certs", "crt", "crts"},
+		Long:    "Manage KraftCloud TLS certificates.",
+		Annotations: map[string]string{
+			cmdfactory.AnnotationHelpGroup:  "kraftcloud-certificate",
+			cmdfactory.AnnotationHelpHidden: "true",
+		},
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	cmd.AddCommand(list.NewCmd())
+	cmd.AddCommand(remove.NewCmd())
+	cmd.AddCommand(get.NewCmd())
+
+	return cmd
+}
+
+func (opts *CertificateOptions) Run(_ context.Context, _ []string) error {
+	return pflag.ErrHelp
+}

--- a/internal/cli/kraft/cloud/certificate/get/get.go
+++ b/internal/cli/kraft/cloud/certificate/get/get.go
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2023, Unikraft GmbH and The KraftKit Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+
+package get
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/MakeNowJust/heredoc"
+	"github.com/spf13/cobra"
+
+	kraftcloud "sdk.kraft.cloud"
+	kccerts "sdk.kraft.cloud/certificates"
+
+	"kraftkit.sh/cmdfactory"
+	"kraftkit.sh/config"
+	"kraftkit.sh/internal/cli/kraft/cloud/utils"
+)
+
+type GetOptions struct {
+	Output string `long:"output" short:"o" usage:"Set output format. Options: table,yaml,json,list" default:"table"`
+
+	metro string
+	token string
+}
+
+// Status of a KraftCloud certificate.
+func Get(ctx context.Context, opts *GetOptions, args ...string) error {
+	if opts == nil {
+		opts = &GetOptions{}
+	}
+
+	return opts.Run(ctx, args)
+}
+
+func NewCmd() *cobra.Command {
+	cmd, err := cmdfactory.New(&GetOptions{}, cobra.Command{
+		Short:   "Retrieve the status of a certificate",
+		Use:     "get [FLAGS] UUID|NAME",
+		Args:    cobra.ExactArgs(1),
+		Aliases: []string{"status", "info"},
+		Example: heredoc.Doc(`
+			# Retrieve information about a kraftcloud certificate by UUID
+			$ kraft cloud certificate get fd1684ea-7970-4994-92d6-61dcc7905f2b
+
+			# Retrieve information about a kraftcloud certificate by name
+			$ kraft cloud certificate get my-certificate-431342
+		`),
+		Long: heredoc.Doc(`
+			Retrieve the status of a certificate.
+		`),
+		Annotations: map[string]string{
+			cmdfactory.AnnotationHelpGroup: "kraftcloud-certificate",
+		},
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	return cmd
+}
+
+func (opts *GetOptions) Pre(cmd *cobra.Command, _ []string) error {
+	err := utils.PopulateMetroToken(cmd, &opts.metro, &opts.token)
+	if err != nil {
+		return fmt.Errorf("could not populate metro and token: %w", err)
+	}
+
+	return nil
+}
+
+func (opts *GetOptions) Run(ctx context.Context, args []string) error {
+	auth, err := config.GetKraftCloudAuthConfig(ctx, opts.token)
+	if err != nil {
+		return fmt.Errorf("could not retrieve credentials: %w", err)
+	}
+
+	client := kraftcloud.NewCertificatesClient(
+		kraftcloud.WithToken(config.GetKraftCloudTokenAuthConfig(*auth)),
+	)
+
+	var certs []kccerts.GetResponseItem
+	if utils.IsUUID(args[0]) {
+		certs, err = client.WithMetro(opts.metro).GetByUUIDs(ctx, args[0])
+	} else {
+		certs, err = client.WithMetro(opts.metro).GetByNames(ctx, args[0])
+	}
+	if err != nil {
+		return fmt.Errorf("could not get certificate: %w", err)
+	}
+
+	return utils.PrintCertificates(ctx, opts.Output, certs...)
+}

--- a/internal/cli/kraft/cloud/certificate/list/list.go
+++ b/internal/cli/kraft/cloud/certificate/list/list.go
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2023, Unikraft GmbH and The KraftKit Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+package list
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/MakeNowJust/heredoc"
+	"github.com/spf13/cobra"
+
+	kraftcloud "sdk.kraft.cloud"
+
+	"kraftkit.sh/cmdfactory"
+	"kraftkit.sh/config"
+	"kraftkit.sh/internal/cli/kraft/cloud/utils"
+)
+
+type ListOptions struct {
+	Output string `long:"output" short:"o" usage:"Set output format. Options: table,yaml,json,list" default:"table"`
+
+	metro string
+	token string
+}
+
+func NewCmd() *cobra.Command {
+	cmd, err := cmdfactory.New(&ListOptions{}, cobra.Command{
+		Short:   "List certificates",
+		Use:     "list [FLAGS]",
+		Args:    cobra.NoArgs,
+		Aliases: []string{"ls"},
+		Example: heredoc.Doc(`
+			# List all TLS certificates in your account.
+			$ kraft cloud certificate list
+		`),
+		Long: heredoc.Doc(`
+			List all TLS certificates in your account.
+		`),
+		Annotations: map[string]string{
+			cmdfactory.AnnotationHelpGroup: "kraftcloud-certificate",
+		},
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	return cmd
+}
+
+func (opts *ListOptions) Pre(cmd *cobra.Command, _ []string) error {
+	err := utils.PopulateMetroToken(cmd, &opts.metro, &opts.token)
+	if err != nil {
+		return fmt.Errorf("could not populate metro and token: %w", err)
+	}
+
+	return nil
+}
+
+func (opts *ListOptions) Run(ctx context.Context, args []string) error {
+	auth, err := config.GetKraftCloudAuthConfig(ctx, opts.token)
+	if err != nil {
+		return fmt.Errorf("could not retrieve credentials: %w", err)
+	}
+
+	client := kraftcloud.NewCertificatesClient(
+		kraftcloud.WithToken(config.GetKraftCloudTokenAuthConfig(*auth)),
+	)
+
+	certListResp, err := client.WithMetro(opts.metro).List(ctx)
+	if err != nil {
+		return fmt.Errorf("could not list certificates: %w", err)
+	}
+	if len(certListResp) == 0 {
+		return nil
+	}
+
+	uuids := make([]string, 0, len(certListResp))
+	for _, certItem := range certListResp {
+		uuids = append(uuids, certItem.UUID)
+	}
+	certificates, err := client.WithMetro(opts.metro).GetByUUIDs(ctx, uuids...)
+	if err != nil {
+		return fmt.Errorf("getting details of %d certificate(s): %w", len(certListResp), err)
+	}
+
+	return utils.PrintCertificates(ctx, opts.Output, certificates...)
+}

--- a/internal/cli/kraft/cloud/certificate/remove/remove.go
+++ b/internal/cli/kraft/cloud/certificate/remove/remove.go
@@ -1,0 +1,156 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2022, Unikraft GmbH and The KraftKit Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+
+package remove
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/MakeNowJust/heredoc"
+	"github.com/spf13/cobra"
+
+	kraftcloud "sdk.kraft.cloud"
+
+	"kraftkit.sh/cmdfactory"
+	"kraftkit.sh/config"
+	"kraftkit.sh/internal/cli/kraft/cloud/utils"
+	"kraftkit.sh/log"
+)
+
+type RemoveOptions struct {
+	Output string `long:"output" short:"o" usage:"Set output format. Options: table,yaml,json,list" default:"table"`
+	All    bool   `long:"all" usage:"Remove all certificates"`
+
+	metro string
+	token string
+}
+
+// Remove a KraftCloud certificate.
+func Remove(ctx context.Context, opts *RemoveOptions, args ...string) error {
+	if opts == nil {
+		opts = &RemoveOptions{}
+	}
+
+	return opts.Run(ctx, args)
+}
+
+func NewCmd() *cobra.Command {
+	cmd, err := cmdfactory.New(&RemoveOptions{}, cobra.Command{
+		Short:   "Remove a certificate",
+		Use:     "remove [FLAGS] [UUID|NAME [UUID|NAME]...]",
+		Aliases: []string{"del", "delete", "rm"},
+		Args:    cobra.ArbitraryArgs,
+		Example: heredoc.Doc(`
+			# Remove a KraftCloud certificate by UUID
+			$ kraft cloud certificate remove fd1684ea-7970-4994-92d6-61dcc7905f2b
+
+			# Remove a KraftCloud certificate by name
+			$ kraft cloud certificate remove my-certificate-431342
+
+			# Remove multiple KraftCloud certificates
+			$ kraft cloud certificate remove my-certificate-431342 my-certificate-other-2313
+
+			# Remove all KraftCloud certificates
+			$ kraft cloud certificate remove --all
+		`),
+		Long: heredoc.Doc(`
+			Remove a KraftCloud certificate.
+		`),
+		Annotations: map[string]string{
+			cmdfactory.AnnotationHelpGroup: "kraftcloud-certificate",
+		},
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	return cmd
+}
+
+func (opts *RemoveOptions) Pre(cmd *cobra.Command, args []string) error {
+	if !opts.All && len(args) == 0 {
+		return fmt.Errorf("either specify a certificate name or UUID, or use the --all flag")
+	}
+
+	err := utils.PopulateMetroToken(cmd, &opts.metro, &opts.token)
+	if err != nil {
+		return fmt.Errorf("could not populate metro and token: %w", err)
+	}
+
+	return nil
+}
+
+func (opts *RemoveOptions) Run(ctx context.Context, args []string) error {
+	auth, err := config.GetKraftCloudAuthConfig(ctx, opts.token)
+	if err != nil {
+		return fmt.Errorf("could not retrieve credentials: %w", err)
+	}
+
+	client := kraftcloud.NewCertificatesClient(
+		kraftcloud.WithToken(config.GetKraftCloudTokenAuthConfig(*auth)),
+	)
+
+	if opts.All {
+		certListResp, err := client.WithMetro(opts.metro).List(ctx)
+		if err != nil {
+			return fmt.Errorf("could not list certificates: %w", err)
+		}
+
+		log.G(ctx).Infof("Removing %d certificate(s)", len(certListResp))
+
+		uuids := make([]string, 0, len(certListResp))
+		for _, certItem := range certListResp {
+			uuids = append(uuids, certItem.UUID)
+		}
+
+		if _, err := client.WithMetro(opts.metro).DeleteByUUIDs(ctx, uuids...); err != nil {
+			return fmt.Errorf("removing %d certificate(s): %w", len(certListResp), err)
+		}
+		return nil
+	}
+
+	log.G(ctx).Infof("Removing %d certificate(s)", len(args))
+
+	allUUIDs := true
+	allNames := true
+	for _, arg := range args {
+		if utils.IsUUID(arg) {
+			allNames = false
+		} else {
+			allUUIDs = false
+		}
+		if !(allUUIDs || allNames) {
+			break
+		}
+	}
+
+	switch {
+	case allUUIDs:
+		if _, err := client.WithMetro(opts.metro).DeleteByUUIDs(ctx, args...); err != nil {
+			return fmt.Errorf("removing %d certificate(s): %w", len(args), err)
+		}
+	case allNames:
+		if _, err := client.WithMetro(opts.metro).DeleteByNames(ctx, args...); err != nil {
+			return fmt.Errorf("removing %d certificate(s): %w", len(args), err)
+		}
+	default:
+		for _, arg := range args {
+			log.G(ctx).Infof("Removing certificate %s", arg)
+
+			if utils.IsUUID(arg) {
+				_, err = client.WithMetro(opts.metro).DeleteByUUIDs(ctx, arg)
+			} else {
+				_, err = client.WithMetro(opts.metro).DeleteByNames(ctx, arg)
+			}
+
+			if err != nil {
+				return fmt.Errorf("could not remove certificate %s: %w", arg, err)
+			}
+		}
+	}
+
+	return nil
+}

--- a/internal/cli/kraft/cloud/cloud.go
+++ b/internal/cli/kraft/cloud/cloud.go
@@ -12,6 +12,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 
+	"kraftkit.sh/internal/cli/kraft/cloud/certificate"
 	"kraftkit.sh/internal/cli/kraft/cloud/deploy"
 	"kraftkit.sh/internal/cli/kraft/cloud/img"
 	"kraftkit.sh/internal/cli/kraft/cloud/instance"
@@ -101,6 +102,9 @@ func NewCmd() *cobra.Command {
 
 	cmd.AddGroup(&cobra.Group{ID: "kraftcloud-svc", Title: "SERVICE COMMANDS"})
 	cmd.AddCommand(service.NewCmd())
+
+	cmd.AddGroup(&cobra.Group{ID: "kraftcloud-certificate", Title: "CERTIFICATE COMMANDS"})
+	cmd.AddCommand(certificate.NewCmd())
 
 	cmd.AddGroup(&cobra.Group{ID: "kraftcloud-metro", Title: "METRO COMMANDS"})
 	cmd.AddCommand(metros.NewCmd())


### PR DESCRIPTION
```console
% kraft cloud crt -h
Manage KraftCloud TLS certificates.

USAGE
  kraft cloud certificate SUBCOMMAND

ALIASES
  certificates cert certs crt crts

SUBCOMMANDS
  get      Retrieve the status of a certificate
  list     List certificates
  remove   Remove a certificate

FLAGS
  -h, --help   help for certificate
```
```
...
CERTIFICATE COMMANDS
  certificate get      Retrieve the status of a certificate
  certificate list     List certificates
  certificate remove   Remove a certificate
...
```