### PR TITLE
fix(run): Initialize env map if nil

### DIFF
--- a/internal/cli/kraft/run/utils.go
+++ b/internal/cli/kraft/run/utils.go
@@ -378,6 +378,9 @@ func (opts *RunOptions) prepareRootfs(ctx context.Context, machine *machineapi.M
 		return fmt.Errorf("could not prepare initramfs: %w", err)
 	}
 
+	if machine.Spec.Env == nil {
+		machine.Spec.Env = make(map[string]string)
+	}
 	treemodel, err := processtree.NewProcessTree(
 		ctx,
 		[]processtree.ProcessTreeOption{


### PR DESCRIPTION
PR 1575 introduced env variables from docker, but there was no guarantee that the machine env map was ever initialized at this point.

<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [x] Updated relevant documentation.

### Description of changes

Github-Fixes: https://github.com/unikraft/kraftkit/issues/1612

<!--
Please provide a detailed description of the changes made in this new PR.
-->
