### PR TITLE
feat(log): Set log-level timestamps to nano-level precision

### DIFF
--- a/log/formatter.go
+++ b/log/formatter.go
@@ -19,7 +19,7 @@ import (
 	"golang.org/x/term"
 )
 
-const defaultTimestampFormat = time.RFC3339
+const defaultTimestampFormat = time.RFC3339Nano
 
 var (
 	baseTimestamp      time.Time    = time.Now()
@@ -265,7 +265,7 @@ func (f *TextFormatter) printColored(b *bytes.Buffer, entry *logrus.Entry, keys 
 		if !f.FullTimestamp {
 			timestamp = fmt.Sprintf("[%04d]", miniTS())
 		} else {
-			timestamp = entry.Time.Format(timestampFormat)
+			timestamp = fmt.Sprintf("%-32s", entry.Time.Format(timestampFormat))
 		}
 		fmt.Fprintf(b, "%s %s%s "+messageFormat, level, colorScheme.Timestamp(timestamp), prefix, message)
 	}


### PR DESCRIPTION
This commit adjusts the resolution of timestamps to the nano-
level as well as adjusts the formatting such that it prints
evenly for all log-entries.

Signed-off-by: Alexander Jung <alex@unikraft.io>

<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [ ] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [ ] Tested your changes against relevant architectures and platforms;
  - [ ] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->
