### PR TITLE
fix(processtree): Always show left text in no-render mode

### DIFF
--- a/tui/processtree/processtree.go
+++ b/tui/processtree/processtree.go
@@ -319,7 +319,7 @@ func (pt *ProcessTree) waitForProcessCmd(item *ProcessTreeItem) tea.Cmd {
 	return func() tea.Msg {
 		item := item // golang closures
 
-		if pt.norender && !pt.hide {
+		if pt.norender {
 			log.G(item.ctx).Info(item.textLeft)
 		}
 


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

No render mode is accessed when using basic logging and the left text, regardless of whether the processtee is hidden after it is completed (via `WithHideOnSuccess(true)`) should be shown to enrich the log messages.
