### PR TITLE
feat(cloud): TCP tunnel to remote host

### DIFF
--- a/internal/cli/kraft/cloud/cloud.go
+++ b/internal/cli/kraft/cloud/cloud.go
@@ -21,6 +21,7 @@ import (
 	"kraftkit.sh/internal/cli/kraft/cloud/quotas"
 	"kraftkit.sh/internal/cli/kraft/cloud/scale"
 	"kraftkit.sh/internal/cli/kraft/cloud/service"
+	"kraftkit.sh/internal/cli/kraft/cloud/tunnel"
 	"kraftkit.sh/internal/cli/kraft/cloud/volume"
 
 	"kraftkit.sh/cmdfactory"
@@ -88,6 +89,7 @@ func NewCmd() *cobra.Command {
 
 	cmd.AddCommand(deploy.NewCmd())
 	cmd.AddCommand(quotas.NewCmd())
+	cmd.AddCommand(tunnel.NewCmd())
 
 	cmd.AddGroup(&cobra.Group{ID: "kraftcloud-img", Title: "IMAGE COMMANDS"})
 	cmd.AddCommand(img.NewCmd())

--- a/internal/cli/kraft/cloud/tunnel/relay.go
+++ b/internal/cli/kraft/cloud/tunnel/relay.go
@@ -1,0 +1,159 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2024, Unikraft GmbH and The KraftKit Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+
+package tunnel
+
+import (
+	"context"
+	"crypto/tls"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"time"
+
+	"kraftkit.sh/log"
+)
+
+// Relay relays TCP connections to a local listener to a remote host over TLS.
+type Relay struct {
+	lAddr string
+	rAddr string
+}
+
+func (r *Relay) Up(ctx context.Context) error {
+	l, err := r.listenLocal(ctx)
+	if err != nil {
+		return err
+	}
+	defer func() { l.Close() }()
+	go func() { <-ctx.Done(); l.Close() }()
+
+	log.G(ctx).Info("Tunnelling ", l.Addr(), " to ", r.rAddr)
+
+	for {
+		conn, err := l.Accept()
+		if err != nil {
+			if errors.Is(err, net.ErrClosed) {
+				return nil
+			}
+			return fmt.Errorf("accepting incoming connection: %w", err)
+		}
+
+		c := r.newConnection(conn)
+		go c.handle(ctx)
+	}
+}
+
+// newConnection creates a new connection from the given net.Conn.
+func (r *Relay) newConnection(conn net.Conn) *connection {
+	return &connection{
+		relay: r,
+		conn:  conn,
+	}
+}
+
+func (r *Relay) dialRemote(ctx context.Context) (net.Conn, error) {
+	var d tls.Dialer
+	return d.DialContext(ctx, "tcp4", r.rAddr)
+}
+
+func (r *Relay) listenLocal(ctx context.Context) (net.Listener, error) {
+	var lc net.ListenConfig
+	return lc.Listen(ctx, "tcp4", r.lAddr)
+}
+
+// connection represents the server side of a connection to a local TCP socket.
+type connection struct {
+	// relay is the relay on which the connection arrived.
+	relay *Relay
+	// conn is the underlying network connection.
+	conn net.Conn
+}
+
+// handle handles the client connection by relaying reads and writes from/to
+// the remote host.
+func (c *connection) handle(ctx context.Context) {
+	log.G(ctx).Info("Accepted client connection ", c.conn.RemoteAddr())
+	defer func() {
+		c.conn.Close()
+		log.G(ctx).Info("Closed client connection ", c.conn.RemoteAddr())
+	}()
+
+	rc, err := c.relay.dialRemote(ctx)
+	if err != nil {
+		log.G(ctx).WithError(err).Error("Failed to connect to remote host")
+		return
+	}
+	defer rc.Close()
+
+	// NOTE(antoineco): these calls are critical as they allow reads/writes to be
+	// later cancelled, because the deadline applies to all future and pending
+	// I/O and can be dynamically extended or reduced.
+	_ = rc.SetDeadline(noNetTimeout)
+	_ = rc.SetDeadline(noNetTimeout)
+
+	defer func() {
+		_ = c.conn.SetDeadline(immediateNetCancel)
+	}()
+
+	const bufSize = 32 * 1024 // same as io.Copy
+
+	writerDone := make(chan struct{})
+	go func() {
+		defer func() {
+			_ = rc.SetDeadline(immediateNetCancel)
+			writerDone <- struct{}{}
+		}()
+
+		writeBuf := make([]byte, bufSize)
+		for {
+			n, err := c.conn.Read(writeBuf)
+			if err != nil {
+				if !errors.Is(err, io.EOF) {
+					log.G(ctx).WithError(err).Error("Failed to read from client")
+				}
+				return
+			}
+			if _, err := rc.Write(writeBuf[:n]); err != nil {
+				log.G(ctx).WithError(err).Error("Failed to write to remote host")
+				return
+			}
+		}
+	}()
+
+	readBuf := make([]byte, bufSize)
+	for {
+		n, err := rc.Read(readBuf)
+		if err != nil {
+			// expected when the connection gets aborted by a deadline
+			if !isNetTimeoutError(err) {
+				log.G(ctx).WithError(err).Error("Failed to read from remote host")
+			}
+			break
+		}
+		if _, err := c.conn.Write(readBuf[:n]); err != nil {
+			log.G(ctx).WithError(err).Error("Failed to write to client")
+			break
+		}
+	}
+
+	<-writerDone
+}
+
+var (
+	// zero time value used to prevent network operations from timing out.
+	noNetTimeout = time.Time{}
+	// non-zero time far in the past used for immediate cancellation of network operations.
+	immediateNetCancel = time.Unix(1, 0)
+)
+
+// isNetTimeoutError reports whether err is a network timeout error.
+func isNetTimeoutError(err error) bool {
+	if neterr := net.Error(nil); errors.As(err, &neterr) {
+		return neterr.Timeout()
+	}
+	return false
+}

--- a/internal/cli/kraft/cloud/tunnel/tunnel.go
+++ b/internal/cli/kraft/cloud/tunnel/tunnel.go
@@ -1,0 +1,147 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2024, Unikraft GmbH and The KraftKit Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+
+package tunnel
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"strconv"
+	"strings"
+
+	"github.com/MakeNowJust/heredoc"
+	"github.com/spf13/cobra"
+
+	"sdk.kraft.cloud"
+	kcservices "sdk.kraft.cloud/services"
+
+	"kraftkit.sh/cmdfactory"
+	"kraftkit.sh/config"
+	"kraftkit.sh/internal/cli/kraft/cloud/utils"
+)
+
+type TunnelOptions struct {
+	token string
+	metro string
+}
+
+func NewCmd() *cobra.Command {
+	cmd, err := cmdfactory.New(&TunnelOptions{}, cobra.Command{
+		Short: "Forward a local port to a service group through a TLS tunnel",
+		Use:   "tunnel [FLAGS] SERVICE_GROUP [LOCAL_PORT:]REMOTE_PORT",
+		Args:  cobra.ExactArgs(2),
+		Example: heredoc.Doc(`
+			# Forward the local port 8443 to the port 443 of the "my-service" service group.
+			$ kraft cloud tunnel my-service 8443:443
+		`),
+		Annotations: map[string]string{
+			cmdfactory.AnnotationHelpGroup: "kraftcloud",
+		},
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	return cmd
+}
+
+func (opts *TunnelOptions) Pre(cmd *cobra.Command, _ []string) error {
+	if err := utils.PopulateMetroToken(cmd, &opts.metro, &opts.token); err != nil {
+		return fmt.Errorf("could not populate metro and token: %w", err)
+	}
+	return nil
+}
+
+func (opts *TunnelOptions) Run(ctx context.Context, args []string) error {
+	sgID := args[0]
+
+	lport, rport, err := parsePorts(args[1])
+	if err != nil {
+		return err
+	}
+
+	auth, err := config.GetKraftCloudAuthConfig(ctx, opts.token)
+	if err != nil {
+		return fmt.Errorf("could not retrieve credentials: %w", err)
+	}
+
+	cli := kraftcloud.NewServicesClient(
+		kraftcloud.WithToken(config.GetKraftCloudTokenAuthConfig(*auth)),
+	).WithMetro(opts.metro)
+
+	fqdn, err := serviceGroupSanityCheck(ctx, cli, sgID, rport)
+	if err != nil {
+		return err
+	}
+
+	r := Relay{
+		// TODO(antoineco): allow dual-stack by creating two separate listeners.
+		// Alternatively, we could have defaulted to the address "::" to create a
+		// tcp46 socket, but listening on all addresses is an insecure default.
+		lAddr: net.JoinHostPort("127.0.0.1", strconv.FormatUint(uint64(lport), 10)),
+		rAddr: net.JoinHostPort(fqdn, strconv.FormatUint(uint64(rport), 10)),
+	}
+	return r.Up(ctx)
+}
+
+// serviceGroupSanityCheck verifies that the given service group can be tunneled to.
+// In case of success, the (public) FQDN of service group is returned.
+func serviceGroupSanityCheck(ctx context.Context, cli kcservices.ServicesService, sgID string, rport uint16) (fqdn string, err error) {
+	sgGetResp, err := cli.Get(ctx, sgID)
+	if err != nil {
+		return "", fmt.Errorf("getting service group '%s': %w", sgID, err)
+	}
+	sg, err := sgGetResp.FirstOrErr()
+	if err != nil {
+		return "", fmt.Errorf("getting service group '%s': %w", sgID, err)
+	}
+
+	if len(sg.Domains) == 0 {
+		return "", fmt.Errorf("service group '%s' has no public domain", sgID)
+	}
+
+	var hasPort bool
+	var exposedPorts []int
+	for _, svc := range sg.Services {
+		if svc.Port == int(rport) {
+			hasPort = true
+			break
+		}
+		exposedPorts = append(exposedPorts, svc.Port)
+	}
+	if !hasPort {
+		return "", fmt.Errorf("service group '%s' does not expose port %d. Ports exposed are %v", sgID, rport, exposedPorts)
+	}
+
+	return sg.Domains[0].FQDN, nil
+}
+
+// parsePorts parses a command line argument in the format [lport:]rport into
+// two port numbers lport and rport. If lport isn't set, a random port will be
+// used by the relay.
+func parsePorts(portsArg string) (lport, rport uint16, err error) {
+	ports := strings.SplitN(portsArg, ":", 2)
+
+	if len(ports) == 1 {
+		rport64, err := strconv.ParseUint(ports[0], 10, 16)
+		if err != nil {
+			return 0, 0, fmt.Errorf("%q is not a valid port number", ports[0])
+		}
+		return 0, uint16(rport64), nil
+	}
+
+	lport64, err := strconv.ParseUint(ports[0], 10, 16)
+	if err != nil {
+		return 0, 0, fmt.Errorf("%q is not a valid port number", ports[0])
+	}
+
+	rport64, err := strconv.ParseUint(ports[1], 10, 16)
+	if err != nil {
+		return 0, 0, fmt.Errorf("%q is not a valid port number", ports[1])
+	}
+
+	return uint16(lport64), uint16(rport64), nil
+}


### PR DESCRIPTION
### What

Part of #1495

Introduces a new command `kraft cloud tunnel` which allows relaying TCP packets from a local listener to a service group.

```console
$ kraft cloud
SUBCOMMANDS
  tunnel               Forward a local port to a service group through a TLS tunnel
```

### Demo

#### HTTP

Tunnel terminal
```console
$ kraft cloud tunnel billowing-pine-33428zb5 443
[ i ] Tunnelling 127.0.0.1:46457 to billowing-pine-33428zb5.fra0-test.kraft.host:443
[ i ] Accepted client connection 127.0.0.1:46774
[ i ] Closed client connection 127.0.0.1:46774
```

Client terminal
```console
$ curl -D- -H 'Host: billowing-pine-33428zb5.fra0-test.kraft.host' http://localhost:46457
HTTP/1.1 200 OK
Date: Mon, 08 Apr 2024 10:28:02 GMT
Content-Type: text/html
Content-Length: 612
Connection: keep-alive
Server: nginx/1.25.3
...
```

#### RESP (Redis)

Tunnel terminal
```console
$ kraft cloud tunnel crimson-thunder-askd0cou 6379:6379
[ i ] Tunnelling 127.0.0.1:6379 to crimson-thunder-askd0cou.fra0-test.kraft.host:6379
[ i ] Accepted client connection 127.0.0.1:6379
[ i ] Closed client connection 127.0.0.1:6379
```

Client terminal
```console
$ redis-cli
127.0.0.1:6379> PING
PONG
127.0.0.1:6379> exit
```