### PR TITLE
feat(cloud): Add `https://` prefix to FQDN for relevant services

### DIFF
--- a/internal/cli/kraft/cloud/deploy/deploy.go
+++ b/internal/cli/kraft/cloud/deploy/deploy.go
@@ -218,7 +218,7 @@ func (opts *DeployOptions) Run(ctx context.Context, args []string) error {
 
 	log.G(ctx).WithField("deployer", d.Name()).Debug("using")
 
-	instsResp, _, err := d.Deploy(ctx, opts, args...)
+	instsResp, svcResp, err := d.Deploy(ctx, opts, args...)
 	if err != nil {
 		return fmt.Errorf("could not prepare deployment: %w", err)
 	}
@@ -229,7 +229,9 @@ func (opts *DeployOptions) Run(ctx context.Context, args []string) error {
 	}
 
 	if len(insts) == 1 && opts.Output == "" {
-		utils.PrettyPrintInstance(ctx, insts[0], !opts.NoStart)
+		// No need to check for error, we check if-nil inside PrettyPrintInstance.
+		svc, _ := svcResp.FirstOrErr()
+		utils.PrettyPrintInstance(ctx, insts[0], svc, !opts.NoStart)
 		return nil
 	}
 

--- a/internal/cli/kraft/cloud/instance/create/create.go
+++ b/internal/cli/kraft/cloud/instance/create/create.go
@@ -651,20 +651,23 @@ func (opts *CreateOptions) Pre(cmd *cobra.Command, _ []string) error {
 func (opts *CreateOptions) Run(ctx context.Context, args []string) error {
 	opts.Image = args[0]
 
-	resp, _, err := Create(ctx, opts, args[1:]...)
+	instResp, svcResp, err := Create(ctx, opts, args[1:]...)
 	if err != nil {
 		return err
 	}
 
-	insts, err := resp.AllOrErr()
+	insts, err := instResp.AllOrErr()
 	if err != nil {
 		return err
 	}
 
 	if len(insts) > 1 || opts.Output == "table" {
-		return utils.PrintInstances(ctx, opts.Output, *resp)
+		return utils.PrintInstances(ctx, opts.Output, *instResp)
 	}
-	utils.PrettyPrintInstance(ctx, insts[0], opts.Start)
+
+	// No need to check for error, we check if-nil inside PrettyPrintInstance.
+	svc, _ := svcResp.FirstOrErr()
+	utils.PrettyPrintInstance(ctx, insts[0], svc, opts.Start)
 
 	return nil
 }

--- a/internal/cli/kraft/cloud/utils/print.go
+++ b/internal/cli/kraft/cloud/utils/print.go
@@ -786,7 +786,7 @@ func PrintCertificates(ctx context.Context, format string, resp kcclient.Service
 }
 
 // PrettyPrintInstance outputs a single instance and information about it.
-func PrettyPrintInstance(ctx context.Context, instance kcinstances.GetResponseItem, autoStart bool) {
+func PrettyPrintInstance(ctx context.Context, instance kcinstances.GetResponseItem, service *kcservices.GetResponseItem, autoStart bool) {
 	out := iostreams.G(ctx).Out
 
 	var title string
@@ -820,11 +820,19 @@ func PrettyPrintInstance(ctx context.Context, instance kcinstances.GetResponseIt
 		},
 	}
 
-	if instance.ServiceGroup != nil {
-		for _, domain := range instance.ServiceGroup.Domains {
+	if service != nil {
+		for _, domain := range service.Domains {
+			fqdn := domain.FQDN
+			for _, port := range service.Services {
+				if port.Port == 443 {
+					fqdn = "https://" + fqdn
+					break
+				}
+			}
+
 			entries = append(entries, fancymap.FancyMapEntry{
 				Key:   "domain",
-				Value: domain.FQDN,
+				Value: fqdn,
 			})
 		}
 	}


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

This commit effectively reverts d3851d758b following usability feedback.  The addition makes the domain clickable for relevant HTTPS-based services.
