### PR TITLE
feat: new service domains attribute for multi-dns

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -75,7 +75,7 @@ require (
 	k8s.io/apimachinery v0.29.2
 	k8s.io/apiserver v0.29.2
 	oras.land/oras-go/v2 v2.4.0
-	sdk.kraft.cloud v0.5.5-0.20240315132541-a8336b3efd4d
+	sdk.kraft.cloud v0.5.5-0.20240322172123-97a3fb1ef69f
 	sigs.k8s.io/kustomize/kyaml v0.14.3
 )
 

--- a/go.sum
+++ b/go.sum
@@ -1673,8 +1673,8 @@ oras.land/oras-go/v2 v2.4.0/go.mod h1:osvtg0/ClRq1KkydMAEu/IxFieyjItcsQ4ut4PPF+f
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
 rsc.io/quote/v3 v3.1.0/go.mod h1:yEA65RcK8LyAZtP9Kv3t0HmxON59tX3rD+tICJqUlj0=
 rsc.io/sampler v1.3.0/go.mod h1:T1hPZKmBbMNahiBKFy5HrXp6adAjACjK9JXDnKaTXpA=
-sdk.kraft.cloud v0.5.5-0.20240315132541-a8336b3efd4d h1:9VhnRpb0Gxx9xycgkQfdR6UUkZyx25P74Uy+YScaluA=
-sdk.kraft.cloud v0.5.5-0.20240315132541-a8336b3efd4d/go.mod h1:lgGLp9jSBwSdeQkwrcQZHuejQbkgE3AqbIN+mnaKDkg=
+sdk.kraft.cloud v0.5.5-0.20240322172123-97a3fb1ef69f h1:dYWRBcC8e96TdQShosGVOGZpYkSGg2yF1LGs3V7Aa3U=
+sdk.kraft.cloud v0.5.5-0.20240322172123-97a3fb1ef69f/go.mod h1:lgGLp9jSBwSdeQkwrcQZHuejQbkgE3AqbIN+mnaKDkg=
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.0.14/go.mod h1:LEScyzhFmoF5pso/YSeBstl57mOzx9xlU9n85RGrDQg=
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.0.15/go.mod h1:LEScyzhFmoF5pso/YSeBstl57mOzx9xlU9n85RGrDQg=
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.28.0 h1:TgtAeesdhpm2SGwkQasmbeqDo8th5wOBA5h/AjTKA4I=

