### PR TITLE
fix(cloud): handle volume import cancellation

### DIFF
--- a/internal/cli/kraft/cloud/volume/import/errors.go
+++ b/internal/cli/kraft/cloud/volume/import/errors.go
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2024, Unikraft GmbH and The KraftKit Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+
+package vimport
+
+import "errors"
+
+// Loggable is a type of error that can be asserted for behaviour, and signals
+// whether an error should be logged when handled.
+// It is particularly useful for communicating to a caller that the error was
+// already reported (e.g. logged) in a callee.
+type Loggable interface {
+	error
+	Loggable() bool
+}
+
+// NotLoggable marks an error as not loggable.
+func NotLoggable(err error) error {
+	return noLogError{e: err}
+}
+
+// IsLoggable returns whether err should be logged when handled.
+// All errors are considered loggable unless explicitly marked otherwise.
+func IsLoggable(err error) bool {
+	lerr := (Loggable)(nil)
+	if impl := errors.As(err, &lerr); !impl {
+		return true
+	}
+	return lerr.Loggable()
+}
+
+// noLogError is an error type that should not be logged when handled.
+type noLogError struct {
+	e error
+}
+
+var _ Loggable = (*noLogError)(nil)
+
+// Loggable implements Loggable.
+func (noLogError) Loggable() bool {
+	return false
+}
+
+// Error implements the error interface.
+func (e noLogError) Error() string {
+	return e.e.Error()
+}
+
+// Unwrap implements the Unwrap part of the error interface.
+func (e noLogError) Unwrap() error {
+	return e.e
+}

--- a/internal/cli/kraft/cloud/volume/import/errors_test.go
+++ b/internal/cli/kraft/cloud/volume/import/errors_test.go
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2024, Unikraft GmbH and The KraftKit Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+
+package vimport_test
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"kraftkit.sh/internal/cli/kraft/cloud/volume/import"
+)
+
+func TestLoggableError(t *testing.T) {
+	genericErr := errors.New("an error")
+	nologErr := vimport.NotLoggable(genericErr)
+
+	// generic
+	if !vimport.IsLoggable(genericErr) {
+		t.Error("Expected generic error to be loggable")
+	}
+	if !vimport.IsLoggable(fmt.Errorf("wrapped: %w", genericErr)) {
+		t.Error("Expected wrapped generic error to be loggable")
+	}
+
+	// nolog
+	if vimport.IsLoggable(nologErr) {
+		t.Error("Expected nolog error to not be loggable")
+	}
+	if vimport.IsLoggable(fmt.Errorf("wrapped: %w", nologErr)) {
+		t.Error("Expected wrapped nolog error to not be loggable")
+	}
+}

--- a/internal/cli/kraft/cloud/volume/import/import.go
+++ b/internal/cli/kraft/cloud/volume/import/import.go
@@ -139,7 +139,6 @@ func importVolumeData(ctx context.Context, opts *ImportOptions) (retErr error) {
 			if authStr, err = genRandAuth(); err != nil {
 				return fmt.Errorf("generating random authentication string: %w", err)
 			}
-
 			instID, instFQDN, err = runVolimport(ctx, icli, volUUID, authStr)
 			return err
 		},
@@ -166,10 +165,9 @@ func importVolumeData(ctx context.Context, opts *ImportOptions) (retErr error) {
 				retErr = errors.Join(retErr, conn.Close())
 			}()
 
