### PR TITLE
feat(cloud): raw output format

### DIFF
--- a/internal/cli/kraft/cloud/certificate/get/get.go
+++ b/internal/cli/kraft/cloud/certificate/get/get.go
@@ -96,10 +96,6 @@ func (opts *GetOptions) Run(ctx context.Context, args []string) error {
 	if err != nil {
 		return fmt.Errorf("could not get certificate %s: %w", args[0], err)
 	}
-	cert, err := certResp.FirstOrErr()
-	if err != nil {
-		return fmt.Errorf("could not get certificate %s: %w", args[0], err)
-	}
 
-	return utils.PrintCertificates(ctx, opts.Output, *cert)
+	return utils.PrintCertificates(ctx, opts.Output, certResp)
 }

--- a/internal/cli/kraft/cloud/certificate/list/list.go
+++ b/internal/cli/kraft/cloud/certificate/list/list.go
@@ -92,10 +92,6 @@ func (opts *ListOptions) Run(ctx context.Context, args []string) error {
 	if err != nil {
 		return fmt.Errorf("getting details of %d certificate(s): %w", len(certList), err)
 	}
-	certs, err := certsResp.AllOrErr()
-	if err != nil {
-		return err
-	}
 
-	return utils.PrintCertificates(ctx, opts.Output, certs...)
+	return utils.PrintCertificates(ctx, opts.Output, certsResp)
 }

--- a/internal/cli/kraft/cloud/deploy/deploy.go
+++ b/internal/cli/kraft/cloud/deploy/deploy.go
@@ -226,9 +226,13 @@ func (opts *DeployOptions) Run(ctx context.Context, args []string) error {
 
 	log.G(ctx).WithField("deployer", d.Name()).Debug("using")
 
-	insts, sgs, err := d.Deploy(ctx, opts, args...)
+	instsResp, sgs, err := d.Deploy(ctx, opts, args...)
 	if err != nil {
 		return fmt.Errorf("could not prepare deployment: %w", err)
+	}
+	insts, err := instsResp.AllOrErr()
+	if err != nil {
+		return err
 	}
 
 	if opts.Rollout {
@@ -290,5 +294,5 @@ func (opts *DeployOptions) Run(ctx context.Context, args []string) error {
 		return nil
 	}
 
-	return utils.PrintInstances(ctx, opts.Output, insts...)
+	return utils.PrintInstances(ctx, opts.Output, instsResp)
 }

--- a/internal/cli/kraft/cloud/deploy/deployer.go
+++ b/internal/cli/kraft/cloud/deploy/deployer.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"fmt"
 
+	kcclient "sdk.kraft.cloud/client"
 	kcinstances "sdk.kraft.cloud/instances"
 	kcservices "sdk.kraft.cloud/services"
 )
@@ -30,7 +31,7 @@ type deployer interface {
 	Deployable(context.Context, *DeployOptions, ...string) (bool, error)
 
 	// Deploy performs the deployment based on the determined implementation.
-	Deploy(context.Context, *DeployOptions, ...string) ([]kcinstances.GetResponseItem, []kcservices.GetResponseItem, error)
+	Deploy(context.Context, *DeployOptions, ...string) (*kcclient.ServiceResponse[kcinstances.GetResponseItem], []kcservices.GetResponseItem, error)
 }
 
 // deployers is the list of built-in deployers which are checked

--- a/internal/cli/kraft/cloud/deploy/deployer_image_name.go
+++ b/internal/cli/kraft/cloud/deploy/deployer_image_name.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"strings"
 
+	kcclient "sdk.kraft.cloud/client"
 	kcinstances "sdk.kraft.cloud/instances"
 	kcservices "sdk.kraft.cloud/services"
 
@@ -70,10 +71,10 @@ func (deployer *deployerImageName) Deployable(ctx context.Context, opts *DeployO
 	return true, nil
 }
 
