### PR TITLE
fix(kraft): Fix issue related to empty application arguments

### DIFF
--- a/internal/cli/kraft/run/utils.go
+++ b/internal/cli/kraft/run/utils.go
@@ -407,7 +407,9 @@ func (opts *RunOptions) prepareRootfs(ctx context.Context, machine *machineapi.M
 					machine.Spec.Env[k] = v
 				}
 
-				machine.Spec.ApplicationArgs = ramfs.Args()
+				if len(machine.Spec.ApplicationArgs) == 0 {
+					machine.Spec.ApplicationArgs = ramfs.Args()
+				}
 
 				return nil
 			},


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes
Running `kraft run --rm --plat qemu --arch x86_64` on `helloworld-c` triggers the following assert:
`[    0.104855] ERR:  [appelfloader] Program name missing (no argv[1])`

It seems that `ramfs.Args()` is empty and `machine.Spec.ApplicationArgs` is already set from `runner.project.Command()` (`runner_kraftfile_runtime.go`).
