### PR TITLE
feat(compose): Add pause and unpause commands

### DIFF
--- a/internal/cli/kraft/compose/compose.go
+++ b/internal/cli/kraft/compose/compose.go
@@ -18,6 +18,7 @@ import (
 	"kraftkit.sh/internal/cli/kraft/compose/down"
 	"kraftkit.sh/internal/cli/kraft/compose/logs"
 	"kraftkit.sh/internal/cli/kraft/compose/ls"
+	"kraftkit.sh/internal/cli/kraft/compose/pause"
 	"kraftkit.sh/internal/cli/kraft/compose/ps"
 	"kraftkit.sh/internal/cli/kraft/compose/start"
 	"kraftkit.sh/internal/cli/kraft/compose/stop"
@@ -54,6 +55,7 @@ func NewCmd() *cobra.Command {
 	cmd.AddCommand(down.NewCmd())
 	cmd.AddCommand(logs.NewCmd())
 	cmd.AddCommand(ls.NewCmd())
+	cmd.AddCommand(pause.NewCmd())
 	cmd.AddCommand(ps.NewCmd())
 	cmd.AddCommand(start.NewCmd())
 	cmd.AddCommand(stop.NewCmd())

--- a/internal/cli/kraft/compose/compose.go
+++ b/internal/cli/kraft/compose/compose.go
@@ -22,6 +22,7 @@ import (
 	"kraftkit.sh/internal/cli/kraft/compose/ps"
 	"kraftkit.sh/internal/cli/kraft/compose/start"
 	"kraftkit.sh/internal/cli/kraft/compose/stop"
+	"kraftkit.sh/internal/cli/kraft/compose/unpause"
 	"kraftkit.sh/internal/cli/kraft/compose/up"
 )
 
@@ -59,6 +60,7 @@ func NewCmd() *cobra.Command {
 	cmd.AddCommand(ps.NewCmd())
 	cmd.AddCommand(start.NewCmd())
 	cmd.AddCommand(stop.NewCmd())
+	cmd.AddCommand(unpause.NewCmd())
 	cmd.AddCommand(up.NewCmd())
 
 	return cmd

--- a/internal/cli/kraft/compose/pause/pause.go
+++ b/internal/cli/kraft/compose/pause/pause.go
@@ -1,0 +1,108 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2024, Unikraft GmbH and The KraftKit Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+package pause
+
+import (
+	"context"
+	"os"
+
+	"github.com/MakeNowJust/heredoc"
+	"github.com/spf13/cobra"
+
+	"kraftkit.sh/cmdfactory"
+	"kraftkit.sh/compose"
+	"kraftkit.sh/log"
+	"kraftkit.sh/packmanager"
+
+	machineapi "kraftkit.sh/api/machine/v1alpha1"
+	kernelpause "kraftkit.sh/internal/cli/kraft/pause"
+	mplatform "kraftkit.sh/machine/platform"
+)
+
+type PauseOptions struct {
+	composefile string
+}
+
+func NewCmd() *cobra.Command {
+	cmd, err := cmdfactory.New(&PauseOptions{}, cobra.Command{
+		Short:   "Pause a compose project",
+		Use:     "pause [FLAGS]",
+		Args:    cobra.NoArgs,
+		Aliases: []string{},
+		Example: heredoc.Doc(`
+			# Pause a compose project
+			$ kraft compose pause 
+		`),
+		Annotations: map[string]string{
+			cmdfactory.AnnotationHelpGroup: "compose",
+		},
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	return cmd
+}
+
+func (opts *PauseOptions) Pre(cmd *cobra.Command, _ []string) error {
+	ctx, err := packmanager.WithDefaultUmbrellaManagerInContext(cmd.Context())
+	if err != nil {
+		return err
+	}
+
+	cmd.SetContext(ctx)
+
+	if cmd.Flag("file").Changed {
+		opts.composefile = cmd.Flag("file").Value.String()
+	}
+
+	log.G(cmd.Context()).WithField("composefile", opts.composefile).Debug("using")
+	return nil
+}
+
+func (opts *PauseOptions) Run(ctx context.Context, _ []string) error {
+	workdir, err := os.Getwd()
+	if err != nil {
+		return err
+	}
+
+	project, err := compose.NewProjectFromComposeFile(ctx, workdir, opts.composefile)
+	if err != nil {
+		return err
+	}
+
+	if err := project.Validate(ctx); err != nil {
+		return err
+	}
+
+	machineController, err := mplatform.NewMachineV1alpha1ServiceIterator(ctx)
+	if err != nil {
+		return err
+	}
+
+	machines, err := machineController.List(ctx, &machineapi.MachineList{})
+	if err != nil {
+		return err
+	}
+
+	machinesToPause := []string{}
+	for _, service := range project.Services {
+		for _, machine := range machines.Items {
+			if service.Name == machine.Name && machine.Status.State == machineapi.MachineStateRunning {
+				machinesToPause = append(machinesToPause, machine.Name)
+			}
+		}
+	}
+
+	if len(machinesToPause) == 0 {
+		return nil
+	}
+
+	kernelPauseOptions := kernelpause.PauseOptions{
+		Platform: "auto",
+	}
+
+	return kernelPauseOptions.Run(ctx, machinesToPause)
+}

--- a/internal/cli/kraft/compose/stop/stop.go
+++ b/internal/cli/kraft/compose/stop/stop.go
@@ -90,7 +90,9 @@ func (opts *StopOptions) Run(ctx context.Context, _ []string) error {
 	machinesToStop := []string{}
 	for _, service := range project.Services {
 		for _, machine := range machines.Items {
-			if service.Name == machine.Name && machine.Status.State == machineapi.MachineStateRunning {
+			if service.Name == machine.Name &&
+				(machine.Status.State == machineapi.MachineStateRunning ||
+					machine.Status.State == machineapi.MachineStatePaused) {
 				machinesToStop = append(machinesToStop, machine.Name)
 			}
 		}

--- a/internal/cli/kraft/compose/unpause/unpause.go
+++ b/internal/cli/kraft/compose/unpause/unpause.go
@@ -1,0 +1,122 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2024, Unikraft GmbH and The KraftKit Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+package unpause
+
+import (
+	"context"
+	"os"
+
+	"github.com/MakeNowJust/heredoc"
+	"github.com/spf13/cobra"
+
+	"kraftkit.sh/cmdfactory"
+	"kraftkit.sh/compose"
+	"kraftkit.sh/log"
+	"kraftkit.sh/packmanager"
+
+	machineapi "kraftkit.sh/api/machine/v1alpha1"
+	"kraftkit.sh/internal/cli/kraft/compose/logs"
+	kernelstart "kraftkit.sh/internal/cli/kraft/start"
+	mplatform "kraftkit.sh/machine/platform"
+)
+
+type UnpauseOptions struct {
+	Composefile string `noattribute:"true"`
+	Detach      bool   `long:"detach" short:"d" usage:"Run in background"`
+}
+
+func NewCmd() *cobra.Command {
+	cmd, err := cmdfactory.New(&UnpauseOptions{}, cobra.Command{
+		Short:   "Unpause a compose project",
+		Use:     "unpause [FLAGS]",
+		Args:    cobra.NoArgs,
+		Aliases: []string{},
+		Example: heredoc.Doc(`
+			# Unpause a compose project
+			$ kraft compose unpause 
+		`),
+		Annotations: map[string]string{
+			cmdfactory.AnnotationHelpGroup: "compose",
+		},
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	return cmd
+}
+
+func (opts *UnpauseOptions) Pre(cmd *cobra.Command, _ []string) error {
+	ctx, err := packmanager.WithDefaultUmbrellaManagerInContext(cmd.Context())
+	if err != nil {
+		return err
+	}
+
+	cmd.SetContext(ctx)
+
+	if cmd.Flag("file").Changed {
+		opts.Composefile = cmd.Flag("file").Value.String()
+	}
+
+	log.G(cmd.Context()).WithField("composefile", opts.Composefile).Debug("using")
+	return nil
+}
+
+func (opts *UnpauseOptions) Run(ctx context.Context, _ []string) error {
+	workdir, err := os.Getwd()
+	if err != nil {
+		return err
+	}
+
+	project, err := compose.NewProjectFromComposeFile(ctx, workdir, opts.Composefile)
+	if err != nil {
+		return err
+	}
+
+	if err := project.Validate(ctx); err != nil {
+		return err
+	}
+
+	machineController, err := mplatform.NewMachineV1alpha1ServiceIterator(ctx)
+	if err != nil {
+		return err
+	}
+
+	machines, err := machineController.List(ctx, &machineapi.MachineList{})
+	if err != nil {
+		return err
+	}
+
+	machinesToUnpause := []string{}
+	for _, service := range project.Services {
+		for _, machine := range machines.Items {
+			if service.Name == machine.Name {
+				if machine.Status.State == machineapi.MachineStatePaused {
+					machinesToUnpause = append(machinesToUnpause, machine.Name)
+				}
+			}
+		}
+	}
+
+	kernelStartOptions := kernelstart.StartOptions{
+		Detach:   true,
+		Platform: "auto",
+	}
+
+	if err := kernelStartOptions.Run(ctx, machinesToUnpause); err != nil {
+		return err
+	}
+
+	if opts.Detach {
+		return nil
+	}
+
+	logsOptions := logs.LogsOptions{
+		Composefile: opts.Composefile,
+		Follow:      true,
+	}
+
+	return logsOptions.Run(ctx, []string{})
+}


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [x] Updated relevant documentation.

### Description of changes

The ``pause`` and ``unpause`` commands offer even better granularity over a compose project.
These commands allow users to suspend and resume projects without having to restart them completely.

Depends on: https://github.com/unikraft/kraftkit/pull/1476

<!--
Please provide a detailed description of the changes made in this new PR.
-->
