### PR TITLE
fix(run): Prevent possible nil-pointers by always using `Cut`

### DIFF
--- a/internal/cli/kraft/run/runner_kraftfile_runtime.go
+++ b/internal/cli/kraft/run/runner_kraftfile_runtime.go
@@ -340,9 +340,12 @@ func (runner *runnerKraftfileRuntime) Prepare(ctx context.Context, opts *RunOpti
 			}
 
 			for _, entry := range runtime.Initrd().Env() {
-				split := strings.SplitN(entry, "=", 2)
+				k, v, ok := strings.Cut(entry, "=")
+				if !ok {
+					continue
+				}
 
-				machine.Spec.Env[split[0]] = split[1]
+				machine.Spec.Env[k] = v
 			}
 
 			machine.Spec.ApplicationArgs = runtime.Initrd().Args()

--- a/internal/cli/kraft/run/runner_package.go
+++ b/internal/cli/kraft/run/runner_package.go
@@ -345,13 +345,12 @@ func (runner *runnerPackage) Prepare(ctx context.Context, opts *RunOptions, mach
 		}
 
 		for _, env := range v.Config.Env {
-			if strings.ContainsRune(env, '=') {
-				parts := strings.SplitN(env, "=", 2)
-				machine.Spec.Env[parts[0]] = parts[1]
+			k, v, ok := strings.Cut(env, "=")
+			if !ok {
 				continue
 			}
 
-			machine.Spec.Env[env] = ""
+			machine.Spec.Env[k] = v
 		}
 	default:
 	}


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

When parsing environmental variables in `kraft run`, which are often presented in circumstances with strings with an equals delimeter, the use of `SplitN` was not always checked for empty values.  To prevent possible nil-pointers and to keep code consistent, replace all areas where this type of procedure occurs with `strings.Cut` instead.

