### PR TITLE
feat(qemu): Support both ports and networks

### DIFF
--- a/internal/cli/kraft/run/run.go
+++ b/internal/cli/kraft/run/run.go
@@ -179,10 +179,6 @@ func (opts *RunOptions) Pre(cmd *cobra.Command, _ []string) error {
 		}
 	}
 
-	if len(opts.Ports) > 0 && len(opts.Networks) > 0 {
-		return fmt.Errorf("cannot use both --port and --network flags together")
-	}
-
 	if opts.Memory != "" {
 		qty, err := resource.ParseQuantity(opts.Memory)
 		if err != nil {


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [x] Updated relevant documentation.

### Description of changes

Supporting both networks and forwarded ports on ``qemu`` just involves mixing up user and tap devices. The ports and networks argument have been reordered because it only works this way. This probably has to do with how ``netdevip`` maps the ``netdev.ip`` argument to the qemu netdev devices - if this is done in order, then the ``tap`` devices corresponding to the networks a kernel is connected to should be first.

The result is something like this:

```bash
kraft net create kraft0

kraft net ls
NAME             NETWORK           DRIVER  STATUS
kraft0           172.24.0.1/16     bridge  up

kraft run nginx:1.15 --port 8080:80 --network kraft0

curl localhost:8080
<!DOCTYPE html>
.
.

curl 172.24.0.2
<!DOCTYPE html>
.
.
```

and the nginx output:
```
10.0.2.2 - - [03/Apr/2024:16:17:55 +0000] "GET / HTTP/1.1" 200 325 "-" "curl/7.81.0"
172.24.0.1 - - [03/Apr/2024:16:17:58 +0000] "GET / HTTP/1.1" 200 325 "-" "curl/7.81.0"
```

Port forwarding seems to not be supported at the moment for ``fc`` so this will probably be a ``qemu`` only option for now.


<!--
Please provide a detailed description of the changes made in this new PR.
-->
