### PR TITLE
feat(action): Allow running in privileged mode

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -28,6 +28,10 @@ inputs:
     description: Log-level of the action
     required: false
     default: error
+  privileged:
+    decription: Run kraft in a privileged container
+    required: false
+    default: "false"
   runtimedir:
     description: Path to store runtime artifacts
     required: false
@@ -194,6 +198,7 @@ runs:
     run: |
       ACTION_WORKSPACE=$(echo "${GITHUB_WORKSPACE}" | grep -Eo "^.*work")
       docker run \
+        $([ "${{ inputs.privileged }}" = "true" ] && echo -n "--privileged") \
         --workdir /github/workspace \
         --rm \
         --env-file <(env) \


### PR DESCRIPTION
Running the kraft container in privileged mode allows users to networking operations in workflows.
Tested in https://github.com/unikraft/catalog/actions/runs/9480239077/job/26120574266

<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [x] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->
