### PR TITLE
fix(initrd): Remove parse error message for OCI images

### DIFF
--- a/initrd/ociimage.go
+++ b/initrd/ociimage.go
@@ -42,7 +42,6 @@ func NewFromOCIImage(ctx context.Context, path string, opts ...InitrdOption) (In
 
 	ref, err := alltransports.ParseImageName(path)
 	if err != nil {
-		log.G(ctx).Warnf("could not parse image name: %s", err.Error())
 		return nil, err
 	}
 


### PR DESCRIPTION
This error is interesting only for OCI images, so remove it.

GitHub-Closes: #1672

<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [ ] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [ ] Tested your changes against relevant architectures and platforms;
  - [ ] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->
