### PR TITLE
refactor(cloud): use batch ops for vols and sgs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -75,7 +75,7 @@ require (
 	k8s.io/apimachinery v0.29.2
 	k8s.io/apiserver v0.29.2
 	oras.land/oras-go/v2 v2.4.0
-	sdk.kraft.cloud v0.5.5-0.20240324092701-81cc0f19c11b
+	sdk.kraft.cloud v0.5.5-0.20240324162937-97e7a02629be
 	sigs.k8s.io/kustomize/kyaml v0.14.3
 )
 

--- a/go.sum
+++ b/go.sum
@@ -1673,8 +1673,8 @@ oras.land/oras-go/v2 v2.4.0/go.mod h1:osvtg0/ClRq1KkydMAEu/IxFieyjItcsQ4ut4PPF+f
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
 rsc.io/quote/v3 v3.1.0/go.mod h1:yEA65RcK8LyAZtP9Kv3t0HmxON59tX3rD+tICJqUlj0=
 rsc.io/sampler v1.3.0/go.mod h1:T1hPZKmBbMNahiBKFy5HrXp6adAjACjK9JXDnKaTXpA=
-sdk.kraft.cloud v0.5.5-0.20240324092701-81cc0f19c11b h1:ybmQ36hzampX63sWui35iT6LHeidZGKGhGbXTCf42Uw=
-sdk.kraft.cloud v0.5.5-0.20240324092701-81cc0f19c11b/go.mod h1:lgGLp9jSBwSdeQkwrcQZHuejQbkgE3AqbIN+mnaKDkg=
+sdk.kraft.cloud v0.5.5-0.20240324162937-97e7a02629be h1:6Pvj5Ko1vhJNQhkUZ0ZBLkS43t1CWdlNpsvi70SVboI=
+sdk.kraft.cloud v0.5.5-0.20240324162937-97e7a02629be/go.mod h1:lgGLp9jSBwSdeQkwrcQZHuejQbkgE3AqbIN+mnaKDkg=
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.0.14/go.mod h1:LEScyzhFmoF5pso/YSeBstl57mOzx9xlU9n85RGrDQg=
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.0.15/go.mod h1:LEScyzhFmoF5pso/YSeBstl57mOzx9xlU9n85RGrDQg=
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.28.0 h1:TgtAeesdhpm2SGwkQasmbeqDo8th5wOBA5h/AjTKA4I=

--- a/internal/cli/kraft/cloud/certificate/remove/remove.go
+++ b/internal/cli/kraft/cloud/certificate/remove/remove.go
@@ -153,7 +153,6 @@ func (opts *RemoveOptions) Run(ctx context.Context, args []string) error {
 			} else {
 				_, err = client.WithMetro(opts.metro).DeleteByNames(ctx, arg)
 			}
-
 			if err != nil {
 				return fmt.Errorf("could not remove certificate %s: %w", arg, err)
 			}

