### PR TITLE
feat: Several adjustments to log messages

### DIFF
--- a/internal/cli/kraft/cloud/instance/logs/logs.go
+++ b/internal/cli/kraft/cloud/instance/logs/logs.go
@@ -158,10 +158,7 @@ func Logs(ctx context.Context, opts *LogOptions, args ...string) error {
 					return
 				case line, ok := <-logChan:
 					if ok {
-						if err := consumer.Consume(fmt.Sprintf("%s\n", line)); err != nil {
-							errGroup = append(errGroup, err)
-							return
-						}
+						consumer.Consume(line)
 					}
 				}
 			}

--- a/internal/cli/kraft/logs/colorful_consumer.go
+++ b/internal/cli/kraft/logs/colorful_consumer.go
@@ -13,7 +13,7 @@ import (
 )
 
 type LogConsumer interface {
-	Consume(line string) error
+	Consume(line ...string)
 }
 
 type ColorfulConsumer struct {
@@ -40,12 +40,12 @@ func NewColorfulConsumer(streams *iostreams.IOStreams, color bool, prefix string
 }
 
 // Consume implements logConsumer
-func (c *ColorfulConsumer) Consume(s string) error {
-	if c.prefix != "" {
-		s = fmt.Sprintf("%s | %s", c.color(c.prefix), s)
+func (c *ColorfulConsumer) Consume(strs ...string) {
+	for _, s := range strs {
+		if c.prefix != "" {
+			s = fmt.Sprintf("%s | %s", c.color(c.prefix), s)
+		}
+
+		fmt.Fprintf(c.streams.Out, "%s\n", s)
 	}
-
-	fmt.Fprint(c.streams.Out, s)
-
-	return nil
 }

--- a/internal/cli/kraft/logs/logs.go
+++ b/internal/cli/kraft/logs/logs.go
@@ -193,9 +193,7 @@ func (opts *LogOptions) Run(ctx context.Context, args []string) error {
 			} else {
 				scanner := bufio.NewScanner(fd)
 				for scanner.Scan() {
-					if err := consumer.Consume(scanner.Text() + "\n"); err != nil {
-						errGroup = append(errGroup, err)
-					}
+					consumer.Consume(scanner.Text())
 				}
 			}
 		}
@@ -285,10 +283,7 @@ loop:
 		// Wait on either channel
 		select {
 		case line := <-logs:
-			if err := consumer.Consume(line); err != nil {
-				log.G(ctx).Errorf("could not consume log line: %v", err)
-				return err
-			}
+			consumer.Consume(line)
 
 		case err := <-errs:
 			eof = true

--- a/internal/logtail/logtail.go
+++ b/internal/logtail/logtail.go
@@ -117,7 +117,7 @@ func peekAndRead(file *os.File, reader *bufio.Reader, logs *chan string, errs *c
 	}
 
 	if len(s) > discarded {
-		*logs <- string(s[discarded:])
+		*logs <- string(s[discarded : len(s)-1])
 	}
 
 	return false


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

This small refactor performs a number of actions simultaneously:

1. Removes the unnecessary `error` being returned from `Consume` which was ultimately never used by relevant consumers, resulting unnecessary error handling.
2. Updates the `Consume` prototype to accept multiple lines at once;
3. Employs the new-line at the consumer-level, since all other instances were always appending the newline itself.  This improves the code quality.
4. Subsequent to 3, appropraitely discard the the newline which has been retrieved via the `ReadBytes` from the `peekAndRed` of the internal log tail package.

Finally, it adds helpful troubleshooting message for fatal KraftCloud instances at the end of their logs.

