### PR TITLE
fix(cloud): print aggregated errors

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -75,7 +75,7 @@ require (
 	k8s.io/apimachinery v0.29.2
 	k8s.io/apiserver v0.29.2
 	oras.land/oras-go/v2 v2.4.0
-	sdk.kraft.cloud v0.5.5-0.20240322174103-82eac1c5cd05
+	sdk.kraft.cloud v0.5.5-0.20240324092701-81cc0f19c11b
 	sigs.k8s.io/kustomize/kyaml v0.14.3
 )
 

--- a/go.sum
+++ b/go.sum
@@ -1673,8 +1673,8 @@ oras.land/oras-go/v2 v2.4.0/go.mod h1:osvtg0/ClRq1KkydMAEu/IxFieyjItcsQ4ut4PPF+f
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
 rsc.io/quote/v3 v3.1.0/go.mod h1:yEA65RcK8LyAZtP9Kv3t0HmxON59tX3rD+tICJqUlj0=
 rsc.io/sampler v1.3.0/go.mod h1:T1hPZKmBbMNahiBKFy5HrXp6adAjACjK9JXDnKaTXpA=
-sdk.kraft.cloud v0.5.5-0.20240322174103-82eac1c5cd05 h1:BRQgeGw2BbJe0Inn0hawQXV5QuPMb7MgwiTMuh/AW8g=
-sdk.kraft.cloud v0.5.5-0.20240322174103-82eac1c5cd05/go.mod h1:lgGLp9jSBwSdeQkwrcQZHuejQbkgE3AqbIN+mnaKDkg=
+sdk.kraft.cloud v0.5.5-0.20240324092701-81cc0f19c11b h1:ybmQ36hzampX63sWui35iT6LHeidZGKGhGbXTCf42Uw=
+sdk.kraft.cloud v0.5.5-0.20240324092701-81cc0f19c11b/go.mod h1:lgGLp9jSBwSdeQkwrcQZHuejQbkgE3AqbIN+mnaKDkg=
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.0.14/go.mod h1:LEScyzhFmoF5pso/YSeBstl57mOzx9xlU9n85RGrDQg=
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.0.15/go.mod h1:LEScyzhFmoF5pso/YSeBstl57mOzx9xlU9n85RGrDQg=
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.28.0 h1:TgtAeesdhpm2SGwkQasmbeqDo8th5wOBA5h/AjTKA4I=

--- a/internal/cli/kraft/cloud/utils/print.go
+++ b/internal/cli/kraft/cloud/utils/print.go
@@ -866,7 +866,7 @@ func PrettyPrintInstance(ctx context.Context, instance *kcinstances.GetResponseI
 	}
 }
 
-func printRaw[T any](ctx context.Context, resp *kcclient.ServiceResponse[T]) {
+func printRaw[T kcclient.APIResponseDataEntry](ctx context.Context, resp *kcclient.ServiceResponse[T]) {
 	fmt.Fprint(iostreams.G(ctx).Out, string(resp.RawBody()))
 }
 


### PR DESCRIPTION
Restores the printing of aggregated errors, which got lost as a side effect of the update to the refactored SDK in commit c3f8be988be8cfa189bcfa1153a9e13dc3e42c86.
```console
% kraft cloud service get abc
 E  Failed to perform all operations
No service group with name 'abc' (code=8)
```