-func (deployer *deployerImageName) Deploy(ctx context.Context, opts *DeployOptions, args ...string) ([]kcinstances.GetResponseItem, []kcservices.GetResponseItem, error) {
+func (deployer *deployerImageName) Deploy(ctx context.Context, opts *DeployOptions, args ...string) (*kcclient.ServiceResponse[kcinstances.GetResponseItem], []kcservices.GetResponseItem, error) {
 	var err error
 
-	var inst *kcinstances.GetResponseItem
+	var instResp *kcclient.ServiceResponse[kcinstances.GetResponseItem]
 	var sg *kcservices.GetResponseItem
 
 	paramodel, err := processtree.NewProcessTree(
@@ -91,7 +92,7 @@ func (deployer *deployerImageName) Deploy(ctx context.Context, opts *DeployOptio
 			"deploying",
 			"",
 			func(ctx context.Context) error {
-				inst, sg, err = instancecreate.Create(ctx, &instancecreate.CreateOptions{
+				instResp, sg, err = instancecreate.Create(ctx, &instancecreate.CreateOptions{
 					Env:                    opts.Env,
 					Features:               opts.Features,
 					FQDN:                   opts.FQDN,
@@ -123,5 +124,5 @@ func (deployer *deployerImageName) Deploy(ctx context.Context, opts *DeployOptio
 		return nil, nil, err
 	}
 
-	return []kcinstances.GetResponseItem{*inst}, []kcservices.GetResponseItem{*sg}, nil
+	return instResp, []kcservices.GetResponseItem{*sg}, nil
 }

--- a/internal/cli/kraft/cloud/deploy/deployer_kraftfile_unikraft.go
+++ b/internal/cli/kraft/cloud/deploy/deployer_kraftfile_unikraft.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 
+	kcclient "sdk.kraft.cloud/client"
 	kcinstances "sdk.kraft.cloud/instances"
 	kcservices "sdk.kraft.cloud/services"
 
@@ -47,7 +48,7 @@ func (deployer *deployerKraftfileUnikraft) Deployable(ctx context.Context, opts 
 	return true, nil
 }
 
-func (deployer *deployerKraftfileUnikraft) Deploy(ctx context.Context, opts *DeployOptions, args ...string) ([]kcinstances.GetResponseItem, []kcservices.GetResponseItem, error) {
+func (deployer *deployerKraftfileUnikraft) Deploy(ctx context.Context, opts *DeployOptions, args ...string) (*kcclient.ServiceResponse[kcinstances.GetResponseItem], []kcservices.GetResponseItem, error) {
 	if err := build.Build(ctx, &build.BuildOptions{
 		Architecture: "x86_64",
 		DotConfig:    opts.DotConfig,

--- a/internal/cli/kraft/cloud/instance/get/get.go
+++ b/internal/cli/kraft/cloud/instance/get/get.go
@@ -87,19 +87,15 @@ func (opts *GetOptions) Run(ctx context.Context, args []string) error {
 		kraftcloud.WithToken(config.GetKraftCloudTokenAuthConfig(*auth)),
 	)
 
-	var resp *kcclient.ServiceResponse[kcinstances.GetResponseItem]
+	var instanceResp *kcclient.ServiceResponse[kcinstances.GetResponseItem]
 	if utils.IsUUID(args[0]) {
-		resp, err = client.WithMetro(opts.metro).GetByUUIDs(ctx, args[0])
+		instanceResp, err = client.WithMetro(opts.metro).GetByUUIDs(ctx, args[0])
 	} else {
-		resp, err = client.WithMetro(opts.metro).GetByNames(ctx, args[0])
+		instanceResp, err = client.WithMetro(opts.metro).GetByNames(ctx, args[0])
 	}
-	if err != nil {
-		return fmt.Errorf("could not get instance %s: %w", args[0], err)
-	}
-	instance, err := resp.FirstOrErr()
 	if err != nil {
 		return fmt.Errorf("could not get instance %s: %w", args[0], err)
 	}
 
-	return utils.PrintInstances(ctx, opts.Output, *instance)
+	return utils.PrintInstances(ctx, opts.Output, instanceResp)
 }

--- a/internal/cli/kraft/cloud/instance/list/list.go
+++ b/internal/cli/kraft/cloud/instance/list/list.go
@@ -93,10 +93,6 @@ func (opts *ListOptions) Run(ctx context.Context, args []string) error {
 	if err != nil {
 		return fmt.Errorf("getting details of %d instance(s): %w", len(instList), err)
 	}
-	instances, err := instancesResp.AllOrErr()
-	if err != nil {
-		return fmt.Errorf("getting details of %d instance(s): %w", len(instList), err)
-	}
 
-	return utils.PrintInstances(ctx, opts.Output, instances...)
+	return utils.PrintInstances(ctx, opts.Output, instancesResp)
 }

--- a/internal/cli/kraft/cloud/quotas/quotas.go
+++ b/internal/cli/kraft/cloud/quotas/quotas.go
@@ -81,14 +81,9 @@ func (opts *QuotasOptions) Run(ctx context.Context, _ []string) error {
 	if err != nil {
 		return fmt.Errorf("could not get quotas: %w", err)
 	}
-	quotas, err := quotasResp.FirstOrErr()
-	if err != nil {
-		return fmt.Errorf("could not get quotas: %w", err)
-	}
 
 	if opts.Limits {
-		return utils.PrintLimits(ctx, opts.Output, *quotas)
-	} else {
-		return utils.PrintQuotas(ctx, opts.Output, *quotas)
+		return utils.PrintLimits(ctx, opts.Output, quotasResp)
 	}
+	return utils.PrintQuotas(ctx, opts.Output, quotasResp)
 }

--- a/internal/cli/kraft/cloud/scale/get/get.go
+++ b/internal/cli/kraft/cloud/scale/get/get.go
@@ -151,11 +151,7 @@ func (opts *GetOptions) Run(ctx context.Context, args []string) error {
 		if err != nil {
 			return fmt.Errorf("could not get configuration: %w", err)
 		}
-		conf, err := confResp.FirstOrErr()
-		if err != nil {
-			return fmt.Errorf("could not get configuration: %w", err)
-		}
 
-		return utils.PrintAutoscaleConfiguration(ctx, opts.Output, *conf)
+		return utils.PrintAutoscaleConfiguration(ctx, opts.Output, confResp)
 	}
 }

--- a/internal/cli/kraft/cloud/service/create/create.go
+++ b/internal/cli/kraft/cloud/service/create/create.go
@@ -238,10 +238,6 @@ func (opts *CreateOptions) Run(ctx context.Context, args []string) error {
 	if err != nil {
 		return fmt.Errorf("getting details of service group %s: %w", newSg.UUID, err)
 	}
-	sg, err := sgResp.FirstOrErr()
-	if err != nil {
-		return fmt.Errorf("getting details of service group %s: %w", newSg.UUID, err)
-	}
 
-	return utils.PrintServiceGroups(ctx, opts.Output, *sg)
+	return utils.PrintServiceGroups(ctx, opts.Output, sgResp)
 }

--- a/internal/cli/kraft/cloud/service/get/get.go
+++ b/internal/cli/kraft/cloud/service/get/get.go
@@ -93,10 +93,6 @@ func (opts *GetOptions) Run(ctx context.Context, args []string) error {
 	if err != nil {
 		return fmt.Errorf("could not get service %s: %w", args[0], err)
 	}
-	sg, err := sgResp.FirstOrErr()
-	if err != nil {
-		return fmt.Errorf("could not get service %s: %w", args[0], err)
-	}
 
-	return utils.PrintServiceGroups(ctx, opts.Output, *sg)
+	return utils.PrintServiceGroups(ctx, opts.Output, sgResp)
 }

--- a/internal/cli/kraft/cloud/volume/get/get.go
+++ b/internal/cli/kraft/cloud/volume/get/get.go
@@ -96,10 +96,6 @@ func (opts *GetOptions) Run(ctx context.Context, args []string) error {
 	if err != nil {
 		return fmt.Errorf("could not get volume %s: %w", args[0], err)
 	}
-	vol, err := volResp.FirstOrErr()
-	if err != nil {
-		return fmt.Errorf("could not get volume %s: %w", args[0], err)
-	}
 
-	return utils.PrintVolumes(ctx, opts.Output, *vol)
+	return utils.PrintVolumes(ctx, opts.Output, volResp)
 }


### PR DESCRIPTION
Closes #1207

Introduces the `-o raw` output format to `kraft cloud` commands, which prints KraftCloud's _raw_ API responses (uninterpreted JSON).

Removes the special handling of `-o json`, which was introduced in #1385 as a temporary workaround.