### PR TITLE
feat(kraft): Introduce "rootfs" deployer and packager runtime flag

### DIFF
--- a/internal/cli/kraft/cloud/deploy/deployer.go
+++ b/internal/cli/kraft/cloud/deploy/deployer.go
@@ -42,5 +42,6 @@ func deployers() []deployer {
 		&deployerImageName{},
 		&deployerKraftfileRuntime{},
 		&deployerKraftfileUnikraft{},
+		&deployerRootfs{},
 	}
 }

--- a/internal/cli/kraft/cloud/deploy/deployer_kraftfile_runtime.go
+++ b/internal/cli/kraft/cloud/deploy/deployer_kraftfile_runtime.go
@@ -108,6 +108,7 @@ func (deployer *deployerKraftfileRuntime) Deploy(ctx context.Context, opts *Depl
 		Project:      opts.Project,
 		Push:         true,
 		Rootfs:       opts.Rootfs,
+		Runtime:      opts.Runtime,
 		Strategy:     opts.Strategy,
 		Workdir:      opts.Workdir,
 	})

--- a/internal/cli/kraft/cloud/deploy/deployer_rootfs.go
+++ b/internal/cli/kraft/cloud/deploy/deployer_rootfs.go
@@ -1,0 +1,107 @@
+package deploy
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	kcclient "sdk.kraft.cloud/client"
+	kcinstances "sdk.kraft.cloud/instances"
+	kcservices "sdk.kraft.cloud/services"
+
+	"kraftkit.sh/unikraft/app"
+	"kraftkit.sh/unikraft/runtime"
+	"kraftkit.sh/unikraft/target"
+)
+
+type deployerRootfs struct {
+	args []string
+}
+
+func (deployer *deployerRootfs) Name() string {
+	return "rootfs"
+}
+
+func (deployer *deployerRootfs) String() string {
+	if len(deployer.args) == 0 {
+		return "run the cwd with Dockerfile"
+	}
+
+	return fmt.Sprintf("run the detected Dockerfile in the cwd and use '%s' as arg(s)", strings.Join(deployer.args, " "))
+}
+
+func (deployer *deployerRootfs) Deployable(ctx context.Context, opts *DeployOptions, args ...string) (bool, error) {
+	if opts.Project == nil {
+		// Do not capture the the project is not initialized, as we can still build
+		// the unikernel using the Dockerfile provided with the `--rootfs`.
+		_ = opts.initProject(ctx)
+	}
+
+	if opts.Project != nil && opts.Project.Rootfs() != "" && opts.Rootfs == "" {
+		opts.Rootfs = opts.Project.Rootfs()
+	}
+
+	// Maybe no `--rootfs` flag was provided, but there may be a local Dockerfile
+	// in the working directory.  If so, we can use that as the rootfs.
+
+	var rootfs string
+
+	if len(opts.Rootfs) > 0 {
+		rootfs = opts.Rootfs
+	} else {
+		rootfs = filepath.Join(opts.Workdir, "Dockerfile")
+
+		if _, err := os.Stat(rootfs); err != nil {
+			return false, fmt.Errorf("could not find Dockerfile")
+		}
+	}
+
+	opts.Rootfs = rootfs
+
+	if opts.Project == nil {
+		rt := runtime.DefaultKraftCloudRuntime
+
+		if len(opts.Runtime) > 0 {
+			rt = opts.Runtime
+
+			// Sanitize the runtime for Unikraft Cloud.
+
+			if !strings.Contains(rt, ":") {
+				rt += ":latest"
+			}
+
+			if strings.HasPrefix(rt, "unikraft.io") {
+				rt = "index." + rt
+			} else if strings.Contains(rt, "/") && !strings.Contains(rt, "unikraft.io") {
+				rt = "index.unikraft.io/" + rt
+			} else if !strings.HasPrefix(rt, "index.unikraft.io") {
+				rt = "index.unikraft.io/official/" + rt
+			}
+		}
+
+		runtime, err := runtime.NewRuntime(ctx, rt)
+		if err != nil {
+			return false, fmt.Errorf("could not create runtime: %w", err)
+		}
+
+		opts.Project, err = app.NewApplicationFromOptions(
+			app.WithRuntime(runtime),
+			app.WithName(opts.Name),
+			app.WithTargets([]*target.TargetConfig{target.DefaultKraftCloudTarget}),
+			app.WithCommand(args...),
+			app.WithWorkingDir(opts.Workdir),
+			app.WithRootfs(opts.Rootfs),
+		)
+		if err != nil {
+			return false, fmt.Errorf("could not create unikernel application: %w", err)
+		}
+	}
+
+	return true, nil
+}
+
+func (deployer *deployerRootfs) Deploy(ctx context.Context, opts *DeployOptions, args ...string) (*kcclient.ServiceResponse[kcinstances.GetResponseItem], *kcclient.ServiceResponse[kcservices.GetResponseItem], error) {
+	return (&deployerKraftfileRuntime{}).Deploy(ctx, opts, args...)
+}

--- a/internal/cli/kraft/pkg/packager_kraftfile_runtime.go
+++ b/internal/cli/kraft/pkg/packager_kraftfile_runtime.go
@@ -54,8 +54,14 @@ func (p *packagerKraftfileRuntime) Packagable(ctx context.Context, opts *PkgOpti
 func (p *packagerKraftfileRuntime) Pack(ctx context.Context, opts *PkgOptions, args ...string) ([]pack.Package, error) {
 	var err error
 	var targ target.Target
+	var runtimeName string
 
-	runtimeName := opts.Project.Runtime().Name()
+	if len(opts.Runtime) > 0 {
+		runtimeName = opts.Runtime
+	} else {
+		runtimeName = opts.Project.Runtime().Name()
+	}
+
 	if opts.Platform == "kraftcloud" || (opts.Project.Runtime().Platform() != nil && opts.Project.Runtime().Platform().Name() == "kraftcloud") {
 		runtimeName = utils.RewrapAsKraftCloudPackage(runtimeName)
 	}

--- a/internal/cli/kraft/pkg/pkg.go
+++ b/internal/cli/kraft/pkg/pkg.go
@@ -52,6 +52,7 @@ type PkgOptions struct {
 	Project      app.Application           `noattribute:"true"`
 	Push         bool                      `local:"true" long:"push" short:"P" usage:"Push the package on if successfully packaged"`
 	Rootfs       string                    `local:"true" long:"rootfs" usage:"Specify a path to use as root file system (can be volume or initramfs)"`
+	Runtime      string                    `local:"true" long:"runtime" short:"r" usage:"Set the runtime to use for the package"`
 	Strategy     packmanager.MergeStrategy `noattribute:"true"`
 	Target       string                    `local:"true" long:"target" short:"t" usage:"Package a particular known target"`
 	Workdir      string                    `local:"true" long:"workdir" short:"w" usage:"Set an alternative working directory (default is cwd)"`


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

This PR introduces a new deployer which is able to deploy a context where no working directory with no Kraftfile is present and either a `--rootfs` flag is supplied or a detected `Dockerfile` in the current working directory is detected.

In this scenario we can dynamically create a new project and supply related information such that we are able to from this basic scenario create a new Unikraft Cloud deployment.