### PR TITLE
feat(compose): Support depends_on property

### DIFF
--- a/internal/cli/kraft/compose/create/create.go
+++ b/internal/cli/kraft/compose/create/create.go
@@ -274,7 +274,9 @@ func (opts *CreateOptions) Run(ctx context.Context, args []string) error {
 		return err
 	}
 
-	for _, service := range services {
+	orderedServices := project.ServicesOrderedByDependencies(ctx, services, true)
+	for _, service := range orderedServices {
+		log.G(ctx).Debugf("creating service %s...", service.Name)
 		alreadyCreated := false
 		for _, machine := range machines.Items {
 			if service.ContainerName != machine.Name {

--- a/internal/cli/kraft/compose/down/down.go
+++ b/internal/cli/kraft/compose/down/down.go
@@ -99,7 +99,8 @@ func (opts *DownOptions) Run(ctx context.Context, args []string) error {
 		return err
 	}
 
-	for _, service := range project.Services {
+	orderedServices := project.ServicesReversedByDependencies(ctx, project.Services, false)
+	for _, service := range orderedServices {
 		for _, machine := range machines.Items {
 			if service.ContainerName == machine.Name {
 				if err := removeService(ctx, service); err != nil {

--- a/internal/cli/kraft/compose/pause/pause.go
+++ b/internal/cli/kraft/compose/pause/pause.go
@@ -91,8 +91,9 @@ func (opts *PauseOptions) Run(ctx context.Context, args []string) error {
 		return err
 	}
 
+	orderedServices := project.ServicesReversedByDependencies(ctx, services, false)
 	machinesToPause := []string{}
-	for _, service := range services {
+	for _, service := range orderedServices {
 		for _, machine := range machines.Items {
 			if service.ContainerName == machine.Name && machine.Status.State == machineapi.MachineStateRunning {
 				machinesToPause = append(machinesToPause, machine.Name)

--- a/internal/cli/kraft/compose/start/start.go
+++ b/internal/cli/kraft/compose/start/start.go
@@ -91,8 +91,9 @@ func (opts *StartOptions) Run(ctx context.Context, args []string) error {
 		return err
 	}
 
+	orderedServices := project.ServicesOrderedByDependencies(ctx, services, true)
 	machinesToStart := []string{}
-	for _, service := range services {
+	for _, service := range orderedServices {
 		for _, machine := range machines.Items {
 			if service.ContainerName == machine.Name {
 				if machine.Status.State == machineapi.MachineStateCreated || machine.Status.State == machineapi.MachineStateExited {

--- a/internal/cli/kraft/compose/stop/stop.go
+++ b/internal/cli/kraft/compose/stop/stop.go
@@ -91,8 +91,9 @@ func (opts *StopOptions) Run(ctx context.Context, args []string) error {
 		return err
 	}
 
+	orderedServices := project.ServicesReversedByDependencies(ctx, services, false)
 	machinesToStop := []string{}
-	for _, service := range services {
+	for _, service := range orderedServices {
 		for _, machine := range machines.Items {
 			if service.ContainerName == machine.Name &&
 				(machine.Status.State == machineapi.MachineStateRunning ||

--- a/internal/cli/kraft/compose/unpause/unpause.go
+++ b/internal/cli/kraft/compose/unpause/unpause.go
@@ -91,8 +91,9 @@ func (opts *UnpauseOptions) Run(ctx context.Context, args []string) error {
 		return err
 	}
 
+	orderedServices := project.ServicesOrderedByDependencies(ctx, services, true)
 	machinesToUnpause := []string{}
-	for _, service := range services {
+	for _, service := range orderedServices {
 		for _, machine := range machines.Items {
 			if service.ContainerName == machine.Name {
 				if machine.Status.State == machineapi.MachineStatePaused {


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [x] Updated relevant documentation.

### Description of changes
The depends_on property allows specifying dependencies between services. The services will always be started in the order of the dependencies and always be stopped in the opposite order. At the moment we cannot do healthchecks in krafkit, so the condition of the dependency is ignored.

E.g.
```yaml
services:
  a:   
    image: nginx:1.15
    depends_on:
      - b
  b:
    image: nginx:1.15
```

``kraft compose up -d``

```
 i  creating network test_default...
 i  creating service b...
 i  creating service a..
```

```kraft compose down```

```
 i  removing service a...
 i  removing service b...
 i  removing network test_default..
```
<!--
Please provide a detailed description of the changes made in this new PR.
-->
