### PR TITLE
fix(ukargparse): Split only first = of kernel args

### DIFF
--- a/unikraft/export/v0/ukargparse/parse.go
+++ b/unikraft/export/v0/ukargparse/parse.go
@@ -17,7 +17,7 @@ func Parse(args ...string) (Params, error) {
 	params := []Param{}
 
 	for _, arg := range args {
-		nameAndValue := strings.Split(arg, "=")
+		nameAndValue := strings.SplitN(arg, "=", 2)
 		if len(nameAndValue) != 2 {
 			return nil, fmt.Errorf("expected param to be in the format 'libname.param=value' but got: '%s'", arg)
 		}


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

https://github.com/unikraft/kraftkit/issues/1407