### PR TITLE
fix(volume): Use `vimport` as import name

### DIFF
--- a/internal/cli/kraft/cloud/volume/volume.go
+++ b/internal/cli/kraft/cloud/volume/volume.go
@@ -16,7 +16,7 @@ import (
 	"kraftkit.sh/internal/cli/kraft/cloud/volume/create"
 	"kraftkit.sh/internal/cli/kraft/cloud/volume/detach"
 	"kraftkit.sh/internal/cli/kraft/cloud/volume/get"
-	"kraftkit.sh/internal/cli/kraft/cloud/volume/import"
+	vimport "kraftkit.sh/internal/cli/kraft/cloud/volume/import"
 	"kraftkit.sh/internal/cli/kraft/cloud/volume/list"
 	"kraftkit.sh/internal/cli/kraft/cloud/volume/remove"
 


### PR DESCRIPTION
This fixes a new static check signalling an unidentified
type import.

Signed-off-by: Alexander Jung <alex@unikraft.io>

<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [ ] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [ ] Tested your changes against relevant architectures and platforms;
  - [ ] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->
