### PR TITLE
fix(tui): Pass in the context's stdin

### DIFF
--- a/tui/paraprogress/paraprogress.go
+++ b/tui/paraprogress/paraprogress.go
@@ -125,8 +125,13 @@ func NewParaProgress(ctx context.Context, processes []*Process, opts ...ParaProg
 
 func (pd *ParaProgress) Start() error {
 	teaOpts := []tea.ProgramOption{
-		tea.WithInput(nil),
 		tea.WithContext(pd.ctx),
+	}
+
+	if iostreams.G(pd.ctx).IsStdinTTY() {
+		teaOpts = append(teaOpts, tea.WithInput(iostreams.G(pd.ctx).In))
+	} else {
+		teaOpts = append(teaOpts, tea.WithInput(nil))
 	}
 
 	if pd.norender {

--- a/tui/processtree/processtree.go
+++ b/tui/processtree/processtree.go
@@ -199,8 +199,13 @@ func (pti *ProcessTreeItem) Close() error {
 
 func (pt *ProcessTree) Start() error {
 	teaOpts := []tea.ProgramOption{
-		tea.WithInput(nil),
 		tea.WithContext(pt.ctx),
+	}
+
+	if iostreams.G(pt.ctx).IsStdinTTY() {
+		teaOpts = append(teaOpts, tea.WithInput(iostreams.G(pt.ctx).In))
+	} else {
+		teaOpts = append(teaOpts, tea.WithInput(nil))
 	}
 
 	// Restore the old output for the IOStreams which is manipulated per process.


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

This commit fixes an issue where input would not be recognised since the stdin was set to nil.  Occassionally (likely after successive calls to TUI programs), this would result in the TUI programs to become unresponsive to Ctrl+C.

See: https://github.com/unikraft/kraftkit/pull/1507
