### PR TITLE
fix(webinstall): Fix repo link in install script

### DIFF
--- a/tools/webinstall/install.sh
+++ b/tools/webinstall/install.sh
@@ -1078,7 +1078,7 @@ install_linux_gnu() {
         _ilg_msg=$(printf "error: %s%s%s"                               \
             "Unsupported Linux distribution. "                          \
             "Try downloading the tar.gz file from "                     \
-            "https://github/unikraft/kraftkit or switch to manual mode" \
+            "https://github.com/unikraft/kraftkit or switch to manual mode" \
         )
         err "$_ilg_msg"
     fi
@@ -1102,7 +1102,7 @@ install_linux_musl() {
         _ilm_msg=$(printf "error: %s%s%s"                               \
             "Unsupported Linux distribution. "                          \
             "Try downloading the tar.gz file from "                     \
-            "https://github/unikraft/kraftkit or switch to manual mode" \
+            "https://github.com/unikraft/kraftkit or switch to manual mode" \
         )
         err "$_ilm_msg"
     fi


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [x] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

The link to the repository displayed in the "Unsupported Linux distribution" error message in the install script was broken. This PR fixes it :D