-			if err = copyCPIO(conn, authStr, cpioPath, cpioSize, callback); err != nil {
-				return fmt.Errorf("copying data to volume data import instance: %w", err)
-			}
-			return nil
+			ctx, cancel := context.WithCancel(ctx)
+			defer cancel()
+			return copyCPIO(ctx, conn, authStr, cpioPath, cpioSize, callback)
 		},
 	)
 	if err != nil {

--- a/internal/cli/kraft/cloud/volume/import/import.go
+++ b/internal/cli/kraft/cloud/volume/import/import.go
@@ -84,6 +84,9 @@ func (opts *ImportOptions) Run(ctx context.Context, _ []string) error {
 	}
 
 	if err = importVolumeData(ctx, opts); err != nil {
+		if IsLoggable(err) {
+			return fmt.Errorf("could not import volume data: %w", err)
+		}
 		return errors.New("could not import volume data")
 	}
 	return nil
@@ -112,7 +115,7 @@ func importVolumeData(ctx context.Context, opts *ImportOptions) (retErr error) {
 		return err
 	}
 	if err = paramodel.Start(); err != nil {
-		return err
+		return NotLoggable(err) // already logged by runner
 	}
 
 	defer func() {
@@ -126,7 +129,6 @@ func importVolumeData(ctx context.Context, opts *ImportOptions) (retErr error) {
 	var volUUID string
 	var volSize int64
 	if volUUID, volSize, err = volumeSanityCheck(ctx, vcli, opts.VolID, cpioSize); err != nil {
-		log.G(ctx).WithError(err).Error("Volume sanity check failed")
 		return err
 	}
 
@@ -147,7 +149,7 @@ func importVolumeData(ctx context.Context, opts *ImportOptions) (retErr error) {
 		return err
 	}
 	if err = paramodel.Start(); err != nil {
-		return err
+		return NotLoggable(err) // already logged by runner
 	}
 
 	defer func() {
@@ -174,7 +176,7 @@ func importVolumeData(ctx context.Context, opts *ImportOptions) (retErr error) {
 		return err
 	}
 	if err = paraprogress.Start(); err != nil {
-		return err
+		return NotLoggable(err) // already logged by runner
 	}
 
 	fancymap.PrintFancyMap(iostreams.G(ctx).Out, tui.TextGreen, "Import complete",

--- a/internal/cli/kraft/cloud/volume/import/import.go
+++ b/internal/cli/kraft/cloud/volume/import/import.go
@@ -153,7 +153,10 @@ func importVolumeData(ctx context.Context, opts *ImportOptions) (retErr error) {
 	}
 
 	defer func() {
-		retErr = errors.Join(retErr, terminateVolimport(ctx, icli, instID))
+		noInterrupt := context.Background()
+		retErr = errors.Join(retErr,
+			terminateVolimport(noInterrupt, icli, instID),
+		)
 	}()
 
 	paraprogress, err := paraProgress(ctx, fmt.Sprintf("Importing data (%s)", humanize.IBytes(uint64(cpioSize))),


### PR DESCRIPTION
Until now, context cancellations (e.g. through `Ctrl-C`) were not propagated to `copyCPIO`. As a result, imports would continue until completion instead of being interrupted, potentially for a very long time if the tranfered data is large.

This PR ensures that context cancellations are propagated to the `tls.Conn` by setting a write deadline accordingly.

--- 

⚠️ Due to a bug in KraftKit, `paraprogress.Start()` returns `nil` upon context cancellation instead of the error returned by the inner function.

For example, when the context is cancelled after introducing the feature from this PR, `io.Copy` returns:
```
write tcp4 172.24.172.99:51516->136.144.49.17:42069: i/o timeout
```
And `copyCPIO` returns:
```
incomplete write (42/100)
```

Yet, `paraprogress.Start()` returns `nil` so `fancymap.PrintFancyMap` is called regardless.

Illustration, with a few `Println()` added to show errors:
```
[\] Importing data (19 MiB) ••••••••••••••••••••••••••••••••••••••   23% [1.0s]
^C
write tcp4 172.24.172.99:51516->136.144.49.17:42069: i/o timeout
incomplete write (42/100)

[●] Import complete
 │
 ├─── volume: f127ea39-0e42-4c1d-b416-805e22872408
 ├─ imported: 19 MiB
 └─ capacity: 25 MiB

 E  could not import volume data
```