### PR TITLE
refactor(compose): Wrap with processtree

### DIFF
--- a/internal/cli/kraft/compose/build/build.go
+++ b/internal/cli/kraft/compose/build/build.go
@@ -109,9 +109,9 @@ func (opts *BuildOptions) Run(ctx context.Context, args []string) error {
 
 	model, err := processtree.NewProcessTree(ctx,
 		[]processtree.ProcessTreeOption{
+			processtree.IsParallel(false),
 			processtree.WithHideOnSuccess(false),
 			processtree.WithRenderer(topLevelRender),
-			processtree.IsParallel(false),
 		},
 		buildProcesses...,
 	)
@@ -125,9 +125,9 @@ func (opts *BuildOptions) Run(ctx context.Context, args []string) error {
 
 	model, err = processtree.NewProcessTree(ctx,
 		[]processtree.ProcessTreeOption{
+			processtree.IsParallel(false),
 			processtree.WithHideOnSuccess(false),
 			processtree.WithRenderer(topLevelRender),
-			processtree.IsParallel(!config.G[config.KraftKit](ctx).NoParallel),
 		},
 		pkgProcesses...,
 	)

--- a/internal/cli/kraft/compose/unpause/unpause.go
+++ b/internal/cli/kraft/compose/unpause/unpause.go
@@ -6,6 +6,7 @@ package unpause
 
 import (
 	"context"
+	"fmt"
 	"os"
 
 	"github.com/MakeNowJust/heredoc"
@@ -13,8 +14,10 @@ import (
 
 	"kraftkit.sh/cmdfactory"
 	"kraftkit.sh/compose"
+	"kraftkit.sh/config"
 	"kraftkit.sh/log"
 	"kraftkit.sh/packmanager"
+	"kraftkit.sh/tui/processtree"
 
 	machineapi "kraftkit.sh/api/machine/v1alpha1"
 	"kraftkit.sh/internal/cli/kraft/compose/logs"
@@ -89,24 +92,51 @@ func (opts *UnpauseOptions) Run(ctx context.Context, _ []string) error {
 		return err
 	}
 
-	machinesToUnpause := []string{}
+	topLevelRender := log.LoggerTypeFromString(config.G[config.KraftKit](ctx).Log.Type) != log.FANCY
+	oldLogType := config.G[config.KraftKit](ctx).Log.Type
+	config.G[config.KraftKit](ctx).Log.Type = log.LoggerTypeToString(log.BASIC)
+	defer func() {
+		config.G[config.KraftKit](ctx).Log.Type = oldLogType
+	}()
+
+	processes := make([]*processtree.ProcessTreeItem, 0)
 	for _, service := range project.Services {
 		for _, machine := range machines.Items {
 			if service.Name == machine.Name {
 				if machine.Status.State == machineapi.MachineStatePaused {
-					machinesToUnpause = append(machinesToUnpause, machine.Name)
+					processes = append(processes, processtree.NewProcessTreeItem(
+						fmt.Sprintf("resuming service %s", service.Name),
+						"",
+						func(ctx context.Context) error {
+							kernelStartOptions := kernelstart.StartOptions{
+								Detach:   true,
+								Platform: "auto",
+							}
+
+							return kernelStartOptions.Run(ctx, []string{service.Name})
+						},
+					))
 				}
 			}
 		}
 	}
 
-	kernelStartOptions := kernelstart.StartOptions{
-		Detach:   true,
-		Platform: "auto",
-	}
+	if len(processes) != 0 {
+		model, err := processtree.NewProcessTree(ctx,
+			[]processtree.ProcessTreeOption{
+				processtree.IsParallel(false),
+				processtree.WithHideOnSuccess(false),
+				processtree.WithRenderer(topLevelRender),
+			},
+			processes...,
+		)
+		if err != nil {
+			return err
+		}
 
-	if err := kernelStartOptions.Run(ctx, machinesToUnpause); err != nil {
-		return err
+		if err := model.Start(); err != nil {
+			return err
+		}
 	}
 
 	if opts.Detach {

--- a/iostreams/iostreams.go
+++ b/iostreams/iostreams.go
@@ -188,7 +188,7 @@ func (s *IOStreams) IsStdoutTTY() bool {
 	}
 
 	// support KRAFTKIT_FORCE_TTY
-	if s.term.IsTerminalOutput() {
+	if s.term != nil && s.term.IsTerminalOutput() {
 		return true
 	}
 


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [x] Updated relevant documentation.

### Description of changes

Improve the CLI by wrapping the underlying kraft calls with processtree.

The solution is a bit hacky, since embedding processtrees within one another does not work if they are in ``--log-type fancy``. Instead, only use ``--log-type`` for the top level processtree and artificially set the logging type to ``basic`` for the inner ones.

<!--
Please provide a detailed description of the changes made in this new PR.
-->
