### PR TITLE
feat(compose): Introduce create, start, stop subcommands

### DIFF
--- a/compose/v1.go
+++ b/compose/v1.go
@@ -88,9 +88,9 @@ func (v1 *v1Compose) refreshRunningServices(ctx context.Context, embeddedProject
 		}
 
 		for _, m := range machines.Items {
-			if m.Name == machine.Name && m.Status.State == machineapi.MachineStateRunning {
+			if m.Name == machine.Name {
 				runningMachines = append(runningMachines, machine)
-				if !isService {
+				if !isService && m.Status.State == machineapi.MachineStateRunning {
 					log.G(ctx).WithField("machine", machine.Name).Warn("found orphan machine")
 				}
 			}

--- a/internal/cli/kraft/compose/compose.go
+++ b/internal/cli/kraft/compose/compose.go
@@ -20,6 +20,7 @@ import (
 	"kraftkit.sh/internal/cli/kraft/compose/ls"
 	"kraftkit.sh/internal/cli/kraft/compose/ps"
 	"kraftkit.sh/internal/cli/kraft/compose/start"
+	"kraftkit.sh/internal/cli/kraft/compose/stop"
 	"kraftkit.sh/internal/cli/kraft/compose/up"
 )
 
@@ -55,6 +56,7 @@ func NewCmd() *cobra.Command {
 	cmd.AddCommand(ls.NewCmd())
 	cmd.AddCommand(ps.NewCmd())
 	cmd.AddCommand(start.NewCmd())
+	cmd.AddCommand(stop.NewCmd())
 	cmd.AddCommand(up.NewCmd())
 
 	return cmd

--- a/internal/cli/kraft/compose/compose.go
+++ b/internal/cli/kraft/compose/compose.go
@@ -14,6 +14,7 @@ import (
 
 	"kraftkit.sh/cmdfactory"
 	"kraftkit.sh/internal/cli/kraft/compose/build"
+	"kraftkit.sh/internal/cli/kraft/compose/create"
 	"kraftkit.sh/internal/cli/kraft/compose/down"
 	"kraftkit.sh/internal/cli/kraft/compose/logs"
 	"kraftkit.sh/internal/cli/kraft/compose/ls"
@@ -47,6 +48,7 @@ func NewCmd() *cobra.Command {
 	}
 
 	cmd.AddCommand(build.NewCmd())
+	cmd.AddCommand(create.NewCmd())
 	cmd.AddCommand(down.NewCmd())
 	cmd.AddCommand(logs.NewCmd())
 	cmd.AddCommand(ls.NewCmd())

--- a/internal/cli/kraft/compose/compose.go
+++ b/internal/cli/kraft/compose/compose.go
@@ -19,6 +19,7 @@ import (
 	"kraftkit.sh/internal/cli/kraft/compose/logs"
 	"kraftkit.sh/internal/cli/kraft/compose/ls"
 	"kraftkit.sh/internal/cli/kraft/compose/ps"
+	"kraftkit.sh/internal/cli/kraft/compose/start"
 	"kraftkit.sh/internal/cli/kraft/compose/up"
 )
 
@@ -53,6 +54,7 @@ func NewCmd() *cobra.Command {
 	cmd.AddCommand(logs.NewCmd())
 	cmd.AddCommand(ls.NewCmd())
 	cmd.AddCommand(ps.NewCmd())
+	cmd.AddCommand(start.NewCmd())
 	cmd.AddCommand(up.NewCmd())
 
 	return cmd

--- a/internal/cli/kraft/compose/create/create.go
+++ b/internal/cli/kraft/compose/create/create.go
@@ -1,0 +1,409 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2024, Unikraft GmbH and The KraftKit Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+
+package create
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/MakeNowJust/heredoc"
+	"github.com/compose-spec/compose-go/types"
+	"github.com/spf13/cobra"
+
+	"kraftkit.sh/cmdfactory"
+	"kraftkit.sh/compose"
+	"kraftkit.sh/internal/cli/kraft/build"
+	"kraftkit.sh/internal/cli/kraft/net/create"
+	"kraftkit.sh/internal/cli/kraft/pkg"
+	"kraftkit.sh/internal/cli/kraft/pkg/pull"
+	"kraftkit.sh/internal/cli/kraft/remove"
+	"kraftkit.sh/internal/cli/kraft/run"
+	"kraftkit.sh/log"
+	"kraftkit.sh/packmanager"
+	"kraftkit.sh/unikraft"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	composeapi "kraftkit.sh/api/compose/v1"
+	machineapi "kraftkit.sh/api/machine/v1alpha1"
+	networkapi "kraftkit.sh/api/network/v1alpha1"
+	mnetwork "kraftkit.sh/machine/network"
+	mplatform "kraftkit.sh/machine/platform"
+)
+
+type CreateOptions struct {
+	Composefile string `noattribute:"true"`
+}
+
+func NewCmd() *cobra.Command {
+	cmd, err := cmdfactory.New(&CreateOptions{}, cobra.Command{
+		Short:   "Create a compose project",
+		Use:     "create [FLAGS]",
+		Args:    cobra.NoArgs,
+		Aliases: []string{},
+		Long:    "Create the services and networks for a project.",
+		Example: heredoc.Doc(`
+			# Create the networks and services without running them
+			$ kraft compose create 
+		`),
+		Annotations: map[string]string{
+			cmdfactory.AnnotationHelpGroup: "compose",
+		},
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	return cmd
+}
+
+func (opts *CreateOptions) Pre(cmd *cobra.Command, _ []string) error {
+	ctx, err := packmanager.WithDefaultUmbrellaManagerInContext(cmd.Context())
+	if err != nil {
+		return err
+	}
+
+	cmd.SetContext(ctx)
+
+	if cmd.Flag("file").Changed {
+		opts.Composefile = cmd.Flag("file").Value.String()
+	}
+
+	log.G(cmd.Context()).WithField("composefile", opts.Composefile).Debug("using")
+	return nil
+}
+
+func (opts *CreateOptions) Run(ctx context.Context, args []string) error {
+	workdir, err := os.Getwd()
+	if err != nil {
+		return err
+	}
+
+	project, err := compose.NewProjectFromComposeFile(ctx, workdir, opts.Composefile)
+	if err != nil {
+		return err
+	}
+
+	if err := project.Validate(ctx); err != nil {
+		return err
+	}
+
+	if err := project.AssignIPs(ctx); err != nil {
+		return err
+	}
+
+	composeController, err := compose.NewComposeProjectV1(ctx)
+	if err != nil {
+		return err
+	}
+
+	embeddedProject, err := composeController.Get(ctx, &composeapi.Compose{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: project.Name,
+		},
+	})
+	if err != nil {
+		return err
+	}
+
+	projectNetworks := []metav1.ObjectMeta{}
+	if embeddedProject != nil {
+		projectNetworks = embeddedProject.Status.Networks
+	}
+
+	networkController, err := mnetwork.NewNetworkV1alpha1ServiceIterator(ctx)
+	if err != nil {
+		return err
+	}
+
+	networks, err := networkController.List(ctx, &networkapi.NetworkList{})
+	if err != nil {
+		return err
+	}
+
+	// We need to first create the networks with a provided subnet
+	// and then the ones which we will assign IPs to
+	subnetNetworks := []string{}
+	emptyNetworks := []string{}
+	for name, network := range project.Networks {
+		if network.Ipam.Config == nil || len(network.Ipam.Config) == 0 {
+			emptyNetworks = append(emptyNetworks, name)
+		} else {
+			subnetNetworks = append(subnetNetworks, name)
+		}
+	}
+
+	orderedNetworks := append(subnetNetworks, emptyNetworks...)
+
+	for _, networkName := range orderedNetworks {
+		network := project.Networks[networkName]
+		alreadyRunning := false
+		for _, n := range networks.Items {
+			if n.Name == network.Name {
+				alreadyRunning = true
+				break
+			}
+		}
+		if alreadyRunning {
+			continue
+		}
+
+		driver := mnetwork.DefaultStrategyName()
+		if network.Driver != "" {
+			driver = network.Driver
+		}
+
+		subnet := ""
+		if len(network.Ipam.Config) > 0 {
+			subnet = network.Ipam.Config[0].Subnet
+		}
+		createOptions := create.CreateOptions{
+			Driver:  driver,
+			Network: subnet,
+		}
+
+		log.G(ctx).Infof("creating network %s...", network.Name)
+		if err := createOptions.Run(ctx, []string{network.Name}); err != nil {
+			return err
+		}
+
+		if network, err := networkController.Get(ctx, &networkapi.Network{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: network.Name,
+			},
+		}); err == nil && network.Status.State == networkapi.NetworkStateUp {
+			projectNetworks = append(projectNetworks, network.ObjectMeta)
+		}
+
+	}
+
+	projectMachines := []metav1.ObjectMeta{}
+	if embeddedProject != nil {
+		projectMachines = embeddedProject.Status.Machines
+	}
+
+	// Check that none of the services are already running
+	machineController, err := mplatform.NewMachineV1alpha1ServiceIterator(ctx)
+	if err != nil {
+		return err
+	}
+
+	machines, err := machineController.List(ctx, &machineapi.MachineList{})
+	if err != nil {
+		return err
+	}
+
+	for _, service := range project.Services {
+		alreadyCreated := false
+		for _, machine := range machines.Items {
+			if service.Name != machine.Name {
+				continue
+			}
+			if machine.Status.State == machineapi.MachineStateRunning || machine.Status.State == machineapi.MachineStateCreated {
+				alreadyCreated = true
+				break
+			}
+			rmOpts := remove.RemoveOptions{
+				Platform: machine.Spec.Platform,
+			}
+
+			if err := rmOpts.Run(ctx, []string{service.Name}); err != nil {
+				return err
+			}
+
+			for i, m := range projectMachines {
+				if m.Name == machine.Name {
+					projectMachines = append(projectMachines[:i], projectMachines[i+1:]...)
+					break
+				}
+			}
+			break
+		}
+		if alreadyCreated {
+			continue
+		}
+		if service.Image == "" {
+			if err := buildService(ctx, service); err != nil {
+				return err
+			}
+		} else if err := ensureServiceIsPackaged(ctx, service); err != nil {
+			return err
+		}
+
+		if err := createService(ctx, project, service); err != nil {
+			log.G(ctx).WithError(err).Errorf("failed to create service %s", service.Name)
+		}
+
+		if machine, err := machineController.Get(ctx, &machineapi.Machine{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: service.Name,
+			},
+		}); err == nil && machine.Status.State == machineapi.MachineStateCreated {
+			projectMachines = append(projectMachines, machine.ObjectMeta)
+		} else if err != nil {
+			return err
+		}
+	}
+
+	if _, err := composeController.Update(ctx, &composeapi.Compose{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: project.Name,
+		},
+		Spec: composeapi.ComposeSpec{
+			Composefile: project.ComposeFiles[0],
+			Workdir:     project.WorkingDir,
+		},
+		Status: composeapi.ComposeStatus{
+			Machines: projectMachines,
+			Networks: projectNetworks,
+		},
+	}); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func platArchFromService(service types.ServiceConfig) (string, string, error) {
+	// The service platform should be in the form <platform>/<arch>
+
+	parts := strings.SplitN(service.Platform, "/", 2)
+
+	if len(parts) != 2 {
+		return "", "", fmt.Errorf("invalid platform: %s for service %s", service.Platform, service.Name)
+	}
+
+	return parts[0], parts[1], nil
+}
+
+func ensureServiceIsPackaged(ctx context.Context, service types.ServiceConfig) error {
+	plat, arch, err := platArchFromService(service)
+	if err != nil {
+		return err
+	}
+
+	parts := strings.SplitN(service.Image, ":", 2)
+	imageName := parts[0]
+	imageVersion := "latest"
+	if len(parts) == 2 {
+		imageVersion = parts[1]
+	}
+
+	service.Image = imageName + ":" + imageVersion
+
+	log.G(ctx).Debugf("searching for service %s locally...", service.Name)
+	// Check whether the image is already in the local catalog
+	packages, err := packmanager.G(ctx).Catalog(ctx,
+		packmanager.WithArchitecture(arch),
+		packmanager.WithName(imageName),
+		packmanager.WithPlatform(plat),
+		packmanager.WithTypes(unikraft.ComponentTypeApp),
+		packmanager.WithVersion(imageVersion))
+	if err != nil {
+		return err
+	}
+
+	// If we have it locally, we are done
+	if len(packages) != 0 {
+		log.G(ctx).Debugf("found service %s locally", service.Name)
+		return nil
+	}
+
+	log.G(ctx).Debugf("searching for service %s remotely...", service.Name)
+	// Check whether the image is in the remote catalog
+	packages, err = packmanager.G(ctx).Catalog(ctx,
+		packmanager.WithArchitecture(arch),
+		packmanager.WithName(imageName),
+		packmanager.WithPlatform(plat),
+		packmanager.WithTypes(unikraft.ComponentTypeApp),
+		packmanager.WithRemote(true),
+		packmanager.WithVersion(imageVersion))
+	if err != nil {
+		return err
+	}
+
+	// If we have it remotely, we are done
+	if len(packages) != 0 {
+		log.G(ctx).Infof("found service %s remotely, pulling...", service.Name)
+		// We need to pull it locally
+		pullOptions := pull.PullOptions{Platform: plat, Architecture: arch}
+		return pullOptions.Run(ctx, []string{service.Image})
+	}
+
+	// Otherwise, we need to build and package it
+	if err := buildService(ctx, service); err != nil {
+		return err
+	}
+
+	return pkgService(ctx, service)
+}
+
+func buildService(ctx context.Context, service types.ServiceConfig) error {
+	if service.Build == nil {
+		return fmt.Errorf("service %s has no build context", service.Name)
+	}
+
+	plat, arch, err := platArchFromService(service)
+	if err != nil {
+		return err
+	}
+
+	log.G(ctx).Infof("building service %s...", service.Name)
+
+	buildOptions := build.BuildOptions{Platform: plat, Architecture: arch}
+
+	return buildOptions.Run(ctx, []string{service.Build.Context})
+}
+
+func pkgService(ctx context.Context, service types.ServiceConfig) error {
+	plat, arch, err := platArchFromService(service)
+	if err != nil {
+		return err
+	}
+
+	log.G(ctx).Infof("packaging service %s...", service.Name)
+
+	pkgOptions := pkg.PkgOptions{
+		Architecture: arch,
+		Name:         service.Image,
+		Format:       "oci",
+		Platform:     plat,
+		Strategy:     packmanager.StrategyOverwrite,
+	}
+
+	return pkgOptions.Run(ctx, []string{service.Build.Context})
+}
+
+func createService(ctx context.Context, project *compose.Project, service types.ServiceConfig) error {
+	// The service should be packaged at this point
+	plat, arch, err := platArchFromService(service)
+	if err != nil {
+		return err
+	}
+
+	log.G(ctx).Infof("creating service %s...", service.Name)
+
+	networks := []string{}
+	for name, network := range service.Networks {
+		networks = append(networks, fmt.Sprintf("%s:%s", project.Networks[name].Name, network.Ipv4Address))
+	}
+
+	runOptions := run.RunOptions{
+		Architecture: arch,
+		Detach:       true,
+		Name:         service.Name,
+		Networks:     networks,
+		NoStart:      true,
+		Platform:     plat,
+	}
+
+	if service.Image != "" {
+		return runOptions.Run(ctx, []string{service.Image})
+	}
+
+	return runOptions.Run(ctx, []string{service.Build.Context})
+}

--- a/internal/cli/kraft/compose/logs/logs.go
+++ b/internal/cli/kraft/compose/logs/logs.go
@@ -28,7 +28,7 @@ import (
 type LogsOptions struct {
 	Follow bool `long:"follow" usage:"Follow log output"`
 
-	composefile string
+	Composefile string `noattribute:"true"`
 }
 
 func NewCmd() *cobra.Command {
@@ -55,10 +55,10 @@ func (opts *LogsOptions) Pre(cmd *cobra.Command, _ []string) error {
 	cmd.SetContext(ctx)
 
 	if cmd.Flag("file").Changed {
-		opts.composefile = cmd.Flag("file").Value.String()
+		opts.Composefile = cmd.Flag("file").Value.String()
 	}
 
-	log.G(cmd.Context()).WithField("composefile", opts.composefile).Debug("using")
+	log.G(cmd.Context()).WithField("composefile", opts.Composefile).Debug("using")
 
 	return nil
 }
@@ -69,7 +69,7 @@ func (opts *LogsOptions) Run(ctx context.Context, args []string) error {
 		return err
 	}
 
-	project, err := compose.NewProjectFromComposeFile(ctx, workdir, opts.composefile)
+	project, err := compose.NewProjectFromComposeFile(ctx, workdir, opts.Composefile)
 	if err != nil {
 		return err
 	}

--- a/internal/cli/kraft/compose/start/start.go
+++ b/internal/cli/kraft/compose/start/start.go
@@ -1,0 +1,122 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2024, Unikraft GmbH and The KraftKit Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+package start
+
+import (
+	"context"
+	"os"
+
+	"github.com/MakeNowJust/heredoc"
+	"github.com/spf13/cobra"
+
+	"kraftkit.sh/cmdfactory"
+	"kraftkit.sh/compose"
+	"kraftkit.sh/log"
+	"kraftkit.sh/packmanager"
+
+	machineapi "kraftkit.sh/api/machine/v1alpha1"
+	"kraftkit.sh/internal/cli/kraft/compose/logs"
+	kernelstart "kraftkit.sh/internal/cli/kraft/start"
+	mplatform "kraftkit.sh/machine/platform"
+)
+
+type StartOptions struct {
+	Composefile string `noattribute:"true"`
+	Detach      bool   `long:"detach" short:"d" usage:"Run in background"`
+}
+
+func NewCmd() *cobra.Command {
+	cmd, err := cmdfactory.New(&StartOptions{}, cobra.Command{
+		Short:   "Start a compose project",
+		Use:     "start [FLAGS]",
+		Args:    cobra.NoArgs,
+		Aliases: []string{},
+		Example: heredoc.Doc(`
+			# Start a compose project
+			$ kraft compose start 
+		`),
+		Annotations: map[string]string{
+			cmdfactory.AnnotationHelpGroup: "compose",
+		},
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	return cmd
+}
+
+func (opts *StartOptions) Pre(cmd *cobra.Command, _ []string) error {
+	ctx, err := packmanager.WithDefaultUmbrellaManagerInContext(cmd.Context())
+	if err != nil {
+		return err
+	}
+
+	cmd.SetContext(ctx)
+
+	if cmd.Flag("file").Changed {
+		opts.Composefile = cmd.Flag("file").Value.String()
+	}
+
+	log.G(cmd.Context()).WithField("composefile", opts.Composefile).Debug("using")
+	return nil
+}
+
+func (opts *StartOptions) Run(ctx context.Context, _ []string) error {
+	workdir, err := os.Getwd()
+	if err != nil {
+		return err
+	}
+
+	project, err := compose.NewProjectFromComposeFile(ctx, workdir, opts.Composefile)
+	if err != nil {
+		return err
+	}
+
+	if err := project.Validate(ctx); err != nil {
+		return err
+	}
+
+	machineController, err := mplatform.NewMachineV1alpha1ServiceIterator(ctx)
+	if err != nil {
+		return err
+	}
+
+	machines, err := machineController.List(ctx, &machineapi.MachineList{})
+	if err != nil {
+		return err
+	}
+
+	machinesToStart := []string{}
+	for _, service := range project.Services {
+		for _, machine := range machines.Items {
+			if service.Name == machine.Name {
+				if machine.Status.State == machineapi.MachineStateCreated || machine.Status.State == machineapi.MachineStateExited {
+					machinesToStart = append(machinesToStart, machine.Name)
+				}
+			}
+		}
+	}
+
+	kernelStartOptions := kernelstart.StartOptions{
+		Detach:   true,
+		Platform: "auto",
+	}
+
+	if err := kernelStartOptions.Run(ctx, machinesToStart); err != nil {
+		return err
+	}
+
+	if opts.Detach {
+		return nil
+	}
+
+	logsOptions := logs.LogsOptions{
+		Composefile: opts.Composefile,
+		Follow:      true,
+	}
+
+	return logsOptions.Run(ctx, []string{})
+}

--- a/internal/cli/kraft/compose/stop/stop.go
+++ b/internal/cli/kraft/compose/stop/stop.go
@@ -1,0 +1,108 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2024, Unikraft GmbH and The KraftKit Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+package stop
+
+import (
+	"context"
+	"os"
+
+	"github.com/MakeNowJust/heredoc"
+	"github.com/spf13/cobra"
+
+	"kraftkit.sh/cmdfactory"
+	"kraftkit.sh/compose"
+	"kraftkit.sh/log"
+	"kraftkit.sh/packmanager"
+
+	machineapi "kraftkit.sh/api/machine/v1alpha1"
+	kernelstop "kraftkit.sh/internal/cli/kraft/stop"
+	mplatform "kraftkit.sh/machine/platform"
+)
+
+type StopOptions struct {
+	composefile string
+}
+
+func NewCmd() *cobra.Command {
+	cmd, err := cmdfactory.New(&StopOptions{}, cobra.Command{
+		Short:   "Stop a compose project",
+		Use:     "stop [FLAGS]",
+		Args:    cobra.NoArgs,
+		Aliases: []string{},
+		Example: heredoc.Doc(`
+			# Stop a compose project
+			$ kraft compose stop 
+		`),
+		Annotations: map[string]string{
+			cmdfactory.AnnotationHelpGroup: "compose",
+		},
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	return cmd
+}
+
+func (opts *StopOptions) Pre(cmd *cobra.Command, _ []string) error {
+	ctx, err := packmanager.WithDefaultUmbrellaManagerInContext(cmd.Context())
+	if err != nil {
+		return err
+	}
+
+	cmd.SetContext(ctx)
+
+	if cmd.Flag("file").Changed {
+		opts.composefile = cmd.Flag("file").Value.String()
+	}
+
+	log.G(cmd.Context()).WithField("composefile", opts.composefile).Debug("using")
+	return nil
+}
+
+func (opts *StopOptions) Run(ctx context.Context, _ []string) error {
+	workdir, err := os.Getwd()
+	if err != nil {
+		return err
+	}
+
+	project, err := compose.NewProjectFromComposeFile(ctx, workdir, opts.composefile)
+	if err != nil {
+		return err
+	}
+
+	if err := project.Validate(ctx); err != nil {
+		return err
+	}
+
+	machineController, err := mplatform.NewMachineV1alpha1ServiceIterator(ctx)
+	if err != nil {
+		return err
+	}
+
+	machines, err := machineController.List(ctx, &machineapi.MachineList{})
+	if err != nil {
+		return err
+	}
+
+	machinesToStop := []string{}
+	for _, service := range project.Services {
+		for _, machine := range machines.Items {
+			if service.Name == machine.Name && machine.Status.State == machineapi.MachineStateRunning {
+				machinesToStop = append(machinesToStop, machine.Name)
+			}
+		}
+	}
+
+	if len(machinesToStop) == 0 {
+		return nil
+	}
+
+	kernelStopOptions := kernelstop.StopOptions{
+		Platform: "auto",
+	}
+
+	return kernelStopOptions.Run(ctx, machinesToStop)
+}

--- a/internal/cli/kraft/compose/up/up.go
+++ b/internal/cli/kraft/compose/up/up.go
@@ -7,34 +7,15 @@ package up
 
 import (
 	"context"
-	"fmt"
-	"os"
-	"strings"
-	"sync"
 
 	"github.com/MakeNowJust/heredoc"
-	"github.com/compose-spec/compose-go/types"
 	"github.com/spf13/cobra"
 
 	"kraftkit.sh/cmdfactory"
-	"kraftkit.sh/compose"
-	"kraftkit.sh/internal/cli/kraft/build"
-	"kraftkit.sh/internal/cli/kraft/logs"
-	"kraftkit.sh/internal/cli/kraft/net/create"
-	"kraftkit.sh/internal/cli/kraft/pkg"
-	"kraftkit.sh/internal/cli/kraft/pkg/pull"
-	"kraftkit.sh/internal/cli/kraft/remove"
-	"kraftkit.sh/internal/cli/kraft/run"
+	"kraftkit.sh/internal/cli/kraft/compose/create"
+	"kraftkit.sh/internal/cli/kraft/compose/start"
 	"kraftkit.sh/log"
-	"kraftkit.sh/machine/network"
 	"kraftkit.sh/packmanager"
-	"kraftkit.sh/unikraft"
-
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	composeapi "kraftkit.sh/api/compose/v1"
-	machineapi "kraftkit.sh/api/machine/v1alpha1"
-	networkapi "kraftkit.sh/api/network/v1alpha1"
-	mplatform "kraftkit.sh/machine/platform"
 )
 
 type UpOptions struct {
@@ -47,7 +28,6 @@ func NewCmd() *cobra.Command {
 		Use:     "up [FLAGS]",
 		Args:    cobra.NoArgs,
 		Aliases: []string{},
-		Long:    "Run a compose project.",
 		Example: heredoc.Doc(`
 			# Run a compose project
 			$ kraft compose up
@@ -79,360 +59,18 @@ func (opts *UpOptions) Pre(cmd *cobra.Command, _ []string) error {
 	return nil
 }
 
-func (opts *UpOptions) Run(ctx context.Context, args []string) error {
-	workdir, err := os.Getwd()
-	if err != nil {
+func (opts *UpOptions) Run(ctx context.Context, _ []string) error {
+	createOptions := create.CreateOptions{
+		Composefile: opts.composefile,
+	}
+
+	if err := createOptions.Run(ctx, []string{}); err != nil {
 		return err
 	}
 
-	project, err := compose.NewProjectFromComposeFile(ctx, workdir, opts.composefile)
-	if err != nil {
-		return err
+	startOptions := start.StartOptions{
+		Composefile: opts.composefile,
 	}
 
-	if err := project.Validate(ctx); err != nil {
-		return err
-	}
-
-	if err := project.AssignIPs(ctx); err != nil {
-		return err
-	}
-
-	composeController, err := compose.NewComposeProjectV1(ctx)
-	if err != nil {
-		return err
-	}
-
-	embeddedProject, err := composeController.Get(ctx, &composeapi.Compose{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: project.Name,
-		},
-	})
-	if err != nil {
-		return err
-	}
-
-	projectNetworks := []metav1.ObjectMeta{}
-	if embeddedProject != nil {
-		projectNetworks = embeddedProject.Status.Networks
-	}
-
-	networkController, err := network.NewNetworkV1alpha1ServiceIterator(ctx)
-	if err != nil {
-		return err
-	}
-
-	networks, err := networkController.List(ctx, &networkapi.NetworkList{})
-	if err != nil {
-		return err
-	}
-
-	// We need to first create the networks with a provided subnet
-	// and then the ones which we will assign IPs to
-	subnetNetworks := []string{}
-	emptyNetworks := []string{}
-	for name, network := range project.Networks {
-		if network.Ipam.Config == nil || len(network.Ipam.Config) == 0 {
-			emptyNetworks = append(emptyNetworks, name)
-		} else {
-			subnetNetworks = append(subnetNetworks, name)
-		}
-	}
-
-	orderedNetworks := append(subnetNetworks, emptyNetworks...)
-
-	for _, networkName := range orderedNetworks {
-		network := project.Networks[networkName]
-		alreadyRunning := false
-		for _, n := range networks.Items {
-			if n.Name == network.Name {
-				alreadyRunning = true
-				break
-			}
-		}
-		if alreadyRunning {
-			continue
-		}
-
-		driver := "bridge"
-		if network.Driver != "" {
-			driver = network.Driver
-		}
-
-		subnet := ""
-		if len(network.Ipam.Config) > 0 {
-			subnet = network.Ipam.Config[0].Subnet
-		}
-		createOptions := create.CreateOptions{
-			Driver:  driver,
-			Network: subnet,
-		}
-
-		log.G(ctx).Infof("creating network %s...", network.Name)
-		if err := createOptions.Run(ctx, []string{network.Name}); err != nil {
-			return err
-		}
-
-		if network, err := networkController.Get(ctx, &networkapi.Network{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: network.Name,
-			},
-		}); err == nil && network.Status.State == networkapi.NetworkStateUp {
-			projectNetworks = append(projectNetworks, network.ObjectMeta)
-		}
-
-	}
-
-	projectMachines := []metav1.ObjectMeta{}
-	if embeddedProject != nil {
-		projectMachines = embeddedProject.Status.Machines
-	}
-
-	// Check that none of the services are already running
-	machineController, err := mplatform.NewMachineV1alpha1ServiceIterator(ctx)
-	if err != nil {
-		return err
-	}
-
-	machines, err := machineController.List(ctx, &machineapi.MachineList{})
-	if err != nil {
-		return err
-	}
-
-	for _, service := range project.Services {
-		alreadyRunning := false
-		for _, machine := range machines.Items {
-			if service.Name == machine.Name {
-				if machine.Status.State == machineapi.MachineStateRunning {
-					alreadyRunning = true
-				} else {
-					rmOpts := remove.RemoveOptions{
-						Platform: machine.Spec.Platform,
-					}
-
-					if err := rmOpts.Run(ctx, []string{service.Name}); err != nil {
-						return err
-					}
-				}
-				break
-			}
-		}
-		if alreadyRunning {
-			continue
-		}
-		if service.Image == "" {
-			if err := buildService(ctx, service); err != nil {
-				return err
-			}
-		} else {
-			if err := ensureServiceIsPackaged(ctx, service); err != nil {
-				return err
-			}
-		}
-
-		if err := runService(ctx, project, service); err != nil {
-			log.G(ctx).WithError(err).Errorf("failed to run service %s", service.Name)
-		}
-
-		if machine, err := machineController.Get(ctx, &machineapi.Machine{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: service.Name,
-			},
-		}); err == nil && machine.Status.State == machineapi.MachineStateRunning {
-			projectMachines = append(projectMachines, machine.ObjectMeta)
-		}
-	}
-
-	if _, err := composeController.Update(ctx, &composeapi.Compose{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: project.Name,
-		},
-		Spec: composeapi.ComposeSpec{
-			Composefile: project.ComposeFiles[0],
-			Workdir:     project.WorkingDir,
-		},
-		Status: composeapi.ComposeStatus{
-			Machines: projectMachines,
-			Networks: projectNetworks,
-		},
-	}); err != nil {
-		return err
-	}
-
-	var wg sync.WaitGroup
-
-	longestName := 0
-	for _, service := range project.Services {
-		if len(service.Name) > longestName {
-			longestName = len(service.Name)
-		}
-	}
-	for i := range project.Services {
-		wg.Add(1)
-		go func(service types.ServiceConfig) {
-			defer wg.Done()
-
-			if err := logService(ctx, service); err != nil {
-				log.G(ctx).WithError(err).Errorf("failed to log service %s", service.Name)
-			}
-		}(project.Services[i])
-	}
-
-	wg.Wait()
-
-	return nil
-}
-
-func platArchFromService(service types.ServiceConfig) (string, string, error) {
-	// The service platform should be in the form <platform>/<arch>
-
-	parts := strings.SplitN(service.Platform, "/", 2)
-
-	if len(parts) != 2 {
-		return "", "", fmt.Errorf("invalid platform: %s for service %s", service.Platform, service.Name)
-	}
-
-	return parts[0], parts[1], nil
-}
-
-func ensureServiceIsPackaged(ctx context.Context, service types.ServiceConfig) error {
-	plat, arch, err := platArchFromService(service)
-	if err != nil {
-		return err
-	}
-
-	parts := strings.SplitN(service.Image, ":", 2)
-	imageName := parts[0]
-	imageVersion := "latest"
-	if len(parts) == 2 {
-		imageVersion = parts[1]
-	}
-
-	service.Image = imageName + ":" + imageVersion
-
-	log.G(ctx).Debugf("searching for service %s locally...", service.Name)
-	// Check whether the image is already in the local catalog
-	packages, err := packmanager.G(ctx).Catalog(ctx,
-		packmanager.WithArchitecture(arch),
-		packmanager.WithName(imageName),
-		packmanager.WithPlatform(plat),
-		packmanager.WithTypes(unikraft.ComponentTypeApp),
-		packmanager.WithVersion(imageVersion))
-	if err != nil {
-		return err
-	}
-
-	// If we have it locally, we are done
-	if len(packages) != 0 {
-		log.G(ctx).Debugf("found service %s locally", service.Name)
-		return nil
-	}
-
-	log.G(ctx).Debugf("searching for service %s remotely...", service.Name)
-	// Check whether the image is in the remote catalog
-	packages, err = packmanager.G(ctx).Catalog(ctx,
-		packmanager.WithArchitecture(arch),
-		packmanager.WithName(imageName),
-		packmanager.WithPlatform(plat),
-		packmanager.WithTypes(unikraft.ComponentTypeApp),
-		packmanager.WithRemote(true),
-		packmanager.WithVersion(imageVersion))
-	if err != nil {
-		return err
-	}
-
-	// If we have it remotely, we are done
-	if len(packages) != 0 {
-		log.G(ctx).Infof("found service %s remotely, pulling...", service.Name)
-		// We need to pull it locally
-		pullOptions := pull.PullOptions{Platform: plat, Architecture: arch}
-		return pullOptions.Run(ctx, []string{service.Image})
-	}
-
-	// Otherwise, we need to build and package it
-	if err := buildService(ctx, service); err != nil {
-		return err
-	}
-
-	return pkgService(ctx, service)
-}
-
-func buildService(ctx context.Context, service types.ServiceConfig) error {
-	if service.Build == nil {
-		return fmt.Errorf("service %s has no build context", service.Name)
-	}
-
-	plat, arch, err := platArchFromService(service)
-	if err != nil {
-		return err
-	}
-
-	log.G(ctx).Infof("building service %s...", service.Name)
-
-	buildOptions := build.BuildOptions{Platform: plat, Architecture: arch}
-
-	return buildOptions.Run(ctx, []string{service.Build.Context})
-}
-
-func pkgService(ctx context.Context, service types.ServiceConfig) error {
-	plat, arch, err := platArchFromService(service)
-	if err != nil {
-		return err
-	}
-
-	log.G(ctx).Infof("packaging service %s...", service.Name)
-
-	pkgOptions := pkg.PkgOptions{
-		Architecture: arch,
-		Name:         service.Image,
-		Format:       "oci",
-		Platform:     plat,
-		Strategy:     packmanager.StrategyOverwrite,
-	}
-
-	return pkgOptions.Run(ctx, []string{service.Build.Context})
-}
-
-func runService(ctx context.Context, project *compose.Project, service types.ServiceConfig) error {
-	// The service should be packaged at this point
-	plat, arch, err := platArchFromService(service)
-	if err != nil {
-		return err
-	}
-
-	log.G(ctx).Infof("running service %s...", service.Name)
-
-	networks := []string{}
-	for name, network := range service.Networks {
-		networkArg := fmt.Sprintf("%s:%s", project.Networks[name].Name, network.Ipv4Address)
-		networks = append(networks, networkArg)
-	}
-
-	runOptions := run.RunOptions{
-		Architecture: arch,
-		Detach:       true,
-		Name:         service.Name,
-		Networks:     networks,
-		Platform:     plat,
-	}
-
-	if service.Image != "" {
-		return runOptions.Run(ctx, []string{service.Image})
-	}
-
-	return runOptions.Run(ctx, []string{service.Build.Context})
-}
-
-func logService(ctx context.Context, service types.ServiceConfig) error {
-	plat, _, err := platArchFromService(service)
-	if err != nil {
-		return err
-	}
-
-	logOptions := logs.LogOptions{
-		Follow:   true,
-		Platform: plat,
-	}
-
-	return logOptions.Run(ctx, []string{service.Name})
+	return startOptions.Run(ctx, []string{})
 }

--- a/internal/cli/kraft/stop/stop.go
+++ b/internal/cli/kraft/stop/stop.go
@@ -19,8 +19,8 @@ import (
 )
 
 type StopOptions struct {
-	All      bool `long:"all" usage:"Remove all machines"`
-	platform string
+	All      bool   `long:"all" usage:"Remove all machines"`
+	Platform string `noattribute:"true"`
 }
 
 // Stop a local Unikraft virtual machine.
@@ -70,7 +70,7 @@ func (opts *StopOptions) Pre(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("please supply a machine ID or name or use the --all flag")
 	}
 
-	opts.platform = cmd.Flag("plat").Value.String()
+	opts.Platform = cmd.Flag("plat").Value.String()
 	return nil
 }
 
@@ -84,19 +84,19 @@ func (opts *StopOptions) Run(ctx context.Context, args []string) error {
 	platform := mplatform.PlatformUnknown
 	var controller machineapi.MachineService
 
-	if opts.All || opts.platform == "auto" {
+	if opts.All || opts.Platform == "auto" {
 		controller, err = mplatform.NewMachineV1alpha1ServiceIterator(ctx)
 	} else {
-		if opts.platform == "host" {
+		if opts.Platform == "host" {
 			platform, _, err = mplatform.Detect(ctx)
 			if err != nil {
 				return err
 			}
 		} else {
 			var ok bool
-			platform, ok = mplatform.PlatformsByName()[opts.platform]
+			platform, ok = mplatform.PlatformsByName()[opts.Platform]
 			if !ok {
-				return fmt.Errorf("unknown platform driver: %s", opts.platform)
+				return fmt.Errorf("unknown platform driver: %s", opts.Platform)
 			}
 		}
 

--- a/internal/cli/kraft/stop/stop.go
+++ b/internal/cli/kraft/stop/stop.go
@@ -123,9 +123,10 @@ func (opts *StopOptions) Run(ctx context.Context, args []string) error {
 			stop = append(stop, machine)
 			continue
 		}
-
-		if args[0] == machine.Name || args[0] == string(machine.UID) {
-			stop = append(stop, machine)
+		for _, arg := range args {
+			if arg == machine.Name || arg == string(machine.UID) {
+				stop = append(stop, machine)
+			}
 		}
 	}
 

--- a/machine/network/register_darwin.go
+++ b/machine/network/register_darwin.go
@@ -11,6 +11,8 @@ import (
 	networkv1alpha1 "kraftkit.sh/api/network/v1alpha1"
 )
 
+var defaultStrategyName = "bridge"
+
 // hostSupportedStrategies returns the map of known supported drivers for the
 // given host.
 func hostSupportedStrategies() map[string]*Strategy {

--- a/machine/network/register_freebsd.go
+++ b/machine/network/register_freebsd.go
@@ -4,6 +4,8 @@
 // You may not use this file except in compliance with the License.
 package network
 
+var defaultStrategyName = ""
+
 // hostSupportedStrategies returns the map of known supported drivers for the
 // given host.
 // Currently stubbed out for FreeBSD.

--- a/machine/network/register_linux.go
+++ b/machine/network/register_linux.go
@@ -16,6 +16,8 @@ import (
 	"kraftkit.sh/store"
 )
 
+var defaultStrategyName = "bridge"
+
 // hostSupportedStrategies returns the map of known supported drivers for the
 // given host.
 func hostSupportedStrategies() map[string]*Strategy {

--- a/machine/network/register_windows.go
+++ b/machine/network/register_windows.go
@@ -11,6 +11,8 @@ import (
 	networkv1alpha1 "kraftkit.sh/api/network/v1alpha1"
 )
 
+var defaultStrategyName = "bridge"
+
 // hostSupportedStrategies returns the map of known supported drivers for the
 // given host.
 func hostSupportedStrategies() map[string]*Strategy {

--- a/machine/network/service.go
+++ b/machine/network/service.go
@@ -26,6 +26,11 @@ type Strategy struct {
 	NewNetworkV1alpha1 NewStrategyConstructor[networkv1alpha1.NetworkService]
 }
 
+// DefaultStrategyName return the name of the default strategy of the platform.
+func DefaultStrategyName() string {
+	return defaultStrategyName
+}
+
 // Strategies returns the list of registered platform implementations.
 func Strategies() map[string]*Strategy {
 	base := hostSupportedStrategies()


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

Add the ``compose create``, ``start`` and ``stop`` subcommands which provide higher granularity to the state of a project.

Also refactors ``up`` because it is now trivially a ``create`` followed by a ``start``.

This was all mostly achieved by splitting the previous code from ``up`` into multiple parts.

<!--
Please provide a detailed description of the changes made in this new PR.
-->
