### PR TITLE
feat(ps): Add ``--all`` flag

### DIFF
--- a/internal/cli/kraft/compose/ps/ps.go
+++ b/internal/cli/kraft/compose/ps/ps.go
@@ -22,6 +22,8 @@ import (
 )
 
 type PsOptions struct {
+	ShowAll bool `long:"all" short:"a" usage:"Show all machines (default shows just running)"`
+
 	composefile string
 }
 
@@ -78,7 +80,8 @@ func (opts *PsOptions) Run(ctx context.Context, args []string) error {
 	}
 
 	pslistOptions := pslist.PsOptions{
-		Output: "table",
+		Output:  "table",
+		ShowAll: opts.ShowAll,
 	}
 
 	psTable, err := pslistOptions.PsTable(ctx)


### PR DESCRIPTION
The all flag allows users to list all services in a project, regardeless of status.

<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

Allows ``compose ps`` to list machines that are not running as well.

<!--
Please provide a detailed description of the changes made in this new PR.
-->
