### PR TITLE
feat(kconfig): Introduce `Walk` and minor fixes

### DIFF
--- a/kconfig/kconfig.go
+++ b/kconfig/kconfig.go
@@ -238,6 +238,12 @@ func (kp *kconfigParser) parseLine() {
 		return
 	}
 
+	// To make this package compatible with Linux, ignore error-if statements
+	if kp.TryConsume("$(error-if") {
+		_ = kp.ConsumeLine()
+		return
+	}
+
 	ident := kp.Ident()
 	if kp.TryConsume("=") || kp.TryConsume(":=") {
 		// Macro definition, see:

--- a/kconfig/kconfig.go
+++ b/kconfig/kconfig.go
@@ -172,7 +172,7 @@ func ParseData(data []byte, file string, extra ...*KeyValue) (*KConfigFile, erro
 		env[kcv.Key] = kcv
 	}
 	kp := &kconfigParser{
-		parser:  newParser(data, file, env),
+		parser:  newParser(data, filepath.Dir(file), file, env),
 		baseDir: filepath.Dir(file),
 	}
 
@@ -426,7 +426,7 @@ func (kp *kconfigParser) includeSource(file string) {
 	}
 
 	kp.includes = append(kp.includes, kp.parser)
-	kp.parser = newParser(data, file, kp.env)
+	kp.parser = newParser(data, kp.baseDir, file, kp.env)
 	kp.parseFile()
 	err = kp.err
 	kp.parser = kp.includes[len(kp.includes)-1]

--- a/kconfig/parser.go
+++ b/kconfig/parser.go
@@ -23,13 +23,15 @@ type parser struct {
 	line    int
 	err     error
 	env     KeyValueMap
+	baseDir string
 }
 
-func newParser(data []byte, file string, env KeyValueMap) *parser {
+func newParser(data []byte, baseDir, file string, env KeyValueMap) *parser {
 	return &parser{
-		data: data,
-		file: file,
-		env:  env,
+		data:    data,
+		file:    file,
+		env:     env,
+		baseDir: baseDir,
 	}
 }
 
@@ -211,6 +213,7 @@ func (p *parser) interpolate(b []byte) string {
 
 		var buf bytes.Buffer
 		cmd := exec.Command(args[0], args[1:]...)
+		cmd.Dir = p.baseDir
 		cmd.Stdout = bufio.NewWriter(&buf)
 		if err := cmd.Run(); err != nil {
 			p.failf("could not execute shell: %s", err.Error())


### PR DESCRIPTION
The newly exposed `Walk` method allows for iterating across all
elements of the parsed KConfig tree.  To make this change possible,
a number of changes were necessary:

1. All menu known menu types are required to be expressed and this
   is expressed as new `const`s;
2. The "`Source`" of the file is provided for all menu items which
   aids in identify the placement of the menu given its file
   context.

Signed-off-by: Alexander Jung <alex@unikraft.io>

<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [ ] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [ ] Tested your changes against relevant architectures and platforms;
  - [ ] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->
