### PR TITLE
fix(oci): Remove duplicate OS features from OCI config files

### DIFF
--- a/oci/manifest.go
+++ b/oci/manifest.go
@@ -11,6 +11,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"slices"
 	"sort"
 	"strconv"
 	"sync"
@@ -297,7 +298,7 @@ func (manifest *Manifest) Save(ctx context.Context, fullref string, onProgress f
 		Architecture: manifest.config.Architecture,
 		OS:           manifest.config.OS,
 		OSVersion:    manifest.config.OSVersion,
-		OSFeatures:   manifest.config.OSFeatures,
+		OSFeatures:   slices.Compact(manifest.config.OSFeatures),
 	}
 
 	configBlob, err := NewBlob(


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

Since this list is sorted, it is safe to use `Compact`.  The fact that duplicate KConfig entries are added are a symptom of re-packaging; so this simply cleans duplicates but persists old and new values.
