### PR TITLE
fix(webinstall): Escape '[trusted=yes]' for kraftkit.list

### DIFF
--- a/tools/webinstall/install.sh
+++ b/tools/webinstall/install.sh
@@ -1044,7 +1044,7 @@ install_linux_gnu() {
         _ilg_deb_path="deb [trusted=yes] https://deb.pkg.kraftkit.sh /"
 
         _ilg_deb_cmd=$(printf "%s%s"                    \
-            "echo ${_ilg_deb_path} | "                  \
+            "echo '${_ilg_deb_path}' | "                  \
             "tee /etc/apt/sources.list.d/kraftkit.list" \
         )
 


### PR DESCRIPTION
### Description of changes

Currently install.sh runs:

```sh
echo deb [trusted=yes] https://deb.pkg.kraftkit.sh / | tee /etc/apt/sources.list.d/kraftkit.list
```

which becomes the following if there is a file matching the glob pattern "[trusted=yes]"
```
deb <name of file in current directory> https://deb.pkg.kraftkit.sh /
```

This commit adds necessary escaping to prevent it.

### Prerequisite checklist

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR; N/A
  - [x] Updated relevant documentation. N/A
