### PR TITLE
feat(bridge): Allow arbitrary network length

### DIFF
--- a/test/e2e/cli/net_inspect_test.go
+++ b/test/e2e/cli/net_inspect_test.go
@@ -61,7 +61,7 @@ var _ = Describe("kraft net inspect", func() {
 			Expect(err).To(HaveOccurred())
 
 			Expect(stderr.String()).To(BeEmpty())
-			Expect(stdout.String()).To(MatchRegexp(`^{"level":"error","msg":"could not get link t-in-0: Link not found"}\n$`))
+			Expect(stdout.String()).To(MatchRegexp(`^{"level":"error","msg":"no such network: t-in-0"}\n$`))
 		})
 	})
 


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [ ] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

Linux has a limitation on the length of interface names. Hence, this commit attempts to maintain the old naming scheme on a best effort basis, but in case that is not possible, it instead uses a hash to name the bridge, keeping the mapping internally.

Previously, the ``network.name`` used to be the same as the interface name. This was convenient because it allowed easy checks on whether a network already exists. 

The approach I used here is the following: 
* During creation, if the object from the store already has a ``UUID``, then it means the network with that name was already created (regardless of the actual interface name)
* During creation, if we error out, return ``nil`` instead of ``network`` such that nothing gets saved and we dont pollute the store with networks that do not actually have an interface.
<!--
Please provide a detailed description of the changes made in this new PR.
-->