--- a/internal/cli/kraft/cloud/instance/create/create.go
+++ b/internal/cli/kraft/cloud/instance/create/create.go
@@ -247,11 +247,15 @@ func Create(ctx context.Context, opts *CreateOptions, args ...string) (*kcinstan
 			dnsName := strings.TrimSuffix(opts.SubDomain, ".")
 			if req.ServiceGroup == nil {
 				req.ServiceGroup = &kcinstances.CreateRequestServiceGroup{
-					DNSName:  &dnsName,
+					Domains: []kcservices.CreateRequestDomain{{
+						Name: dnsName,
+					}},
 					Services: services,
 				}
 			} else {
-				req.ServiceGroup.DNSName = &dnsName
+				req.ServiceGroup.Domains = []kcservices.CreateRequestDomain{{
+					Name: dnsName,
+				}}
 			}
 		} else if opts.FQDN != "" {
 			if !strings.HasSuffix(".", opts.FQDN) {
@@ -260,11 +264,15 @@ func Create(ctx context.Context, opts *CreateOptions, args ...string) (*kcinstan
 
 			if req.ServiceGroup == nil {
 				req.ServiceGroup = &kcinstances.CreateRequestServiceGroup{
-					DNSName:  &opts.FQDN,
+					Domains: []kcservices.CreateRequestDomain{{
+						Name: opts.FQDN,
+					}},
 					Services: services,
 				}
 			} else {
-				req.ServiceGroup.DNSName = &opts.FQDN
+				req.ServiceGroup.Domains = []kcservices.CreateRequestDomain{{
+					Name: opts.FQDN,
+				}}
 			}
 		}
 	}

--- a/internal/cli/kraft/cloud/service/create/create.go
+++ b/internal/cli/kraft/cloud/service/create/create.go
@@ -155,13 +155,17 @@ func Create(ctx context.Context, opts *CreateOptions, args ...string) (*kcservic
 
 	if len(opts.SubDomain) > 0 {
 		dnsName := strings.TrimSuffix(opts.SubDomain, ".")
-		req.DNSName = &dnsName
+		req.Domains = []kcservices.CreateRequestDomain{{
+			Name: dnsName,
+		}}
 	} else if len(opts.FQDN) > 0 {
 		if !strings.HasSuffix(".", opts.FQDN) {
 			opts.FQDN += "."
 		}
 
-		req.DNSName = &opts.FQDN
+		req.Domains = []kcservices.CreateRequestDomain{{
+			Name: opts.FQDN,
+		}}
 	}
 
 	return opts.Client.WithMetro(opts.Metro).Create(ctx, req)

--- a/internal/cli/kraft/cloud/utils/print.go
+++ b/internal/cli/kraft/cloud/utils/print.go
@@ -134,7 +134,12 @@ func PrintInstances(ctx context.Context, format string, instances ...kcinstances
 		}
 
 		table.AddField(instance.Name, nil)
-		table.AddField(instance.FQDN, nil)
+
+		var fqdn string
+		if instance.ServiceGroup != nil && len(instance.ServiceGroup.Domains) > 0 {
+			fqdn = instance.ServiceGroup.Domains[0].FQDN
+		}
+		table.AddField(fqdn, nil)
 
 		if format != "table" {
 			table.AddField(instance.PrivateFQDN, nil)
@@ -393,7 +398,12 @@ func PrintServiceGroups(ctx context.Context, format string, serviceGroups ...kcs
 		}
 
 		table.AddField(sg.Name, nil)
-		table.AddField(sg.FQDN, nil)
+
+		var fqdn string
+		if len(sg.Domains) > 0 {
+			fqdn = sg.Domains[0].FQDN
+		}
+		table.AddField(fqdn, nil)
 
 		var services []string
 		for _, service := range sg.Services {
@@ -678,7 +688,11 @@ func PrintCertificates(ctx context.Context, format string, certs ...kccerts.GetR
 // PrettyPrintInstance outputs a single instance and information about it.
 func PrettyPrintInstance(ctx context.Context, instance *kcinstances.GetResponseItem, serviceGroup *kcservices.GetResponseItem, autoStart bool) {
 	out := iostreams.G(ctx).Out
-	fqdn := instance.FQDN
+
+	var fqdn string
+	if instance.ServiceGroup != nil && len(instance.ServiceGroup.Domains) > 0 {
+		fqdn = instance.ServiceGroup.Domains[0].FQDN
+	}
 
 	if serviceGroup != nil && fqdn != "" {
 		for _, port := range serviceGroup.Services {
@@ -720,7 +734,7 @@ func PrettyPrintInstance(ctx context.Context, instance *kcinstances.GetResponseI
 		},
 	}
 
-	if len(fqdn) > 0 {
+	if fqdn != "" {
 		if strings.HasPrefix(fqdn, "https://") {
 			entries = append(entries, fancymap.FancyMapEntry{
 				Key:   "url",


### PR DESCRIPTION
### Description of changes

Adds support for the new multi-DNS feature which, more specifically, adds a new `domains` array to responses from the `instances` and `services` services.

### Out of scope

- Changing the command line API to allow people to create instances or services with multiple domains.
- Changing `get/ls` outputs to include multiple domains and/or certificate information.
- Changing the output of `kraft cloud deploy` to include multiple domains and/or certificate information.

We should do these as follow ups. Let's support API changes first, and add features later.