### PR TITLE
fix(buildenvs): Create '/run/user' directories

### DIFF
--- a/buildenvs/github-action.Dockerfile
+++ b/buildenvs/github-action.Dockerfile
@@ -113,7 +113,16 @@ RUN set -xe; \
     chown -R runner:runner /github/workspace; \
     usermod -aG 1000 runner; \
     usermod -aG 1001 runner; \
-    usermod -aG 1002 runner;
+    usermod -aG 1002 runner; \
+    mkdir -p /run/user/1000; \
+    mkdir -p /run/user/1001; \
+    mkdir -p /run/user/1002; \
+    chown -R runner:arunner /run/user/1000; \
+    chown -R runner:brunner /run/user/1001; \
+    chown -R runner:crunner /run/user/1002; \
+    chmod 0700 /run/user/1000; \
+    chmod 0700 /run/user/1001; \
+    chmod 0700 /run/user/1002;
 USER runner
 
 ENV CLICOLOR_FORCE=1


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [ ] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [ ] Tested your changes against relevant architectures and platforms;
  - [ ] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->


Fixes indirect warning:
```
time="2024-06-05T21:58:13Z" level=warning msg="\"/run/user/1001\" directory set by $XDG_RUNTIME_DIR does not exist. Either create the directory or unset $XDG_RUNTIME_DIR.: stat /run/user/1001: no such file or directory: Trying to pull image in the event that it is a public image."
```
