### PR TITLE
feat(internal): Prompt for rerunning configure step

### DIFF
--- a/internal/cli/kraft/fetch/fetch.go
+++ b/internal/cli/kraft/fetch/fetch.go
@@ -25,6 +25,7 @@ import (
 	"kraftkit.sh/log"
 	"kraftkit.sh/make"
 	"kraftkit.sh/packmanager"
+	"kraftkit.sh/tui/confirm"
 	"kraftkit.sh/tui/paraprogress"
 	"kraftkit.sh/tui/selection"
 	"kraftkit.sh/unikraft/app"
@@ -419,23 +420,38 @@ func (opts *FetchOptions) Run(ctx context.Context, _ []string) error {
 		targ := targ
 
 		if !opts.NoConfigure {
-			processes = append(processes, paraprogress.NewProcess(
-				fmt.Sprintf("configuring %s (%s)", targ.Name(), target.TargetPlatArchName(targ)),
-				func(ctx context.Context, w func(progress float64)) error {
-					return opts.project.Configure(
-						ctx,
-						targ, // Target-specific options
-						nil,  // No extra configuration options
-						make.WithProgressFunc(w),
-						make.WithSilent(true),
-						make.WithExecOptions(
-							exec.WithStdin(iostreams.G(ctx).In),
-							exec.WithStdout(log.G(ctx).Writer()),
-							exec.WithStderr(log.G(ctx).WriterLevel(logrus.ErrorLevel)),
-						),
-					)
-				},
-			))
+			var err error
+			configure := true
+
+			if opts.project.IsConfigured(targ) {
+				configure, err = confirm.NewConfirm("project already configured, are you sure you want to rerun the configure step:")
+				if err != nil {
+					return err
+				}
+			}
+
+			if configure {
+				processes = append(processes, paraprogress.NewProcess(
+					fmt.Sprintf("configuring %s (%s)", targ.Name(), target.TargetPlatArchName(targ)),
+					func(ctx context.Context, w func(progress float64)) error {
+						return opts.project.Configure(
+							ctx,
+							targ, // Target-specific options
+							nil,  // No extra configuration options
+							make.WithProgressFunc(w),
+							make.WithSilent(true),
+							make.WithExecOptions(
+								exec.WithStdin(iostreams.G(ctx).In),
+								exec.WithStdout(log.G(ctx).Writer()),
+								exec.WithStderr(log.G(ctx).WriterLevel(logrus.ErrorLevel)),
+							),
+						)
+					},
+				))
+			} else {
+				log.G(ctx).Info("skipping configure step")
+				log.G(ctx).Info("to omit this prompt, use the '--no-configure' flag")
+			}
 		}
 
 		processes = append(processes, paraprogress.NewProcess(


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [ ] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [ ] Tested your changes against relevant architectures and platforms;
  - [ ] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

This is needed, as the `configure` step would run `make defconfig` in the background which basically ignores options in the case where a user disables an option `=N` and the default is `=Y`.

By skipping the configure step, we skip this problem. The configure step should not be needed more than once and should only be ran if the user wants so explicitly.

GitHub-Fixes: #1192