### PR TITLE
fix(cloud): Updating the help information

### DIFF
--- a/internal/cli/kraft/cloud/deploy/deploy.go
+++ b/internal/cli/kraft/cloud/deploy/deploy.go
@@ -144,7 +144,7 @@ func NewCmd() *cobra.Command {
 	cmd.Flags().Var(
 		cmdfactory.NewEnumFlag[kcinstances.ScaleToZeroPolicy](
 			kcinstances.ScaleToZeroPolicies(),
-			kcinstances.ScaleToZeroPolicyOn,
+			kcinstances.ScaleToZeroPolicyOff,
 		),
 		"scale-to-zero",
 		"Scale to zero policy of the instance (on/off/idle)",

--- a/internal/cli/kraft/cloud/instance/create/create.go
+++ b/internal/cli/kraft/cloud/instance/create/create.go
@@ -735,7 +735,7 @@ func NewCmd() *cobra.Command {
 	cmd.Flags().Var(
 		cmdfactory.NewEnumFlag[kcinstances.ScaleToZeroPolicy](
 			kcinstances.ScaleToZeroPolicies(),
-			kcinstances.ScaleToZeroPolicyOn,
+			kcinstances.ScaleToZeroPolicyOff,
 		),
 		"scale-to-zero",
 		"Scale to zero policy of the instance (on/off/idle)",

--- a/internal/cli/kraft/cloud/instance/create/create.go
+++ b/internal/cli/kraft/cloud/instance/create/create.go
@@ -60,7 +60,7 @@ type CreateOptions struct {
 	ScaleToZeroCooldown time.Duration                  `local:"true" long:"scale-to-zero-cooldown" usage:"Cooldown period before scaling to zero (ms/s/m/h)"`
 	SubDomain           []string                       `local:"true" long:"subdomain" short:"s" usage:"Set the subdomains to use when creating the service"`
 	Token               string                         `noattribute:"true"`
-	Volumes             []string                       `local:"true" long:"volumes" short:"v" usage:"List of volumes to attach instance to"`
+	Volumes             []string                       `local:"true" long:"volume" short:"v" usage:"List of volumes to attach instance to"`
 	WaitForImage        bool                           `local:"true" long:"wait-for-image" short:"w" usage:"Wait for the image to be available before creating the instance"`
 	WaitForImageTimeout time.Duration                  `local:"true" long:"wait-for-image-timeout" usage:"Time to wait before timing out when waiting for image (ms/s/m/h)" default:"60s"`
 

--- a/internal/cli/kraft/cloud/instance/create/create.go
+++ b/internal/cli/kraft/cloud/instance/create/create.go
@@ -414,7 +414,7 @@ func Create(ctx context.Context, opts *CreateOptions, args ...string) (*kcclient
 	if len(opts.Ports) == 1 && strings.HasPrefix(opts.Ports[0], "443:") && strings.Count(opts.Ports[0], "/") == 0 {
 		split := strings.Split(opts.Ports[0], ":")
 		if len(split) != 2 {
-			return nil, nil, fmt.Errorf("malformed port expected format EXTERNAL:INTERNAL[/HANDLER[,HANDLER...]]")
+			return nil, nil, fmt.Errorf("malformed port expected format EXTERNAL:INTERNAL[/HANDLER]")
 		}
 
 		destPort, err := strconv.Atoi(split[1])
@@ -449,7 +449,7 @@ func Create(ctx context.Context, opts *CreateOptions, args ...string) (*kcclient
 			if strings.ContainsRune(port, '/') {
 				split := strings.Split(port, "/")
 				if len(split) != 2 {
-					return nil, nil, fmt.Errorf("malformed port expected format EXTERNAL:INTERNAL[/HANDLER[,HANDLER...]]")
+					return nil, nil, fmt.Errorf("malformed port expected format EXTERNAL:INTERNAL[/HANDLER]")
 				}
 
 				for _, handler := range strings.Split(split[1], "+") {

--- a/internal/cli/kraft/cloud/instance/start/start.go
+++ b/internal/cli/kraft/cloud/instance/start/start.go
@@ -22,7 +22,7 @@ import (
 )
 
 type StartOptions struct {
-	All    bool                  `long:"all" usage:"Start all instances"`
+	All    bool                  `long:"all" short:"a" usage:"Start all instances"`
 	Auth   *config.AuthConfig    `noattribute:"true"`
 	Client kraftcloud.KraftCloud `noattribute:"true"`
 	Metro  string                `noattribute:"true"`

--- a/internal/cli/kraft/cloud/instance/stop/stop.go
+++ b/internal/cli/kraft/cloud/instance/stop/stop.go
@@ -26,7 +26,7 @@ type StopOptions struct {
 	Client       kraftcloud.KraftCloud `noattribute:"true"`
 	Wait         time.Duration         `local:"true" long:"wait" short:"w" usage:"Time to wait for the instance to drain all connections before it is stopped (ms/s/m/h)"`
 	DrainTimeout time.Duration         `local:"true" long:"drain-timeout" short:"d" usage:"Timeout for the instance to stop (ms/s/m/h)"`
-	All          bool                  `long:"all" usage:"Stop all instances"`
+	All          bool                  `long:"all" short:"a" usage:"Stop all instances"`
 	Force        bool                  `long:"force" short:"f" usage:"Force stop the instance(s)"`
 	Metro        string                `noattribute:"true"`
 	Token        string                `noattribute:"true"`

--- a/internal/cli/kraft/cloud/service/create/create.go
+++ b/internal/cli/kraft/cloud/service/create/create.go
@@ -70,7 +70,7 @@ func Create(ctx context.Context, opts *CreateOptions, args ...string) (*kcservic
 	if len(args) == 1 && strings.HasPrefix(args[0], "443:") && strings.Count(args[0], "/") == 0 {
 		split := strings.Split(args[0], ":")
 		if len(split) != 2 {
-			return nil, fmt.Errorf("malformed port expeted format EXTERNAL:INTERNAL[/HANDLER[,HANDLER...]]")
+			return nil, fmt.Errorf("malformed port expeted format EXTERNAL:INTERNAL[/HANDLER]")
 		}
 
 		destPort, err := strconv.Atoi(split[1])
@@ -108,7 +108,7 @@ func Create(ctx context.Context, opts *CreateOptions, args ...string) (*kcservic
 			if strings.ContainsRune(port, '/') {
 				split := strings.Split(port, "/")
 				if len(split) != 2 {
-					return nil, fmt.Errorf("malformed port, expected format EXTERNAL:INTERNAL[/HANDLER[,HANDLER...]]")
+					return nil, fmt.Errorf("malformed port, expected format EXTERNAL:INTERNAL[/HANDLER]")
 				}
 
 				for _, handler := range strings.Split(split[1], "+") {
@@ -215,13 +215,13 @@ func Create(ctx context.Context, opts *CreateOptions, args ...string) (*kcservic
 func NewCmd() *cobra.Command {
 	cmd, err := cmdfactory.New(&CreateOptions{}, cobra.Command{
 		Short:   "Create a service",
-		Use:     "create [FLAGS] NAME",
+		Use:     "create [FLAGS] EXTERNAL:INTERNAL[/HANDLER]",
 		Args:    cobra.ExactArgs(1),
 		Aliases: []string{"new"},
 		Long:    "Create a service.",
 		Example: heredoc.Doc(`
 			# Create a service with a single service listening on port 443 named "my-service"
-			$ kraft cloud service create -p 443:8080/http+tls my-service
+			$ kraft cloud service create -n my-service 443:8080/http+tls
 		`),
 		Annotations: map[string]string{
 			cmdfactory.AnnotationHelpGroup: "kraftcloud-svc",

--- a/internal/cli/kraft/cloud/service/remove/remove.go
+++ b/internal/cli/kraft/cloud/service/remove/remove.go
@@ -23,7 +23,7 @@ import (
 )
 
 type RemoveOptions struct {
-	All       bool                  `long:"all" usage:"Remove all services"`
+	All       bool                  `long:"all" short:"a" usage:"Remove all services"`
 	Auth      *config.AuthConfig    `noattribute:"true"`
 	Client    kraftcloud.KraftCloud `noattribute:"true"`
 	Metro     string                `noattribute:"true"`

--- a/internal/cli/kraft/pkg/pkg.go
+++ b/internal/cli/kraft/pkg/pkg.go
@@ -35,7 +35,7 @@ import (
 )
 
 type PkgOptions struct {
-	Architecture string                    `local:"true" long:"arch" short:"m" usage:"Filter the creation of the package by architecture of known targets"`
+	Architecture string                    `local:"true" long:"arch" short:"m" usage:"Filter the creation of the package by architecture of known targets (x86_64/arm64/arm)"`
 	Args         []string                  `local:"true" long:"args" short:"a" usage:"Pass arguments that will be part of the running kernel's command line"`
 	Compress     bool                      `local:"true" long:"compress" short:"c" usage:"Compress the initrd package (experimental)"`
 	Dbg          bool                      `local:"true" long:"dbg" usage:"Package the debuggable (symbolic) kernel image instead of the stripped image"`
@@ -49,7 +49,7 @@ type PkgOptions struct {
 	NoKConfig    bool                      `local:"true" long:"no-kconfig" usage:"Do not include target .config as metadata"`
 	NoPull       bool                      `local:"true" long:"no-pull" usage:"Do not pull package dependencies before packaging"`
 	Output       string                    `local:"true" long:"output" short:"o" usage:"Save the package at the following output"`
-	Platform     string                    `local:"true" long:"plat" short:"p" usage:"Filter the creation of the package by platform of known targets"`
+	Platform     string                    `local:"true" long:"plat" short:"p" usage:"Filter the creation of the package by platform of known targets (fc/qemu/xen/kraftcloud)"`
 	Project      app.Application           `noattribute:"true"`
 	Push         bool                      `local:"true" long:"push" short:"P" usage:"Push the package on if successfully packaged"`
 	Rootfs       string                    `local:"true" long:"rootfs" usage:"Specify a path to use as root file system (can be volume or initramfs)"`

--- a/internal/cli/kraft/pkg/pkg.go
+++ b/internal/cli/kraft/pkg/pkg.go
@@ -8,6 +8,8 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"slices"
+	"strings"
 
 	"github.com/MakeNowJust/heredoc"
 	"github.com/dustin/go-humanize"
@@ -20,6 +22,7 @@ import (
 	"kraftkit.sh/tui/processtree"
 	"kraftkit.sh/tui/selection"
 	"kraftkit.sh/unikraft/app"
+	"kraftkit.sh/unikraft/arch"
 
 	"kraftkit.sh/cmdfactory"
 	"kraftkit.sh/packmanager"
@@ -32,6 +35,10 @@ import (
 	"kraftkit.sh/internal/cli/kraft/pkg/source"
 	"kraftkit.sh/internal/cli/kraft/pkg/unsource"
 	"kraftkit.sh/internal/cli/kraft/pkg/update"
+)
+
+const (
+	PlatformKraftcloud = "kraftcloud"
 )
 
 type PkgOptions struct {
@@ -62,6 +69,15 @@ type PkgOptions struct {
 	pm       packmanager.PackageManager
 }
 
+// toStringSlice converts a slice of fmt.Stringer to a slice of strings.
+func toStringSlice[T fmt.Stringer](slice []T) []string {
+	strSlice := make([]string, len(slice))
+	for i, v := range slice {
+		strSlice[i] = v.String()
+	}
+	return strSlice
+}
+
 // Pkg a Unikraft project.
 func Pkg(ctx context.Context, opts *PkgOptions, args ...string) ([]pack.Package, error) {
 	var err error
@@ -89,6 +105,23 @@ func Pkg(ctx context.Context, opts *PkgOptions, args ...string) ([]pack.Package,
 
 	if (len(opts.Architecture) > 0 || len(opts.Platform) > 0) && len(opts.Target) > 0 {
 		return nil, fmt.Errorf("the `--arch` and `--plat` options are not supported in addition to `--target`")
+	}
+
+	platforms := platform.Platforms()
+	platforms = append(platforms, PlatformKraftcloud)
+	platformsSlice := toStringSlice(platforms)
+
+	if !slices.Contains(platformsSlice, opts.Platform) {
+		platformsString := strings.Join(platformsSlice, ", ")
+		return nil, fmt.Errorf("unsupported platform: %s\nsupported platforms are: %s", opts.Platform, platformsString)
+	}
+
+	architectures := arch.Architectures()
+	architecturesSlice := toStringSlice(architectures)
+
+	if !slices.Contains(architecturesSlice, opts.Architecture) {
+		architecturesString := strings.Join(architecturesSlice, ", ")
+		return nil, fmt.Errorf("unsupported architecture: %s\nsupported architectures are: %s", opts.Architecture, architecturesString)
 	}
 
 	if config.G[config.KraftKit](ctx).NoPrompt && opts.Strategy == packmanager.StrategyPrompt {


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes
- Updated help for scale-to-zero with the correct default value
   According to the help string, the default value is `on`, while in reality, it is `off`.
- Added short `-a` flag to remove all services
   The `kraft cloud inst rm` accepts long `--all` and short `-a` flags, but `kraft cloud svc rm` accepted only long `--all` flag.
- Updated the example for `kraft cloud svc create` and the malformed port error message
   The example used flag `-p` which doesn't exist and also the syntax was incorrect.
   Also, the malformed port message was incorrect.
- Updated the flag for attaching a volume to instance to singular `--volume`
   That will make it aligned with the examples below and the actual behavior as we can actually pass only one volume name to the flag.
- Added short flag `-a` to `kraft cloud inst stop` and `kraft cloud inst start`
- Added information about supported and default values for flags `--plat` and `--arch` of `kraft pkg`
- Added validation for the values set to `--plat` and `--arch` when used with `kraft pkg`
- Added validation for the values set to `--plat` and `--arch` when used with `kraft build`