### PR TITLE
feat(compose): Accept args and improve CLI

### DIFF
--- a/internal/cli/kraft/compose/build/build.go
+++ b/internal/cli/kraft/compose/build/build.go
@@ -72,7 +72,12 @@ func (opts *BuildOptions) Run(ctx context.Context, args []string) error {
 		return err
 	}
 
-	for _, service := range project.Services {
+	services, err := project.GetServices(args...)
+	if err != nil {
+		return err
+	}
+
+	for _, service := range services {
 		if service.Build == nil {
 			continue
 		}

--- a/internal/cli/kraft/compose/create/create.go
+++ b/internal/cli/kraft/compose/create/create.go
@@ -43,7 +43,6 @@ func NewCmd() *cobra.Command {
 	cmd, err := cmdfactory.New(&CreateOptions{}, cobra.Command{
 		Short:   "Create a compose project",
 		Use:     "create [FLAGS]",
-		Args:    cobra.NoArgs,
 		Aliases: []string{},
 		Long:    "Create the services and networks for a project.",
 		Example: heredoc.Doc(`
@@ -197,7 +196,12 @@ func (opts *CreateOptions) Run(ctx context.Context, args []string) error {
 		return err
 	}
 
-	for _, service := range project.Services {
+	services, err := project.GetServices(args...)
+	if err != nil {
+		return err
+	}
+
+	for _, service := range services {
 		alreadyCreated := false
 		for _, machine := range machines.Items {
 			if service.Name != machine.Name {

--- a/internal/cli/kraft/compose/logs/logs.go
+++ b/internal/cli/kraft/compose/logs/logs.go
@@ -83,8 +83,13 @@ func (opts *LogsOptions) Run(ctx context.Context, args []string) error {
 		return err
 	}
 
+	services, err := project.GetServices(args...)
+	if err != nil {
+		return err
+	}
+
 	machinesToLog := []string{}
-	for _, service := range project.Services {
+	for _, service := range services {
 		machine, _ := controller.Get(ctx, &machineapi.Machine{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: service.Name,

--- a/internal/cli/kraft/compose/pause/pause.go
+++ b/internal/cli/kraft/compose/pause/pause.go
@@ -29,7 +29,6 @@ func NewCmd() *cobra.Command {
 	cmd, err := cmdfactory.New(&PauseOptions{}, cobra.Command{
 		Short:   "Pause a compose project",
 		Use:     "pause [FLAGS]",
-		Args:    cobra.NoArgs,
 		Aliases: []string{},
 		Example: heredoc.Doc(`
 			# Pause a compose project
@@ -62,7 +61,7 @@ func (opts *PauseOptions) Pre(cmd *cobra.Command, _ []string) error {
 	return nil
 }
 
-func (opts *PauseOptions) Run(ctx context.Context, _ []string) error {
+func (opts *PauseOptions) Run(ctx context.Context, args []string) error {
 	workdir, err := os.Getwd()
 	if err != nil {
 		return err
@@ -87,8 +86,13 @@ func (opts *PauseOptions) Run(ctx context.Context, _ []string) error {
 		return err
 	}
 
+	services, err := project.GetServices(args...)
+	if err != nil {
+		return err
+	}
+
 	machinesToPause := []string{}
-	for _, service := range project.Services {
+	for _, service := range services {
 		for _, machine := range machines.Items {
 			if service.Name == machine.Name && machine.Status.State == machineapi.MachineStateRunning {
 				machinesToPause = append(machinesToPause, machine.Name)

--- a/internal/cli/kraft/compose/start/start.go
+++ b/internal/cli/kraft/compose/start/start.go
@@ -31,7 +31,6 @@ func NewCmd() *cobra.Command {
 	cmd, err := cmdfactory.New(&StartOptions{}, cobra.Command{
 		Short:   "Start a compose project",
 		Use:     "start [FLAGS]",
-		Args:    cobra.NoArgs,
 		Aliases: []string{},
 		Example: heredoc.Doc(`
 			# Start a compose project
@@ -64,7 +63,7 @@ func (opts *StartOptions) Pre(cmd *cobra.Command, _ []string) error {
 	return nil
 }
 
-func (opts *StartOptions) Run(ctx context.Context, _ []string) error {
+func (opts *StartOptions) Run(ctx context.Context, args []string) error {
 	workdir, err := os.Getwd()
 	if err != nil {
 		return err
@@ -89,8 +88,13 @@ func (opts *StartOptions) Run(ctx context.Context, _ []string) error {
 		return err
 	}
 
+	services, err := project.GetServices(args...)
+	if err != nil {
+		return err
+	}
+
 	machinesToStart := []string{}
-	for _, service := range project.Services {
+	for _, service := range services {
 		for _, machine := range machines.Items {
 			if service.Name == machine.Name {
 				if machine.Status.State == machineapi.MachineStateCreated || machine.Status.State == machineapi.MachineStateExited {

--- a/internal/cli/kraft/compose/start/start.go
+++ b/internal/cli/kraft/compose/start/start.go
@@ -17,14 +17,12 @@ import (
 	"kraftkit.sh/packmanager"
 
 	machineapi "kraftkit.sh/api/machine/v1alpha1"
-	"kraftkit.sh/internal/cli/kraft/compose/logs"
 	kernelstart "kraftkit.sh/internal/cli/kraft/start"
 	mplatform "kraftkit.sh/machine/platform"
 )
 
 type StartOptions struct {
 	Composefile string `noattribute:"true"`
-	Detach      bool   `long:"detach" short:"d" usage:"Run in background"`
 }
 
 func NewCmd() *cobra.Command {
@@ -113,14 +111,5 @@ func (opts *StartOptions) Run(ctx context.Context, args []string) error {
 		return err
 	}
 
-	if opts.Detach {
-		return nil
-	}
-
-	logsOptions := logs.LogsOptions{
-		Composefile: opts.Composefile,
-		Follow:      true,
-	}
-
-	return logsOptions.Run(ctx, []string{})
+	return nil
 }

--- a/internal/cli/kraft/compose/stop/stop.go
+++ b/internal/cli/kraft/compose/stop/stop.go
@@ -29,7 +29,6 @@ func NewCmd() *cobra.Command {
 	cmd, err := cmdfactory.New(&StopOptions{}, cobra.Command{
 		Short:   "Stop a compose project",
 		Use:     "stop [FLAGS]",
-		Args:    cobra.NoArgs,
 		Aliases: []string{},
 		Example: heredoc.Doc(`
 			# Stop a compose project
@@ -62,7 +61,7 @@ func (opts *StopOptions) Pre(cmd *cobra.Command, _ []string) error {
 	return nil
 }
 
-func (opts *StopOptions) Run(ctx context.Context, _ []string) error {
+func (opts *StopOptions) Run(ctx context.Context, args []string) error {
 	workdir, err := os.Getwd()
 	if err != nil {
 		return err
@@ -87,8 +86,13 @@ func (opts *StopOptions) Run(ctx context.Context, _ []string) error {
 		return err
 	}
 
+	services, err := project.GetServices(args...)
+	if err != nil {
+		return err
+	}
+
 	machinesToStop := []string{}
-	for _, service := range project.Services {
+	for _, service := range services {
 		for _, machine := range machines.Items {
 			if service.Name == machine.Name &&
 				(machine.Status.State == machineapi.MachineStateRunning ||

--- a/internal/cli/kraft/compose/stop/stop.go
+++ b/internal/cli/kraft/compose/stop/stop.go
@@ -22,7 +22,7 @@ import (
 )
 
 type StopOptions struct {
-	composefile string
+	Composefile string
 }
 
 func NewCmd() *cobra.Command {
@@ -54,10 +54,10 @@ func (opts *StopOptions) Pre(cmd *cobra.Command, _ []string) error {
 	cmd.SetContext(ctx)
 
 	if cmd.Flag("file").Changed {
-		opts.composefile = cmd.Flag("file").Value.String()
+		opts.Composefile = cmd.Flag("file").Value.String()
 	}
 
-	log.G(cmd.Context()).WithField("composefile", opts.composefile).Debug("using")
+	log.G(cmd.Context()).WithField("composefile", opts.Composefile).Debug("using")
 	return nil
 }
 
@@ -67,7 +67,7 @@ func (opts *StopOptions) Run(ctx context.Context, args []string) error {
 		return err
 	}
 
-	project, err := compose.NewProjectFromComposeFile(ctx, workdir, opts.composefile)
+	project, err := compose.NewProjectFromComposeFile(ctx, workdir, opts.Composefile)
 	if err != nil {
 		return err
 	}

--- a/internal/cli/kraft/compose/unpause/unpause.go
+++ b/internal/cli/kraft/compose/unpause/unpause.go
@@ -31,7 +31,6 @@ func NewCmd() *cobra.Command {
 	cmd, err := cmdfactory.New(&UnpauseOptions{}, cobra.Command{
 		Short:   "Unpause a compose project",
 		Use:     "unpause [FLAGS]",
-		Args:    cobra.NoArgs,
 		Aliases: []string{},
 		Example: heredoc.Doc(`
 			# Unpause a compose project
@@ -64,7 +63,7 @@ func (opts *UnpauseOptions) Pre(cmd *cobra.Command, _ []string) error {
 	return nil
 }
 
-func (opts *UnpauseOptions) Run(ctx context.Context, _ []string) error {
+func (opts *UnpauseOptions) Run(ctx context.Context, args []string) error {
 	workdir, err := os.Getwd()
 	if err != nil {
 		return err
@@ -89,8 +88,13 @@ func (opts *UnpauseOptions) Run(ctx context.Context, _ []string) error {
 		return err
 	}
 
+	services, err := project.GetServices(args...)
+	if err != nil {
+		return err
+	}
+
 	machinesToUnpause := []string{}
-	for _, service := range project.Services {
+	for _, service := range services {
 		for _, machine := range machines.Items {
 			if service.Name == machine.Name {
 				if machine.Status.State == machineapi.MachineStatePaused {

--- a/internal/cli/kraft/compose/unpause/unpause.go
+++ b/internal/cli/kraft/compose/unpause/unpause.go
@@ -17,14 +17,12 @@ import (
 	"kraftkit.sh/packmanager"
 
 	machineapi "kraftkit.sh/api/machine/v1alpha1"
-	"kraftkit.sh/internal/cli/kraft/compose/logs"
 	kernelstart "kraftkit.sh/internal/cli/kraft/start"
 	mplatform "kraftkit.sh/machine/platform"
 )
 
 type UnpauseOptions struct {
 	Composefile string `noattribute:"true"`
-	Detach      bool   `long:"detach" short:"d" usage:"Run in background"`
 }
 
 func NewCmd() *cobra.Command {
@@ -113,14 +111,5 @@ func (opts *UnpauseOptions) Run(ctx context.Context, args []string) error {
 		return err
 	}
 
-	if opts.Detach {
-		return nil
-	}
-
-	logsOptions := logs.LogsOptions{
-		Composefile: opts.Composefile,
-		Follow:      true,
-	}
-
-	return logsOptions.Run(ctx, []string{})
+	return nil
 }

--- a/internal/cli/kraft/compose/up/up.go
+++ b/internal/cli/kraft/compose/up/up.go
@@ -15,6 +15,7 @@ import (
 	"kraftkit.sh/internal/cli/kraft/compose/create"
 	"kraftkit.sh/internal/cli/kraft/compose/logs"
 	"kraftkit.sh/internal/cli/kraft/compose/start"
+	"kraftkit.sh/internal/cli/kraft/compose/stop"
 	"kraftkit.sh/log"
 	"kraftkit.sh/packmanager"
 )
@@ -87,5 +88,18 @@ func (opts *UpOptions) Run(ctx context.Context, _ []string) error {
 		Follow:      true,
 	}
 
-	return logsOptions.Run(ctx, []string{})
+	if err := logsOptions.Run(ctx, []string{}); err != nil {
+		return err
+	}
+
+	// If we get here it means the context was cancelled, stop the machines
+	log.G(ctx).Infof("stopping machines...")
+	stopOptions := stop.StopOptions{
+		Composefile: opts.composefile,
+	}
+
+	if err := stopOptions.Run(ctx, []string{}); err != nil {
+		return err
+	}
+	return nil
 }

--- a/internal/cli/kraft/compose/up/up.go
+++ b/internal/cli/kraft/compose/up/up.go
@@ -13,6 +13,7 @@ import (
 
 	"kraftkit.sh/cmdfactory"
 	"kraftkit.sh/internal/cli/kraft/compose/create"
+	"kraftkit.sh/internal/cli/kraft/compose/logs"
 	"kraftkit.sh/internal/cli/kraft/compose/start"
 	"kraftkit.sh/log"
 	"kraftkit.sh/packmanager"
@@ -71,8 +72,20 @@ func (opts *UpOptions) Run(ctx context.Context, _ []string) error {
 
 	startOptions := start.StartOptions{
 		Composefile: opts.composefile,
-		Detach:      opts.Detach,
 	}
 
-	return startOptions.Run(ctx, []string{})
+	if err := startOptions.Run(ctx, []string{}); err != nil {
+		return err
+	}
+
+	if opts.Detach {
+		return nil
+	}
+
+	logsOptions := logs.LogsOptions{
+		Composefile: opts.composefile,
+		Follow:      true,
+	}
+
+	return logsOptions.Run(ctx, []string{})
 }


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [x] Updated relevant documentation.

### Description of changes

* Allow users to pass args to ``kraft compose`` when they want to do operations on a subset of services
* Only attach to logs when running ``kraft compose up``
* When running ``kraft compose up`` (in attached mode), stop the machines when the context gets cancelled.

These changes aim to make the CLI experience more natural to users already familiar with ``docker compose``

<!--
Please provide a detailed description of the changes made in this new PR.
-->

