### PR TITLE
feat(run): Allow application args overriding from CLI

### DIFF
--- a/internal/cli/kraft/run/runner_kraftfile_runtime.go
+++ b/internal/cli/kraft/run/runner_kraftfile_runtime.go
@@ -352,7 +352,9 @@ func (runner *runnerKraftfileRuntime) Prepare(ctx context.Context, opts *RunOpti
 		}
 	}
 
-	if len(runner.project.Command()) > 0 {
+	if len(runner.args) > 0 {
+		machine.Spec.ApplicationArgs = runner.args
+	} else if len(runner.project.Command()) > 0 {
 		machine.Spec.ApplicationArgs = runner.project.Command()
 	} else if len(runtime.Command()) > 0 {
 		machine.Spec.ApplicationArgs = runtime.Command()


### PR DESCRIPTION
Passing arguments from the CLI directly overrides any commands from the Kraftfile or Dockerfile. The first argument of kraft run is the context and any subsequence argument is considered an application argument.

<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [x] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

Closes: #1614