### PR TITLE
feat(internal): Set platform/architecture for runtimes

### DIFF
--- a/internal/cli/kraft/cloud/compose/build/build.go
+++ b/internal/cli/kraft/cloud/compose/build/build.go
@@ -200,7 +200,10 @@ func Build(ctx context.Context, opts *BuildOptions, args ...string) error {
 				app.WithProjectDefaultKraftfiles(),
 			)
 			if err != nil && errors.Is(err, app.ErrNoKraftfile) {
-				runtime, err := runtime.NewRuntime(ctx, runtime.DefaultKraftCloudRuntime)
+				runtime, err := runtime.NewRuntime(ctx, runtime.DefaultKraftCloudRuntime,
+					runtime.WithPlatform(project.Targets()[0].Platform().String()),
+					runtime.WithArchitecture(project.Targets()[0].Architecture().String()),
+				)
 				if err != nil {
 					return fmt.Errorf("could not create runtime: %w", err)
 				}
@@ -256,7 +259,10 @@ func Build(ctx context.Context, opts *BuildOptions, args ...string) error {
 				WithField("service", serviceName).
 				Debug("using")
 
-			rt, err := runtime.NewRuntime(ctx, runtimeName)
+			rt, err := runtime.NewRuntime(ctx, runtimeName,
+				runtime.WithPlatform(project.Targets()[0].Platform().String()),
+				runtime.WithArchitecture(project.Targets()[0].Architecture().String()),
+			)
 			if err != nil {
 				return fmt.Errorf("could not create runtime: %w", err)
 			}

--- a/internal/cli/kraft/cloud/deploy/deployer_rootfs.go
+++ b/internal/cli/kraft/cloud/deploy/deployer_rootfs.go
@@ -12,6 +12,8 @@ import (
 	kcservices "sdk.kraft.cloud/services"
 
 	"kraftkit.sh/unikraft/app"
+	"kraftkit.sh/unikraft/arch"
+	"kraftkit.sh/unikraft/plat"
 	"kraftkit.sh/unikraft/runtime"
 	"kraftkit.sh/unikraft/target"
 )
@@ -57,8 +59,13 @@ func (deployer *deployerRootfs) Deployable(ctx context.Context, opts *DeployOpti
 	if opts.Project == nil {
 		rt := runtime.DefaultKraftCloudRuntime
 
+		// NOTE(craciunoiuc): If we do not set values the default case will fail
+		// When we add platform/architecture options we will replace this
+		platform := plat.NewPlatformFromOptions(plat.WithName("kraftcloud"))
+
 		if len(opts.Runtime) > 0 {
 			rt = opts.Runtime
+			platform = plat.NewPlatformFromOptions()
 
 			// Sanitize the runtime for Unikraft Cloud.
 
@@ -75,7 +82,10 @@ func (deployer *deployerRootfs) Deployable(ctx context.Context, opts *DeployOpti
 			}
 		}
 
-		runtime, err := runtime.NewRuntime(ctx, rt)
+		runtime, err := runtime.NewRuntime(ctx, rt,
+			runtime.WithPlatform(platform.String()),
+			runtime.WithArchitecture(arch.ArchitectureX86_64.String()),
+		)
 		if err != nil {
 			return false, fmt.Errorf("could not create runtime: %w", err)
 		}

--- a/internal/cli/kraft/run/runner_linuxu.go
+++ b/internal/cli/kraft/run/runner_linuxu.go
@@ -121,7 +121,14 @@ func (runner *runnerLinuxu) Runnable(ctx context.Context, opts *RunOptions, args
 
 // Prepare implements Runner.
 func (runner *runnerLinuxu) Prepare(ctx context.Context, opts *RunOptions, machine *machineapi.Machine, args ...string) error {
-	loader, err := runtime.NewRuntime(ctx, opts.Runtime)
+	if opts.Platform == "" {
+		opts.Platform = "qemu"
+	}
+
+	loader, err := runtime.NewRuntime(ctx, opts.Runtime,
+		runtime.WithPlatform(opts.Platform),
+		runtime.WithArchitecture(opts.Architecture),
+	)
 	if err != nil {
 		return err
 	}

--- a/unikraft/runtime/runtime.go
+++ b/unikraft/runtime/runtime.go
@@ -22,6 +22,12 @@ type Runtime struct {
 	// The package representing the ELF Loader.
 	pack pack.Package
 
+	// Platform specifies the platform of the loader.
+	platform string
+
+	// Architecture specifies the architecture of the loader.
+	architecture string
+
 	// The name of the elfloader.
 	name string
 

--- a/unikraft/runtime/runtime_options.go
+++ b/unikraft/runtime/runtime_options.go
@@ -39,3 +39,19 @@ func WithKernel(kernel string) RuntimeOption {
 		return nil
 	}
 }
+
+// WithPlatform sets the platform of the runtime.
+func WithPlatform(platform string) RuntimeOption {
+	return func(runtime *Runtime) error {
+		runtime.platform = platform
+		return nil
+	}
+}
+
+// WithArchitecture sets the architecture of the runtime.
+func WithArchitecture(architecture string) RuntimeOption {
+	return func(runtime *Runtime) error {
+		runtime.architecture = architecture
+		return nil
+	}
+}

--- a/unikraft/runtime/runtime_pack.go
+++ b/unikraft/runtime/runtime_pack.go
@@ -89,7 +89,7 @@ func NewRuntime(ctx context.Context, name string, pbopts ...RuntimeOption) (*Run
 	} else if len(results) > 1 {
 		options := make([]string, len(results))
 		for i, result := range results {
-			options[i] = result.Name()
+			options[i] = result.String()
 		}
 		return nil, fmt.Errorf("too many options: %v", options)
 	}

--- a/unikraft/runtime/runtime_pack.go
+++ b/unikraft/runtime/runtime_pack.go
@@ -67,6 +67,8 @@ func NewRuntime(ctx context.Context, name string, pbopts ...RuntimeOption) (*Run
 	// First try locally
 	results, err := runtime.registry.Catalog(ctx,
 		packmanager.WithName(runtime.name),
+		packmanager.WithPlatform(runtime.platform),
+		packmanager.WithArchitecture(runtime.architecture),
 		packmanager.WithTypes(unikraft.ComponentTypeApp),
 	)
 	if err != nil {
@@ -76,6 +78,8 @@ func NewRuntime(ctx context.Context, name string, pbopts ...RuntimeOption) (*Run
 	if len(results) == 0 {
 		results, err = runtime.registry.Catalog(ctx,
 			packmanager.WithName(runtime.name),
+			packmanager.WithPlatform(runtime.platform),
+			packmanager.WithArchitecture(runtime.architecture),
 			packmanager.WithTypes(unikraft.ComponentTypeApp),
 			packmanager.WithRemote(true),
 		)


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [ ] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [ ] Tested your changes against relevant architectures and platforms;
  - [ ] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->


This needs to happen because we now have `fc`/`qemu` `base` images, running with runtimes it fails cause it does not know what to pick.