--- a/internal/cli/kraft/cloud/instance/create/create.go
+++ b/internal/cli/kraft/cloud/instance/create/create.go
@@ -131,9 +131,9 @@ func Create(ctx context.Context, opts *CreateOptions, args ...string) (*kcclient
 	if opts.ServiceGroupNameOrUUID != "" {
 		var resp *kcclient.ServiceResponse[kcservices.GetResponseItem]
 		if utils.IsUUID(opts.ServiceGroupNameOrUUID) {
-			resp, err = opts.Client.Services().WithMetro(opts.Metro).GetByUUID(ctx, opts.ServiceGroupNameOrUUID)
+			resp, err = opts.Client.Services().WithMetro(opts.Metro).GetByUUIDs(ctx, opts.ServiceGroupNameOrUUID)
 		} else {
-			resp, err = opts.Client.Services().WithMetro(opts.Metro).GetByName(ctx, opts.ServiceGroupNameOrUUID)
+			resp, err = opts.Client.Services().WithMetro(opts.Metro).GetByNames(ctx, opts.ServiceGroupNameOrUUID)
 		}
 		if err != nil {
 			return nil, nil, fmt.Errorf("could not use service %s: %w", opts.ServiceGroupNameOrUUID, err)
@@ -314,7 +314,7 @@ func Create(ctx context.Context, opts *CreateOptions, args ...string) (*kcclient
 	}
 
 	if sg := instance.ServiceGroup; sg != nil && sg.UUID != "" {
-		serviceGroupResp, err := opts.Client.Services().WithMetro(opts.Metro).GetByUUID(ctx, sg.UUID)
+		serviceGroupResp, err := opts.Client.Services().WithMetro(opts.Metro).GetByUUIDs(ctx, sg.UUID)
 		if err != nil {
 			return nil, nil, fmt.Errorf("getting details of service %s: %w", sg.UUID, err)
 		}

--- a/internal/cli/kraft/cloud/instance/remove/remove.go
+++ b/internal/cli/kraft/cloud/instance/remove/remove.go
@@ -191,7 +191,6 @@ func (opts *RemoveOptions) Run(ctx context.Context, args []string) error {
 			} else {
 				_, err = client.WithMetro(opts.metro).DeleteByNames(ctx, arg)
 			}
-
 			if err != nil {
 				return fmt.Errorf("could not remove instance %s: %w", arg, err)
 			}

--- a/internal/cli/kraft/cloud/scale/add/add.go
+++ b/internal/cli/kraft/cloud/scale/add/add.go
@@ -105,7 +105,7 @@ func (opts *AddOptions) Run(ctx context.Context, args []string) error {
 
 	// Look up the configuration by name
 	if !utils.IsUUID(args[0]) {
-		confResp, err := opts.Client.Services().WithMetro(opts.Metro).GetByName(ctx, args[0])
+		confResp, err := opts.Client.Services().WithMetro(opts.Metro).GetByNames(ctx, args[0])
 		if err != nil {
 			return fmt.Errorf("could not get configuration: %w", err)
 		}

--- a/internal/cli/kraft/cloud/scale/get/get.go
+++ b/internal/cli/kraft/cloud/scale/get/get.go
@@ -97,7 +97,7 @@ func (opts *GetOptions) Run(ctx context.Context, args []string) error {
 
 	// Look up the configuration by name
 	if !utils.IsUUID(args[0]) {
-		confResp, err := opts.Client.Services().WithMetro(opts.Metro).GetByName(ctx, args[0])
+		confResp, err := opts.Client.Services().WithMetro(opts.Metro).GetByNames(ctx, args[0])
 		if err != nil {
 			return fmt.Errorf("could not get configuration: %w", err)
 		}

--- a/internal/cli/kraft/cloud/scale/initialize/initialize.go
+++ b/internal/cli/kraft/cloud/scale/initialize/initialize.go
@@ -93,7 +93,7 @@ func (opts *InitOptions) Run(ctx context.Context, args []string) error {
 
 	// Look up the configuration by name
 	if !utils.IsUUID(args[0]) {
-		confResp, err := opts.Client.Services().WithMetro(opts.Metro).GetByName(ctx, args[0])
+		confResp, err := opts.Client.Services().WithMetro(opts.Metro).GetByNames(ctx, args[0])
 		if err != nil {
 			return fmt.Errorf("could not get configuration: %w", err)
 		}

--- a/internal/cli/kraft/cloud/service/create/create.go
+++ b/internal/cli/kraft/cloud/service/create/create.go
@@ -234,7 +234,7 @@ func (opts *CreateOptions) Run(ctx context.Context, args []string) error {
 		return fmt.Errorf("creating service group: %w", err)
 	}
 
-	sgResp, err := opts.Client.WithMetro(opts.Metro).GetByUUID(ctx, newSg.UUID)
+	sgResp, err := opts.Client.WithMetro(opts.Metro).GetByUUIDs(ctx, newSg.UUID)
 	if err != nil {
 		return fmt.Errorf("getting details of service group %s: %w", newSg.UUID, err)
 	}

--- a/internal/cli/kraft/cloud/service/get/get.go
+++ b/internal/cli/kraft/cloud/service/get/get.go
@@ -86,9 +86,9 @@ func (opts *GetOptions) Run(ctx context.Context, args []string) error {
 
 	var sgResp *kcclient.ServiceResponse[kcservices.GetResponseItem]
 	if utils.IsUUID(args[0]) {
-		sgResp, err = client.WithMetro(opts.metro).GetByUUID(ctx, args[0])
+		sgResp, err = client.WithMetro(opts.metro).GetByUUIDs(ctx, args[0])
 	} else {
-		sgResp, err = client.WithMetro(opts.metro).GetByName(ctx, args[0])
+		sgResp, err = client.WithMetro(opts.metro).GetByNames(ctx, args[0])
 	}
 	if err != nil {
 		return fmt.Errorf("could not get service %s: %w", args[0], err)

--- a/internal/cli/kraft/cloud/utils/print.go
+++ b/internal/cli/kraft/cloud/utils/print.go
@@ -200,17 +200,6 @@ func PrintVolumes(ctx context.Context, format string, resp *kcclient.ServiceResp
 		return err
 	}
 
-	return PrintVolumesCompat(ctx, format, volumes...)
-}
-
-// PrintVolumesCompat pretty-prints the provided set of volumes or returns an
-// error if unable to send to stdout via the provided context.
-//
-// TODO(antoineco): implement batch GET of service groups in the KraftCloud SDK to
-// avoid this compatibility function. Its only caller is in volume/list/list.go
-func PrintVolumesCompat(ctx context.Context, format string, volumes ...kcvolumes.GetResponseItem) error {
-	var err error
-
 	if err = iostreams.G(ctx).StartPager(); err != nil {
 		log.G(ctx).Errorf("error starting pager: %v", err)
 	}
@@ -392,17 +381,6 @@ func PrintServiceGroups(ctx context.Context, format string, resp *kcclient.Servi
 	if err != nil {
 		return err
 	}
-
-	return PrintServiceGroupsCompat(ctx, format, serviceGroups...)
-}
-
-// PrintServiceGroupsCompat pretty-prints the provided set of service groups or
-// returns an error if unable to send to stdout via the provided context.
-//
-// TODO(antoineco): implement batch GET of service groups in the KraftCloud SDK to
-// avoid this compatibility function. Its only caller is in service/list/list.go
-func PrintServiceGroupsCompat(ctx context.Context, format string, serviceGroups ...kcservices.GetResponseItem) error {
-	var err error
 
 	if err = iostreams.G(ctx).StartPager(); err != nil {
 		log.G(ctx).Errorf("error starting pager: %v", err)

--- a/internal/cli/kraft/cloud/volume/get/get.go
+++ b/internal/cli/kraft/cloud/volume/get/get.go
@@ -89,9 +89,9 @@ func (opts *GetOptions) Run(ctx context.Context, args []string) error {
 
 	var volResp *kcclient.ServiceResponse[kcvolumes.GetResponseItem]
 	if utils.IsUUID(args[0]) {
-		volResp, err = client.WithMetro(opts.metro).GetByUUID(ctx, args[0])
+		volResp, err = client.WithMetro(opts.metro).GetByUUIDs(ctx, args[0])
 	} else {
-		volResp, err = client.WithMetro(opts.metro).GetByName(ctx, args[0])
+		volResp, err = client.WithMetro(opts.metro).GetByNames(ctx, args[0])
 	}
 	if err != nil {
 		return fmt.Errorf("could not get volume %s: %w", args[0], err)


### PR DESCRIPTION
In #1443 I had to implement the `-o raw` printing of volumes and service groups differently from other services because the SDK did not support batch operations for `GET` and `DELETE`.

This is now addressed in the SDK. This PR is simply the reflection of those changes.

Fixes #1449 as a side effect.