### PR TITLE
feat(logs): Log multiple machines at once

### DIFF
--- a/internal/cli/kraft/compose/up/up.go
+++ b/internal/cli/kraft/compose/up/up.go
@@ -272,7 +272,7 @@ func (opts *UpOptions) Run(ctx context.Context, args []string) error {
 		go func(service types.ServiceConfig) {
 			defer wg.Done()
 
-			if err := logService(ctx, service, longestName); err != nil {
+			if err := logService(ctx, service); err != nil {
 				log.G(ctx).WithError(err).Errorf("failed to log service %s", service.Name)
 			}
 		}(project.Services[i])
@@ -423,9 +423,7 @@ func runService(ctx context.Context, project *compose.Project, service types.Ser
 	return runOptions.Run(ctx, []string{service.Build.Context})
 }
 
-func logService(ctx context.Context, service types.ServiceConfig, prefixLength int) error {
-	prefix := service.Name + strings.Repeat(" ", prefixLength-len(service.Name))
-
+func logService(ctx context.Context, service types.ServiceConfig) error {
 	plat, _, err := platArchFromService(service)
 	if err != nil {
 		return err
@@ -434,7 +432,6 @@ func logService(ctx context.Context, service types.ServiceConfig, prefixLength i
 	logOptions := logs.LogOptions{
 		Follow:   true,
 		Platform: plat,
-		Prefix:   prefix,
 	}
 
 	return logOptions.Run(ctx, []string{service.Name})

--- a/internal/cli/kraft/run/run.go
+++ b/internal/cli/kraft/run/run.go
@@ -371,10 +371,8 @@ func (opts *RunOptions) Run(ctx context.Context, args []string) error {
 	}
 
 	return start.Start(ctx, &start.StartOptions{
-		Detach:     opts.Detach,
-		Platform:   opts.platform.String(),
-		Prefix:     opts.Prefix,
-		PrefixName: opts.PrefixName,
-		Remove:     opts.Remove,
+		Detach:   opts.Detach,
+		Platform: opts.platform.String(),
+		Remove:   opts.Remove,
 	}, machine.Name)
 }


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

Allows ``kraft logs`` to log multiple machines at once.
The ``logs`` module takes care of synchronization internally, so it can be directly called into by other command (e.g. ``start``).
The ``prefix-name`` and ``prefix`` arguments were removed in favor of the following intuitive behavior:
* When logging a single machine, don't prefix the name
* When logging multiple machines, prefix each line with the name of the machine that produced it (if the user doesn't opt out of this via ``no-prefix``

<!--
Please provide a detailed description of the changes made in this new PR.
-->
