### PR TITLE
fix(action): Elevate group permissions if unknown UID:GID are used

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -32,6 +32,10 @@ inputs:
     description: Path to store runtime artifacts
     required: false
     default: /github/workspace/.kraftkit/runtime
+  grouprwx:
+    description: Set group read/write/execute permissions on all files
+    required: false
+    default: "true"
 
   #
   # Project flags
@@ -133,14 +137,26 @@ runs:
     run: |
       mkdir -p "${GITHUB_WORKSPACE}/.kraftkit"
 
-      cat <<'EOF' > "${GITHUB_WORKSPACE}/.kraftkit/before.sh"
+      if [ "${{ inputs.grouprwx }}" = "true" ] && ([ "$(id -u)" != "1001" ] || [ "$(id -g)" != "127" ]); then
+        cat <<'EOF' > "${GITHUB_WORKSPACE}/.kraftkit/before.sh"
       #!/usr/bin/env bash
-      if [ "$(id -u)" != "1001" ] || [ "$(id -g)" != "127" ]; then
-        sudo chown -R runner:runner /home/runner
-        sudo chown -R runner:runner /github/workspace
+
+      sudo find /home/runner -exec chmod g+rwx {} +
+      sudo find /github/workspace -exec chmod g+rwx {} +
+      sudo chmod g+rwx . || true;
+      sudo chmod g+rwx "${{ inputs.runtimedir }}" || true;
+      if [ -n "${{ inputs.workdir }}" ]; then
+          sudo chmod g+rwx "${{ inputs.workdir }}" || true;
       fi
       ${{ inputs.before }}
       EOF
+      else
+        cat <<'EOF' > "${GITHUB_WORKSPACE}/.kraftkit/before.sh"
+      #!/usr/bin/env bash
+
+      ${{ inputs.before }}
+      EOF
+      fi
       chmod +x "${GITHUB_WORKSPACE}/.kraftkit/before.sh"
 
       # Always dump the contents of the inputs into relevant files, and simply

--- a/buildenvs/github-action.Dockerfile
+++ b/buildenvs/github-action.Dockerfile
@@ -102,12 +102,18 @@ WORKDIR /github/workspace
 
 RUN set -xe; \
     groupadd -g 127 runner; \
+    groupadd -g 1000 arunner; \
+    groupadd -g 1001 brunner; \
+    groupadd -g 1002 crunner; \
     useradd -rm -d /home/runner -s /bin/bash -g runner -G sudo -u 1001 runner; \
     sed -i /etc/sudoers -re 's/^%sudo.*/%sudo ALL=(ALL:ALL) NOPASSWD: ALL/g'; \
     sed -i /etc/sudoers -re 's/^root.*/root ALL=(ALL:ALL) NOPASSWD: ALL/g'; \
     sed -i /etc/sudoers -re 's/^#includedir.*/## **Removed the include directive** ##"/g'; \
     echo "runner ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers; \
-    chown -R runner:runner /github/workspace
+    chown -R runner:runner /github/workspace; \
+    usermod -aG 1000 runner; \
+    usermod -aG 1001 runner; \
+    usermod -aG 1002 runner;
 USER runner
 
 ENV CLICOLOR_FORCE=1


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [ ] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [ ] Tested your changes against relevant architectures and platforms;
  - [ ] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

This moves the check outside the container and makes sure that files are always accesible. To do this, group permissions are elevated in the working directories when unknown UID:GID are used. This works because groups are hardcoded in the container for the 1000, 1001, 1002 GIDs.

To disable this if permissions are to be left untouched set 'grouprwx' to 'false'.