### PR TITLE
fix(run): Pass workdir when preparing rootfs

### DIFF
--- a/internal/cli/kraft/run/utils.go
+++ b/internal/cli/kraft/run/utils.go
@@ -373,6 +373,7 @@ func (opts *RunOptions) prepareRootfs(ctx context.Context, machine *machineapi.M
 			"rootfs-cache",
 		)),
 		initrd.WithArchitecture(machine.Spec.Architecture),
+		initrd.WithWorkdir(opts.workdir),
 	)
 	if err != nil {
 		return fmt.Errorf("could not prepare initramfs: %w", err)


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [x] Updated relevant documentation.

### Description of changes

Follow-up for https://github.com/unikraft/kraftkit/pull/1696. Passing the workdir in the ``prepareRootfs`` step was previously missed, causing runs outside the current directory to fail.

<!--
Please provide a detailed description of the changes made in this new PR.
-->
