### PR TITLE
fix(kraft): Handle better error messages and prevent preemptive checks

### DIFF
--- a/internal/cli/kraft/build/build.go
+++ b/internal/cli/kraft/build/build.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"slices"
 	"sort"
 	"strings"
 
@@ -22,13 +21,11 @@ import (
 	"kraftkit.sh/internal/cli/kraft/utils"
 	"kraftkit.sh/internal/fancymap"
 	"kraftkit.sh/iostreams"
-	"kraftkit.sh/machine/platform"
 	"kraftkit.sh/tui"
 
 	"kraftkit.sh/log"
 	"kraftkit.sh/packmanager"
 	"kraftkit.sh/unikraft/app"
-	"kraftkit.sh/unikraft/arch"
 	"kraftkit.sh/unikraft/target"
 )
 
@@ -61,15 +58,6 @@ type BuildOptions struct {
 	statistics map[string]string
 }
 
-// toStringSlice converts a slice of fmt.Stringer to a slice of strings.
-func toStringSlice[T fmt.Stringer](slice []T) []string {
-	strSlice := make([]string, len(slice))
-	for i, v := range slice {
-		strSlice[i] = v.String()
-	}
-	return strSlice
-}
-
 // Build a Unikraft unikernel.
 func Build(ctx context.Context, opts *BuildOptions, args ...string) error {
 	var err error
@@ -89,23 +77,6 @@ func Build(ctx context.Context, opts *BuildOptions, args ...string) error {
 		}
 	}
 
-	platforms := platform.Platforms()
-	platformsSlice := toStringSlice(platforms)
-
-	if !slices.Contains(platformsSlice, opts.Platform) {
-		platformsString := strings.Join(platformsSlice, ", ")
-		return fmt.Errorf("unsupported platform: %s\nsupported platforms are: %s", opts.Platform, platformsString)
-	}
-
-	architectures := arch.Architectures()
-	architecturesSlice := toStringSlice(architectures)
-
-	if !slices.Contains(architecturesSlice, opts.Architecture) {
-		architecturesString := strings.Join(architecturesSlice, ", ")
-		return fmt.Errorf("unsupported architecture: %s\nsupported architectures are: %s", opts.Architecture, architecturesString)
-	}
-
-	opts.Platform = platform.PlatformByName(opts.Platform).String()
 	opts.statistics = map[string]string{}
 
 	var build builder

--- a/internal/cli/kraft/build/builder_kraftfile_runtime.go
+++ b/internal/cli/kraft/build/builder_kraftfile_runtime.go
@@ -115,11 +115,35 @@ func (*builderKraftfileRuntime) Prepare(ctx context.Context, opts *BuildOptions,
 	}
 
 	if len(packs) == 0 {
-		return fmt.Errorf(
-			"could not find runtime '%s:%s'",
-			opts.Project.Runtime().Name(),
-			opts.Project.Runtime().Version(),
-		)
+		if len(opts.Platform) > 0 && len(opts.Architecture) > 0 {
+			return fmt.Errorf(
+				"could not find runtime '%s:%s' (%s/%s)",
+				opts.Project.Runtime().Name(),
+				opts.Project.Runtime().Version(),
+				opts.Platform,
+				opts.Architecture,
+			)
+		} else if len(opts.Architecture) > 0 {
+			return fmt.Errorf(
+				"could not find runtime '%s:%s' with '%s' architecture",
+				opts.Project.Runtime().Name(),
+				opts.Project.Runtime().Version(),
+				opts.Architecture,
+			)
+		} else if len(opts.Platform) > 0 {
+			return fmt.Errorf(
+				"could not find runtime '%s:%s' with '%s' platform",
+				opts.Project.Runtime().Name(),
+				opts.Project.Runtime().Version(),
+				opts.Platform,
+			)
+		} else {
+			return fmt.Errorf(
+				"could not find runtime %s:%s",
+				opts.Project.Runtime().Name(),
+				opts.Project.Runtime().Version(),
+			)
+		}
 	} else if len(packs) == 1 {
 		selected = &packs[0]
 	} else if len(packs) > 1 {

--- a/internal/cli/kraft/pkg/packager_kraftfile_runtime.go
+++ b/internal/cli/kraft/pkg/packager_kraftfile_runtime.go
@@ -163,11 +163,35 @@ func (p *packagerKraftfileRuntime) Pack(ctx context.Context, opts *PkgOptions, a
 	}
 
 	if len(packs) == 0 {
-		return nil, fmt.Errorf(
-			"could not find runtime '%s:%s'",
-			runtimeName,
-			opts.Project.Runtime().Version(),
-		)
+		if len(opts.Platform) > 0 && len(opts.Architecture) > 0 {
+			return nil, fmt.Errorf(
+				"could not find runtime '%s:%s' (%s/%s)",
+				opts.Project.Runtime().Name(),
+				opts.Project.Runtime().Version(),
+				opts.Platform,
+				opts.Architecture,
+			)
+		} else if len(opts.Architecture) > 0 {
+			return nil, fmt.Errorf(
+				"could not find runtime '%s:%s' with '%s' architecture",
+				opts.Project.Runtime().Name(),
+				opts.Project.Runtime().Version(),
+				opts.Architecture,
+			)
+		} else if len(opts.Platform) > 0 {
+			return nil, fmt.Errorf(
+				"could not find runtime '%s:%s' with '%s' platform",
+				opts.Project.Runtime().Name(),
+				opts.Project.Runtime().Version(),
+				opts.Platform,
+			)
+		} else {
+			return nil, fmt.Errorf(
+				"could not find runtime %s:%s",
+				opts.Project.Runtime().Name(),
+				opts.Project.Runtime().Version(),
+			)
+		}
 	} else if len(packs) == 1 {
 		selected = &packs[0]
 	} else if len(packs) > 1 {


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

This commit essentially reverts the changes made in d5990f336 and b34585f24 as preemptive checks for architecture and platform should not be performed at this stage.  These commits address a real issue which is undescriptive error messages (which is tackled in this new commit).  The reason for not wishing to preemptively check for the architecture and platform is that these can be dynamically determined based on the `packager` and `builder` contexts which involve retrieving a remote runtime and can contain values which are not directly managed by KraftKit.