### PR TITLE
fix(kraft): Only accept single target in `utils.BuildRootfs`

### DIFF
--- a/internal/cli/kraft/pkg/packager_cli_kernel.go
+++ b/internal/cli/kraft/pkg/packager_cli_kernel.go
@@ -68,22 +68,18 @@ func (p *packagerCliKernel) Pack(ctx context.Context, opts *PkgOptions, args ...
 		return nil, fmt.Errorf("could not prepare phony target: %w", err)
 	}
 
-	var cmds [][]string
-	var envs [][]string
+	var cmds []string
+	var envs []string
 	if opts.Rootfs, cmds, envs, err = utils.BuildRootfs(ctx, opts.Workdir, opts.Rootfs, opts.Compress, targ); err != nil {
 		return nil, fmt.Errorf("could not build rootfs: %w", err)
 	}
 
-	if len(opts.Args) == 0 {
-		if cmds[0] != nil {
-			opts.Args = cmds[0]
-		}
+	if len(opts.Args) == 0 && cmds != nil {
+		opts.Args = cmds
 	}
 
-	if len(opts.Env) == 0 {
-		if envs[0] != nil {
-			opts.Env = envs[0]
-		}
+	if envs != nil {
+		opts.Env = append(opts.Env, envs...)
 	}
 
 	cmdShellArgs, err := shellwords.Parse(strings.Join(opts.Args, " "))

--- a/internal/cli/kraft/pkg/packager_kraftfile_runtime.go
+++ b/internal/cli/kraft/pkg/packager_kraftfile_runtime.go
@@ -283,16 +283,14 @@ func (p *packagerKraftfileRuntime) Pack(ctx context.Context, opts *PkgOptions, a
 		return nil, fmt.Errorf("package does not convert to target")
 	}
 
-	var cmds [][]string
-	var envs [][]string
+	var cmds []string
+	var envs []string
 	if opts.Rootfs, cmds, envs, err = utils.BuildRootfs(ctx, opts.Workdir, opts.Rootfs, opts.Compress, targ); err != nil {
 		return nil, fmt.Errorf("could not build rootfs: %w", err)
 	}
 
-	if len(opts.Env) == 0 {
-		if envs[0] != nil {
-			opts.Env = envs[0]
-		}
+	if envs != nil {
+		opts.Env = append(opts.Env, envs...)
 	}
 
 	// If no arguments have been specified, use the ones which are default and
@@ -302,8 +300,8 @@ func (p *packagerKraftfileRuntime) Pack(ctx context.Context, opts *PkgOptions, a
 			opts.Args = opts.Project.Command()
 		} else if len(targ.Command()) > 0 {
 			opts.Args = targ.Command()
-		} else if cmds[0] != nil {
-			opts.Args = cmds[0]
+		} else if cmds != nil {
+			opts.Args = cmds
 		}
 	}
 


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

This commit fixes a number of issues simultaneously by removing the ability to build multiple targets at once in the utility method `BuildRootfs`;

1. The resulting rootfs string would be overwritten by the last build rootfs, resulting in potential mismatch between the resulting architecture of the rootfs;
2. Returning the discovered command-line and environmental variables as a single slice, preventing duplication;
3. Appending environmental variables to user-supplied ones made with the `-e` flag.

