### PR TITLE
fix(run): Don't erase existing volumes when passing volume arg

### DIFF
--- a/internal/cli/kraft/run/utils.go
+++ b/internal/cli/kraft/run/utils.go
@@ -189,8 +189,10 @@ func (opts *RunOptions) parseVolumes(ctx context.Context, machine *machineapi.Ma
 
 	var err error
 	controllers := map[string]volumeapi.VolumeService{}
-	machine.Spec.Volumes = []volumeapi.Volume{}
 
+	if machine.Spec.Volumes == nil {
+		machine.Spec.Volumes = make([]volumeapi.Volume, 0)
+	}
 	for _, volLine := range opts.Volumes {
 		var hostPath, mountPath string
 		split := strings.Split(volLine, ":")


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

Take a simple `Kraftfile` example:
```yaml
spec: v0.6

runtime: base-9p:latest

rootfs: ./Dockerfile
 
cmd: ["/server"]
```

Here, we would like to be able to run this application both with the default rootfs:
```
kraft run
```
or maybe we want to sometimes provide a volume on top of it:
```
kraft run --volume ./some-path:/other-path
```

This PR ensures the fact that the ``volume`` cli argument is applied on top of the config from the ``Kraftfile``.

Github-fixes: https://github.com/unikraft/kraftkit/issues/1340
<!--
Please provide a detailed description of the changes made in this new PR.
-->
