### PR TITLE
fix(tui): Quit on timeout

### DIFF
--- a/tui/paraprogress/process.go
+++ b/tui/paraprogress/process.go
@@ -212,6 +212,7 @@ func (d *Process) Update(msg tea.Msg) (*Process, tea.Cmd) {
 		if d.timeout != 0 && d.timer.Elapsed() > d.timeout {
 			d.err = fmt.Errorf("process timedout after %s", d.timeout.String())
 			d.Status = StatusFailed
+			cmds = append(cmds, tea.Quit)
 		}
 
 		d.spinner, cmd = d.spinner.Update(msg)

--- a/tui/processtree/update.go
+++ b/tui/processtree/update.go
@@ -46,6 +46,10 @@ func (pt *ProcessTree) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if pti.timeout != 0 && pti.timer.Elapsed() > pti.timeout {
 				pti.err = fmt.Errorf("process timedout after %s", pti.timeout.String())
 				pti.status = StatusFailed
+				if pt.failFast {
+					pt.quitting = true
+					cmd = tea.Quit
+				}
 			} else {
 				pti.spinner, cmd = pti.spinner.Update(msg)
 			}


### PR DESCRIPTION
This commit fixes an issue where the timeout only updated the
status but did not quit the individual process.

Signed-off-by: Alexander Jung <alex@unikraft.io>

<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [ ] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [ ] Tested your changes against relevant architectures and platforms;
  - [ ] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->
