### PR TITLE
fix(deploy): Prevent deployers with empty `String()` from prompting

### DIFF
--- a/internal/cli/kraft/cloud/deploy/deploy.go
+++ b/internal/cli/kraft/cloud/deploy/deploy.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
 	"strconv"
 	"time"
 
@@ -246,6 +247,11 @@ func (opts *DeployOptions) Run(ctx context.Context, args []string) error {
 	} else if len(candidates) == 1 {
 		d = candidates[0]
 	} else if !config.G[config.KraftKit](ctx).NoPrompt {
+		// Remove any candidates that do not have String prompts.
+		candidates = slices.DeleteFunc(candidates, func(d deployer) bool {
+			return d.String() == ""
+		})
+
 		candidate, err := selection.Select[deployer]("multiple deployable contexts discovered: how would you like to proceed?", candidates...)
 		if err != nil {
 			return err

--- a/internal/cli/kraft/cloud/deploy/deployer_rootfs.go
+++ b/internal/cli/kraft/cloud/deploy/deployer_rootfs.go
@@ -16,20 +16,14 @@ import (
 	"kraftkit.sh/unikraft/target"
 )
 
-type deployerRootfs struct {
-	args []string
-}
+type deployerRootfs struct{}
 
 func (deployer *deployerRootfs) Name() string {
 	return "rootfs"
 }
 
 func (deployer *deployerRootfs) String() string {
-	if len(deployer.args) == 0 {
-		return "run the cwd with Dockerfile"
-	}
-
-	return fmt.Sprintf("run the detected Dockerfile in the cwd and use '%s' as arg(s)", strings.Join(deployer.args, " "))
+	return ""
 }
 
 func (deployer *deployerRootfs) Deployable(ctx context.Context, opts *DeployOptions, args ...string) (bool, error) {


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

Simultaneously, remove the "rootfs" deployer from being promptable. In a circumstance where the rootfs is promptable, there are other potential deployers.  These deployers should in fact take priority and the rootfs deployer should not be made available to the user as it relies heavily on CLI flags and arguments which are otherwise provided by other deployers.