### PR TITLE
feat(internal): Allow for specifying optional measurement units

### DIFF
--- a/internal/cli/kraft/cloud/compose/up/up.go
+++ b/internal/cli/kraft/cloud/compose/up/up.go
@@ -248,7 +248,7 @@ func Up(ctx context.Context, opts *UpOptions, args ...string) error {
 			Client:                 opts.Client,
 			Env:                    env,
 			Image:                  service.Image,
-			Memory:                 uint(memory),
+			Memory:                 fmt.Sprintf("%d", memory),
 			Metro:                  opts.Metro,
 			Name:                   name,
 			ServiceGroupNameOrUUID: serviceGroup,

--- a/internal/cli/kraft/cloud/deploy/deploy.go
+++ b/internal/cli/kraft/cloud/deploy/deploy.go
@@ -45,7 +45,7 @@ type DeployOptions struct {
 	Jobs                   int                       `long:"jobs" short:"j" usage:"Allow N jobs at once"`
 	KernelDbg              bool                      `long:"dbg" usage:"Build the debuggable (symbolic) kernel image instead of the stripped image"`
 	Kraftfile              string                    `local:"true" long:"kraftfile" short:"K" usage:"Set the Kraftfile to use"`
-	Memory                 int                       `local:"true" long:"memory" short:"M" usage:"Specify the amount of memory to allocate (MiB)"`
+	Memory                 string                    `local:"true" long:"memory" short:"M" usage:"Specify the amount of memory to allocate (MiB increments)"`
 	Metro                  string                    `noattribute:"true"`
 	Name                   string                    `local:"true" long:"name" short:"n" usage:"Name of the deployment"`
 	NoCache                bool                      `long:"no-cache" short:"F" usage:"Force a rebuild even if existing intermediate artifacts already exist"`

--- a/internal/cli/kraft/cloud/deploy/deployer_image_name.go
+++ b/internal/cli/kraft/cloud/deploy/deployer_image_name.go
@@ -97,7 +97,7 @@ func (deployer *deployerImageName) Deploy(ctx context.Context, opts *DeployOptio
 					Features:               opts.Features,
 					Domain:                 opts.Domain,
 					Image:                  deployer.imageName,
-					Memory:                 uint(opts.Memory),
+					Memory:                 opts.Memory,
 					Metro:                  opts.Metro,
 					Name:                   opts.Name,
 					Ports:                  opts.Ports,

--- a/internal/cli/kraft/cloud/deploy/deployer_kraftfile_runtime.go
+++ b/internal/cli/kraft/cloud/deploy/deployer_kraftfile_runtime.go
@@ -124,7 +124,7 @@ func (deployer *deployerKraftfileRuntime) Deploy(ctx context.Context, opts *Depl
 		Env:                    opts.Env,
 		Domain:                 opts.Domain,
 		Image:                  packs[0].ID(),
-		Memory:                 uint(opts.Memory),
+		Memory:                 opts.Memory,
 		Metro:                  opts.Metro,
 		Name:                   opts.Name,
 		Ports:                  opts.Ports,


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [ ] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [ ] Tested your changes against relevant architectures and platforms;
  - [ ] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

The value is then converted to mebibytes by deviding the integer by 1024*1024. If something like ~3.2Mi are specified, the value will be truncated down to 3Mi.

GitHub-Closes: #1513