### PR TITLE
fix(oci): Don't delete dependencies of index

### DIFF
--- a/oci/pack.go
+++ b/oci/pack.go
@@ -291,7 +291,7 @@ func NewPackageFromTarget(ctx context.Context, targ target.Target, opts ...packm
 		}
 
 	case packmanager.StrategyOverwrite:
-		if err := ocipack.handle.DeleteIndex(ctx, ocipack.ref.Name(), true); err != nil {
+		if err := ocipack.handle.DeleteIndex(ctx, ocipack.ref.Name(), false); err != nil {
 			return nil, fmt.Errorf("could not remove existing index: %w", err)
 		}
 


### PR DESCRIPTION
When we package an application it can be the case that we have a dependency on another package (e.g. a kernel). In these cases, the dependency is not actually packed together with our application, instead we just keep a reference to it. The problem arises when we attempt to overwrite such a package. Because all dependencies were previously deleted, this meant that both of the underlying packages would be removed, but only the application would get repackaged, resulting in an app that cannot be run due to missing layers.

Setting this flag to false and not removing dependencies solves this issue, but causes the cache to grow indefinitely, which is less than ideal.

<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [x] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->
