### PR TITLE
fix(tableprinter): Do not render spaces in attribute name

### DIFF
--- a/internal/tableprinter/render_json.go
+++ b/internal/tableprinter/render_json.go
@@ -22,7 +22,7 @@ func (printer *TablePrinter) renderJSON(w io.Writer) error {
 		m := make(map[string]string)
 
 		for j, column := range row {
-			m[strings.ToLower(header[j].text)] = column.text
+			m[strings.ReplaceAll(strings.ToLower(header[j].text), " ", "_")] = column.text
 		}
 
 		if len(m) > 0 {

--- a/internal/tableprinter/render_yaml.go
+++ b/internal/tableprinter/render_yaml.go
@@ -23,7 +23,7 @@ func (printer *TablePrinter) renderYAML(w io.Writer) error {
 		m := make(map[string]string)
 
 		for j, column := range row {
-			m[strings.ToLower(header[j].text)] = column.text
+			m[strings.ReplaceAll(strings.ToLower(header[j].text), " ", "_")] = column.text
 		}
 
 		if len(m) > 0 {


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

This is invalid schema for both JSON and YAML.  Use an underscore instead of a space.
