### PR TITLE
build(deps): update sdk.kraft.cloud

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -76,7 +76,7 @@ require (
 	k8s.io/apimachinery v0.29.3
 	k8s.io/apiserver v0.29.3
 	oras.land/oras-go/v2 v2.5.0
-	sdk.kraft.cloud v0.5.5-0.20240408121712-ec441de26d77
+	sdk.kraft.cloud v0.5.5-0.20240408130935-44faa2c974b3
 	sigs.k8s.io/kustomize/kyaml v0.14.3
 )
 

--- a/go.sum
+++ b/go.sum
@@ -1677,8 +1677,8 @@ oras.land/oras-go/v2 v2.5.0/go.mod h1:z4eisnLP530vwIOUOJeBIj0aGI0L1C3d53atvCBqZH
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
 rsc.io/quote/v3 v3.1.0/go.mod h1:yEA65RcK8LyAZtP9Kv3t0HmxON59tX3rD+tICJqUlj0=
 rsc.io/sampler v1.3.0/go.mod h1:T1hPZKmBbMNahiBKFy5HrXp6adAjACjK9JXDnKaTXpA=
-sdk.kraft.cloud v0.5.5-0.20240408121712-ec441de26d77 h1:gfJ1OWQ5Uo7qJVA5/2hAzYFCw7SrZ7r0woDV10NidQc=
-sdk.kraft.cloud v0.5.5-0.20240408121712-ec441de26d77/go.mod h1:u88mmv6PoEASnMLNkyYgrMCzJ4tkMGurV8ZMvXA9a2I=
+sdk.kraft.cloud v0.5.5-0.20240408130935-44faa2c974b3 h1:WNGjGRijO9vHa2DOVqOAJXqL+RBhsdkQAG/Jb9JmQnk=
+sdk.kraft.cloud v0.5.5-0.20240408130935-44faa2c974b3/go.mod h1:u88mmv6PoEASnMLNkyYgrMCzJ4tkMGurV8ZMvXA9a2I=
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.0.14/go.mod h1:LEScyzhFmoF5pso/YSeBstl57mOzx9xlU9n85RGrDQg=
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.0.15/go.mod h1:LEScyzhFmoF5pso/YSeBstl57mOzx9xlU9n85RGrDQg=
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.28.0 h1:TgtAeesdhpm2SGwkQasmbeqDo8th5wOBA5h/AjTKA4I=

--- a/internal/cli/kraft/cloud/scale/get/get.go
+++ b/internal/cli/kraft/cloud/scale/get/get.go
@@ -147,7 +147,7 @@ func (opts *GetOptions) Run(ctx context.Context, args []string) error {
 		return nil
 
 	} else {
-		resp, err := opts.Client.Autoscale().WithMetro(opts.Metro).GetConfiguration(ctx, id)
+		resp, err := opts.Client.Autoscale().WithMetro(opts.Metro).GetConfigurations(ctx, id)
 		if err != nil {
 			return fmt.Errorf("could not get configuration: %w", err)
 		}

--- a/internal/cli/kraft/cloud/scale/initialize/initialize.go
+++ b/internal/cli/kraft/cloud/scale/initialize/initialize.go
@@ -164,7 +164,7 @@ func (opts *InitOptions) Run(ctx context.Context, args []string) error {
 				possible = append(possible, stringerInstance{&inst})
 			}
 
-			result, err := selection.Select[stringerInstance](
+			result, err := selection.Select(
 				"select master instance",
 				possible...,
 			)

--- a/internal/cli/kraft/cloud/scale/reset/reset.go
+++ b/internal/cli/kraft/cloud/scale/reset/reset.go
@@ -81,7 +81,7 @@ func (opts *ResetOptions) Run(ctx context.Context, args []string) error {
 		)
 	}
 
-	delResp, err := opts.Client.WithMetro(opts.Metro).DeleteConfiguration(ctx, args[0])
+	delResp, err := opts.Client.WithMetro(opts.Metro).DeleteConfigurations(ctx, args[0])
 	if err != nil {
 		return fmt.Errorf("could not reset configuration: %w", err)
 	}


### PR DESCRIPTION
Follow up to PR #1528

Adds support for deleting autoscale configurations by UUIDs, additionally to names.