### PR TITLE
feat: Add pause command

### DIFF
--- a/internal/cli/kraft/kraft.go
+++ b/internal/cli/kraft/kraft.go
@@ -20,6 +20,7 @@ import (
 	"kraftkit.sh/internal/bootstrap"
 	"kraftkit.sh/internal/cli"
 	"kraftkit.sh/internal/cli/kraft/lib"
+	"kraftkit.sh/internal/cli/kraft/pause"
 	kitupdate "kraftkit.sh/internal/update"
 	kitversion "kraftkit.sh/internal/version"
 	"kraftkit.sh/iostreams"
@@ -96,6 +97,7 @@ func NewCmd() *cobra.Command {
 	cmd.AddCommand(run.NewCmd())
 	cmd.AddCommand(start.NewCmd())
 	cmd.AddCommand(stop.NewCmd())
+	cmd.AddCommand(pause.NewCmd())
 
 	cmd.AddGroup(&cobra.Group{ID: "net", Title: "LOCAL NETWORKING COMMANDS"})
 	cmd.AddCommand(net.NewCmd())

--- a/internal/cli/kraft/pause/pause.go
+++ b/internal/cli/kraft/pause/pause.go
@@ -1,0 +1,148 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2024, Unikraft GmbH and The KraftKit Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+package pause
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/MakeNowJust/heredoc"
+	"github.com/spf13/cobra"
+
+	machineapi "kraftkit.sh/api/machine/v1alpha1"
+	"kraftkit.sh/cmdfactory"
+	"kraftkit.sh/iostreams"
+	"kraftkit.sh/log"
+	mplatform "kraftkit.sh/machine/platform"
+)
+
+type PauseOptions struct {
+	All      bool   `long:"all" usage:"Pause all machines"`
+	Platform string `noattribute:"true"`
+}
+
+// Pause a local Unikraft virtual machine.
+func Pause(ctx context.Context, opts *PauseOptions, args ...string) error {
+	if opts == nil {
+		opts = &PauseOptions{}
+	}
+
+	return opts.Run(ctx, args)
+}
+
+func NewCmd() *cobra.Command {
+	cmd, err := cmdfactory.New(&PauseOptions{}, cobra.Command{
+		Short:   "Pause one or more running unikernels",
+		Use:     "pause [FLAGS] MACHINE [MACHINE [...]]",
+		Aliases: []string{},
+		Long: heredoc.Doc(`
+			Pause one or more running unikernels
+		`),
+		Example: heredoc.Doc(`
+			# Pause a running unikernel
+			$ kraft pause my-machine
+		`),
+		Annotations: map[string]string{
+			cmdfactory.AnnotationHelpGroup: "run",
+		},
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	cmd.Flags().VarP(
+		cmdfactory.NewEnumFlag[mplatform.Platform](
+			mplatform.Platforms(),
+			mplatform.Platform("auto"),
+		),
+		"plat",
+		"p",
+		"Set the platform virtual machine monitor driver.  Set to 'auto' to detect the guest's platform and 'host' to use the host platform.",
+	)
+
+	return cmd
+}
+
+func (opts *PauseOptions) Pre(cmd *cobra.Command, args []string) error {
+	if len(args) == 0 && !opts.All {
+		return fmt.Errorf("please supply a machine ID or name or use the --all flag")
+	}
+
+	opts.Platform = cmd.Flag("plat").Value.String()
+	return nil
+}
+
+func (opts *PauseOptions) Run(ctx context.Context, args []string) error {
+	if len(args) == 0 && !opts.All {
+		return fmt.Errorf("please supply a machine ID or name or use the --all flag")
+	}
+
+	var err error
+
+	platform := mplatform.PlatformUnknown
+	var controller machineapi.MachineService
+
+	if opts.All || opts.Platform == "auto" {
+		controller, err = mplatform.NewMachineV1alpha1ServiceIterator(ctx)
+	} else {
+		if opts.Platform == "host" {
+			platform, _, err = mplatform.Detect(ctx)
+			if err != nil {
+				return err
+			}
+		} else {
+			var ok bool
+			platform, ok = mplatform.PlatformsByName()[opts.Platform]
+			if !ok {
+				return fmt.Errorf("unknown platform driver: %s", opts.Platform)
+			}
+		}
+
+		strategy, ok := mplatform.Strategies()[platform]
+		if !ok {
+			return fmt.Errorf("unsupported platform driver: %s (contributions welcome!)", platform.String())
+		}
+
+		controller, err = strategy.NewMachineV1alpha1(ctx)
+	}
+	if err != nil {
+		return err
+	}
+
+	machines, err := controller.List(ctx, &machineapi.MachineList{})
+	if err != nil {
+		return err
+	}
+
+	var pause []machineapi.Machine
+
+	for _, machine := range machines.Items {
+		if opts.All {
+			pause = append(pause, machine)
+			continue
+		}
+		for _, arg := range args {
+			if arg == machine.Name || arg == string(machine.UID) {
+				pause = append(pause, machine)
+			}
+		}
+	}
+
+	if len(pause) == 0 {
+		return fmt.Errorf("machine(s) not found")
+	}
+
+	for _, machine := range pause {
+		if machine.Status.State != machineapi.MachineStateRunning {
+			continue
+		} else if _, err := controller.Pause(ctx, &machine); err != nil {
+			log.G(ctx).Errorf("could not pause machine %s: %v", machine.Name, err)
+		} else {
+			fmt.Fprintln(iostreams.G(ctx).Out, machine.Name)
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [x] Updated relevant documentation.

### Description of changes

The pause command is similar to ``stop``, except on running ``start`` the unikernel will not be restarted, instead it will just resume from the instruction when it was paused. This commit just adapts ``stop`` to instead use the already existing ``Pause`` functionality inside the machine controller.

<!--
Please provide a detailed description of the changes made in this new PR.
-->
