### PR TITLE
revert(oci): Do not reset the list of OS features

### DIFF
--- a/oci/pack.go
+++ b/oci/pack.go
@@ -363,9 +363,6 @@ func NewPackageFromTarget(ctx context.Context, targ target.Target, opts ...packm
 		log.G(ctx).
 			Debug("including list of kconfig as features")
 
-		// Reset the list of features.
-		ocipack.manifest.config.OSFeatures = make([]string, 0)
-
 		// TODO(nderjung): Not sure if these filters are best placed here or
 		// elsewhere.
 		skippable := set.NewStringSet(


### PR DESCRIPTION
This revert is needed because otherwise the hash changes and then it no longer matches the cached remote config.

Revert the 99c179b commit until a proper solution is in.

GitHub-Fixes: #1378

<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [ ] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [ ] Tested your changes against relevant architectures and platforms;
  - [ ] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->
