### PR TITLE
feat(initrd): Support Dockerfile secrets, targets and build arguments

### DIFF
--- a/cmdfactory/flags_string_array.go
+++ b/cmdfactory/flags_string_array.go
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2012 Alex Ogier.
+// Copyright (c) 2012 The Go Authors.
+// Copyright (c) 2022, Unikraft GmbH and The KraftKit Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+package cmdfactory
+
+import (
+	"bytes"
+	"encoding/csv"
+	"strings"
+
+	"github.com/spf13/pflag"
+)
+
+// -- stringArray Value
+type stringArrayValue struct {
+	value   *[]string
+	changed bool
+}
+
+func newStringArrayValue(val []string, p *[]string) *stringArrayValue {
+	ssv := new(stringArrayValue)
+	ssv.value = p
+	*ssv.value = val
+	return ssv
+}
+
+func (s *stringArrayValue) Set(val string) error {
+	if !s.changed {
+		*s.value = []string{val}
+		s.changed = true
+	} else {
+		*s.value = append(*s.value, val)
+	}
+	return nil
+}
+
+func (s *stringArrayValue) Append(val string) error {
+	*s.value = append(*s.value, val)
+	return nil
+}
+
+func (s *stringArrayValue) Replace(val []string) error {
+	out := make([]string, len(val))
+	for i, d := range val {
+		var err error
+		out[i] = d
+		if err != nil {
+			return err
+		}
+	}
+	*s.value = out
+	return nil
+}
+
+func (s *stringArrayValue) GetSlice() []string {
+	out := make([]string, len(*s.value))
+	copy(out, *s.value)
+	return out
+}
+
+func (s *stringArrayValue) Type() string {
+	return "strings"
+}
+
+func (s *stringArrayValue) String() string {
+	str, _ := writeAsCSV(*s.value)
+	return "[" + str + "]"
+}
+
+func writeAsCSV(vals []string) (string, error) {
+	b := &bytes.Buffer{}
+	w := csv.NewWriter(b)
+	err := w.Write(vals)
+	if err != nil {
+		return "", err
+	}
+	w.Flush()
+	return strings.TrimSuffix(b.String(), "\n"), nil
+}
+
+// StringArrayVar defines a string flag with specified name, default value, and usage string.
+// The argument p points to a []string variable in which to store the value of the flag.
+// The value of each argument will not try to be separated by comma. Use a StringSlice for that.
+func StringArrayVar(p *[]string, name string, value []string, usage string) *pflag.Flag {
+	return VarF(newStringArrayValue(value, p), name, usage)
+}
+
+// StringArrayVarP is like StringArrayVar, but accepts a shorthand letter that can be used after a single dash.
+func StringArrayVarP(p *[]string, name, shorthand string, value []string, usage string) *pflag.Flag {
+	return VarPF(newStringArrayValue(value, p), name, shorthand, usage)
+}

--- a/go.sum
+++ b/go.sum
@@ -729,6 +729,8 @@ github.com/hashicorp/errwrap v0.0.0-20141028054710-7554cd9344ce/go.mod h1:YH+1FK
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/errwrap v1.1.0 h1:OxrOeh75EUXMY8TBjag2fzXGZ40LB6IKw45YeGUDY2I=
 github.com/hashicorp/errwrap v1.1.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
+github.com/hashicorp/go-cleanhttp v0.5.2 h1:035FKYIWjmULyFRBKPs8TBQoi0x6d9G4xc9neXJWAZQ=
+github.com/hashicorp/go-cleanhttp v0.5.2/go.mod h1:kO/YDlP8L1346E6Sodw+PrpBSV4/SoxCXGY6BqNFT48=
 github.com/hashicorp/go-multierror v0.0.0-20161216184304-ed905158d874/go.mod h1:JMRHfdO9jKNzS/+BTlxCjKNQHg/jZAft8U7LloJvN7I=
 github.com/hashicorp/go-multierror v1.0.0/go.mod h1:dHtQlpGsu+cZNNAkkCN/P3hoUDHhCYQXV3UM06sGGrk=
 github.com/hashicorp/go-multierror v1.1.0/go.mod h1:spPvp8C1qA32ftKqdAHm4hHTbPw+vmowP0z+KUhOZdA=


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

This PR introduces support to passing build-time arguments, secrets and defining the target when perfoming constructions via buildkit.

The following subcommands:

- `kraft build`
- `kraft cloud compose build`
- `kraft cloud compose up`
- `kraft cloud deploy`
- `kraft compose build`
- `kraft compose up`
- `kraft pkg`

Now have the following new configurable flags:

- `--build-arg`
- `--build-target`
- `--build-secret`

### Build arguments

Arguments supplied through the `ARG` syntax of a `Dockerfile` can be seeded through the new `--build-arg` flag using familiar syntax, e.g. with `kraft build`:

```bash
kraft build --build-arg MY_VAR=my_val [...]
```

### Build targets

For multi-stage builds of a `Dockerfile`, it is now possible to target this through the use of the `--build-target` flag, e.g. via `kraft build`.

### Build secrets

A secret can be provided to BuildKit through KraftKit using the same syntax as `buildctl`, e.g. within a `Dockerfile` one may have:

```Dockerfile
RUN --mount=type=secret,id=ssh_id,target=/root/.ssh/id_rsa \
    [...]
```

Through one of the commands above, e.g. `kraft build`, the secret file can be passed via:

```bash
kraft build --build-secret id=ssh_id,src=$HOME/.ssh/id_rsa [...]
```

### SSH Socket

Additionally, support for the an SSH auth socket is provided which can be set at the environmental variable `KRAFTKIT_BUILDKIT_SSH_AGENT` (priority) or using the default `SSH_AUTH_SOCK`.
