### PR TITLE
fix(qemu): Show first line after receiving "Booting from ROM"

### DIFF
--- a/machine/qemu/v1alpha1.go
+++ b/machine/qemu/v1alpha1.go
@@ -782,6 +782,7 @@ func (service *machineV1alpha1Service) Logs(ctx context.Context, machine *machin
 				if strings.Contains(line, "Booting from ") {
 					qcfg.ShowSGABiosPreamble = true
 					machine.Status.PlatformConfig = qcfg
+					return out, errOut, nil
 				}
 				continue
 			}


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

Return the channel if the phrase from QEMU has been received. Since the line has now been consumed, the next won't be if we simply `continue`, because this will be consumed to be checked.  Without this, the first line from the QEMU log will be lost.  For applications which output a single line, this would otherwise be lost.
