### PR TITLE
feat(cloud): print total size of volume import data

### DIFF
--- a/internal/cli/kraft/cloud/volume/import/import.go
+++ b/internal/cli/kraft/cloud/volume/import/import.go
@@ -155,7 +155,7 @@ func importVolumeData(ctx context.Context, opts *ImportOptions) (retErr error) {
 		retErr = errors.Join(retErr, terminateVolimport(ctx, icli, instID))
 	}()
 
-	paraprogress, err := paraProgress(ctx, "Importing data",
+	paraprogress, err := paraProgress(ctx, fmt.Sprintf("Importing data (%s)", humanize.IBytes(uint64(cpioSize))),
 		func(ctx context.Context, callback func(float64)) (retErr error) {
 			instAddr := instFQDN + ":" + strconv.FormatUint(uint64(volimportPort), 10)
 			conn, err := tls.Dial("tcp4", instAddr, nil)


### PR DESCRIPTION
A small quality of life improvement so that the user knows up front how much data is about to be transferred.

```diff
- [/] Importing data •••••••••••••••••••••••
+ [/] Importing data (19 MiB) ••••••••••••••
```