### PR TITLE
fix(webinstall): Disable completion prompt

### DIFF
--- a/tools/webinstall/install.sh
+++ b/tools/webinstall/install.sh
@@ -1713,7 +1713,9 @@ main() {
     _main_kraft_ret="$?"
 
     # Install kraftkit completions
-    install_completions "$_main_arch"
+    if [ "$NEED_TTY" = "y" ]; then
+        install_completions "$_main_arch"
+    fi
 
     return $_main_kraft_ret
 }


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [x] Updated relevant documentation.

### Description of changes

**Problem:** When passing -y to disable confirmation prompts, the user was still prompted to select a language for shell completions.

**Solution:** Added logic to skip `install_completions` function when `-y` is used on installer script.
