### PR TITLE
feat(deploy): Expose the entrypoint flag

### DIFF
--- a/internal/cli/kraft/cloud/deploy/deploy.go
+++ b/internal/cli/kraft/cloud/deploy/deploy.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/MakeNowJust/heredoc"
+	"github.com/compose-spec/compose-go/v2/types"
 	"github.com/spf13/cobra"
 
 	"kraftkit.sh/cmdfactory"
@@ -40,6 +41,7 @@ type DeployOptions struct {
 	DeployAs            string                         `local:"true" long:"as" short:"D" usage:"Set the deployment type"`
 	Domain              []string                       `local:"true" long:"domain" short:"d" usage:"Set the domain names for the service"`
 	DotConfig           string                         `long:"config" short:"c" usage:"Override the path to the KConfig .config file"`
+	Entrypoint          types.ShellCommand             `local:"true" long:"entrypoint" usage:"Set the entrypoint for the instance"`
 	Env                 []string                       `local:"true" long:"env" short:"e" usage:"Environmental variables"`
 	Features            []string                       `local:"true" long:"feature" usage:"Specify the special features to enable"`
 	Follow              bool                           `local:"true" long:"follow" short:"f" usage:"Follow the logs of the instance"`

--- a/internal/cli/kraft/cloud/deploy/deployer_image_name.go
+++ b/internal/cli/kraft/cloud/deploy/deployer_image_name.go
@@ -94,6 +94,7 @@ func (deployer *deployerImageName) Deploy(ctx context.Context, opts *DeployOptio
 			func(ctx context.Context) error {
 				insts, groups, err = instancecreate.Create(ctx, &instancecreate.CreateOptions{
 					Certificate:         opts.Certificate,
+					Entrypoint:          opts.Entrypoint,
 					Env:                 opts.Env,
 					Features:            opts.Features,
 					Domain:              opts.Domain,

--- a/internal/cli/kraft/cloud/deploy/deployer_kraftfile_runtime.go
+++ b/internal/cli/kraft/cloud/deploy/deployer_kraftfile_runtime.go
@@ -125,6 +125,7 @@ func (deployer *deployerKraftfileRuntime) Deploy(ctx context.Context, opts *Depl
 		Certificate:         opts.Certificate,
 		Env:                 opts.Env,
 		Domain:              opts.Domain,
+		Entrypoint:          opts.Entrypoint,
 		Image:               packs[0].ID(),
 		Memory:              opts.Memory,
 		Metro:               opts.Metro,


### PR DESCRIPTION
This allows for overriding the default image arguments.  The normal
behaviour is to simply append to them.

Signed-off-by: Alexander Jung <alex@unikraft.io>

<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [ ] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [ ] Tested your changes against relevant architectures and platforms;
  - [ ] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->
