### PR TITLE
fix(initrd): Correctly propagate workdir to dockerfile

### DIFF
--- a/initrd/dockerfile.go
+++ b/initrd/dockerfile.go
@@ -111,7 +111,6 @@ type dockerfile struct {
 	dockerfile string
 	env        []string
 	files      []string
-	workdir    string
 }
 
 func fixedWriteCloser(wc io.WriteCloser) filesync.FileOutputFunc {
@@ -128,9 +127,10 @@ func NewFromDockerfile(ctx context.Context, path string, opts ...InitrdOption) (
 	}
 
 	initrd := dockerfile{
-		opts:       InitrdOptions{},
+		opts:       InitrdOptions{
+			workdir: filepath.Dir(path),
+		},
 		dockerfile: path,
-		workdir:    filepath.Dir(path),
 	}
 
 	for _, opt := range opts {
@@ -297,8 +297,8 @@ func (initrd *dockerfile) Build(ctx context.Context) (string, error) {
 		},
 		CacheExports: cacheExports,
 		LocalDirs: map[string]string{
-			"context":    initrd.workdir,
-			"dockerfile": filepath.Dir(initrd.dockerfile),
+			"context":    initrd.opts.workdir,
+			"dockerfile": filepath.Dir(filepath.Join(initrd.opts.workdir, initrd.dockerfile)),
 		},
 		Frontend: "dockerfile.v0",
 		FrontendAttrs: map[string]string{


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [x] Updated relevant documentation.

### Description of changes
Commit 5cb57adbb0cf81fbc59ce69761c31fbe186030d5 reworked the way the workdir is passed to different initrd implementation. This ended up
in having a duplicate workdir entry in the dockerfile initrd type. Changes take into account that with the new implementation, the path of the dockerfile is relative to the workdir.

This change ultimately solves an issue related to kraftkit not being able to find the dockerfile when building outside the cwd:

```
$ kraft build ../scss/redis/
<!> building rootfs                                                                                                                                                                                                                                               x86_64 [2.8s]
 i  creating ephemeral buildkit container
 i  #1 [internal] load build definition from Dockerfile
 i  #1 transferring dockerfile: 2B done
 i  #1 DONE 0.0s
 E  could not wait for err group: could not solve: failed to solve: failed to read dockerfile: open Dockerfile: no such file or directory
```

<!--
Please provide a detailed description of the changes made in this new PR.
-->
