### PR TITLE
refactor(e2e): Remove unneeded nesting for pkg tests

### DIFF
--- a/test/e2e/cli/pkg_source_test.go
+++ b/test/e2e/cli/pkg_source_test.go
@@ -19,7 +19,7 @@ import (
 	fcfg "kraftkit.sh/test/e2e/framework/config"
 )
 
-var _ = Describe("kraft pkg", func() {
+var _ = Describe("kraft pkg source", func() {
 	var cmd *fcmd.Cmd
 
 	var stdout *fcmd.IOStream
@@ -34,378 +34,372 @@ var _ = Describe("kraft pkg", func() {
 		cfg = fcfg.NewTempConfig()
 
 		cmd = fcmd.NewKraft(stdout, stderr, cfg.Path())
-		cmd.Args = append(cmd.Args, "pkg")
+		cmd.Args = append(cmd.Args, "pkg", "source", "--log-level", "info", "--log-type", "json")
 	})
 
-	_ = Describe("source", func() {
-		BeforeEach(func() {
-			cmd.Args = append(cmd.Args, "source", "--log-level", "info", "--log-type", "json")
-		})
-
-		Context("sourcing a new link in the config file", func() {
-			When("the config file doesn't exist", func() {
-				BeforeEach(func() {
-					// Save the config file by moving it to a temporary location
-					err := os.Rename(cfg.Path(), cfg.Path()+".tmp")
-					if err != nil {
-						fmt.Print(cmd.DumpError(stdout, stderr, err))
-					}
-					Expect(err).ToNot(HaveOccurred())
-				})
-
-				AfterEach(func() {
-					// Restore the config file
-					err := os.Rename(cfg.Path()+".tmp", cfg.Path())
-					if err != nil {
-						fmt.Print(cmd.DumpError(stdout, stderr, err))
-					}
-					Expect(err).ToNot(HaveOccurred())
-				})
-				It("should create the config file, add the default manifests, and the new link, and print nothing", func() {
-					cmd.Args = append(cmd.Args, "--force")
-					cmd.Args = append(cmd.Args, "https://example.com")
-					err := cmd.Run()
-					if err != nil {
-						fmt.Print(cmd.DumpError(stdout, stderr, err))
-					}
-					Expect(err).ToNot(HaveOccurred())
-					Expect(stderr.String()).To(BeEmpty())
-
-					// Read the config file
-					osFile, err := os.Open(cfg.Path())
-					if err != nil {
-						fmt.Print(cmd.DumpError(stdout, stderr, err))
-					}
-					Expect(err).ToNot(HaveOccurred())
-					defer osFile.Close()
-
-					osFileInfo, err := osFile.Stat()
-					if err != nil {
-						fmt.Print(cmd.DumpError(stdout, stderr, err))
-					}
-					Expect(err).ToNot(HaveOccurred())
-
-					// Check if the config file is not empty
-					Expect(osFileInfo.Size()).To(BeNumerically(">", 0))
-
-					// Check if the config file has 600 permissions
-					Expect(osFileInfo.Mode().Perm()).To(Equal(os.FileMode(0o600)))
-
-					// Read file content
-					readBytes, err := os.ReadFile(cfg.Path())
-					if err != nil {
-						fmt.Print(cmd.DumpError(stdout, stderr, err))
-					}
-					Expect(err).ToNot(HaveOccurred())
-
-					// Marshal the yaml file into a map
-					var cfgMap map[string]interface{}
-					err = yaml.Unmarshal([]byte(readBytes), &cfgMap)
-					if err != nil {
-						fmt.Print(cmd.DumpError(stdout, stderr, err))
-					}
-					Expect(err).ToNot(HaveOccurred())
-
-					// Check if the config file contains the default manifests
-					cfgMapUnikernel, ok := cfgMap["unikraft"].(map[string]interface{})
-					Expect(ok).To(BeTrue())
-
-					// Cast the manifests list to an array
-					cfgMapUnikernelManifests, ok := cfgMapUnikernel["manifests"].([]interface{})
-					Expect(ok).To(BeTrue())
-
-					// Check if the default manifests are present and in the first position
-					Expect(cfgMapUnikernelManifests).To(HaveLen(2))
-					Expect(cfgMapUnikernelManifests[0]).To(Equal("https://manifests.kraftkit.sh/index.yaml"))
-
-					// Check if the config file contains the new link
-					Expect(cfgMapUnikernelManifests[1]).To(Equal("https://example.com"))
-
-					// Check if stdout is empty
-					Expect(stdout.String()).To(BeEmpty())
-				})
+	Context("sourcing a new link in the config file", func() {
+		When("the config file doesn't exist", func() {
+			BeforeEach(func() {
+				// Save the config file by moving it to a temporary location
+				err := os.Rename(cfg.Path(), cfg.Path()+".tmp")
+				if err != nil {
+					fmt.Print(cmd.DumpError(stdout, stderr, err))
+				}
+				Expect(err).ToNot(HaveOccurred())
 			})
 
-			When("the config file exists", func() {
-				BeforeEach(func() {
-					oldArgs := make([]string, len(cmd.Args))
-					copy(oldArgs, cmd.Args)
-
-					cmd.Args = append(cmd.Args, "--force")
-					cmd.Args = append(cmd.Args, "https://example1.com")
-					err := cmd.Run()
-					if err != nil {
-						fmt.Print(cmd.DumpError(stdout, stderr, err))
-					}
-					Expect(err).ToNot(HaveOccurred())
-					Expect(stderr.String()).To(BeEmpty())
-
-					// Recreate the command to reuse
-					stdout = fcmd.NewIOStream()
-					stderr = fcmd.NewIOStream()
-
-					cmd = fcmd.NewKraft(stdout, stderr, cfg.Path())
-					cmd.Args = oldArgs
-				})
-
-				It("should leave the config file intact, add the new link, and print nothing", func() {
-					cmd.Args = append(cmd.Args, "--force")
-					cmd.Args = append(cmd.Args, "https://example2.com")
-					err := cmd.Run()
-					if err != nil {
-						fmt.Print(cmd.DumpError(stdout, stderr, err))
-					}
-					Expect(err).ToNot(HaveOccurred())
-					Expect(stderr.String()).To(BeEmpty())
-
-					// Read the config file
-					osFile, err := os.Open(cfg.Path())
-					if err != nil {
-						fmt.Print(cmd.DumpError(stdout, stderr, err))
-					}
-					Expect(err).ToNot(HaveOccurred())
-					defer osFile.Close()
-
-					osFileInfo, err := osFile.Stat()
-					if err != nil {
-						fmt.Print(cmd.DumpError(stdout, stderr, err))
-					}
-					Expect(err).ToNot(HaveOccurred())
-
-					// Check if the config file is not empty
-					Expect(osFileInfo.Size()).To(BeNumerically(">", 0))
-
-					// Check if the config file has 600 permissions
-					Expect(osFileInfo.Mode().Perm()).To(Equal(os.FileMode(0o600)))
-
-					// Read file content
-					readBytes, err := os.ReadFile(cfg.Path())
-					if err != nil {
-						fmt.Print(cmd.DumpError(stdout, stderr, err))
-					}
-					Expect(err).ToNot(HaveOccurred())
-
-					// Marshal the yaml file into a map
-					var cfgMap map[string]interface{}
-					err = yaml.Unmarshal([]byte(readBytes), &cfgMap)
-					if err != nil {
-						fmt.Print(cmd.DumpError(stdout, stderr, err))
-					}
-					Expect(err).ToNot(HaveOccurred())
-
-					// Check if the config file contains the default manifests
-					cfgMapUnikernel, ok := cfgMap["unikraft"].(map[string]interface{})
-					Expect(ok).To(BeTrue())
-
-					// Cast the manifests list to an array
-					cfgMapUnikernelManifests, ok := cfgMapUnikernel["manifests"].([]interface{})
-					Expect(ok).To(BeTrue())
-
-					// Check if the default manifests are present and in the first position
-					Expect(cfgMapUnikernelManifests).To(HaveLen(3))
-					Expect(cfgMapUnikernelManifests[0]).To(Equal("https://manifests.kraftkit.sh/index.yaml"))
-
-					// Check if the config file contains the new link
-					Expect(cfgMapUnikernelManifests[1]).To(Equal("https://example1.com"))
-					Expect(cfgMapUnikernelManifests[2]).To(Equal("https://example2.com"))
-
-					// Check if stdout is empty
-					Expect(stdout.String()).To(BeEmpty())
-				})
+			AfterEach(func() {
+				// Restore the config file
+				err := os.Rename(cfg.Path()+".tmp", cfg.Path())
+				if err != nil {
+					fmt.Print(cmd.DumpError(stdout, stderr, err))
+				}
+				Expect(err).ToNot(HaveOccurred())
 			})
+			It("should create the config file, add the default manifests, and the new link, and print nothing", func() {
+				cmd.Args = append(cmd.Args, "--force")
+				cmd.Args = append(cmd.Args, "https://example.com")
+				err := cmd.Run()
+				if err != nil {
+					fmt.Print(cmd.DumpError(stdout, stderr, err))
+				}
+				Expect(err).ToNot(HaveOccurred())
+				Expect(stderr.String()).To(BeEmpty())
 
-			When("sourcing an existing link in the config file", func() {
-				It("should warn the user and leave the file intact", func() {
-					oldArgs := make([]string, len(cmd.Args))
-					copy(oldArgs, cmd.Args)
+				// Read the config file
+				osFile, err := os.Open(cfg.Path())
+				if err != nil {
+					fmt.Print(cmd.DumpError(stdout, stderr, err))
+				}
+				Expect(err).ToNot(HaveOccurred())
+				defer osFile.Close()
 
-					// Generate a clean config file
-					cmd.Args = append(cmd.Args, "https://manifests.kraftkit.sh/index.yaml")
-					err := cmd.Run()
-					if err != nil {
-						fmt.Print(cmd.DumpError(stdout, stderr, err))
-					}
-					Expect(err).ToNot(HaveOccurred())
-					Expect(stderr.String()).To(BeEmpty())
+				osFileInfo, err := osFile.Stat()
+				if err != nil {
+					fmt.Print(cmd.DumpError(stdout, stderr, err))
+				}
+				Expect(err).ToNot(HaveOccurred())
 
-					// Calculate config file hash
-					bytes, err := os.ReadFile(cfg.Path())
-					if err != nil {
-						fmt.Print(cmd.DumpError(stdout, stderr, err))
-					}
-					Expect(err).ToNot(HaveOccurred())
+				// Check if the config file is not empty
+				Expect(osFileInfo.Size()).To(BeNumerically(">", 0))
 
-					// Calculate sha1 hash of bytes
-					sha1Hash := sha1.Sum(bytes)
+				// Check if the config file has 600 permissions
+				Expect(osFileInfo.Mode().Perm()).To(Equal(os.FileMode(0o600)))
 
-					// Recreate the command to reuse
-					stdout = fcmd.NewIOStream()
-					stderr = fcmd.NewIOStream()
+				// Read file content
+				readBytes, err := os.ReadFile(cfg.Path())
+				if err != nil {
+					fmt.Print(cmd.DumpError(stdout, stderr, err))
+				}
+				Expect(err).ToNot(HaveOccurred())
 
-					cmd = fcmd.NewKraft(stdout, stderr, cfg.Path())
-					cmd.Args = oldArgs
+				// Marshal the yaml file into a map
+				var cfgMap map[string]interface{}
+				err = yaml.Unmarshal([]byte(readBytes), &cfgMap)
+				if err != nil {
+					fmt.Print(cmd.DumpError(stdout, stderr, err))
+				}
+				Expect(err).ToNot(HaveOccurred())
 
-					cmd.Args = append(cmd.Args, "https://manifests.kraftkit.sh/index.yaml")
-					err = cmd.Run()
-					if err != nil {
-						fmt.Print(cmd.DumpError(stdout, stderr, err))
-					}
-					Expect(err).ToNot(HaveOccurred())
-					Expect(stderr.String()).To(BeEmpty())
+				// Check if the config file contains the default manifests
+				cfgMapUnikernel, ok := cfgMap["unikraft"].(map[string]interface{})
+				Expect(ok).To(BeTrue())
 
-					// Check warning message exists in stdout
-					Expect(stdout.String()).To(MatchRegexp(`^{"level":"warning","msg":"manifest already saved: https://manifests\.kraftkit\.sh/index\.yaml"}\n$`))
+				// Cast the manifests list to an array
+				cfgMapUnikernelManifests, ok := cfgMapUnikernel["manifests"].([]interface{})
+				Expect(ok).To(BeTrue())
 
-					// Check if the config file was not modified
-					newBytes, err := os.ReadFile(cfg.Path())
-					if err != nil {
-						fmt.Print(cmd.DumpError(stdout, stderr, err))
-					}
-					Expect(err).ToNot(HaveOccurred())
+				// Check if the default manifests are present and in the first position
+				Expect(cfgMapUnikernelManifests).To(HaveLen(2))
+				Expect(cfgMapUnikernelManifests[0]).To(Equal("https://manifests.kraftkit.sh/index.yaml"))
 
-					newSha1Hash := sha1.Sum(newBytes)
-					Expect(newSha1Hash).To(Equal(sha1Hash))
-				})
+				// Check if the config file contains the new link
+				Expect(cfgMapUnikernelManifests[1]).To(Equal("https://example.com"))
+
+				// Check if stdout is empty
+				Expect(stdout.String()).To(BeEmpty())
 			})
 		})
 
-		Context("sourcing multiple links in the config file", func() {
-			When("the config file was already present, and all links are unique", func() {
-				It("should add all links and print nothing", func() {
-					cmd.Args = append(cmd.Args, "--force")
-					cmd.Args = append(cmd.Args, "https://example1.com")
-					cmd.Args = append(cmd.Args, "https://example2.com")
-					cmd.Args = append(cmd.Args, "https://example3.com")
-					err := cmd.Run()
-					if err != nil {
-						fmt.Print(cmd.DumpError(stdout, stderr, err))
-					}
-					Expect(err).ToNot(HaveOccurred())
-					Expect(stderr.String()).To(BeEmpty())
+		When("the config file exists", func() {
+			BeforeEach(func() {
+				oldArgs := make([]string, len(cmd.Args))
+				copy(oldArgs, cmd.Args)
 
-					// Read the config file
-					osFile, err := os.Open(cfg.Path())
-					if err != nil {
-						fmt.Print(cmd.DumpError(stdout, stderr, err))
-					}
-					Expect(err).ToNot(HaveOccurred())
-					defer osFile.Close()
+				cmd.Args = append(cmd.Args, "--force")
+				cmd.Args = append(cmd.Args, "https://example1.com")
+				err := cmd.Run()
+				if err != nil {
+					fmt.Print(cmd.DumpError(stdout, stderr, err))
+				}
+				Expect(err).ToNot(HaveOccurred())
+				Expect(stderr.String()).To(BeEmpty())
 
-					osFileInfo, err := osFile.Stat()
-					if err != nil {
-						fmt.Print(cmd.DumpError(stdout, stderr, err))
-					}
-					Expect(err).ToNot(HaveOccurred())
+				// Recreate the command to reuse
+				stdout = fcmd.NewIOStream()
+				stderr = fcmd.NewIOStream()
 
-					// Check if the config file is not empty
-					Expect(osFileInfo.Size()).To(BeNumerically(">", 0))
-
-					// Check if the config file has 600 permissions
-					Expect(osFileInfo.Mode().Perm()).To(Equal(os.FileMode(0o600)))
-
-					// Read file content
-					readBytes, err := os.ReadFile(cfg.Path())
-					if err != nil {
-						fmt.Print(cmd.DumpError(stdout, stderr, err))
-					}
-					Expect(err).ToNot(HaveOccurred())
-
-					// Marshal the yaml file into a map
-					var cfgMap map[string]interface{}
-					err = yaml.Unmarshal([]byte(readBytes), &cfgMap)
-					if err != nil {
-						fmt.Print(cmd.DumpError(stdout, stderr, err))
-					}
-					Expect(err).ToNot(HaveOccurred())
-
-					// Check if the config file contains the default manifests
-					cfgMapUnikernel, ok := cfgMap["unikraft"].(map[string]interface{})
-					Expect(ok).To(BeTrue())
-
-					// Cast the manifests list to an array
-					cfgMapUnikernelManifests, ok := cfgMapUnikernel["manifests"].([]interface{})
-					Expect(ok).To(BeTrue())
-
-					// Check if the default manifests are present and in the first position
-					Expect(cfgMapUnikernelManifests).To(HaveLen(4))
-					Expect(cfgMapUnikernelManifests[0]).To(Equal("https://manifests.kraftkit.sh/index.yaml"))
-
-					// Check if the config file contains the new links
-					Expect(cfgMapUnikernelManifests[1]).To(Equal("https://example1.com"))
-					Expect(cfgMapUnikernelManifests[2]).To(Equal("https://example2.com"))
-					Expect(cfgMapUnikernelManifests[3]).To(Equal("https://example3.com"))
-
-					// Check if stdout is empty
-					Expect(stdout.String()).To(BeEmpty())
-				})
+				cmd = fcmd.NewKraft(stdout, stderr, cfg.Path())
+				cmd.Args = oldArgs
 			})
 
-			When("the config file was already present, and a link is duplicate", func() {
-				It("should add links until the first error is met", func() {
-					cmd.Args = append(cmd.Args, "--force")
-					cmd.Args = append(cmd.Args, "https://example.com")
-					cmd.Args = append(cmd.Args, "https://example.com")
-					cmd.Args = append(cmd.Args, "https://example2.com")
-					err := cmd.Run()
-					if err != nil {
-						fmt.Print(cmd.DumpError(stdout, stderr, err))
-					}
-					Expect(err).ToNot(HaveOccurred())
-					Expect(stderr.String()).To(BeEmpty())
+			It("should leave the config file intact, add the new link, and print nothing", func() {
+				cmd.Args = append(cmd.Args, "--force")
+				cmd.Args = append(cmd.Args, "https://example2.com")
+				err := cmd.Run()
+				if err != nil {
+					fmt.Print(cmd.DumpError(stdout, stderr, err))
+				}
+				Expect(err).ToNot(HaveOccurred())
+				Expect(stderr.String()).To(BeEmpty())
 
-					// Read the config file
-					osFile, err := os.Open(cfg.Path())
-					if err != nil {
-						fmt.Print(cmd.DumpError(stdout, stderr, err))
-					}
-					Expect(err).ToNot(HaveOccurred())
-					defer osFile.Close()
+				// Read the config file
+				osFile, err := os.Open(cfg.Path())
+				if err != nil {
+					fmt.Print(cmd.DumpError(stdout, stderr, err))
+				}
+				Expect(err).ToNot(HaveOccurred())
+				defer osFile.Close()
 
-					osFileInfo, err := osFile.Stat()
-					if err != nil {
-						fmt.Print(cmd.DumpError(stdout, stderr, err))
-					}
-					Expect(err).ToNot(HaveOccurred())
+				osFileInfo, err := osFile.Stat()
+				if err != nil {
+					fmt.Print(cmd.DumpError(stdout, stderr, err))
+				}
+				Expect(err).ToNot(HaveOccurred())
 
-					// Check if the config file is not empty
-					Expect(osFileInfo.Size()).To(BeNumerically(">", 0))
+				// Check if the config file is not empty
+				Expect(osFileInfo.Size()).To(BeNumerically(">", 0))
 
-					// Check if the config file has 600 permissions
-					Expect(osFileInfo.Mode().Perm()).To(Equal(os.FileMode(0o600)))
+				// Check if the config file has 600 permissions
+				Expect(osFileInfo.Mode().Perm()).To(Equal(os.FileMode(0o600)))
 
-					// Read file content
-					readBytes, err := os.ReadFile(cfg.Path())
-					if err != nil {
-						fmt.Print(cmd.DumpError(stdout, stderr, err))
-					}
-					Expect(err).ToNot(HaveOccurred())
+				// Read file content
+				readBytes, err := os.ReadFile(cfg.Path())
+				if err != nil {
+					fmt.Print(cmd.DumpError(stdout, stderr, err))
+				}
+				Expect(err).ToNot(HaveOccurred())
 
-					// Marshal the yaml file into a map
-					var cfgMap map[string]interface{}
-					err = yaml.Unmarshal([]byte(readBytes), &cfgMap)
-					if err != nil {
-						fmt.Print(cmd.DumpError(stdout, stderr, err))
-					}
-					Expect(err).ToNot(HaveOccurred())
+				// Marshal the yaml file into a map
+				var cfgMap map[string]interface{}
+				err = yaml.Unmarshal([]byte(readBytes), &cfgMap)
+				if err != nil {
+					fmt.Print(cmd.DumpError(stdout, stderr, err))
+				}
+				Expect(err).ToNot(HaveOccurred())
 
-					// Check if the config file contains the default manifests
-					cfgMapUnikernel, ok := cfgMap["unikraft"].(map[string]interface{})
-					Expect(ok).To(BeTrue())
+				// Check if the config file contains the default manifests
+				cfgMapUnikernel, ok := cfgMap["unikraft"].(map[string]interface{})
+				Expect(ok).To(BeTrue())
 
-					// Cast the manifests list to an array
-					cfgMapUnikernelManifests, ok := cfgMapUnikernel["manifests"].([]interface{})
-					Expect(ok).To(BeTrue())
+				// Cast the manifests list to an array
+				cfgMapUnikernelManifests, ok := cfgMapUnikernel["manifests"].([]interface{})
+				Expect(ok).To(BeTrue())
 
-					// Check if the default manifests are present and in the first position
-					Expect(cfgMapUnikernelManifests).To(HaveLen(2))
-					Expect(cfgMapUnikernelManifests[0]).To(Equal("https://manifests.kraftkit.sh/index.yaml"))
+				// Check if the default manifests are present and in the first position
+				Expect(cfgMapUnikernelManifests).To(HaveLen(3))
+				Expect(cfgMapUnikernelManifests[0]).To(Equal("https://manifests.kraftkit.sh/index.yaml"))
 
-					// Check if the config file contains the new link
-					Expect(cfgMapUnikernelManifests[1]).To(Equal("https://example.com"))
+				// Check if the config file contains the new link
+				Expect(cfgMapUnikernelManifests[1]).To(Equal("https://example1.com"))
+				Expect(cfgMapUnikernelManifests[2]).To(Equal("https://example2.com"))
 
-					// Check if stdout contains the warning message
-					Expect(stdout.String()).To(MatchRegexp(`^{"level":"warning","msg":"manifest already saved: https://example\.com"}\n$`))
-				})
+				// Check if stdout is empty
+				Expect(stdout.String()).To(BeEmpty())
+			})
+		})
+
+		When("sourcing an existing link in the config file", func() {
+			It("should warn the user and leave the file intact", func() {
+				oldArgs := make([]string, len(cmd.Args))
+				copy(oldArgs, cmd.Args)
+
+				// Generate a clean config file
+				cmd.Args = append(cmd.Args, "https://manifests.kraftkit.sh/index.yaml")
+				err := cmd.Run()
+				if err != nil {
+					fmt.Print(cmd.DumpError(stdout, stderr, err))
+				}
+				Expect(err).ToNot(HaveOccurred())
+				Expect(stderr.String()).To(BeEmpty())
+
+				// Calculate config file hash
+				bytes, err := os.ReadFile(cfg.Path())
+				if err != nil {
+					fmt.Print(cmd.DumpError(stdout, stderr, err))
+				}
+				Expect(err).ToNot(HaveOccurred())
+
+				// Calculate sha1 hash of bytes
+				sha1Hash := sha1.Sum(bytes)
+
+				// Recreate the command to reuse
+				stdout = fcmd.NewIOStream()
+				stderr = fcmd.NewIOStream()
+
+				cmd = fcmd.NewKraft(stdout, stderr, cfg.Path())
+				cmd.Args = oldArgs
+
+				cmd.Args = append(cmd.Args, "https://manifests.kraftkit.sh/index.yaml")
+				err = cmd.Run()
+				if err != nil {
+					fmt.Print(cmd.DumpError(stdout, stderr, err))
+				}
+				Expect(err).ToNot(HaveOccurred())
+				Expect(stderr.String()).To(BeEmpty())
+
+				// Check warning message exists in stdout
+				Expect(stdout.String()).To(MatchRegexp(`^{"level":"warning","msg":"manifest already saved: https://manifests\.kraftkit\.sh/index\.yaml"}\n$`))
+
+				// Check if the config file was not modified
+				newBytes, err := os.ReadFile(cfg.Path())
+				if err != nil {
+					fmt.Print(cmd.DumpError(stdout, stderr, err))
+				}
+				Expect(err).ToNot(HaveOccurred())
+
+				newSha1Hash := sha1.Sum(newBytes)
+				Expect(newSha1Hash).To(Equal(sha1Hash))
+			})
+		})
+	})
+
+	Context("sourcing multiple links in the config file", func() {
+		When("the config file was already present, and all links are unique", func() {
+			It("should add all links and print nothing", func() {
+				cmd.Args = append(cmd.Args, "--force")
+				cmd.Args = append(cmd.Args, "https://example1.com")
+				cmd.Args = append(cmd.Args, "https://example2.com")
+				cmd.Args = append(cmd.Args, "https://example3.com")
+				err := cmd.Run()
+				if err != nil {
+					fmt.Print(cmd.DumpError(stdout, stderr, err))
+				}
+				Expect(err).ToNot(HaveOccurred())
+				Expect(stderr.String()).To(BeEmpty())
+
+				// Read the config file
+				osFile, err := os.Open(cfg.Path())
+				if err != nil {
+					fmt.Print(cmd.DumpError(stdout, stderr, err))
+				}
+				Expect(err).ToNot(HaveOccurred())
+				defer osFile.Close()
+
+				osFileInfo, err := osFile.Stat()
+				if err != nil {
+					fmt.Print(cmd.DumpError(stdout, stderr, err))
+				}
+				Expect(err).ToNot(HaveOccurred())
+
+				// Check if the config file is not empty
+				Expect(osFileInfo.Size()).To(BeNumerically(">", 0))
+
+				// Check if the config file has 600 permissions
+				Expect(osFileInfo.Mode().Perm()).To(Equal(os.FileMode(0o600)))
+
+				// Read file content
+				readBytes, err := os.ReadFile(cfg.Path())
+				if err != nil {
+					fmt.Print(cmd.DumpError(stdout, stderr, err))
+				}
+				Expect(err).ToNot(HaveOccurred())
+
+				// Marshal the yaml file into a map
+				var cfgMap map[string]interface{}
+				err = yaml.Unmarshal([]byte(readBytes), &cfgMap)
+				if err != nil {
+					fmt.Print(cmd.DumpError(stdout, stderr, err))
+				}
+				Expect(err).ToNot(HaveOccurred())
+
+				// Check if the config file contains the default manifests
+				cfgMapUnikernel, ok := cfgMap["unikraft"].(map[string]interface{})
+				Expect(ok).To(BeTrue())
+
+				// Cast the manifests list to an array
+				cfgMapUnikernelManifests, ok := cfgMapUnikernel["manifests"].([]interface{})
+				Expect(ok).To(BeTrue())
+
+				// Check if the default manifests are present and in the first position
+				Expect(cfgMapUnikernelManifests).To(HaveLen(4))
+				Expect(cfgMapUnikernelManifests[0]).To(Equal("https://manifests.kraftkit.sh/index.yaml"))
+
+				// Check if the config file contains the new links
+				Expect(cfgMapUnikernelManifests[1]).To(Equal("https://example1.com"))
+				Expect(cfgMapUnikernelManifests[2]).To(Equal("https://example2.com"))
+				Expect(cfgMapUnikernelManifests[3]).To(Equal("https://example3.com"))
+
+				// Check if stdout is empty
+				Expect(stdout.String()).To(BeEmpty())
+			})
+		})
+
+		When("the config file was already present, and a link is duplicate", func() {
+			It("should add links until the first error is met", func() {
+				cmd.Args = append(cmd.Args, "--force")
+				cmd.Args = append(cmd.Args, "https://example.com")
+				cmd.Args = append(cmd.Args, "https://example.com")
+				cmd.Args = append(cmd.Args, "https://example2.com")
+				err := cmd.Run()
+				if err != nil {
+					fmt.Print(cmd.DumpError(stdout, stderr, err))
+				}
+				Expect(err).ToNot(HaveOccurred())
+				Expect(stderr.String()).To(BeEmpty())
+
+				// Read the config file
+				osFile, err := os.Open(cfg.Path())
+				if err != nil {
+					fmt.Print(cmd.DumpError(stdout, stderr, err))
+				}
+				Expect(err).ToNot(HaveOccurred())
+				defer osFile.Close()
+
+				osFileInfo, err := osFile.Stat()
+				if err != nil {
+					fmt.Print(cmd.DumpError(stdout, stderr, err))
+				}
+				Expect(err).ToNot(HaveOccurred())
+
+				// Check if the config file is not empty
+				Expect(osFileInfo.Size()).To(BeNumerically(">", 0))
+
+				// Check if the config file has 600 permissions
+				Expect(osFileInfo.Mode().Perm()).To(Equal(os.FileMode(0o600)))
+
+				// Read file content
+				readBytes, err := os.ReadFile(cfg.Path())
+				if err != nil {
+					fmt.Print(cmd.DumpError(stdout, stderr, err))
+				}
+				Expect(err).ToNot(HaveOccurred())
+
+				// Marshal the yaml file into a map
+				var cfgMap map[string]interface{}
+				err = yaml.Unmarshal([]byte(readBytes), &cfgMap)
+				if err != nil {
+					fmt.Print(cmd.DumpError(stdout, stderr, err))
+				}
+				Expect(err).ToNot(HaveOccurred())
+
+				// Check if the config file contains the default manifests
+				cfgMapUnikernel, ok := cfgMap["unikraft"].(map[string]interface{})
+				Expect(ok).To(BeTrue())
+
+				// Cast the manifests list to an array
+				cfgMapUnikernelManifests, ok := cfgMapUnikernel["manifests"].([]interface{})
+				Expect(ok).To(BeTrue())
+
+				// Check if the default manifests are present and in the first position
+				Expect(cfgMapUnikernelManifests).To(HaveLen(2))
+				Expect(cfgMapUnikernelManifests[0]).To(Equal("https://manifests.kraftkit.sh/index.yaml"))
+
+				// Check if the config file contains the new link
+				Expect(cfgMapUnikernelManifests[1]).To(Equal("https://example.com"))
+
+				// Check if stdout contains the warning message
+				Expect(stdout.String()).To(MatchRegexp(`^{"level":"warning","msg":"manifest already saved: https://example\.com"}\n$`))
 			})
 		})
 	})

--- a/test/e2e/cli/pkg_unsource_test.go
+++ b/test/e2e/cli/pkg_unsource_test.go
@@ -18,7 +18,7 @@ import (
 	fcfg "kraftkit.sh/test/e2e/framework/config"
 )
 
-var _ = Describe("kraft pkg", func() {
+var _ = Describe("kraft pkg unsource", func() {
 	var cmd *fcmd.Cmd
 
 	var stdout *fcmd.IOStream
@@ -33,420 +33,414 @@ var _ = Describe("kraft pkg", func() {
 		cfg = fcfg.NewTempConfig()
 
 		cmd = fcmd.NewKraft(stdout, stderr, cfg.Path())
-		cmd.Args = append(cmd.Args, "pkg")
+		cmd.Args = append(cmd.Args, "pkg", "unsource", "--log-level", "info", "--log-type", "json")
 	})
 
-	_ = Describe("unsource", func() {
-		BeforeEach(func() {
-			cmd.Args = append(cmd.Args, "unsource", "--log-level", "info", "--log-type", "json")
-		})
+	Context("unsourcing a link in the config file", func() {
+		When("the config file already exists", func() {
+			It("should remove the link and print nothing", func() {
+				cmd.Args = append(cmd.Args, "https://manifests.kraftkit.sh/index.yaml")
+				err := cmd.Run()
+				if err != nil {
+					fmt.Print(cmd.DumpError(stdout, stderr, err))
+				}
+				Expect(err).ToNot(HaveOccurred())
+				Expect(stderr.String()).To(BeEmpty())
 
-		Context("unsourcing a link in the config file", func() {
-			When("the config file already exists", func() {
-				It("should remove the link and print nothing", func() {
-					cmd.Args = append(cmd.Args, "https://manifests.kraftkit.sh/index.yaml")
-					err := cmd.Run()
-					if err != nil {
-						fmt.Print(cmd.DumpError(stdout, stderr, err))
-					}
-					Expect(err).ToNot(HaveOccurred())
-					Expect(stderr.String()).To(BeEmpty())
+				// Read the config file
+				osFile, err := os.Open(cfg.Path())
+				if err != nil {
+					fmt.Print(cmd.DumpError(stdout, stderr, err))
+				}
+				Expect(err).ToNot(HaveOccurred())
+				defer osFile.Close()
 
-					// Read the config file
-					osFile, err := os.Open(cfg.Path())
-					if err != nil {
-						fmt.Print(cmd.DumpError(stdout, stderr, err))
-					}
-					Expect(err).ToNot(HaveOccurred())
-					defer osFile.Close()
+				osFileInfo, err := osFile.Stat()
+				if err != nil {
+					fmt.Print(cmd.DumpError(stdout, stderr, err))
+				}
+				Expect(err).ToNot(HaveOccurred())
 
-					osFileInfo, err := osFile.Stat()
-					if err != nil {
-						fmt.Print(cmd.DumpError(stdout, stderr, err))
-					}
-					Expect(err).ToNot(HaveOccurred())
+				// Check if the config file is not empty
+				Expect(osFileInfo.Size()).To(BeNumerically(">", 0))
 
-					// Check if the config file is not empty
-					Expect(osFileInfo.Size()).To(BeNumerically(">", 0))
+				// Check if the config file has 600 permissions
+				Expect(osFileInfo.Mode().Perm()).To(Equal(os.FileMode(0o600)))
 
-					// Check if the config file has 600 permissions
-					Expect(osFileInfo.Mode().Perm()).To(Equal(os.FileMode(0o600)))
+				// Read file content
+				readBytes, err := os.ReadFile(cfg.Path())
+				if err != nil {
+					fmt.Print(cmd.DumpError(stdout, stderr, err))
+				}
+				Expect(err).ToNot(HaveOccurred())
 
-					// Read file content
-					readBytes, err := os.ReadFile(cfg.Path())
-					if err != nil {
-						fmt.Print(cmd.DumpError(stdout, stderr, err))
-					}
-					Expect(err).ToNot(HaveOccurred())
+				// Marshal the yaml file into a map
+				var cfgMap map[string]interface{}
+				err = yaml.Unmarshal([]byte(readBytes), &cfgMap)
+				if err != nil {
+					fmt.Print(cmd.DumpError(stdout, stderr, err))
+				}
+				Expect(err).ToNot(HaveOccurred())
 
-					// Marshal the yaml file into a map
-					var cfgMap map[string]interface{}
-					err = yaml.Unmarshal([]byte(readBytes), &cfgMap)
-					if err != nil {
-						fmt.Print(cmd.DumpError(stdout, stderr, err))
-					}
-					Expect(err).ToNot(HaveOccurred())
+				// Check if the config file contains the default manifests
+				cfgMapUnikernel, ok := cfgMap["unikraft"].(map[string]interface{})
+				Expect(ok).To(BeTrue())
 
-					// Check if the config file contains the default manifests
-					cfgMapUnikernel, ok := cfgMap["unikraft"].(map[string]interface{})
-					Expect(ok).To(BeTrue())
+				// Cast the manifests list to an array
+				cfgMapUnikernelManifests, ok := cfgMapUnikernel["manifests"].([]interface{})
+				Expect(ok).To(BeTrue())
 
-					// Cast the manifests list to an array
-					cfgMapUnikernelManifests, ok := cfgMapUnikernel["manifests"].([]interface{})
-					Expect(ok).To(BeTrue())
+				// Check if the default manifests are removed
+				Expect(cfgMapUnikernelManifests).To(HaveLen(0))
 
-					// Check if the default manifests are removed
-					Expect(cfgMapUnikernelManifests).To(HaveLen(0))
-
-					// Check if stdout is empty
-					Expect(stdout.String()).To(BeEmpty())
-				})
-			})
-
-			When("there is no config file", func() {
-				BeforeEach(func() {
-					// Save the config file by moving it to a temporary location
-					err := os.Rename(cfg.Path(), cfg.Path()+".tmp")
-					if err != nil {
-						fmt.Print(cmd.DumpError(stdout, stderr, err))
-					}
-					Expect(err).ToNot(HaveOccurred())
-				})
-				AfterEach(func() {
-					// Restore the config file
-					err := os.Rename(cfg.Path()+".tmp", cfg.Path())
-					if err != nil {
-						fmt.Print(cmd.DumpError(stdout, stderr, err))
-					}
-					Expect(err).ToNot(HaveOccurred())
-				})
-				It("should create the config file, add the default manifests, remove the link, and print nothing", func() {
-					cmd.Args = append(cmd.Args, "https://manifests.kraftkit.sh/index.yaml")
-					err := cmd.Run()
-					if err != nil {
-						fmt.Print(cmd.DumpError(stdout, stderr, err))
-					}
-					Expect(err).ToNot(HaveOccurred())
-					Expect(stderr.String()).To(BeEmpty())
-
-					// Read the config file
-					osFile, err := os.Open(cfg.Path())
-					if err != nil {
-						fmt.Print(cmd.DumpError(stdout, stderr, err))
-					}
-					Expect(err).ToNot(HaveOccurred())
-					defer osFile.Close()
-
-					osFileInfo, err := osFile.Stat()
-					if err != nil {
-						fmt.Print(cmd.DumpError(stdout, stderr, err))
-					}
-					Expect(err).ToNot(HaveOccurred())
-
-					// Check if the config file is not empty
-					Expect(osFileInfo.Size()).To(BeNumerically(">", 0))
-
-					// Check if the config file has 600 permissions
-					Expect(osFileInfo.Mode().Perm()).To(Equal(os.FileMode(0o600)))
-
-					// Read file content
-					readBytes, err := os.ReadFile(cfg.Path())
-					if err != nil {
-						fmt.Print(cmd.DumpError(stdout, stderr, err))
-					}
-					Expect(err).ToNot(HaveOccurred())
-
-					// Marshal the yaml file into a map
-					var cfgMap map[string]interface{}
-					err = yaml.Unmarshal([]byte(readBytes), &cfgMap)
-					if err != nil {
-						fmt.Print(cmd.DumpError(stdout, stderr, err))
-					}
-					Expect(err).ToNot(HaveOccurred())
-
-					// Check if the config file contains the default manifests
-					cfgMapUnikernel, ok := cfgMap["unikraft"].(map[string]interface{})
-					Expect(ok).To(BeTrue())
-
-					// Cast the manifests list to an array
-					cfgMapUnikernelManifests, ok := cfgMapUnikernel["manifests"].([]interface{})
-					Expect(ok).To(BeTrue())
-
-					// Check if the default manifests are removed
-					Expect(cfgMapUnikernelManifests).To(HaveLen(0))
-
-					// Check if stdout is empty
-					Expect(stdout.String()).To(BeEmpty())
-				})
-			})
-
-			When("the config does not contain the link or it doesn't exist", func() {
-				BeforeEach(func() {
-					// Save the config file by moving it to a temporary location
-					err := os.Rename(cfg.Path(), cfg.Path()+".tmp")
-					if err != nil {
-						fmt.Print(cmd.DumpError(stdout, stderr, err))
-					}
-					Expect(err).ToNot(HaveOccurred())
-				})
-				AfterEach(func() {
-					// Restore the config file
-					err := os.Rename(cfg.Path()+".tmp", cfg.Path())
-					if err != nil {
-						fmt.Print(cmd.DumpError(stdout, stderr, err))
-					}
-					Expect(err).ToNot(HaveOccurred())
-				})
-				It("should do nothing and print a warning", func() {
-					cmd.Args = append(cmd.Args, "https://example.com")
-					err := cmd.Run()
-					if err != nil {
-						fmt.Print(cmd.DumpError(stdout, stderr, err))
-					}
-					Expect(err).ToNot(HaveOccurred())
-					Expect(stderr.String()).To(BeEmpty())
-
-					// Read the config file
-					osFile, err := os.Open(cfg.Path())
-					if err != nil {
-						fmt.Print(cmd.DumpError(stdout, stderr, err))
-					}
-					Expect(err).ToNot(HaveOccurred())
-					defer osFile.Close()
-
-					osFileInfo, err := osFile.Stat()
-					if err != nil {
-						fmt.Print(cmd.DumpError(stdout, stderr, err))
-					}
-					Expect(err).ToNot(HaveOccurred())
-
-					// Check if the config file is not empty
-					Expect(osFileInfo.Size()).To(BeNumerically(">", 0))
-
-					// Check if the config file has 600 permissions
-					Expect(osFileInfo.Mode().Perm()).To(Equal(os.FileMode(0o600)))
-
-					// Read file content
-					readBytes, err := os.ReadFile(cfg.Path())
-					if err != nil {
-						fmt.Print(cmd.DumpError(stdout, stderr, err))
-					}
-					Expect(err).ToNot(HaveOccurred())
-
-					// Marshal the yaml file into a map
-					var cfgMap map[string]interface{}
-					err = yaml.Unmarshal([]byte(readBytes), &cfgMap)
-					if err != nil {
-						fmt.Print(cmd.DumpError(stdout, stderr, err))
-					}
-					Expect(err).ToNot(HaveOccurred())
-
-					// Check if the config file contains the default manifests
-					cfgMapUnikernel, ok := cfgMap["unikraft"].(map[string]interface{})
-					Expect(ok).To(BeTrue())
-
-					// Cast the manifests list to an array
-					cfgMapUnikernelManifests, ok := cfgMapUnikernel["manifests"].([]interface{})
-					Expect(ok).To(BeTrue())
-
-					// Check if the default manifests are still there
-					Expect(cfgMapUnikernelManifests).To(HaveLen(1))
-					Expect(cfgMapUnikernelManifests[0]).To(Equal("https://manifests.kraftkit.sh/index.yaml"))
-
-					// Check if stdout contains the warning
-					Expect(stdout.String()).To(MatchRegexp(`^{"level":"warning","msg":"manifest not found: https://example\.com"}\n$`))
-				})
+				// Check if stdout is empty
+				Expect(stdout.String()).To(BeEmpty())
 			})
 		})
 
-		Context("unsourcing multiple links in the config file", func() {
-			When("a config file was already present, and all links are unique", func() {
-				BeforeEach(func() {
-					unsourceArgs := make([]string, len(cmd.Args))
-					copy(unsourceArgs, cmd.Args)
+		When("there is no config file", func() {
+			BeforeEach(func() {
+				// Save the config file by moving it to a temporary location
+				err := os.Rename(cfg.Path(), cfg.Path()+".tmp")
+				if err != nil {
+					fmt.Print(cmd.DumpError(stdout, stderr, err))
+				}
+				Expect(err).ToNot(HaveOccurred())
+			})
+			AfterEach(func() {
+				// Restore the config file
+				err := os.Rename(cfg.Path()+".tmp", cfg.Path())
+				if err != nil {
+					fmt.Print(cmd.DumpError(stdout, stderr, err))
+				}
+				Expect(err).ToNot(HaveOccurred())
+			})
+			It("should create the config file, add the default manifests, remove the link, and print nothing", func() {
+				cmd.Args = append(cmd.Args, "https://manifests.kraftkit.sh/index.yaml")
+				err := cmd.Run()
+				if err != nil {
+					fmt.Print(cmd.DumpError(stdout, stderr, err))
+				}
+				Expect(err).ToNot(HaveOccurred())
+				Expect(stderr.String()).To(BeEmpty())
 
-					for idx, arg := range cmd.Args {
-						if arg == "unsource" {
-							cmd.Args[idx] = "source"
-							break
-						}
+				// Read the config file
+				osFile, err := os.Open(cfg.Path())
+				if err != nil {
+					fmt.Print(cmd.DumpError(stdout, stderr, err))
+				}
+				Expect(err).ToNot(HaveOccurred())
+				defer osFile.Close()
+
+				osFileInfo, err := osFile.Stat()
+				if err != nil {
+					fmt.Print(cmd.DumpError(stdout, stderr, err))
+				}
+				Expect(err).ToNot(HaveOccurred())
+
+				// Check if the config file is not empty
+				Expect(osFileInfo.Size()).To(BeNumerically(">", 0))
+
+				// Check if the config file has 600 permissions
+				Expect(osFileInfo.Mode().Perm()).To(Equal(os.FileMode(0o600)))
+
+				// Read file content
+				readBytes, err := os.ReadFile(cfg.Path())
+				if err != nil {
+					fmt.Print(cmd.DumpError(stdout, stderr, err))
+				}
+				Expect(err).ToNot(HaveOccurred())
+
+				// Marshal the yaml file into a map
+				var cfgMap map[string]interface{}
+				err = yaml.Unmarshal([]byte(readBytes), &cfgMap)
+				if err != nil {
+					fmt.Print(cmd.DumpError(stdout, stderr, err))
+				}
+				Expect(err).ToNot(HaveOccurred())
+
+				// Check if the config file contains the default manifests
+				cfgMapUnikernel, ok := cfgMap["unikraft"].(map[string]interface{})
+				Expect(ok).To(BeTrue())
+
+				// Cast the manifests list to an array
+				cfgMapUnikernelManifests, ok := cfgMapUnikernel["manifests"].([]interface{})
+				Expect(ok).To(BeTrue())
+
+				// Check if the default manifests are removed
+				Expect(cfgMapUnikernelManifests).To(HaveLen(0))
+
+				// Check if stdout is empty
+				Expect(stdout.String()).To(BeEmpty())
+			})
+		})
+
+		When("the config does not contain the link or it doesn't exist", func() {
+			BeforeEach(func() {
+				// Save the config file by moving it to a temporary location
+				err := os.Rename(cfg.Path(), cfg.Path()+".tmp")
+				if err != nil {
+					fmt.Print(cmd.DumpError(stdout, stderr, err))
+				}
+				Expect(err).ToNot(HaveOccurred())
+			})
+			AfterEach(func() {
+				// Restore the config file
+				err := os.Rename(cfg.Path()+".tmp", cfg.Path())
+				if err != nil {
+					fmt.Print(cmd.DumpError(stdout, stderr, err))
+				}
+				Expect(err).ToNot(HaveOccurred())
+			})
+			It("should do nothing and print a warning", func() {
+				cmd.Args = append(cmd.Args, "https://example.com")
+				err := cmd.Run()
+				if err != nil {
+					fmt.Print(cmd.DumpError(stdout, stderr, err))
+				}
+				Expect(err).ToNot(HaveOccurred())
+				Expect(stderr.String()).To(BeEmpty())
+
+				// Read the config file
+				osFile, err := os.Open(cfg.Path())
+				if err != nil {
+					fmt.Print(cmd.DumpError(stdout, stderr, err))
+				}
+				Expect(err).ToNot(HaveOccurred())
+				defer osFile.Close()
+
+				osFileInfo, err := osFile.Stat()
+				if err != nil {
+					fmt.Print(cmd.DumpError(stdout, stderr, err))
+				}
+				Expect(err).ToNot(HaveOccurred())
+
+				// Check if the config file is not empty
+				Expect(osFileInfo.Size()).To(BeNumerically(">", 0))
+
+				// Check if the config file has 600 permissions
+				Expect(osFileInfo.Mode().Perm()).To(Equal(os.FileMode(0o600)))
+
+				// Read file content
+				readBytes, err := os.ReadFile(cfg.Path())
+				if err != nil {
+					fmt.Print(cmd.DumpError(stdout, stderr, err))
+				}
+				Expect(err).ToNot(HaveOccurred())
+
+				// Marshal the yaml file into a map
+				var cfgMap map[string]interface{}
+				err = yaml.Unmarshal([]byte(readBytes), &cfgMap)
+				if err != nil {
+					fmt.Print(cmd.DumpError(stdout, stderr, err))
+				}
+				Expect(err).ToNot(HaveOccurred())
+
+				// Check if the config file contains the default manifests
+				cfgMapUnikernel, ok := cfgMap["unikraft"].(map[string]interface{})
+				Expect(ok).To(BeTrue())
+
+				// Cast the manifests list to an array
+				cfgMapUnikernelManifests, ok := cfgMapUnikernel["manifests"].([]interface{})
+				Expect(ok).To(BeTrue())
+
+				// Check if the default manifests are still there
+				Expect(cfgMapUnikernelManifests).To(HaveLen(1))
+				Expect(cfgMapUnikernelManifests[0]).To(Equal("https://manifests.kraftkit.sh/index.yaml"))
+
+				// Check if stdout contains the warning
+				Expect(stdout.String()).To(MatchRegexp(`^{"level":"warning","msg":"manifest not found: https://example\.com"}\n$`))
+			})
+		})
+	})
+
+	Context("unsourcing multiple links in the config file", func() {
+		When("a config file was already present, and all links are unique", func() {
+			BeforeEach(func() {
+				unsourceArgs := make([]string, len(cmd.Args))
+				copy(unsourceArgs, cmd.Args)
+
+				for idx, arg := range cmd.Args {
+					if arg == "unsource" {
+						cmd.Args[idx] = "source"
+						break
 					}
+				}
 
-					cmd.Args = append(cmd.Args, "--force")
-					cmd.Args = append(cmd.Args, "https://example1.com")
-					cmd.Args = append(cmd.Args, "https://example2.com")
-					cmd.Args = append(cmd.Args, "https://example3.com")
-					err := cmd.Run()
-					if err != nil {
-						fmt.Print(cmd.DumpError(stdout, stderr, err))
-					}
-					Expect(err).ToNot(HaveOccurred())
-					Expect(stderr.String()).To(BeEmpty())
+				cmd.Args = append(cmd.Args, "--force")
+				cmd.Args = append(cmd.Args, "https://example1.com")
+				cmd.Args = append(cmd.Args, "https://example2.com")
+				cmd.Args = append(cmd.Args, "https://example3.com")
+				err := cmd.Run()
+				if err != nil {
+					fmt.Print(cmd.DumpError(stdout, stderr, err))
+				}
+				Expect(err).ToNot(HaveOccurred())
+				Expect(stderr.String()).To(BeEmpty())
 
-					// Recreate the command to reuse
-					stdout = fcmd.NewIOStream()
-					stderr = fcmd.NewIOStream()
+				// Recreate the command to reuse
+				stdout = fcmd.NewIOStream()
+				stderr = fcmd.NewIOStream()
 
-					cmd = fcmd.NewKraft(stdout, stderr, cfg.Path())
-					cmd.Args = unsourceArgs
-				})
-
-				It("should remove the links and print nothing", func() {
-					cmd.Args = append(cmd.Args, "https://example1.com")
-					cmd.Args = append(cmd.Args, "https://example2.com")
-					cmd.Args = append(cmd.Args, "https://example3.com")
-					err := cmd.Run()
-					if err != nil {
-						fmt.Print(cmd.DumpError(stdout, stderr, err))
-					}
-					Expect(err).ToNot(HaveOccurred())
-					Expect(stderr.String()).To(BeEmpty())
-
-					// Read the config file
-					osFile, err := os.Open(cfg.Path())
-					if err != nil {
-						fmt.Print(cmd.DumpError(stdout, stderr, err))
-					}
-					Expect(err).ToNot(HaveOccurred())
-					defer osFile.Close()
-
-					osFileInfo, err := osFile.Stat()
-					if err != nil {
-						fmt.Print(cmd.DumpError(stdout, stderr, err))
-					}
-					Expect(err).ToNot(HaveOccurred())
-
-					// Check if the config file is not empty
-					Expect(osFileInfo.Size()).To(BeNumerically(">", 0))
-
-					// Check if the config file has 600 permissions
-					Expect(osFileInfo.Mode().Perm()).To(Equal(os.FileMode(0o600)))
-
-					// Read file content
-					readBytes, err := os.ReadFile(cfg.Path())
-					if err != nil {
-						fmt.Print(cmd.DumpError(stdout, stderr, err))
-					}
-					Expect(err).ToNot(HaveOccurred())
-
-					// Marshal the yaml file into a map
-					var cfgMap map[string]interface{}
-					err = yaml.Unmarshal([]byte(readBytes), &cfgMap)
-					if err != nil {
-						fmt.Print(cmd.DumpError(stdout, stderr, err))
-					}
-					Expect(err).ToNot(HaveOccurred())
-
-					// Check if the config file contains the default manifests
-					cfgMapUnikernel, ok := cfgMap["unikraft"].(map[string]interface{})
-					Expect(ok).To(BeTrue())
-
-					// Cast the manifests list to an array
-					cfgMapUnikernelManifests, ok := cfgMapUnikernel["manifests"].([]interface{})
-					Expect(ok).To(BeTrue())
-
-					// Check if the additional links are removed
-					Expect(cfgMapUnikernelManifests).To(HaveLen(1))
-					Expect(cfgMapUnikernelManifests[0]).To(Equal("https://manifests.kraftkit.sh/index.yaml"))
-
-					// Check if stdout is empty
-					Expect(stdout.String()).To(BeEmpty())
-				})
+				cmd = fcmd.NewKraft(stdout, stderr, cfg.Path())
+				cmd.Args = unsourceArgs
 			})
 
-			When("a config file was already presend, and the second unsourced link is duplicate", func() {
-				BeforeEach(func() {
-					unsourceArgs := make([]string, len(cmd.Args))
-					copy(unsourceArgs, cmd.Args)
+			It("should remove the links and print nothing", func() {
+				cmd.Args = append(cmd.Args, "https://example1.com")
+				cmd.Args = append(cmd.Args, "https://example2.com")
+				cmd.Args = append(cmd.Args, "https://example3.com")
+				err := cmd.Run()
+				if err != nil {
+					fmt.Print(cmd.DumpError(stdout, stderr, err))
+				}
+				Expect(err).ToNot(HaveOccurred())
+				Expect(stderr.String()).To(BeEmpty())
 
-					for idx, arg := range cmd.Args {
-						if arg == "unsource" {
-							cmd.Args[idx] = "source"
-							break
-						}
+				// Read the config file
+				osFile, err := os.Open(cfg.Path())
+				if err != nil {
+					fmt.Print(cmd.DumpError(stdout, stderr, err))
+				}
+				Expect(err).ToNot(HaveOccurred())
+				defer osFile.Close()
+
+				osFileInfo, err := osFile.Stat()
+				if err != nil {
+					fmt.Print(cmd.DumpError(stdout, stderr, err))
+				}
+				Expect(err).ToNot(HaveOccurred())
+
+				// Check if the config file is not empty
+				Expect(osFileInfo.Size()).To(BeNumerically(">", 0))
+
+				// Check if the config file has 600 permissions
+				Expect(osFileInfo.Mode().Perm()).To(Equal(os.FileMode(0o600)))
+
+				// Read file content
+				readBytes, err := os.ReadFile(cfg.Path())
+				if err != nil {
+					fmt.Print(cmd.DumpError(stdout, stderr, err))
+				}
+				Expect(err).ToNot(HaveOccurred())
+
+				// Marshal the yaml file into a map
+				var cfgMap map[string]interface{}
+				err = yaml.Unmarshal([]byte(readBytes), &cfgMap)
+				if err != nil {
+					fmt.Print(cmd.DumpError(stdout, stderr, err))
+				}
+				Expect(err).ToNot(HaveOccurred())
+
+				// Check if the config file contains the default manifests
+				cfgMapUnikernel, ok := cfgMap["unikraft"].(map[string]interface{})
+				Expect(ok).To(BeTrue())
+
+				// Cast the manifests list to an array
+				cfgMapUnikernelManifests, ok := cfgMapUnikernel["manifests"].([]interface{})
+				Expect(ok).To(BeTrue())
+
+				// Check if the additional links are removed
+				Expect(cfgMapUnikernelManifests).To(HaveLen(1))
+				Expect(cfgMapUnikernelManifests[0]).To(Equal("https://manifests.kraftkit.sh/index.yaml"))
+
+				// Check if stdout is empty
+				Expect(stdout.String()).To(BeEmpty())
+			})
+		})
+
+		When("a config file was already presend, and the second unsourced link is duplicate", func() {
+			BeforeEach(func() {
+				unsourceArgs := make([]string, len(cmd.Args))
+				copy(unsourceArgs, cmd.Args)
+
+				for idx, arg := range cmd.Args {
+					if arg == "unsource" {
+						cmd.Args[idx] = "source"
+						break
 					}
+				}
 
-					cmd.Args = append(cmd.Args, "--force")
-					cmd.Args = append(cmd.Args, "https://example1.com")
-					cmd.Args = append(cmd.Args, "https://example2.com")
-					cmd.Args = append(cmd.Args, "https://example3.com")
-					err := cmd.Run()
-					if err != nil {
-						fmt.Print(cmd.DumpError(stdout, stderr, err))
-					}
-					Expect(err).ToNot(HaveOccurred())
-					Expect(stderr.String()).To(BeEmpty())
+				cmd.Args = append(cmd.Args, "--force")
+				cmd.Args = append(cmd.Args, "https://example1.com")
+				cmd.Args = append(cmd.Args, "https://example2.com")
+				cmd.Args = append(cmd.Args, "https://example3.com")
+				err := cmd.Run()
+				if err != nil {
+					fmt.Print(cmd.DumpError(stdout, stderr, err))
+				}
+				Expect(err).ToNot(HaveOccurred())
+				Expect(stderr.String()).To(BeEmpty())
 
-					// Recreate the command to reuse
-					stdout = fcmd.NewIOStream()
-					stderr = fcmd.NewIOStream()
+				// Recreate the command to reuse
+				stdout = fcmd.NewIOStream()
+				stderr = fcmd.NewIOStream()
 
-					cmd = fcmd.NewKraft(stdout, stderr, cfg.Path())
-					cmd.Args = unsourceArgs
-				})
+				cmd = fcmd.NewKraft(stdout, stderr, cfg.Path())
+				cmd.Args = unsourceArgs
+			})
 
-				It("should remove the first two links and print a warning", func() {
-					cmd.Args = append(cmd.Args, "https://example1.com")
-					cmd.Args = append(cmd.Args, "https://example2.com")
-					cmd.Args = append(cmd.Args, "https://example2.com")
-					err := cmd.Run()
-					if err != nil {
-						fmt.Print(cmd.DumpError(stdout, stderr, err))
-					}
-					Expect(err).ToNot(HaveOccurred())
-					Expect(stderr.String()).To(BeEmpty())
+			It("should remove the first two links and print a warning", func() {
+				cmd.Args = append(cmd.Args, "https://example1.com")
+				cmd.Args = append(cmd.Args, "https://example2.com")
+				cmd.Args = append(cmd.Args, "https://example2.com")
+				err := cmd.Run()
+				if err != nil {
+					fmt.Print(cmd.DumpError(stdout, stderr, err))
+				}
+				Expect(err).ToNot(HaveOccurred())
+				Expect(stderr.String()).To(BeEmpty())
 
-					// Read the config file
-					osFile, err := os.Open(cfg.Path())
-					if err != nil {
-						fmt.Print(cmd.DumpError(stdout, stderr, err))
-					}
-					Expect(err).ToNot(HaveOccurred())
-					defer osFile.Close()
+				// Read the config file
+				osFile, err := os.Open(cfg.Path())
+				if err != nil {
+					fmt.Print(cmd.DumpError(stdout, stderr, err))
+				}
+				Expect(err).ToNot(HaveOccurred())
+				defer osFile.Close()
 
-					osFileInfo, err := osFile.Stat()
-					if err != nil {
-						fmt.Print(cmd.DumpError(stdout, stderr, err))
-					}
-					Expect(err).ToNot(HaveOccurred())
+				osFileInfo, err := osFile.Stat()
+				if err != nil {
+					fmt.Print(cmd.DumpError(stdout, stderr, err))
+				}
+				Expect(err).ToNot(HaveOccurred())
 
-					// Check if the config file is not empty
-					Expect(osFileInfo.Size()).To(BeNumerically(">", 0))
+				// Check if the config file is not empty
+				Expect(osFileInfo.Size()).To(BeNumerically(">", 0))
 
-					// Check if the config file has 600 permissions
-					Expect(osFileInfo.Mode().Perm()).To(Equal(os.FileMode(0o600)))
+				// Check if the config file has 600 permissions
+				Expect(osFileInfo.Mode().Perm()).To(Equal(os.FileMode(0o600)))
 
-					// Read file content
-					readBytes, err := os.ReadFile(cfg.Path())
-					if err != nil {
-						fmt.Print(cmd.DumpError(stdout, stderr, err))
-					}
-					Expect(err).ToNot(HaveOccurred())
+				// Read file content
+				readBytes, err := os.ReadFile(cfg.Path())
+				if err != nil {
+					fmt.Print(cmd.DumpError(stdout, stderr, err))
+				}
+				Expect(err).ToNot(HaveOccurred())
 
-					// Marshal the yaml file into a map
-					var cfgMap map[string]interface{}
-					err = yaml.Unmarshal([]byte(readBytes), &cfgMap)
-					if err != nil {
-						fmt.Print(cmd.DumpError(stdout, stderr, err))
-					}
-					Expect(err).ToNot(HaveOccurred())
+				// Marshal the yaml file into a map
+				var cfgMap map[string]interface{}
+				err = yaml.Unmarshal([]byte(readBytes), &cfgMap)
+				if err != nil {
+					fmt.Print(cmd.DumpError(stdout, stderr, err))
+				}
+				Expect(err).ToNot(HaveOccurred())
 
-					// Check if the config file contains the default manifests
-					cfgMapUnikernel, ok := cfgMap["unikraft"].(map[string]interface{})
-					Expect(ok).To(BeTrue())
+				// Check if the config file contains the default manifests
+				cfgMapUnikernel, ok := cfgMap["unikraft"].(map[string]interface{})
+				Expect(ok).To(BeTrue())
 
-					// Cast the manifests list to an array
-					cfgMapUnikernelManifests, ok := cfgMapUnikernel["manifests"].([]interface{})
-					Expect(ok).To(BeTrue())
+				// Cast the manifests list to an array
+				cfgMapUnikernelManifests, ok := cfgMapUnikernel["manifests"].([]interface{})
+				Expect(ok).To(BeTrue())
 
-					// Check if the default manifest and the third link is still there
-					Expect(cfgMapUnikernelManifests).To(HaveLen(2))
-					Expect(cfgMapUnikernelManifests[0]).To(Equal("https://manifests.kraftkit.sh/index.yaml"))
-					Expect(cfgMapUnikernelManifests[1]).To(Equal("https://example3.com"))
+				// Check if the default manifest and the third link is still there
+				Expect(cfgMapUnikernelManifests).To(HaveLen(2))
+				Expect(cfgMapUnikernelManifests[0]).To(Equal("https://manifests.kraftkit.sh/index.yaml"))
+				Expect(cfgMapUnikernelManifests[1]).To(Equal("https://example3.com"))
 
-					// Check if stdout has a warning
-					Expect(stdout.String()).To(MatchRegexp(`^{"level":"warning","msg":"manifest not found: https://example2\.com"}\n$`))
-				})
+				// Check if stdout has a warning
+				Expect(stdout.String()).To(MatchRegexp(`^{"level":"warning","msg":"manifest not found: https://example2\.com"}\n$`))
 			})
 		})
 	})


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [x] Updated relevant documentation.

### Description of changes

This removes unneeded `Describe` calls in the `pkg` e2e tests to match the structure of the `net` tests.
