### PR TITLE
fix(bridge): Error out if not able to assign interface name

### DIFF
--- a/machine/network/bridge/v1alpha1.go
+++ b/machine/network/bridge/v1alpha1.go
@@ -121,9 +121,17 @@ func (service *v1alpha1Network) Create(ctx context.Context, network *networkv1al
 			j := 0
 			for {
 				ifname := fmt.Sprintf("%s@if%d", network.Name, j)
-				if _, err := netlink.LinkByName(ifname); err != nil && err.Error() == "Link not found" {
-					iface.Spec.IfName = ifname
-					break
+				if _, err := netlink.LinkByName(ifname); err != nil {
+					if err.Error() == "Link not found" {
+						iface.Spec.IfName = ifname
+						break
+					}
+
+					if err.Error() == "numerical result out of range" {
+						return network, fmt.Errorf("interface name is too long: %s, consider using a shorter network name", ifname)
+					}
+
+					return network, err
 				}
 				j++
 			}
@@ -269,9 +277,17 @@ func (service *v1alpha1Network) Update(ctx context.Context, network *networkv1al
 			j := 0
 			for {
 				ifname := fmt.Sprintf("%s@if%d", network.Name, j)
-				if _, err := netlink.LinkByName(ifname); err != nil && err.Error() == "Link not found" {
-					iface.Spec.IfName = ifname
-					break
+				if _, err := netlink.LinkByName(ifname); err != nil {
+					if err.Error() == "Link not found" {
+						iface.Spec.IfName = ifname
+						break
+					}
+
+					if err.Error() == "numerical result out of range" {
+						return network, fmt.Errorf("interface name is too long: %s, consider using a shorter network name", ifname)
+					}
+
+					return network, err
 				}
 				j++
 			}


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [x] Updated relevant documentation.

### Description of changes

This solves a problem where a longer network name would cause all interface names to be too long due to our naming scheme. This then results in an infinite loop. Instead, generate a better error message.

```
 E  all iterated drivers failed: interface name is too long: 12345678901234@if0, consider using a shorter network name
```

<!--
Please provide a detailed description of the changes made in this new PR.
-->
