### PR TITLE
feat(kraft): Introduce the volume subcommand

### DIFF
--- a/internal/cli/kraft/kraft.go
+++ b/internal/cli/kraft/kraft.go
@@ -45,6 +45,7 @@ import (
 	"kraftkit.sh/internal/cli/kraft/stop"
 	"kraftkit.sh/internal/cli/kraft/unset"
 	"kraftkit.sh/internal/cli/kraft/version"
+	"kraftkit.sh/internal/cli/kraft/volume"
 	"kraftkit.sh/internal/cli/kraft/x"
 
 	// Additional initializers
@@ -113,6 +114,9 @@ func NewCmd() *cobra.Command {
 
 	cmd.AddGroup(&cobra.Group{ID: "compose", Title: "COMPOSE COMMANDS"})
 	cmd.AddCommand(compose.NewCmd())
+
+	cmd.AddGroup(&cobra.Group{ID: "vol", Title: "LOCAL VOLUME COMMANDS"})
+	cmd.AddCommand(volume.NewCmd())
 
 	cmd.AddCommand(login.NewCmd())
 	cmd.AddCommand(version.NewCmd())

--- a/internal/cli/kraft/run/run.go
+++ b/internal/cli/kraft/run/run.go
@@ -354,11 +354,11 @@ func (opts *RunOptions) Run(ctx context.Context, args []string) error {
 		return err
 	}
 
-	if err := opts.parseVolumes(ctx, machine); err != nil {
+	if err := opts.assignName(ctx, machine); err != nil {
 		return err
 	}
 
-	if err := opts.assignName(ctx, machine); err != nil {
+	if err := opts.parseVolumes(ctx, machine); err != nil {
 		return err
 	}
 

--- a/internal/cli/kraft/volume/create/create.go
+++ b/internal/cli/kraft/volume/create/create.go
@@ -1,0 +1,97 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2024, Unikraft GmbH and The KraftKit Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file expect in compliance with the License.
+package create
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/MakeNowJust/heredoc"
+	"github.com/spf13/cobra"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	volumeapi "kraftkit.sh/api/volume/v1alpha1"
+	"kraftkit.sh/cmdfactory"
+	"kraftkit.sh/iostreams"
+	"kraftkit.sh/machine/volume"
+)
+
+type CreateOptions struct {
+	Driver string `noattribute:"true"`
+}
+
+func NewCmd() *cobra.Command {
+	cmd, err := cmdfactory.New(&CreateOptions{}, cobra.Command{
+		Short: "Create a machine volume",
+		Use:   "create VOLUME",
+		Args:  cobra.MaximumNArgs(1),
+		Annotations: map[string]string{
+			cmdfactory.AnnotationHelpGroup: "volume",
+		},
+		Example: heredoc.Doc(`
+			# Create a volume with a randomly generated name
+			$ kraft volume create
+
+			# Create a volume with a specific name
+			$ kraft volume create my-volume
+		`),
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	return cmd
+}
+
+func (opts *CreateOptions) Pre(cmd *cobra.Command, _ []string) error {
+	opts.Driver = cmd.Flag("driver").Value.String()
+	return nil
+}
+
+func (opts *CreateOptions) Run(ctx context.Context, args []string) error {
+	var err error
+
+	strategy, ok := volume.Strategies()[opts.Driver]
+	if !ok {
+		return fmt.Errorf("unsupported network driver strategy: %v (contributions welcome!)", opts.Driver)
+	}
+
+	controller, err := strategy.NewVolumeV1alpha1(ctx)
+	if err != nil {
+		return err
+	}
+
+	name := ""
+	if len(args) > 0 {
+		name = args[0]
+	}
+
+	vol, err := controller.Get(ctx, &volumeapi.Volume{
+		ObjectMeta: v1.ObjectMeta{
+			Name: name,
+		},
+	})
+	if err != nil {
+		return err
+	}
+
+	if vol != nil {
+		return fmt.Errorf("volume %s already exists", args[0])
+	}
+
+	if vol, err = controller.Create(ctx, &volumeapi.Volume{
+		ObjectMeta: v1.ObjectMeta{
+			Name: args[0],
+		},
+		Spec: volumeapi.VolumeSpec{
+			Driver: opts.Driver,
+		},
+	}); err != nil {
+		return err
+	}
+
+	fmt.Fprintln(iostreams.G(ctx).Out, vol.Name)
+	return nil
+}

--- a/internal/cli/kraft/volume/inspect/inspect.go
+++ b/internal/cli/kraft/volume/inspect/inspect.go
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2024, Unikraft GmbH and The KraftKit Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file expect in compliance with the License.
+package inspect
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/MakeNowJust/heredoc"
+	"github.com/spf13/cobra"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	volumeapi "kraftkit.sh/api/volume/v1alpha1"
+	"kraftkit.sh/cmdfactory"
+	"kraftkit.sh/iostreams"
+	"kraftkit.sh/machine/volume"
+)
+
+type Inspect struct {
+	Driver string `noattribute:"true"`
+}
+
+func NewCmd() *cobra.Command {
+	cmd, err := cmdfactory.New(&Inspect{}, cobra.Command{
+		Short:   "Inspect a machine volume",
+		Use:     "inspect VOLUME",
+		Aliases: []string{"get"},
+		Args:    cobra.ExactArgs(1),
+		Annotations: map[string]string{
+			cmdfactory.AnnotationHelpGroup: "volume",
+		},
+		Example: heredoc.Doc(`
+			# Inspect a volume
+			$ kraft volume inspect my-volume
+		`),
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	return cmd
+}
+
+func (opts *Inspect) Pre(cmd *cobra.Command, _ []string) error {
+	opts.Driver = cmd.Flag("driver").Value.String()
+	return nil
+}
+
+func (opts *Inspect) Run(ctx context.Context, args []string) error {
+	var err error
+
+	strategy, ok := volume.Strategies()[opts.Driver]
+	if !ok {
+		return fmt.Errorf("unsupported network driver strategy: %v (contributions welcome!)", opts.Driver)
+	}
+
+	controller, err := strategy.NewVolumeV1alpha1(ctx)
+	if err != nil {
+		return err
+	}
+
+	volume, err := controller.Get(ctx, &volumeapi.Volume{
+		ObjectMeta: v1.ObjectMeta{
+			Name: args[0],
+		},
+	})
+	if err != nil {
+		return err
+	}
+
+	ret, err := json.Marshal(volume)
+	if err != nil {
+		return err
+	}
+
+	fmt.Fprintf(iostreams.G(ctx).Out, "%s\n", ret)
+
+	return nil
+}

--- a/internal/cli/kraft/volume/list/list.go
+++ b/internal/cli/kraft/volume/list/list.go
@@ -1,0 +1,145 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2024, Unikraft GmbH and The KraftKit Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file expect in compliance with the License.
+package list
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	volumeapi "kraftkit.sh/api/volume/v1alpha1"
+	"kraftkit.sh/cmdfactory"
+	"kraftkit.sh/config"
+	"kraftkit.sh/internal/tableprinter"
+	"kraftkit.sh/iostreams"
+	"kraftkit.sh/log"
+	"kraftkit.sh/machine/volume"
+)
+
+type List struct {
+	driver string
+	Long   bool   `long:"long" short:"l" usage:"Show more information"`
+	Output string `long:"output" short:"o" usage:"Set output format. Options: table,yaml,json,list" default:"table"`
+}
+
+type colorFunc func(string) string
+
+var (
+	VolumeStateColor = map[volumeapi.VolumeState]colorFunc{
+		volumeapi.VolumeStateBound:   iostreams.Green,
+		volumeapi.VolumeStateLost:    iostreams.Red,
+		volumeapi.VolumeStatePending: iostreams.Blue,
+	}
+	VolumeStateColorNil = map[volumeapi.VolumeState]colorFunc{
+		volumeapi.VolumeStateBound:   nil,
+		volumeapi.VolumeStateLost:    nil,
+		volumeapi.VolumeStatePending: nil,
+	}
+)
+
+func NewCmd() *cobra.Command {
+	cmd, err := cmdfactory.New(&List{}, cobra.Command{
+		Short:   "List machine volumes",
+		Use:     "ls [FLAGS]",
+		Aliases: []string{"list"},
+		Args:    cobra.NoArgs,
+		Annotations: map[string]string{
+			cmdfactory.AnnotationHelpGroup: "volume",
+		},
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	return cmd
+}
+
+func (opts *List) Pre(cmd *cobra.Command, _ []string) error {
+	opts.driver = cmd.Flag("driver").Value.String()
+	return nil
+}
+
+func (opts *List) Run(ctx context.Context, args []string) error {
+	var err error
+
+	strategy, ok := volume.Strategies()[opts.driver]
+	if !ok {
+		return fmt.Errorf("unsupported volume driver strategy: %s", opts.driver)
+	}
+
+	controller, err := strategy.NewVolumeV1alpha1(ctx)
+	if err != nil {
+		return err
+	}
+
+	volumes, err := controller.List(ctx, &volumeapi.VolumeList{})
+	if err != nil {
+		return err
+	}
+
+	type volTableEntry struct {
+		driver string
+		id     string
+		name   string
+		source string
+		status volumeapi.VolumeState
+	}
+
+	var items []volTableEntry
+
+	for _, volume := range volumes.Items {
+		items = append(items, volTableEntry{
+			driver: opts.driver,
+			id:     string(volume.UID),
+			name:   volume.Name,
+			source: volume.Spec.Source,
+			status: volume.Status.State,
+		})
+	}
+
+	err = iostreams.G(ctx).StartPager()
+	if err != nil {
+		log.G(ctx).Errorf("error starting pager: %v", err)
+	}
+
+	defer iostreams.G(ctx).StopPager()
+
+	cs := iostreams.G(ctx).ColorScheme()
+	table, err := tableprinter.NewTablePrinter(ctx,
+		tableprinter.WithMaxWidth(iostreams.G(ctx).TerminalWidth()),
+		tableprinter.WithOutputFormatFromString(opts.Output),
+	)
+	if err != nil {
+		return err
+	}
+
+	if config.G[config.KraftKit](ctx).NoColor {
+		VolumeStateColor = VolumeStateColorNil
+	}
+
+	// Header row
+	table.AddField("DRIVER", cs.Bold)
+	table.AddField("VOLUME NAME", cs.Bold)
+	if opts.Long {
+		table.AddField("VOLUME ID", cs.Bold)
+	}
+	table.AddField("STATUS", cs.Bold)
+	table.AddField("SOURCE", cs.Bold)
+	table.EndRow()
+
+	for _, item := range items {
+		table.AddField(item.driver, nil)
+		table.AddField(item.name, nil)
+		if opts.Long {
+			table.AddField(item.id, nil)
+		}
+		table.AddField(item.status.String(), VolumeStateColor[item.status])
+		table.AddField(item.source, nil)
+		table.EndRow()
+	}
+
+	return table.Render(iostreams.G(ctx).Out)
+}

--- a/internal/cli/kraft/volume/remove/remove.go
+++ b/internal/cli/kraft/volume/remove/remove.go
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2024, Unikraft GmbH and The KraftKit Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file expect in compliance with the License.
+package remove
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/MakeNowJust/heredoc"
+	"github.com/spf13/cobra"
+
+	volumeapi "kraftkit.sh/api/volume/v1alpha1"
+
+	"kraftkit.sh/cmdfactory"
+	"kraftkit.sh/iostreams"
+	"kraftkit.sh/machine/volume"
+)
+
+type RemoveOptions struct {
+	Driver string `noattribute:"true"`
+}
+
+// Remove a local machine network.
+func Remove(ctx context.Context, opts *RemoveOptions, args ...string) error {
+	if opts == nil {
+		opts = &RemoveOptions{}
+	}
+
+	return opts.Run(ctx, args)
+}
+
+func NewCmd() *cobra.Command {
+	cmd, err := cmdfactory.New(&RemoveOptions{}, cobra.Command{
+		Short:   "Remove a volume",
+		Use:     "remove",
+		Aliases: []string{"rm", "delete", "del"},
+		Args:    cobra.ExactArgs(1),
+		Long:    "Remove a volume.",
+		Example: heredoc.Doc(`
+			# Remove a volume 
+			$ kraft volume remove my-volume
+		`),
+		Annotations: map[string]string{
+			cmdfactory.AnnotationHelpGroup: "volume",
+		},
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	return cmd
+}
+
+func (opts *RemoveOptions) Pre(cmd *cobra.Command, _ []string) error {
+	opts.Driver = cmd.Flag("driver").Value.String()
+	return nil
+}
+
+func (opts *RemoveOptions) Run(ctx context.Context, args []string) error {
+	if len(args) != 1 {
+		return fmt.Errorf("expected exactly one volume to remove, got %d", len(args))
+	}
+
+	var err error
+
+	strategy, ok := volume.Strategies()[opts.Driver]
+	if !ok {
+		return fmt.Errorf("unsupported network driver strategy: %v (contributions welcome!)", opts.Driver)
+	}
+
+	controller, err := strategy.NewVolumeV1alpha1(ctx)
+	if err != nil {
+		return err
+	}
+
+	volumes, err := controller.List(ctx, &volumeapi.VolumeList{})
+	if err != nil {
+		return err
+	}
+
+	for _, v := range volumes.Items {
+		if v.Name == args[0] || string(v.UID) == args[0] {
+			_, err = controller.Delete(ctx, &v)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	fmt.Fprintln(iostreams.G(ctx).Out, args[0])
+
+	return nil
+}

--- a/internal/cli/kraft/volume/volume.go
+++ b/internal/cli/kraft/volume/volume.go
@@ -14,6 +14,7 @@ import (
 	"kraftkit.sh/cmdfactory"
 	"kraftkit.sh/internal/cli/kraft/volume/create"
 	"kraftkit.sh/internal/cli/kraft/volume/inspect"
+	"kraftkit.sh/internal/cli/kraft/volume/list"
 	"kraftkit.sh/internal/set"
 	"kraftkit.sh/machine/volume"
 )
@@ -38,6 +39,7 @@ func NewCmd() *cobra.Command {
 
 	cmd.AddCommand(create.NewCmd())
 	cmd.AddCommand(inspect.NewCmd())
+	cmd.AddCommand(list.NewCmd())
 
 	return cmd
 }

--- a/internal/cli/kraft/volume/volume.go
+++ b/internal/cli/kraft/volume/volume.go
@@ -13,6 +13,7 @@ import (
 
 	"kraftkit.sh/cmdfactory"
 	"kraftkit.sh/internal/cli/kraft/volume/create"
+	"kraftkit.sh/internal/cli/kraft/volume/inspect"
 	"kraftkit.sh/internal/set"
 	"kraftkit.sh/machine/volume"
 )
@@ -36,6 +37,7 @@ func NewCmd() *cobra.Command {
 	}
 
 	cmd.AddCommand(create.NewCmd())
+	cmd.AddCommand(inspect.NewCmd())
 
 	return cmd
 }

--- a/internal/cli/kraft/volume/volume.go
+++ b/internal/cli/kraft/volume/volume.go
@@ -15,6 +15,7 @@ import (
 	"kraftkit.sh/internal/cli/kraft/volume/create"
 	"kraftkit.sh/internal/cli/kraft/volume/inspect"
 	"kraftkit.sh/internal/cli/kraft/volume/list"
+	"kraftkit.sh/internal/cli/kraft/volume/remove"
 	"kraftkit.sh/internal/set"
 	"kraftkit.sh/machine/volume"
 )
@@ -40,6 +41,7 @@ func NewCmd() *cobra.Command {
 	cmd.AddCommand(create.NewCmd())
 	cmd.AddCommand(inspect.NewCmd())
 	cmd.AddCommand(list.NewCmd())
+	cmd.AddCommand(remove.NewCmd())
 
 	return cmd
 }

--- a/internal/cli/kraft/volume/volume.go
+++ b/internal/cli/kraft/volume/volume.go
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2024, Unikraft GmbH and The KraftKit Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+package volume
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+
+	"kraftkit.sh/cmdfactory"
+	"kraftkit.sh/internal/cli/kraft/volume/create"
+	"kraftkit.sh/internal/set"
+	"kraftkit.sh/machine/volume"
+)
+
+type Volume struct {
+	Driver string `local:"false" long:"driver" short:"d" usage:"Set the volume driver." default:"9pfs"`
+}
+
+func NewCmd() *cobra.Command {
+	cmd, err := cmdfactory.New(&Volume{}, cobra.Command{
+		Short:   "Manage machine volumes",
+		Use:     "vol SUBCOMMAND",
+		Aliases: []string{"volume", "vols", "volumes"},
+		Hidden:  true,
+		Annotations: map[string]string{
+			cmdfactory.AnnotationHelpGroup: "volume",
+		},
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	cmd.AddCommand(create.NewCmd())
+
+	return cmd
+}
+
+func (opts *Volume) Pre(cmd *cobra.Command, _ []string) error {
+	if opts.Driver == "" {
+		return fmt.Errorf("volume driver must be set")
+	} else if !set.NewStringSet(volume.DriverNames()...).Contains(opts.Driver) {
+		return fmt.Errorf("unsupported volume driver strategy: %s", opts.Driver)
+	}
+
+	return nil
+}
+
+func (opts *Volume) Run(ctx context.Context, args []string) error {
+	return pflag.ErrHelp
+}

--- a/machine/volume/9pfs/v1alpha1.go
+++ b/machine/volume/9pfs/v1alpha1.go
@@ -8,10 +8,13 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"path/filepath"
 
 	"k8s.io/apimachinery/pkg/util/uuid"
 
 	volumev1alpha1 "kraftkit.sh/api/volume/v1alpha1"
+	"kraftkit.sh/config"
+	"kraftkit.sh/log"
 )
 
 type v1alpha1Volume struct{}
@@ -22,42 +25,99 @@ func NewVolumeServiceV1alpha1(ctx context.Context, opts ...any) (volumev1alpha1.
 
 // Create implements kraftkit.sh/api/volume/v1alpha1.Create
 func (*v1alpha1Volume) Create(ctx context.Context, volume *volumev1alpha1.Volume) (*volumev1alpha1.Volume, error) {
+	var err error
+
 	if len(volume.Spec.Driver) == 0 {
 		volume.Spec.Driver = "9pfs"
 	} else if volume.Spec.Driver != "9pfs" {
 		return volume, fmt.Errorf("cannot use 9pfs driver when driver set to %s", volume.Spec.Driver)
 	}
 
-	if len(volume.Spec.Source) == 0 {
-		return volume, fmt.Errorf("cannot use 9pfs volume without host path")
-	}
-
-	if _, err := os.Stat(volume.Spec.Source); err != nil {
-		return volume, fmt.Errorf("cannot stat host path volume: %w", err)
-	}
-
 	if volume.ObjectMeta.UID == "" {
 		volume.ObjectMeta.UID = uuid.NewUUID()
 	}
 
-	volume.Status.State = volumev1alpha1.VolumeStateBound
+	if volume.ObjectMeta.Name == "" {
+		volume.ObjectMeta.Name = string(volume.ObjectMeta.UID)
+	}
+
+	if len(volume.Spec.Source) == 0 {
+		// If no Source is specified, create a new volume entry in the runtime store
+		log.G(ctx).Debugf("creating new volume entry in the runtime store %s", volume.ObjectMeta.UID)
+		volume.Spec.Source = filepath.Join(config.G[config.KraftKit](ctx).RuntimeDir, "volumes", string(volume.ObjectMeta.UID))
+		volume.Spec.Managed = true
+	} else {
+		volume.Spec.Managed = false
+	}
+
+	volume.Spec.Source, err = filepath.Abs(volume.Spec.Source)
+	if err != nil {
+		return volume, fmt.Errorf("cannot get absolute path for volume source: %w", err)
+	}
+
+	// Create the volume directory if it does not exist
+	if err := os.MkdirAll(volume.Spec.Source, 0o755); err != nil {
+		return volume, fmt.Errorf("cannot create volume directory: %w", err)
+	}
+
+	fileInfo, err := os.Stat(volume.Spec.Source)
+	if err != nil {
+		return volume, fmt.Errorf("cannot stat volume directory: %w", err)
+	}
+
+	if !fileInfo.IsDir() {
+		return volume, fmt.Errorf("volume source is not a directory: %s", volume.Spec.Source)
+	}
+
+	volume.Status.State = volumev1alpha1.VolumeStatePending
 
 	return volume, nil
 }
 
 // Delete implements kraftkit.sh/api/volume/v1alpha1.Delete
-func (*v1alpha1Volume) Delete(_ context.Context, _ *volumev1alpha1.Volume) (*volumev1alpha1.Volume, error) {
+func (*v1alpha1Volume) Delete(_ context.Context, volume *volumev1alpha1.Volume) (*volumev1alpha1.Volume, error) {
+	if len(volume.Spec.Driver) == 0 || volume.Spec.Driver != "9pfs" {
+		return nil, nil
+	}
+
+	if len(volume.Spec.Source) == 0 {
+		return nil, nil
+	}
+
+	if volume.Status.State == volumev1alpha1.VolumeStateBound {
+		return volume, fmt.Errorf("cannot delete volume in state %s", volume.Status.State)
+	}
+
+	if volume.Spec.Managed {
+		if err := os.RemoveAll(volume.Spec.Source); err != nil {
+			return volume, fmt.Errorf("cannot remove volume directory: %w", err)
+		}
+	}
+
 	return nil, nil
 }
 
 // Get implements kraftkit.sh/api/volume/v1alpha1.Get
 func (*v1alpha1Volume) Get(_ context.Context, volume *volumev1alpha1.Volume) (*volumev1alpha1.Volume, error) {
+	if len(volume.Spec.Driver) == 0 || volume.Spec.Driver != "9pfs" {
+		return nil, nil
+	}
+
+	if len(volume.Spec.Source) == 0 {
+		return nil, nil
+	}
+
 	return volume, nil
 }
 
 // List implements kraftkit.sh/api/volume/v1alpha1.List
 func (*v1alpha1Volume) List(_ context.Context, volumes *volumev1alpha1.VolumeList) (*volumev1alpha1.VolumeList, error) {
 	return volumes, nil
+}
+
+// Update implements kraftkit.sh/api/volume/v1alpha1.Update
+func (*v1alpha1Volume) Update(_ context.Context, volume *volumev1alpha1.Volume) (*volumev1alpha1.Volume, error) {
+	return volume, nil
 }
 
 // Watch implements kraftkit.sh/api/volume/v1alpha1.Watch

--- a/machine/volume/iterator_v1alpha1.go
+++ b/machine/volume/iterator_v1alpha1.go
@@ -1,0 +1,125 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2024, Unikraft GmbH and The KraftKit Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+package volume
+
+import (
+	"context"
+	"fmt"
+
+	zip "api.zip"
+	"github.com/acorn-io/baaah/pkg/merr"
+	volumev1alpha1 "kraftkit.sh/api/volume/v1alpha1"
+)
+
+type volumeV1alpha1ServiceIterator struct {
+	strategies map[string]volumev1alpha1.VolumeService
+}
+
+// NewVolumeV1alpha1ServiceIterator returns a
+// volumev1alpha1.VolumeService -compatible implementation which iterates over
+// each supported volume driver and calls the representing method.  This is
+// useful in circumstances where the driver is not supplied.  The first volume
+// driver to succeed is returned in all circumstances.
+func NewVolumeV1alpha1ServiceIterator(ctx context.Context) (volumev1alpha1.VolumeService, error) {
+	var err error
+	iterator := volumeV1alpha1ServiceIterator{
+		strategies: map[string]volumev1alpha1.VolumeService{},
+	}
+
+	for driver, strategy := range hostSupportedStrategies() {
+		iterator.strategies[driver], err = strategy.NewVolumeV1alpha1(ctx)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return &iterator, nil
+}
+
+// Create implements kraftkit.sh/api/volume/v1alpha1.Create
+func (iterator *volumeV1alpha1ServiceIterator) Create(ctx context.Context, volume *volumev1alpha1.Volume) (*volumev1alpha1.Volume, error) {
+	var errs []error
+
+	for _, strategy := range iterator.strategies {
+		ret, err := strategy.Create(ctx, volume)
+		if err != nil {
+			errs = append(errs, err)
+			continue
+		}
+
+		return ret, nil
+	}
+
+	return volume, fmt.Errorf("all iterated drivers failed: %w", merr.NewErrors(errs...))
+}
+
+// Update implements kraftkit.sh/api/volume/v1alpha1.Update.
+func (iterator *volumeV1alpha1ServiceIterator) Update(ctx context.Context, volume *volumev1alpha1.Volume) (*volumev1alpha1.Volume, error) {
+	var errs []error
+
+	for _, strategy := range iterator.strategies {
+		ret, err := strategy.Update(ctx, volume)
+		if err != nil {
+			errs = append(errs, err)
+			continue
+		}
+
+		return ret, nil
+	}
+
+	return volume, fmt.Errorf("all iterated drivers failed: %w", merr.NewErrors(errs...))
+}
+
+// Delete implements kraftkit.sh/api/volume/v1alpha1.Delete
+func (iterator *volumeV1alpha1ServiceIterator) Delete(ctx context.Context, volume *volumev1alpha1.Volume) (*volumev1alpha1.Volume, error) {
+	var errs []error
+
+	for _, strategy := range iterator.strategies {
+		ret, err := strategy.Delete(ctx, volume)
+		if err != nil {
+			errs = append(errs, err)
+			continue
+		}
+
+		return ret, nil
+	}
+
+	return volume, fmt.Errorf("all iterated drivers failed: %w", merr.NewErrors(errs...))
+}
+
+// Get implements kraftkit.sh/api/volume/v1alpha1.Get
+func (iterator *volumeV1alpha1ServiceIterator) Get(ctx context.Context, volume *volumev1alpha1.Volume) (*volumev1alpha1.Volume, error) {
+	var errs []error
+
+	for _, strategy := range iterator.strategies {
+		ret, err := strategy.Get(ctx, volume)
+		if err != nil {
+			errs = append(errs, err)
+			continue
+		}
+
+		return ret, nil
+	}
+
+	return volume, fmt.Errorf("all iterated drivers failed: %w", merr.NewErrors(errs...))
+}
+
+// List implements kraftkit.sh/api/volume/v1alpha1.List
+func (iterator *volumeV1alpha1ServiceIterator) List(ctx context.Context, cached *volumev1alpha1.VolumeList) (*volumev1alpha1.VolumeList, error) {
+	found := []zip.Object[volumev1alpha1.VolumeSpec, volumev1alpha1.VolumeStatus]{}
+
+	for _, strategy := range iterator.strategies {
+		ret, err := strategy.List(ctx, &volumev1alpha1.VolumeList{})
+		if err != nil {
+			continue
+		}
+
+		found = append(found, ret.Items...)
+	}
+
+	cached.Items = found
+
+	return cached, nil
+}


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [x] Updated relevant documentation.

### Description of changes

This ``PR`` introduces the ``volume`` subcommand and also allows users to run machines with named volumes (as opposed to paths on host).

<!--
Please provide a detailed description of the changes made in this new PR.
-->
