### PR TITLE
refactor(cloud)!: Improve rollout strateg(ies)

### DIFF
--- a/internal/cli/kraft/cloud/certificate/get/get.go
+++ b/internal/cli/kraft/cloud/certificate/get/get.go
@@ -90,5 +90,5 @@ func (opts *GetOptions) Run(ctx context.Context, args []string) error {
 		return fmt.Errorf("could not get certificate %s: %w", args[0], err)
 	}
 
-	return utils.PrintCertificates(ctx, opts.Output, certResp)
+	return utils.PrintCertificates(ctx, opts.Output, *certResp)
 }

--- a/internal/cli/kraft/cloud/certificate/list/list.go
+++ b/internal/cli/kraft/cloud/certificate/list/list.go
@@ -93,5 +93,5 @@ func (opts *ListOptions) Run(ctx context.Context, args []string) error {
 		return fmt.Errorf("getting details of %d certificate(s): %w", len(certList), err)
 	}
 
-	return utils.PrintCertificates(ctx, opts.Output, certsResp)
+	return utils.PrintCertificates(ctx, opts.Output, *certsResp)
 }

--- a/internal/cli/kraft/cloud/deploy/deploy.go
+++ b/internal/cli/kraft/cloud/deploy/deploy.go
@@ -217,10 +217,11 @@ func (opts *DeployOptions) Run(ctx context.Context, args []string) error {
 
 	log.G(ctx).WithField("deployer", d.Name()).Debug("using")
 
-	instsResp, sgs, err := d.Deploy(ctx, opts, args...)
+	instsResp, _, err := d.Deploy(ctx, opts, args...)
 	if err != nil {
 		return fmt.Errorf("could not prepare deployment: %w", err)
 	}
+
 	insts, err := instsResp.AllOrErr()
 	if err != nil {
 		return err
@@ -283,11 +284,7 @@ func (opts *DeployOptions) Run(ctx context.Context, args []string) error {
 	}
 
 	if len(insts) == 1 && opts.Output == "" {
-		if len(sgs) == 0 {
-			sgs = append(sgs, kcservices.GetResponseItem{})
-		}
-
-		utils.PrettyPrintInstance(ctx, &insts[0], &sgs[0], !opts.NoStart)
+		utils.PrettyPrintInstance(ctx, insts[0], !opts.NoStart)
 		return nil
 	}
 

--- a/internal/cli/kraft/cloud/deploy/deploy.go
+++ b/internal/cli/kraft/cloud/deploy/deploy.go
@@ -288,5 +288,5 @@ func (opts *DeployOptions) Run(ctx context.Context, args []string) error {
 		return nil
 	}
 
-	return utils.PrintInstances(ctx, opts.Output, instsResp)
+	return utils.PrintInstances(ctx, opts.Output, *instsResp)
 }

--- a/internal/cli/kraft/cloud/deploy/deploy.go
+++ b/internal/cli/kraft/cloud/deploy/deploy.go
@@ -22,12 +22,10 @@ import (
 	"kraftkit.sh/internal/cli/kraft/cloud/utils"
 	"kraftkit.sh/log"
 	"kraftkit.sh/packmanager"
-	"kraftkit.sh/tui/processtree"
 	"kraftkit.sh/tui/selection"
 	"kraftkit.sh/unikraft/app"
 
 	kraftcloud "sdk.kraft.cloud"
-	kcservices "sdk.kraft.cloud/services"
 )
 
 type DeployOptions struct {
@@ -56,7 +54,9 @@ type DeployOptions struct {
 	Ports                  []string                  `local:"true" long:"port" short:"p" usage:"Specify the port mapping between external to internal"`
 	Project                app.Application           `noattribute:"true"`
 	Replicas               int                       `local:"true" long:"replicas" short:"R" usage:"Number of replicas of the instance" default:"0"`
-	Rollout                bool                      `local:"true" long:"rollout" short:"r" usage:"Whether to perform a rolling update of all instances in a service group"`
+	Rollout                create.RolloutStrategy    `noattribute:"true"`
+	RolloutQualifier       create.RolloutQualifier   `noattribute:"true"`
+	RolloutWait            time.Duration             `local:"true" long:"rollout-wait" usage:"Time to wait before performing rolling out action" default:"10s"`
 	Rootfs                 string                    `local:"true" long:"rootfs" usage:"Specify a path to use as root filesystem"`
 	Runtime                string                    `local:"true" long:"runtime" usage:"Set an alternative project runtime"`
 	SaveBuildLog           string                    `long:"build-log" usage:"Use the specified file to save the output from the build"`
@@ -93,6 +93,24 @@ func NewCmd() *cobra.Command {
 	}
 
 	cmd.Flags().Var(
+		cmdfactory.NewEnumFlag[create.RolloutStrategy](
+			append(create.RolloutStrategies(), create.StrategyPrompt),
+			create.StrategyPrompt,
+		),
+		"rollout",
+		"Set the rollout strategy for an instance which has been previously run in the provided service group.",
+	)
+
+	cmd.Flags().Var(
+		cmdfactory.NewEnumFlag[create.RolloutQualifier](
+			create.RolloutQualifiers(),
+			create.RolloutQualifierImageName,
+		),
+		"rollout-qualifier",
+		"Set the rollout qualifier used to determine which instances should be affected by the strategy in the supplied service group.",
+	)
+
+	cmd.Flags().Var(
 		cmdfactory.NewEnumFlag[packmanager.MergeStrategy](
 			append(packmanager.MergeStrategies(), packmanager.StrategyPrompt),
 			packmanager.StrategyOverwrite,
@@ -110,19 +128,13 @@ func (opts *DeployOptions) Pre(cmd *cobra.Command, _ []string) error {
 		return fmt.Errorf("could not populate metro and token: %w", err)
 	}
 
+	opts.Rollout = create.RolloutStrategy(cmd.Flag("rollout").Value.String())
+	opts.RolloutQualifier = create.RolloutQualifier(cmd.Flag("rollout-qualifier").Value.String())
 	opts.Strategy = packmanager.MergeStrategy(cmd.Flag("strategy").Value.String())
 
 	ctx, err := packmanager.WithDefaultUmbrellaManagerInContext(cmd.Context())
 	if err != nil {
 		return err
-	}
-
-	if opts.Rollout && opts.ServiceGroupNameOrUUID == "" {
-		return errors.New("cannot use --rollout without a --service-group")
-	}
-
-	if opts.Rollout && opts.Replicas > 0 {
-		return errors.New("cannot use --rollout with --replicas")
 	}
 
 	cmd.SetContext(ctx)
@@ -143,17 +155,6 @@ func (opts *DeployOptions) Run(ctx context.Context, args []string) error {
 	)
 
 	// TODO: Preflight check: check if `--subdomain` is already taken
-
-	// Preflight check: check if `--name` is already taken:
-	if len(opts.Name) > 0 {
-		resp, err := opts.Client.Instances().WithMetro(opts.Metro).Get(ctx, opts.Name)
-		if err != nil {
-			return err
-		}
-		if _, err = resp.AllOrErr(); err == nil {
-			return fmt.Errorf("instance name '%s' is already taken", opts.Name)
-		}
-	}
 
 	if len(args) > 0 {
 		if fi, err := os.Stat(args[0]); err == nil && fi.IsDir() {
@@ -225,62 +226,6 @@ func (opts *DeployOptions) Run(ctx context.Context, args []string) error {
 	insts, err := instsResp.AllOrErr()
 	if err != nil {
 		return err
-	}
-
-	if opts.Rollout {
-		if len(sgs[0].Instances) == 1 {
-			log.G(ctx).Warn("cannot perform a rolling update on no instances")
-			return nil
-		}
-
-		paramodel, err := processtree.NewProcessTree(
-			ctx,
-			[]processtree.ProcessTreeOption{
-				processtree.IsParallel(false),
-				processtree.WithRenderer(
-					log.LoggerTypeFromString(config.G[config.KraftKit](ctx).Log.Type) != log.FANCY,
-				),
-				processtree.WithFailFast(true),
-				processtree.WithHideOnSuccess(false),
-				processtree.WithTimeout(opts.Timeout),
-			},
-			processtree.NewProcessTreeItem(
-				"updating "+fmt.Sprintf("%d", len(sgs[0].Instances)-1)+" instances of "+sgs[0].Name,
-				"",
-				func(ctx context.Context) error {
-					return create.Rollout(ctx, &create.CreateOptions{
-						Auth:                   opts.Auth,
-						Client:                 opts.Client,
-						Env:                    opts.Env,
-						Features:               opts.Features,
-						Domain:                 opts.Domain,
-						Image:                  insts[0].Image,
-						Memory:                 opts.Memory,
-						Metro:                  opts.Metro,
-						Name:                   opts.Name,
-						Output:                 opts.Output,
-						Ports:                  opts.Ports,
-						Replicas:               opts.Replicas,
-						Rollout:                opts.Rollout,
-						ServiceGroupNameOrUUID: opts.ServiceGroupNameOrUUID,
-						Start:                  !opts.NoStart,
-						ScaleToZero:            opts.ScaleToZero,
-						SubDomain:              opts.SubDomain,
-						Token:                  opts.Token,
-						Volumes:                opts.Volumes,
-						WaitForImage:           true,
-					}, &insts[0], &sgs[0])
-				},
-			),
-		)
-		if err != nil {
-			return nil
-		}
-
-		err = paramodel.Start()
-		if err != nil {
-			return fmt.Errorf("could not start the process tree: %w", err)
-		}
 	}
 
 	if len(insts) == 1 && opts.Output == "" {

--- a/internal/cli/kraft/cloud/deploy/deployer.go
+++ b/internal/cli/kraft/cloud/deploy/deployer.go
@@ -31,7 +31,7 @@ type deployer interface {
 	Deployable(context.Context, *DeployOptions, ...string) (bool, error)
 
 	// Deploy performs the deployment based on the determined implementation.
-	Deploy(context.Context, *DeployOptions, ...string) (*kcclient.ServiceResponse[kcinstances.GetResponseItem], []kcservices.GetResponseItem, error)
+	Deploy(context.Context, *DeployOptions, ...string) (*kcclient.ServiceResponse[kcinstances.GetResponseItem], *kcclient.ServiceResponse[kcservices.GetResponseItem], error)
 }
 
 // deployers is the list of built-in deployers which are checked

--- a/internal/cli/kraft/cloud/deploy/deployer_image_name.go
+++ b/internal/cli/kraft/cloud/deploy/deployer_image_name.go
@@ -71,11 +71,11 @@ func (deployer *deployerImageName) Deployable(ctx context.Context, opts *DeployO
 	return true, nil
 }
 
-func (deployer *deployerImageName) Deploy(ctx context.Context, opts *DeployOptions, args ...string) (*kcclient.ServiceResponse[kcinstances.GetResponseItem], []kcservices.GetResponseItem, error) {
+func (deployer *deployerImageName) Deploy(ctx context.Context, opts *DeployOptions, args ...string) (*kcclient.ServiceResponse[kcinstances.GetResponseItem], *kcclient.ServiceResponse[kcservices.GetResponseItem], error) {
 	var err error
 
-	var instResp *kcclient.ServiceResponse[kcinstances.GetResponseItem]
-	var sg *kcservices.GetResponseItem
+	var insts *kcclient.ServiceResponse[kcinstances.GetResponseItem]
+	var groups *kcclient.ServiceResponse[kcservices.GetResponseItem]
 
 	paramodel, err := processtree.NewProcessTree(
 		ctx,
@@ -92,7 +92,7 @@ func (deployer *deployerImageName) Deploy(ctx context.Context, opts *DeployOptio
 			"deploying",
 			"",
 			func(ctx context.Context) error {
-				instResp, sg, err = instancecreate.Create(ctx, &instancecreate.CreateOptions{
+				insts, groups, err = instancecreate.Create(ctx, &instancecreate.CreateOptions{
 					Env:                    opts.Env,
 					Features:               opts.Features,
 					Domain:                 opts.Domain,
@@ -124,9 +124,5 @@ func (deployer *deployerImageName) Deploy(ctx context.Context, opts *DeployOptio
 		return nil, nil, err
 	}
 
-	if sg != nil {
-		return instResp, []kcservices.GetResponseItem{*sg}, nil
-	}
-
-	return instResp, nil, nil
+	return insts, groups, nil
 }

--- a/internal/cli/kraft/cloud/deploy/deployer_kraftfile_runtime.go
+++ b/internal/cli/kraft/cloud/deploy/deployer_kraftfile_runtime.go
@@ -122,6 +122,8 @@ func (deployer *deployerKraftfileRuntime) Deploy(ctx context.Context, opts *Depl
 		Ports:                  opts.Ports,
 		Replicas:               opts.Replicas,
 		Rollout:                opts.Rollout,
+		RolloutQualifier:       opts.RolloutQualifier,
+		RolloutWait:            opts.RolloutWait,
 		ScaleToZero:            opts.ScaleToZero,
 		ServiceGroupNameOrUUID: opts.ServiceGroupNameOrUUID,
 		Start:                  !opts.NoStart,

--- a/internal/cli/kraft/cloud/deploy/deployer_kraftfile_runtime.go
+++ b/internal/cli/kraft/cloud/deploy/deployer_kraftfile_runtime.go
@@ -72,7 +72,7 @@ func (deployer *deployerKraftfileRuntime) Deployable(ctx context.Context, opts *
 	return true, nil
 }
 
-func (deployer *deployerKraftfileRuntime) Deploy(ctx context.Context, opts *DeployOptions, args ...string) (*kcclient.ServiceResponse[kcinstances.GetResponseItem], []kcservices.GetResponseItem, error) {
+func (deployer *deployerKraftfileRuntime) Deploy(ctx context.Context, opts *DeployOptions, args ...string) (*kcclient.ServiceResponse[kcinstances.GetResponseItem], *kcclient.ServiceResponse[kcservices.GetResponseItem], error) {
 	var pkgName string
 
 	if len(opts.Name) > 0 {
@@ -143,8 +143,8 @@ func (deployer *deployerKraftfileRuntime) Deploy(ctx context.Context, opts *Depl
 		deployer.args = p.Command()
 	}
 
-	var instResp *kcclient.ServiceResponse[kcinstances.GetResponseItem]
-	var sg *kcservices.GetResponseItem
+	var insts *kcclient.ServiceResponse[kcinstances.GetResponseItem]
+	var groups *kcclient.ServiceResponse[kcservices.GetResponseItem]
 
 	ctx, deployCancel := context.WithTimeout(ctx, 60*time.Second)
 	defer deployCancel()
@@ -215,7 +215,7 @@ func (deployer *deployerKraftfileRuntime) Deploy(ctx context.Context, opts *Depl
 					ctxTimeout, cancel = context.WithTimeout(context.TODO(), 5*time.Second)
 					defer cancel()
 
-					instResp, sg, err = create.Create(ctxTimeout, &create.CreateOptions{
+					insts, groups, err = create.Create(ctxTimeout, &create.CreateOptions{
 						Env:                    opts.Env,
 						Domain:                 opts.Domain,
 						Image:                  pkgName,
@@ -253,10 +253,5 @@ func (deployer *deployerKraftfileRuntime) Deploy(ctx context.Context, opts *Depl
 		return nil, nil, err
 	}
 
-	sgItems := make([]kcservices.GetResponseItem, 0, 1)
-	if sg != nil {
-		sgItems = append(sgItems, *sg)
-	}
-
-	return instResp, sgItems, nil
+	return insts, groups, nil
 }

--- a/internal/cli/kraft/cloud/deploy/deployer_kraftfile_runtime.go
+++ b/internal/cli/kraft/cloud/deploy/deployer_kraftfile_runtime.go
@@ -203,42 +203,25 @@ func (deployer *deployerKraftfileRuntime) Deploy(ctx context.Context, opts *Depl
 					}
 				}
 
-			attemptDeployment:
-				for {
-					select {
-					case <-ctx.Done():
-						return fmt.Errorf("context cancelled")
-					default:
-					}
-
-					// Introduce a new context that is used only for iteration
-					ctxTimeout, cancel = context.WithTimeout(context.TODO(), 5*time.Second)
-					defer cancel()
-
-					insts, groups, err = create.Create(ctxTimeout, &create.CreateOptions{
-						Env:                    opts.Env,
-						Domain:                 opts.Domain,
-						Image:                  pkgName,
-						Memory:                 opts.Memory,
-						Metro:                  opts.Metro,
-						Name:                   strings.ReplaceAll(opts.Name, "/", "-"),
-						Ports:                  opts.Ports,
-						Replicas:               opts.Replicas,
-						ScaleToZero:            opts.ScaleToZero,
-						ServiceGroupNameOrUUID: opts.ServiceGroupNameOrUUID,
-						Start:                  !opts.NoStart,
-						SubDomain:              opts.SubDomain,
-						Token:                  opts.Token,
-						Volumes:                opts.Volumes,
-					}, deployer.args...)
-					if err != nil && strings.HasSuffix(err.Error(), "context deadline exceeded") {
-						continue
-					} else if err != nil {
-						return fmt.Errorf("could not create instance: %w", err)
-					}
-
-					cancel()
-					break attemptDeployment
+				insts, groups, err = create.Create(ctx, &create.CreateOptions{
+					Env:                    opts.Env,
+					Domain:                 opts.Domain,
+					Image:                  pkgName,
+					Memory:                 opts.Memory,
+					Metro:                  opts.Metro,
+					Name:                   opts.Name,
+					Ports:                  opts.Ports,
+					Replicas:               opts.Replicas,
+					Rollout:                opts.Rollout,
+					ScaleToZero:            opts.ScaleToZero,
+					ServiceGroupNameOrUUID: opts.ServiceGroupNameOrUUID,
+					Start:                  !opts.NoStart,
+					SubDomain:              opts.SubDomain,
+					Token:                  opts.Token,
+					Volumes:                opts.Volumes,
+				}, deployer.args...)
+				if err != nil {
+					return fmt.Errorf("could not create instance: %w", err)
 				}
 
 				return nil

--- a/internal/cli/kraft/cloud/deploy/deployer_kraftfile_unikraft.go
+++ b/internal/cli/kraft/cloud/deploy/deployer_kraftfile_unikraft.go
@@ -48,7 +48,7 @@ func (deployer *deployerKraftfileUnikraft) Deployable(ctx context.Context, opts 
 	return true, nil
 }
 
-func (deployer *deployerKraftfileUnikraft) Deploy(ctx context.Context, opts *DeployOptions, args ...string) (*kcclient.ServiceResponse[kcinstances.GetResponseItem], []kcservices.GetResponseItem, error) {
+func (deployer *deployerKraftfileUnikraft) Deploy(ctx context.Context, opts *DeployOptions, args ...string) (*kcclient.ServiceResponse[kcinstances.GetResponseItem], *kcclient.ServiceResponse[kcservices.GetResponseItem], error) {
 	if err := build.Build(ctx, &build.BuildOptions{
 		Architecture: "x86_64",
 		DotConfig:    opts.DotConfig,

--- a/internal/cli/kraft/cloud/instance/create/create.go
+++ b/internal/cli/kraft/cloud/instance/create/create.go
@@ -87,10 +87,6 @@ func Create(ctx context.Context, opts *CreateOptions, args ...string) (*kcclient
 
 	// Check if the image exists before creating the instance
 	if opts.WaitForImage {
-		imageClient := kraftcloud.NewClient(
-			kraftcloud.WithToken(config.GetKraftCloudTokenAuthConfig(*opts.Auth)),
-		)
-
 		paramodel, err := processtree.NewProcessTree(
 			ctx,
 			[]processtree.ProcessTreeOption{
@@ -107,7 +103,7 @@ func Create(ctx context.Context, opts *CreateOptions, args ...string) (*kcclient
 				"",
 				func(ctx context.Context) error {
 					for {
-						imgs, err := imageClient.Images().WithMetro(opts.Metro).List(ctx)
+						imgs, err := opts.Client.Images().WithMetro(opts.Metro).List(ctx)
 						if err != nil {
 							return fmt.Errorf("could not list images: %w", err)
 						}

--- a/internal/cli/kraft/cloud/instance/create/create.go
+++ b/internal/cli/kraft/cloud/instance/create/create.go
@@ -616,7 +616,7 @@ func (opts *CreateOptions) Run(ctx context.Context, args []string) error {
 	}
 
 	if len(insts) > 1 || opts.Output == "table" {
-		return utils.PrintInstances(ctx, opts.Output, resp)
+		return utils.PrintInstances(ctx, opts.Output, *resp)
 	}
 	utils.PrettyPrintInstance(ctx, insts[0], opts.Start)
 

--- a/internal/cli/kraft/cloud/instance/create/create.go
+++ b/internal/cli/kraft/cloud/instance/create/create.go
@@ -7,7 +7,6 @@ package create
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"os"
 	"slices"
@@ -28,6 +27,7 @@ import (
 	"kraftkit.sh/internal/cli/kraft/cloud/utils"
 	"kraftkit.sh/log"
 	"kraftkit.sh/tui/processtree"
+	"kraftkit.sh/tui/selection"
 )
 
 type CreateOptions struct {
@@ -43,7 +43,9 @@ type CreateOptions struct {
 	Output                 string                `local:"true" long:"output" short:"o" usage:"Set output format. Options: table,yaml,json,list" default:"table"`
 	Ports                  []string              `local:"true" long:"port" short:"p" usage:"Specify the port mapping between external to internal"`
 	Replicas               int                   `local:"true" long:"replicas" short:"R" usage:"Number of replicas of the instance" default:"0"`
-	Rollout                bool                  `local:"true" long:"rollout" short:"r" usage:"Roll out the instance in a service group"`
+	Rollout                RolloutStrategy       `noattribute:"true"`
+	RolloutQualifier       RolloutQualifier      `noattribute:"true"`
+	RolloutWait            time.Duration         `local:"true" long:"rollout-wait" usage:"Time to wait before performing rolling out action" default:"10s"`
 	ServiceGroupNameOrUUID string                `local:"true" long:"service-group" short:"g" usage:"Attach this instance to an existing service group"`
 	Start                  bool                  `local:"true" long:"start" short:"S" usage:"Immediately start the instance after creation"`
 	ScaleToZero            bool                  `local:"true" long:"scale-to-zero" short:"0" usage:"Scale the instance to zero after deployment"`
@@ -51,7 +53,7 @@ type CreateOptions struct {
 	Token                  string                `noattribute:"true"`
 	Volumes                []string              `local:"true" long:"volumes" short:"v" usage:"List of volumes to attach instance to"`
 	WaitForImage           bool                  `local:"true" long:"wait-for-image" short:"w" usage:"Wait for the image to be available before creating the instance"`
-	WaitForImageTimeout    time.Duration         `local:"true" long:"wait-for-image-timeout" short:"W" usage:"Timeout for waiting for the image to be available" default:"50s"`
+	WaitForImageTimeout    time.Duration         `local:"true" long:"wait-for-image-timeout" usage:"Time to wait before timing out when waiting for image" default:"60s"`
 }
 
 // Create a KraftCloud instance.
@@ -72,6 +74,16 @@ func Create(ctx context.Context, opts *CreateOptions, args ...string) (*kcclient
 		opts.Client = kraftcloud.NewClient(
 			kraftcloud.WithToken(config.GetKraftCloudTokenAuthConfig(*opts.Auth)),
 		)
+	}
+
+	// Check if the user tries to use a service group and a rollout strategy is
+	// set to prompt so that we can use this information later.  We do this very
+	// early on such that we can fail-fast in case prompting is not possible (e.g.
+	// in non-TTY environments).
+	if opts.ServiceGroupNameOrUUID != "" && opts.Rollout == StrategyPrompt {
+		if config.G[config.KraftKit](ctx).NoPrompt {
+			return nil, nil, fmt.Errorf("prompting disabled")
+		}
 	}
 
 	if !strings.Contains(opts.Image, ":") {
@@ -191,13 +203,23 @@ func Create(ctx context.Context, opts *CreateOptions, args ...string) (*kcclient
 	}
 
 	var serviceGroup *kcservices.GetResponseItem
+	var qualifiedInstances []kcinstances.GetResponseItem
 
-	if opts.ServiceGroupNameOrUUID != "" {
-		resp, err := opts.Client.Services().WithMetro(opts.Metro).Get(ctx, opts.ServiceGroupNameOrUUID)
+	// Since an existing service group has been provided, we should now
+	// preemptively look up information about it.  Based on whether there are
+	// active instances inside of this service group, we can then decide how to
+	// proceed with the deployment (aka rollout strategies).
+	if len(opts.ServiceGroupNameOrUUID) > 0 {
+		log.G(ctx).
+			WithField("group", opts.ServiceGroupNameOrUUID).
+			Trace("looking up service")
+
+		groupResp, err := opts.Client.Services().WithMetro(opts.Metro).Get(ctx, opts.ServiceGroupNameOrUUID)
 		if err != nil {
 			return nil, nil, fmt.Errorf("could not use service %s: %w", opts.ServiceGroupNameOrUUID, err)
 		}
-		serviceGroup, err = resp.FirstOrErr()
+
+		serviceGroup, err = groupResp.FirstOrErr()
 		if err != nil {
 			return nil, nil, fmt.Errorf("could not use service %s: %w", opts.ServiceGroupNameOrUUID, err)
 		}
@@ -206,8 +228,103 @@ func Create(ctx context.Context, opts *CreateOptions, args ...string) (*kcclient
 			WithField("uuid", serviceGroup.UUID).
 			Debug("using service group")
 
+		// Save the UUID of the service group to be used in the create request
+		// later.
 		req.ServiceGroup = &kcinstances.CreateRequestServiceGroup{
 			UUID: &serviceGroup.UUID,
+		}
+
+		// Find out if there are any existing instances in this service group.
+		allInstanceUUIDs := make([]string, len(serviceGroup.Instances))
+		for i, instance := range serviceGroup.Instances {
+			allInstanceUUIDs[i] = instance.UUID
+		}
+
+		var instances []kcinstances.GetResponseItem
+		if len(allInstanceUUIDs) > 0 {
+			log.G(ctx).
+				WithField("group", opts.ServiceGroupNameOrUUID).
+				Trace("getting instances in service")
+
+			instancesResp, err := opts.Client.Instances().WithMetro(opts.Metro).Get(ctx, allInstanceUUIDs...)
+			if err != nil {
+				return nil, nil, fmt.Errorf("could not get instances of service group '%s': %w", opts.ServiceGroupNameOrUUID, err)
+			}
+
+			instances, err = instancesResp.AllOrErr()
+			if err != nil {
+				return nil, nil, fmt.Errorf("could not get instances of service group '%s': %w", opts.ServiceGroupNameOrUUID, err)
+			}
+		} else {
+			log.G(ctx).
+				WithField("group", opts.ServiceGroupNameOrUUID).
+				Trace("no existing instances in service group")
+		}
+
+		switch opts.RolloutQualifier {
+		case RolloutQualifierImageName:
+			imageBase := opts.Image
+			if strings.Contains(opts.Image, "@") {
+				imageBase, _, _ = strings.Cut(opts.Image, "@")
+			} else if strings.Contains(opts.Image, ":") {
+				imageBase, _, _ = strings.Cut(opts.Image, ":")
+			}
+
+			for _, instance := range instances {
+				instImageBase, _, _ := strings.Cut(instance.Image, "@")
+				if instImageBase == imageBase {
+					qualifiedInstances = append(qualifiedInstances, instance)
+				}
+			}
+
+		case RolloutQualifierInstanceName:
+			for _, instance := range instances {
+				if instance.Name == opts.Name {
+					qualifiedInstances = append(qualifiedInstances, instance)
+				}
+			}
+
+		case RolloutQualifierAll:
+			qualifiedInstances = instances
+
+		case RolloutQualifierNone:
+			// No-op
+		}
+
+		if len(qualifiedInstances) > 0 {
+			var batch []string
+			for _, instance := range qualifiedInstances {
+				batch = append(batch, instance.UUID)
+			}
+
+			if opts.Rollout == StrategyPrompt {
+				strategy, err := selection.Select(
+					fmt.Sprintf("deployment already exists: what would you like to do with the %d existing instance(s)?", len(qualifiedInstances)),
+					RolloutStrategies()...,
+				)
+				if err != nil {
+					return nil, nil, err
+				}
+
+				log.G(ctx).Infof("use --rollout=%s to skip this prompt in the future", strategy.String())
+
+				opts.Rollout = *strategy
+			}
+
+			switch opts.Rollout {
+			case RolloutStrategyExit:
+				return nil, nil, fmt.Errorf("deployment already exists and merge strategy set to exit on conflict")
+
+			case RolloutStrategyStop:
+				if _, err = opts.Client.Instances().WithMetro(opts.Metro).Stop(ctx, 60, false, batch...); err != nil {
+					return nil, nil, fmt.Errorf("could not stop instance(s): %w", err)
+				}
+
+			case RolloutStrategyRemove:
+				if _, err = opts.Client.Instances().WithMetro(opts.Metro).Delete(ctx, batch...); err != nil {
+					return nil, nil, fmt.Errorf("could not delete instance(s): %w", err)
+				}
+			}
 		}
 	}
 
@@ -371,6 +488,58 @@ func Create(ctx context.Context, opts *CreateOptions, args ...string) (*kcclient
 		return nil, nil, err
 	}
 
+	// Handle the rollout only after the new instance has been created.
+	// KraftCloud's service group load balancer will temporarily handle blue-green
+	// deployments.
+	if len(qualifiedInstances) > 0 {
+		paramodel, err := processtree.NewProcessTree(
+			ctx,
+			[]processtree.ProcessTreeOption{
+				processtree.IsParallel(false),
+				processtree.WithRenderer(
+					log.LoggerTypeFromString(config.G[config.KraftKit](ctx).Log.Type) != log.FANCY,
+				),
+				processtree.WithFailFast(true),
+				processtree.WithHideOnSuccess(true),
+			},
+			processtree.NewProcessTreeItem(
+				"waiting for new instance to start before performing rollout action",
+				"",
+				func(ctx context.Context) error {
+					_, err := opts.Client.Instances().WithMetro(opts.Metro).Wait(ctx, kcinstances.StateRunning, int(opts.RolloutWait.Milliseconds()), newInstance.UUID)
+					return err
+				},
+			),
+		)
+		if err != nil {
+			return nil, nil, fmt.Errorf("could not start wait process: %w", err)
+		}
+
+		err = paramodel.Start()
+		if err != nil {
+			log.G(ctx).
+				WithError(err).
+				Error("aborting rollout: could not wait for new instance to start")
+		} else {
+			var batch []string
+			for _, instance := range qualifiedInstances {
+				batch = append(batch, instance.UUID)
+			}
+
+			switch opts.Rollout {
+			case RolloutStrategyStop:
+				if _, err = opts.Client.Instances().WithMetro(opts.Metro).Stop(ctx, 60, false, batch...); err != nil {
+					return nil, nil, fmt.Errorf("could not stop instance(s): %w", err)
+				}
+
+			case RolloutStrategyRemove:
+				if _, err = opts.Client.Instances().WithMetro(opts.Metro).Delete(ctx, batch...); err != nil {
+					return nil, nil, fmt.Errorf("could not delete instance(s): %w", err)
+				}
+			}
+		}
+	}
+
 	instanceResp, err := opts.Client.Instances().WithMetro(opts.Metro).Get(ctx, newInstance.UUID)
 	if err != nil {
 		return nil, nil, fmt.Errorf("getting details of instance %s: %w", newInstance.UUID, err)
@@ -390,112 +559,6 @@ func Create(ctx context.Context, opts *CreateOptions, args ...string) (*kcclient
 	}
 
 	return instanceResp, serviceGroupResp, nil
-}
-
-// Rollout an instance in a service group.
-func Rollout(ctx context.Context, opts *CreateOptions, newInstance *kcinstances.GetResponseItem, newServiceGroup *kcservices.GetResponseItem) error {
-	oneMinute := int(time.Minute.Milliseconds())
-
-	_, err := opts.Client.Instances().WithMetro(opts.Metro).Wait(ctx, kcinstances.StateRunning, oneMinute, newInstance.UUID)
-	if err != nil {
-		return fmt.Errorf("could not wait for the first new instance to start: %w", err)
-	}
-
-	if newServiceGroup == nil {
-		return fmt.Errorf("empty service group")
-	}
-
-	// First stop one instance which is not the new one
-	for i, instance := range newServiceGroup.Instances {
-		if instance.UUID == newInstance.UUID {
-			continue
-		}
-
-		log.G(ctx).
-			WithField("instance", instance.Name).
-			WithField("service group", newServiceGroup.Name).
-			Info("draining old instance")
-
-		if _, err = opts.Client.Instances().WithMetro(opts.Metro).Stop(ctx, oneMinute, false, instance.UUID); err != nil {
-			return fmt.Errorf("could not stop the old instance: %w", err)
-		}
-
-		if _, err = opts.Client.Instances().WithMetro(opts.Metro).Wait(ctx, kcinstances.StateStopped, oneMinute, instance.UUID); err != nil {
-			return fmt.Errorf("could not wait for the old instance to stop: %w", err)
-		}
-
-		log.G(ctx).
-			WithField("instance", instance).
-			WithField("service group", newServiceGroup.Name).
-			Info("drained old instance")
-
-		newServiceGroup.Instances = append(newServiceGroup.Instances[:i], newServiceGroup.Instances[i+1:]...)
-		break
-	}
-
-	for _, instance := range newServiceGroup.Instances {
-		if instance.UUID == newInstance.UUID {
-			continue
-		}
-
-		log.G(ctx).
-			WithField("service group", newServiceGroup.Name).
-			Info("starting new instance")
-
-		// Create the rest of the instances and wait max 10s for them to start
-		timeout := int(time.Second.Milliseconds() * 10)
-		autoStart := true
-		req := kcinstances.CreateRequest{
-			Image: newInstance.Image,
-			Args:  newInstance.Args,
-			Env:   newInstance.Env,
-			ServiceGroup: &kcinstances.CreateRequestServiceGroup{
-				UUID: &newServiceGroup.UUID,
-			},
-			Autostart:     &autoStart,
-			WaitTimeoutMs: &timeout,
-		}
-
-		if opts.Memory > 0 {
-			req.MemoryMB = &opts.Memory
-		}
-
-		cresp, err := opts.Client.Instances().WithMetro(opts.Metro).Create(ctx, req)
-		if err != nil {
-			return fmt.Errorf("could not create a new instance: %w", err)
-		}
-		if _, err = cresp.FirstOrErr(); err != nil {
-			return fmt.Errorf("could not create a new instance: %w", err)
-		}
-
-		log.G(ctx).
-			WithField("instance", instance).
-			WithField("service group", newServiceGroup.Name).
-			Info("draining old instance")
-
-		sresp, err := opts.Client.Instances().WithMetro(opts.Metro).Stop(ctx, oneMinute, false, instance.UUID)
-		if err != nil {
-			return fmt.Errorf("could not stop the old instance: %w", err)
-		}
-		if _, err = sresp.FirstOrErr(); err != nil {
-			return fmt.Errorf("could not stop the old instance: %w", err)
-		}
-
-		wresp, err := opts.Client.Instances().WithMetro(opts.Metro).Wait(ctx, kcinstances.StateStopped, oneMinute, instance.UUID)
-		if err != nil {
-			return fmt.Errorf("could not wait for the old instance to stop: %w", err)
-		}
-		if _, err = wresp.FirstOrErr(); err != nil {
-			return fmt.Errorf("could not wait for the old instance to stop: %w", err)
-		}
-
-		log.G(ctx).
-			WithField("instance", instance).
-			WithField("service group", newServiceGroup.Name).
-			Info("drained old instance")
-	}
-
-	return nil
 }
 
 func NewCmd() *cobra.Command {
@@ -541,6 +604,24 @@ func NewCmd() *cobra.Command {
 		panic(err)
 	}
 
+	cmd.Flags().Var(
+		cmdfactory.NewEnumFlag[RolloutStrategy](
+			append(RolloutStrategies(), StrategyPrompt),
+			StrategyPrompt,
+		),
+		"rollout",
+		"Set the rollout strategy for an instance which has been previously run in the provided service group.",
+	)
+
+	cmd.Flags().Var(
+		cmdfactory.NewEnumFlag[RolloutQualifier](
+			RolloutQualifiers(),
+			RolloutQualifierImageName,
+		),
+		"rollout-qualifier",
+		"Set the rollout qualifier used to determine which instances should be affected by the strategy in the supplied service group.",
+	)
+
 	return cmd
 }
 
@@ -550,13 +631,8 @@ func (opts *CreateOptions) Pre(cmd *cobra.Command, _ []string) error {
 		return fmt.Errorf("could not populate metro and token: %w", err)
 	}
 
-	if opts.Rollout && opts.ServiceGroupNameOrUUID == "" {
-		return errors.New("cannot use --rollout without a --service-group")
-	}
-
-	if opts.Rollout && opts.Replicas > 0 {
-		return errors.New("cannot use --rollout with --replicas")
-	}
+	opts.Rollout = RolloutStrategy(cmd.Flag("rollout").Value.String())
+	opts.RolloutQualifier = RolloutQualifier(cmd.Flag("rollout-qualifier").Value.String())
 
 	if !utils.IsValidOutputFormat(opts.Output) {
 		return fmt.Errorf("invalid output format: %s", opts.Output)
@@ -577,41 +653,6 @@ func (opts *CreateOptions) Run(ctx context.Context, args []string) error {
 	insts, err := resp.AllOrErr()
 	if err != nil {
 		return err
-	}
-
-	if opts.Rollout {
-		if len(serviceGroup.Instances) == 1 {
-			log.G(ctx).Warn("cannot perform a rolling update on no instances")
-			return nil
-		}
-
-		paramodel, err := processtree.NewProcessTree(
-			ctx,
-			[]processtree.ProcessTreeOption{
-				processtree.IsParallel(false),
-				processtree.WithRenderer(
-					log.LoggerTypeFromString(config.G[config.KraftKit](ctx).Log.Type) != log.FANCY,
-				),
-				processtree.WithFailFast(true),
-				processtree.WithHideOnSuccess(false),
-				processtree.WithTimeout(60),
-			},
-			processtree.NewProcessTreeItem(
-				"updating "+fmt.Sprintf("%d", len(serviceGroup.Instances)-1)+" instances of "+serviceGroup.Name,
-				"",
-				func(ctx context.Context) error {
-					return Rollout(ctx, opts, instance, serviceGroup)
-				},
-			),
-		)
-		if err != nil {
-			return nil
-		}
-
-		err = paramodel.Start()
-		if err != nil {
-			return fmt.Errorf("could not start the process tree: %w", err)
-		}
 	}
 
 	if len(insts) > 1 || opts.Output == "table" {

--- a/internal/cli/kraft/cloud/instance/create/rollout_qualifier.go
+++ b/internal/cli/kraft/cloud/instance/create/rollout_qualifier.go
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2024, Unikraft GmbH and The KraftKit Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+
+package create
+
+import "fmt"
+
+// RolloutQualifier is the detection mechanism used to determine whether the
+// specific instance should be affected by the rollout strategy.
+type RolloutQualifier string
+
+const (
+	// The 'image' qualifier is used to capture instances which have the same
+	// image (ignoring digest).
+	RolloutQualifierImageName = RolloutQualifier("image")
+
+	// The 'name' qualifier is used to capture instances which have the same name.
+	RolloutQualifierInstanceName = RolloutQualifier("name")
+
+	// The 'all' qualifier matches all instances in the service group.
+	RolloutQualifierAll = RolloutQualifier("all")
+
+	// The 'none' qualifier prevents matching any instances in the service group.
+	RolloutQualifierNone = RolloutQualifier("none")
+)
+
+var _ fmt.Stringer = (*RolloutQualifier)(nil)
+
+// String implements fmt.Stringer
+func (strategy RolloutQualifier) String() string {
+	return string(strategy)
+}
+
+// RolloutQualifiers returns the list of possible rollout qualifier.
+func RolloutQualifiers() []RolloutQualifier {
+	return []RolloutQualifier{
+		RolloutQualifierImageName,
+		RolloutQualifierInstanceName,
+		RolloutQualifierAll,
+		RolloutQualifierNone,
+	}
+}
+
+// RolloutQualifierNames returns the string representation of all possible
+// rollout qualifiers.
+func RolloutQualifierNames() []string {
+	qualifiers := []string{}
+	for _, strategy := range RolloutQualifiers() {
+		qualifiers = append(qualifiers, strategy.String())
+	}
+
+	return qualifiers
+}

--- a/internal/cli/kraft/cloud/instance/create/rollout_strategy.go
+++ b/internal/cli/kraft/cloud/instance/create/rollout_strategy.go
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2024, Unikraft GmbH and The KraftKit Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+
+package create
+
+import "fmt"
+
+// RolloutStrategy is the mechanism to describe how to approach managing
+// existing instances part of an existing service group during deployment.
+type RolloutStrategy string
+
+const (
+	// The 'exit' strategy is used to error-out and indicate that no strategy was
+	// provided and that further operations cannot be completed.
+	RolloutStrategyExit = RolloutStrategy("exit")
+
+	// The 'stop' strategy stops the qualified existing instance(s) within the
+	// same service group and starts the new instance(s).
+	RolloutStrategyStop = RolloutStrategy("stop")
+
+	// The 'stop' strategy stops the qualified existing instance(s) within the
+	// same service group and starts the new instance(s).
+	RolloutStrategyRemove = RolloutStrategy("remove")
+
+	// The 'keep' strategy keeps the existing qualified instance(s) within the
+	// same service group and starts the new instance(s).
+	RolloutStrategyKeep = RolloutStrategy("keep")
+
+	// The 'prompt' strategy is an "unlisted" strategy that's used in TTY contexts
+	// where the user is given the opportunity to decide the rollout strategy
+	// before the rollout operation is performed.  The result of this decision
+	// should yield one of the above rollout strategies.
+	StrategyPrompt = RolloutStrategy("prompt")
+)
+
+var _ fmt.Stringer = (*RolloutStrategy)(nil)
+
+// String implements fmt.Stringer
+func (strategy RolloutStrategy) String() string {
+	return string(strategy)
+}
+
+// RolloutStrategies returns the list of possible rollout strategies.
+func RolloutStrategies() []RolloutStrategy {
+	return []RolloutStrategy{
+		RolloutStrategyExit,
+		RolloutStrategyStop,
+		RolloutStrategyRemove,
+		RolloutStrategyKeep,
+	}
+}
+
+// RolloutStrategyNames returns the string representation of all possible
+// rollout strategies.
+func RolloutStrategyNames() []string {
+	strategies := []string{}
+	for _, strategy := range RolloutStrategies() {
+		strategies = append(strategies, strategy.String())
+	}
+
+	return strategies
+}

--- a/internal/cli/kraft/cloud/instance/get/get.go
+++ b/internal/cli/kraft/cloud/instance/get/get.go
@@ -85,10 +85,10 @@ func (opts *GetOptions) Run(ctx context.Context, args []string) error {
 		kraftcloud.WithToken(config.GetKraftCloudTokenAuthConfig(*auth)),
 	)
 
-	instanceResp, err := client.WithMetro(opts.metro).Get(ctx, args[0])
+	resp, err := client.WithMetro(opts.metro).Get(ctx, args[0])
 	if err != nil {
 		return fmt.Errorf("could not get instance %s: %w", args[0], err)
 	}
 
-	return utils.PrintInstances(ctx, opts.Output, instanceResp)
+	return utils.PrintInstances(ctx, opts.Output, *resp)
 }

--- a/internal/cli/kraft/cloud/instance/list/list.go
+++ b/internal/cli/kraft/cloud/instance/list/list.go
@@ -89,10 +89,10 @@ func (opts *ListOptions) Run(ctx context.Context, args []string) error {
 		uuids = append(uuids, instItem.UUID)
 	}
 
-	instancesResp, err := client.WithMetro(opts.metro).Get(ctx, uuids...)
+	resp, err := client.WithMetro(opts.metro).Get(ctx, uuids...)
 	if err != nil {
 		return fmt.Errorf("getting details of %d instance(s): %w", len(instList), err)
 	}
 
-	return utils.PrintInstances(ctx, opts.Output, instancesResp)
+	return utils.PrintInstances(ctx, opts.Output, *resp)
 }

--- a/internal/cli/kraft/cloud/quotas/quotas.go
+++ b/internal/cli/kraft/cloud/quotas/quotas.go
@@ -82,18 +82,18 @@ func (opts *QuotasOptions) Run(ctx context.Context, _ []string) error {
 		kraftcloud.WithToken(config.GetKraftCloudTokenAuthConfig(*auth)),
 	)
 
-	quotasResp, err := client.WithMetro(opts.metro).Quotas(ctx)
+	resp, err := client.WithMetro(opts.metro).Quotas(ctx)
 	if err != nil {
 		return fmt.Errorf("could not get quotas: %w", err)
 	}
 
 	if opts.Limits {
-		return utils.PrintQuotasLimits(ctx, opts.Output, quotasResp)
+		return utils.PrintQuotasLimits(ctx, opts.Output, *resp)
 	}
 
 	if opts.Features {
-		return utils.PrintQuotasFeatures(ctx, opts.Output, quotasResp)
+		return utils.PrintQuotasFeatures(ctx, opts.Output, *resp)
 	}
 
-	return utils.PrintQuotas(ctx, *auth, opts.Output, quotasResp)
+	return utils.PrintQuotas(ctx, *auth, opts.Output, *resp)
 }

--- a/internal/cli/kraft/cloud/scale/get/get.go
+++ b/internal/cli/kraft/cloud/scale/get/get.go
@@ -147,11 +147,11 @@ func (opts *GetOptions) Run(ctx context.Context, args []string) error {
 		return nil
 
 	} else {
-		confResp, err := opts.Client.Autoscale().WithMetro(opts.Metro).GetConfiguration(ctx, id)
+		resp, err := opts.Client.Autoscale().WithMetro(opts.Metro).GetConfiguration(ctx, id)
 		if err != nil {
 			return fmt.Errorf("could not get configuration: %w", err)
 		}
 
-		return utils.PrintAutoscaleConfiguration(ctx, opts.Output, confResp)
+		return utils.PrintAutoscaleConfiguration(ctx, opts.Output, *resp)
 	}
 }

--- a/internal/cli/kraft/cloud/service/create/create.go
+++ b/internal/cli/kraft/cloud/service/create/create.go
@@ -224,10 +224,10 @@ func (opts *CreateOptions) Run(ctx context.Context, args []string) error {
 		return fmt.Errorf("creating service group: %w", err)
 	}
 
-	sgResp, err := opts.Client.WithMetro(opts.Metro).Get(ctx, newSg.UUID)
+	resp, err := opts.Client.WithMetro(opts.Metro).Get(ctx, newSg.UUID)
 	if err != nil {
 		return fmt.Errorf("getting details of service group %s: %w", newSg.UUID, err)
 	}
 
-	return utils.PrintServiceGroups(ctx, opts.Output, sgResp)
+	return utils.PrintServiceGroups(ctx, opts.Output, *resp)
 }

--- a/internal/cli/kraft/cloud/service/get/get.go
+++ b/internal/cli/kraft/cloud/service/get/get.go
@@ -82,10 +82,10 @@ func (opts *GetOptions) Run(ctx context.Context, args []string) error {
 		kraftcloud.WithToken(config.GetKraftCloudTokenAuthConfig(*auth)),
 	)
 
-	sgResp, err := client.WithMetro(opts.metro).Get(ctx, args[0])
+	resp, err := client.WithMetro(opts.metro).Get(ctx, args[0])
 	if err != nil {
 		return fmt.Errorf("could not get service %s: %w", args[0], err)
 	}
 
-	return utils.PrintServiceGroups(ctx, opts.Output, sgResp)
+	return utils.PrintServiceGroups(ctx, opts.Output, *resp)
 }

--- a/internal/cli/kraft/cloud/service/list/list.go
+++ b/internal/cli/kraft/cloud/service/list/list.go
@@ -97,10 +97,10 @@ func (opts *ListOptions) Run(ctx context.Context, args []string) error {
 		uuids = append(uuids, sgItem.UUID)
 	}
 
-	sgResp, err := client.WithMetro(opts.metro).Get(ctx, uuids...)
+	resp, err := client.WithMetro(opts.metro).Get(ctx, uuids...)
 	if err != nil {
 		return fmt.Errorf("getting details of %d service group(s): %w", len(uuids), err)
 	}
 
-	return utils.PrintServiceGroups(ctx, opts.Output, sgResp)
+	return utils.PrintServiceGroups(ctx, opts.Output, *resp)
 }

--- a/internal/cli/kraft/cloud/utils/print.go
+++ b/internal/cli/kraft/cloud/utils/print.go
@@ -782,22 +782,8 @@ func PrintCertificates(ctx context.Context, format string, resp *kcclient.Servic
 }
 
 // PrettyPrintInstance outputs a single instance and information about it.
-func PrettyPrintInstance(ctx context.Context, instance *kcinstances.GetResponseItem, serviceGroup *kcservices.GetResponseItem, autoStart bool) {
+func PrettyPrintInstance(ctx context.Context, instance kcinstances.GetResponseItem, autoStart bool) {
 	out := iostreams.G(ctx).Out
-
-	var fqdn string
-	if instance.ServiceGroup != nil && len(instance.ServiceGroup.Domains) > 0 {
-		fqdn = instance.ServiceGroup.Domains[0].FQDN
-	}
-
-	if serviceGroup != nil && fqdn != "" {
-		for _, port := range serviceGroup.Services {
-			if port.Port == 443 {
-				fqdn = "https://" + fqdn
-				break
-			}
-		}
-	}
 
 	var title string
 	var color func(...string) string
@@ -830,16 +816,11 @@ func PrettyPrintInstance(ctx context.Context, instance *kcinstances.GetResponseI
 		},
 	}
 
-	if fqdn != "" {
-		if strings.HasPrefix(fqdn, "https://") {
+	if instance.ServiceGroup != nil {
+		for _, domain := range instance.ServiceGroup.Domains {
 			entries = append(entries, fancymap.FancyMapEntry{
-				Key:   "url",
-				Value: fqdn,
-			})
-		} else {
-			entries = append(entries, fancymap.FancyMapEntry{
-				Key:   "fqdn",
-				Value: fqdn,
+				Key:   "domain",
+				Value: domain.FQDN,
 			})
 		}
 	}

--- a/internal/cli/kraft/cloud/utils/print.go
+++ b/internal/cli/kraft/cloud/utils/print.go
@@ -66,7 +66,7 @@ var (
 
 // PrintInstances pretty-prints the provided set of instances or returns
 // an error if unable to send to stdout via the provided context.
-func PrintInstances(ctx context.Context, format string, resp *kcclient.ServiceResponse[kcinstances.GetResponseItem]) error {
+func PrintInstances(ctx context.Context, format string, resp kcclient.ServiceResponse[kcinstances.GetResponseItem]) error {
 	if format == "raw" {
 		printRaw(ctx, resp)
 		return nil
@@ -189,7 +189,7 @@ func PrintInstances(ctx context.Context, format string, resp *kcclient.ServiceRe
 
 // PrintVolumes pretty-prints the provided set of volumes or returns
 // an error if unable to send to stdout via the provided context.
-func PrintVolumes(ctx context.Context, format string, resp *kcclient.ServiceResponse[kcvolumes.GetResponseItem]) error {
+func PrintVolumes(ctx context.Context, format string, resp kcclient.ServiceResponse[kcvolumes.GetResponseItem]) error {
 	if format == "raw" {
 		printRaw(ctx, resp)
 		return nil
@@ -266,7 +266,7 @@ func PrintVolumes(ctx context.Context, format string, resp *kcclient.ServiceResp
 
 // PrintAutoscaleConfiguration pretty-prints the provided autoscale configuration or returns
 // an error if unable to send to stdout via the provided context.
-func PrintAutoscaleConfiguration(ctx context.Context, format string, resp *kcclient.ServiceResponse[kcautoscale.GetResponseItem]) error {
+func PrintAutoscaleConfiguration(ctx context.Context, format string, resp kcclient.ServiceResponse[kcautoscale.GetResponseItem]) error {
 	if format == "raw" {
 		printRaw(ctx, resp)
 		return nil
@@ -371,7 +371,7 @@ func PrintAutoscaleConfiguration(ctx context.Context, format string, resp *kccli
 
 // PrintServiceGroups pretty-prints the provided set of service groups or returns
 // an error if unable to send to stdout via the provided context.
-func PrintServiceGroups(ctx context.Context, format string, resp *kcclient.ServiceResponse[kcservices.GetResponseItem]) error {
+func PrintServiceGroups(ctx context.Context, format string, resp kcclient.ServiceResponse[kcservices.GetResponseItem]) error {
 	if format == "raw" {
 		printRaw(ctx, resp)
 		return nil
@@ -468,7 +468,7 @@ func PrintServiceGroups(ctx context.Context, format string, resp *kcclient.Servi
 
 // PrintQuotas pretty-prints the provided set of user quotas or returns
 // an error if unable to send to stdout via the provided context.
-func PrintQuotas(ctx context.Context, auth config.AuthConfig, format string, resp *kcclient.ServiceResponse[kcusers.QuotasResponseItem]) error {
+func PrintQuotas(ctx context.Context, auth config.AuthConfig, format string, resp kcclient.ServiceResponse[kcusers.QuotasResponseItem]) error {
 	if format == "raw" {
 		printRaw(ctx, resp)
 		return nil
@@ -537,7 +537,7 @@ func PrintQuotas(ctx context.Context, auth config.AuthConfig, format string, res
 
 // PrintQuotasLimits pretty-prints the provided set of user limits or returns
 // an error if unable to send to stdout via the provided context.
-func PrintQuotasLimits(ctx context.Context, format string, resp *kcclient.ServiceResponse[kcusers.QuotasResponseItem]) error {
+func PrintQuotasLimits(ctx context.Context, format string, resp kcclient.ServiceResponse[kcusers.QuotasResponseItem]) error {
 	if format == "raw" {
 		printRaw(ctx, resp)
 		return nil
@@ -602,7 +602,7 @@ func PrintQuotasLimits(ctx context.Context, format string, resp *kcclient.Servic
 
 // PrintQuotasFeatures pretty-prints the provided set of user quotas features
 // or returns an error if unable to send to stdout via the provided context.
-func PrintQuotasFeatures(ctx context.Context, format string, resp *kcclient.ServiceResponse[kcusers.QuotasResponseItem]) error {
+func PrintQuotasFeatures(ctx context.Context, format string, resp kcclient.ServiceResponse[kcusers.QuotasResponseItem]) error {
 	if format == "raw" {
 		printRaw(ctx, resp)
 		return nil
@@ -668,7 +668,7 @@ func PrintQuotasFeatures(ctx context.Context, format string, resp *kcclient.Serv
 
 // PrintCertificates pretty-prints the provided set of certificates or returns
 // an error if unable to send to stdout via the provided context.
-func PrintCertificates(ctx context.Context, format string, resp *kcclient.ServiceResponse[kccerts.GetResponseItem]) error {
+func PrintCertificates(ctx context.Context, format string, resp kcclient.ServiceResponse[kccerts.GetResponseItem]) error {
 	if format == "raw" {
 		printRaw(ctx, resp)
 		return nil
@@ -892,8 +892,10 @@ func PrettyPrintInstance(ctx context.Context, instance kcinstances.GetResponseIt
 	}
 }
 
-func printRaw[T kcclient.APIResponseDataEntry](ctx context.Context, resp *kcclient.ServiceResponse[T]) {
-	fmt.Fprint(iostreams.G(ctx).Out, string(resp.RawBody()))
+func printRaw[T kcclient.APIResponseDataEntry](ctx context.Context, resps ...kcclient.ServiceResponse[T]) {
+	for _, resp := range resps {
+		fmt.Fprint(iostreams.G(ctx).Out, string(resp.RawBody()))
+	}
 }
 
 func IsValidOutputFormat(format string) bool {

--- a/internal/cli/kraft/cloud/volume/get/get.go
+++ b/internal/cli/kraft/cloud/volume/get/get.go
@@ -85,10 +85,10 @@ func (opts *GetOptions) Run(ctx context.Context, args []string) error {
 		kraftcloud.WithToken(config.GetKraftCloudTokenAuthConfig(*auth)),
 	)
 
-	volResp, err := client.WithMetro(opts.metro).Get(ctx, args[0])
+	resp, err := client.WithMetro(opts.metro).Get(ctx, args[0])
 	if err != nil {
 		return fmt.Errorf("could not get volume %s: %w", args[0], err)
 	}
 
-	return utils.PrintVolumes(ctx, opts.Output, volResp)
+	return utils.PrintVolumes(ctx, opts.Output, *resp)
 }

--- a/internal/cli/kraft/cloud/volume/list/list.go
+++ b/internal/cli/kraft/cloud/volume/list/list.go
@@ -94,10 +94,10 @@ func (opts *ListOptions) Run(ctx context.Context, args []string) error {
 		uuids = append(uuids, volItem.UUID)
 	}
 
-	volsResp, err := client.WithMetro(opts.metro).Get(ctx, uuids...)
+	resp, err := client.WithMetro(opts.metro).Get(ctx, uuids...)
 	if err != nil {
 		return fmt.Errorf("getting details of %d volume(s): %w", len(uuids), err)
 	}
 
-	return utils.PrintVolumes(ctx, opts.Output, volsResp)
+	return utils.PrintVolumes(ctx, opts.Output, *resp)
 }

--- a/manifest/pack.go
+++ b/manifest/pack.go
@@ -76,6 +76,10 @@ func (mp mpack) Name() string {
 	return mp.manifest.Name
 }
 
+func (mp mpack) ID() string {
+	return fmt.Sprintf("%s/%s:%s", mp.manifest.Type, mp.manifest.Name, mp.version)
+}
+
 // Name implements fmt.Stringer
 func (mp mpack) String() string {
 	return mp.manifest.Name

--- a/oci/pack.go
+++ b/oci/pack.go
@@ -661,6 +661,11 @@ func (ocipack *ociPackage) Name() string {
 	return ocipack.ref.Context().Name()
 }
 
+// ID implements pack.Package
+func (ocipack *ociPackage) ID() string {
+	return fmt.Sprintf("%s@%s", ocipack.Name(), ocipack.index.desc.Digest.String())
+}
+
 // Name implements fmt.Stringer
 func (ocipack *ociPackage) String() string {
 	return fmt.Sprintf("%s (%s/%s)", ocipack.imageRef(), ocipack.Platform().Name(), ocipack.Architecture().Name())

--- a/pack/package.go
+++ b/pack/package.go
@@ -24,6 +24,9 @@ func (pf PackageFormat) String() string {
 type Package interface {
 	unikraft.Nameable
 
+	// ID returns a unique identifier for the package.
+	ID() string
+
 	// Metadata returns any additional metadata associated with this package.
 	Metadata() interface{}
 

--- a/unikraft/runtime/runtime_pack.go
+++ b/unikraft/runtime/runtime_pack.go
@@ -108,6 +108,11 @@ func NewELFLoaderRuntime(ctx context.Context, pbopts ...RuntimeOption) (*Runtime
 	return &elfloader, nil
 }
 
+// ID implements kraftkit.sh/pack.Package
+func (runtime *Runtime) ID() string {
+	return runtime.pack.ID()
+}
+
 // Columns implements kraftkit.sh/pack.Package
 func (elfloader *Runtime) Columns() []tableprinter.Column {
 	return elfloader.pack.Columns()


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

This PR reworks how rollouts are performed and introduces a breaking change by turning the `--rollout` flag into a choice between several different strategies:

- `prompt`: Ask the user how to proceed with existing deployments;
- `stop`: Stop existing instances of the same deployment;
- `remove`: Remove existing instances of the same deployment;
- `none`: Do not change the state of any existing instances; and,
- `exit`: If a conflict occurs, quit the program.

This additional control is migrated directly into the instance- create subcommand and therefore utilizable there and in any CLI-calling (parent) subcommands, e.g. `kraft cloud deploy`.

Additionally, a few additional flags are introduced to help "qualify" whether an instance should be affected by the roll-out procedure.  This is by default the image name, but could also be instance name or "all" instances.

Note that, rollouts only apply when instantiating new instances within an existing service group.

GitHub-Supercedes: #1187