### PR TITLE
feat(compose): Introduce `--remove-orphans` flag

### DIFF
--- a/compose/v1.go
+++ b/compose/v1.go
@@ -86,6 +86,7 @@ func (v1 *v1Compose) refreshRunningServices(ctx context.Context, embeddedProject
 	runningMachines := []metav1.ObjectMeta{}
 
 	// Orphaned machines
+	orphanMachines := []string{}
 	for _, machine := range embeddedProject.Status.Machines {
 		isService := false
 		for _, service := range project.Services {
@@ -99,10 +100,15 @@ func (v1 *v1Compose) refreshRunningServices(ctx context.Context, embeddedProject
 			if m.Name == machine.Name {
 				runningMachines = append(runningMachines, machine)
 				if !isService && m.Status.State == machineapi.MachineStateRunning {
-					log.G(ctx).WithField("machine", machine.Name).Warn("found orphan machine")
+					orphanMachines = append(orphanMachines, machine.Name)
 				}
 			}
 		}
+	}
+
+	if len(orphanMachines) > 0 {
+		log.G(ctx).WithField("machines", orphanMachines).
+			Warn("found orphan machines for this project. You can run this command with the --remove-orphans flag to clean it up")
 	}
 
 	// Name collisions

--- a/internal/cli/kraft/compose/create/create.go
+++ b/internal/cli/kraft/compose/create/create.go
@@ -18,6 +18,7 @@ import (
 	"kraftkit.sh/cmdfactory"
 	"kraftkit.sh/compose"
 	"kraftkit.sh/internal/cli/kraft/build"
+	"kraftkit.sh/internal/cli/kraft/compose/utils"
 	netcreate "kraftkit.sh/internal/cli/kraft/net/create"
 	"kraftkit.sh/internal/cli/kraft/pkg"
 	"kraftkit.sh/internal/cli/kraft/pkg/pull"
@@ -39,7 +40,8 @@ import (
 )
 
 type CreateOptions struct {
-	Composefile string `noattribute:"true"`
+	Composefile   string `noattribute:"true"`
+	RemoveOrphans bool   `long:"remove-orphans" usage:"Remove machines for services not defined in the Compose file"`
 }
 
 func NewCmd() *cobra.Command {
@@ -96,6 +98,12 @@ func (opts *CreateOptions) Run(ctx context.Context, args []string) error {
 
 	if err := project.AssignIPs(ctx); err != nil {
 		return err
+	}
+
+	if opts.RemoveOrphans {
+		if err := utils.RemoveOrphans(ctx, project); err != nil {
+			return err
+		}
 	}
 
 	composeController, err := compose.NewComposeProjectV1(ctx)

--- a/internal/cli/kraft/compose/down/down.go
+++ b/internal/cli/kraft/compose/down/down.go
@@ -15,6 +15,7 @@ import (
 	"github.com/spf13/cobra"
 	"kraftkit.sh/cmdfactory"
 	"kraftkit.sh/compose"
+	"kraftkit.sh/internal/cli/kraft/compose/utils"
 	networkremove "kraftkit.sh/internal/cli/kraft/net/remove"
 	machineremove "kraftkit.sh/internal/cli/kraft/remove"
 	"kraftkit.sh/log"
@@ -27,7 +28,8 @@ import (
 )
 
 type DownOptions struct {
-	composefile string
+	composefile   string
+	RemoveOrphans bool `long:"remove-orphans" usage:"Remove machines for services not defined in the Compose file."`
 }
 
 func NewCmd() *cobra.Command {
@@ -79,6 +81,12 @@ func (opts *DownOptions) Run(ctx context.Context, args []string) error {
 
 	if err := project.Validate(ctx); err != nil {
 		return err
+	}
+
+	if opts.RemoveOrphans {
+		if err := utils.RemoveOrphans(ctx, project); err != nil {
+			return err
+		}
 	}
 
 	machineController, err := mplatform.NewMachineV1alpha1ServiceIterator(ctx)

--- a/internal/cli/kraft/compose/ps/ps.go
+++ b/internal/cli/kraft/compose/ps/ps.go
@@ -23,6 +23,7 @@ import (
 
 type PsOptions struct {
 	Long    bool   `long:"long" short:"l" usage:"Show more information"`
+	Orphans bool   `long:"orphans" usage:"Include orphaned services (default: true)" default:"true"`
 	Output  string `long:"output" short:"o" usage:"Set output format. Options: table,yaml,json,list" default:"table"`
 	Quiet   bool   `long:"quiet" short:"q" usage:"Only display machine IDs"`
 	ShowAll bool   `long:"all" short:"a" usage:"Show all machines (default shows just running)"`
@@ -111,6 +112,18 @@ func (opts *PsOptions) Run(ctx context.Context, args []string) error {
 	filteredPsTable := []pslist.PsEntry{}
 	for _, psEntry := range psTable {
 		for _, machine := range embeddedProject.Status.Machines {
+			orphaned := true
+			for _, service := range project.Services {
+				if service.Name == machine.Name {
+					orphaned = false
+					break
+				}
+			}
+
+			if orphaned && !opts.Orphans {
+				continue
+			}
+
 			if psEntry.Name == machine.Name {
 				filteredPsTable = append(filteredPsTable, psEntry)
 			}

--- a/internal/cli/kraft/compose/up/up.go
+++ b/internal/cli/kraft/compose/up/up.go
@@ -21,8 +21,10 @@ import (
 )
 
 type UpOptions struct {
+	Detach        bool `long:"detach" short:"d" usage:"Run in background"`
+	RemoveOrphans bool `long:"remove-orphans" usage:"Remove machines for services not defined in the Compose file."`
+
 	composefile string
-	Detach      bool `long:"detach" short:"d" usage:"Run in background"`
 }
 
 func NewCmd() *cobra.Command {
@@ -64,7 +66,8 @@ func (opts *UpOptions) Pre(cmd *cobra.Command, _ []string) error {
 
 func (opts *UpOptions) Run(ctx context.Context, _ []string) error {
 	createOptions := create.CreateOptions{
-		Composefile: opts.composefile,
+		Composefile:   opts.composefile,
+		RemoveOrphans: opts.RemoveOrphans,
 	}
 
 	if err := createOptions.Run(ctx, []string{}); err != nil {

--- a/internal/cli/kraft/compose/utils/utils.go
+++ b/internal/cli/kraft/compose/utils/utils.go
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2024, Unikraft GmbH and The KraftKit Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+
+package utils
+
+import (
+	"context"
+
+	"kraftkit.sh/compose"
+	"kraftkit.sh/internal/cli/kraft/remove"
+	"kraftkit.sh/log"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	composeapi "kraftkit.sh/api/compose/v1"
+	machineapi "kraftkit.sh/api/machine/v1alpha1"
+	mplatform "kraftkit.sh/machine/platform"
+)
+
+func RemoveOrphans(ctx context.Context, project *compose.Project) error {
+	composeController, err := compose.NewComposeProjectV1(ctx)
+	if err != nil {
+		return err
+	}
+
+	embeddedProject, err := composeController.Get(ctx, &composeapi.Compose{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: project.Name,
+		},
+	})
+	if err != nil {
+		return err
+	}
+
+	machineController, err := mplatform.NewMachineV1alpha1ServiceIterator(ctx)
+	if err != nil {
+		return err
+	}
+
+	machines, err := machineController.List(ctx, &machineapi.MachineList{})
+	if err != nil {
+		return err
+	}
+
+	orphanMachines := []string{}
+	for _, machine := range embeddedProject.Status.Machines {
+		isService := false
+		for _, service := range project.Services {
+			if service.Name == machine.Name {
+				isService = true
+				break
+			}
+		}
+
+		for _, m := range machines.Items {
+			if m.Name == machine.Name {
+				if !isService && m.Status.State == machineapi.MachineStateRunning {
+					orphanMachines = append(orphanMachines, machine.Name)
+				}
+			}
+		}
+	}
+
+	if len(orphanMachines) == 0 {
+		return nil
+	}
+
+	log.G(ctx).Info("removing orphan machines...")
+	removeOptions := remove.RemoveOptions{
+		Platform: "auto",
+	}
+
+	return removeOptions.Run(ctx, orphanMachines)
+}


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [x] Updated relevant documentation.

### Description of changes

The `remove-orphans` flag remove all machines that are no longer part of the composefile, but that were previously part of the project.

<!--
Please provide a detailed description of the changes made in this new PR.
-->
