### PR TITLE
fix(cloud): suppressed API errors in delete responses

### DIFF
--- a/internal/cli/kraft/cloud/img/remove/remove.go
+++ b/internal/cli/kraft/cloud/img/remove/remove.go
@@ -99,17 +99,20 @@ func (opts *RemoveOptions) Run(ctx context.Context, args []string) error {
 	}
 
 	if opts.All {
-		resp, err := opts.Client.WithMetro(opts.Metro).List(ctx)
+		imgListResp, err := opts.Client.WithMetro(opts.Metro).List(ctx)
 		if err != nil {
 			return fmt.Errorf("listing images: %w", err)
 		}
-		images, err := resp.AllOrErr()
+		imgList, err := imgListResp.AllOrErr()
 		if err != nil {
 			return fmt.Errorf("listing images: %w", err)
+		}
+		if len(imgList) == 0 {
+			return nil
 		}
 
 		var notFoundMessagesCount int
-		for _, image := range images {
+		for _, image := range imgList {
 			if !strings.HasPrefix(image.Digest, strings.TrimSuffix(strings.TrimPrefix(opts.Auth.User, "robot$"), ".users.kraftcloud")) {
 				continue
 			}

--- a/internal/cli/kraft/cloud/scale/remove/remove.go
+++ b/internal/cli/kraft/cloud/scale/remove/remove.go
@@ -85,8 +85,11 @@ func (opts *RemoveOptions) Run(ctx context.Context, args []string) error {
 		)
 	}
 
-	_, err = opts.Client.WithMetro(opts.Metro).DeletePolicyByName(ctx, args[0], args[1])
+	delResp, err := opts.Client.WithMetro(opts.Metro).DeletePolicyByName(ctx, args[0], args[1])
 	if err != nil {
+		return fmt.Errorf("could not delete policy: %w", err)
+	}
+	if _, err := delResp.AllOrErr(); err != nil {
 		return fmt.Errorf("could not delete policy: %w", err)
 	}
 


### PR DESCRIPTION
Responses to delete requests with `status: error` or `status: partial_success` are now handled properly, and any error returned by the KraftCloud API will be displayed.