### PR TITLE
fix(internal): Require at least 1Mi for running

### DIFF
--- a/internal/cli/kraft/run/run.go
+++ b/internal/cli/kraft/run/run.go
@@ -26,7 +26,6 @@ import (
 	mplatform "kraftkit.sh/machine/platform"
 	"kraftkit.sh/packmanager"
 	"kraftkit.sh/tui/selection"
-	"kraftkit.sh/unikraft/arch"
 	ukarch "kraftkit.sh/unikraft/arch"
 )
 
@@ -184,6 +183,17 @@ func (opts *RunOptions) Pre(cmd *cobra.Command, _ []string) error {
 		return fmt.Errorf("cannot use both --port and --network flags together")
 	}
 
+	if opts.Memory != "" {
+		qty, err := resource.ParseQuantity(opts.Memory)
+		if err != nil {
+			return fmt.Errorf("could not parse memory quantity: %w", err)
+		}
+
+		if qty.Value() < 1024*1024 {
+			return fmt.Errorf("memory must be at least 1Mi")
+		}
+	}
+
 	return nil
 }
 
@@ -242,7 +252,7 @@ func (opts *RunOptions) Run(ctx context.Context, args []string) error {
 	}
 
 	if len(opts.Architecture) > 0 {
-		if _, found := arch.ArchitecturesByName()[opts.Architecture]; !found {
+		if _, found := ukarch.ArchitecturesByName()[opts.Architecture]; !found {
 			log.G(ctx).WithFields(logrus.Fields{
 				"arch": opts.Architecture,
 			}).Warn("unknown or incompatible")


### PR DESCRIPTION
Lower values would get divided by Mi and turned to 0, which defaulted to 64Mi.

GitHub-Fixes: #1382

<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [ ] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [ ] Tested your changes against relevant architectures and platforms;
  - [ ] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->
