### PR TITLE
fix(Makefile): Correct verbosity

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -148,6 +148,7 @@ $(addprefix $(.PROXY), $(BIN)):
 	GOOS=$(GOOS) \
 	GOARCH=$(GOARCH) \
 	$(GO) build \
+		-v \
 		-tags "containers_image_storage_stub,containers_image_openpgp" \
 		-buildmode=pie \
 		-gcflags=all='$(GO_GCFLAGS)' \


### PR DESCRIPTION
The PR #1630 accidentally overwrote the changes from #1646.

This commit reverts this mistake.

Signed-off-by: Alexander Jung <alex@unikraft.io>

<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [ ] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [ ] Tested your changes against relevant architectures and platforms;
  - [ ] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->
