### PR TITLE
fix(goreleaser): Publish public key for verification

### DIFF
--- a/.github/workflows/release-stable.yaml
+++ b/.github/workflows/release-stable.yaml
@@ -30,16 +30,21 @@ jobs:
           apt-get update
           apt-get install -y --no-install-recommends \
             fury-cli
+          curl -O -L "https://github.com/sigstore/cosign/releases/latest/download/cosign-linux-amd64"
+          mv cosign-linux-amd64 /usr/local/bin/cosign
+          chmod +x /usr/local/bin/cosign
 
       - name: Generate GoReleaser configuration
         run: |
           ytt -f .goreleaser-stable.yaml > goreleaser-stable.yaml
 
-      - name: Write cosign key to file
+      - name: Write cosign key and pubkey to file
         run: |
           echo "$COSIGN_KEY" > cosign.key
           chmod 600 cosign.key
+          echo "$COSIGN_PASSWORD" | cosign public-key --key cosign.key > public.key
         env:
+          COSIGN_PASSWORD: ${{ secrets.COSIGN_PASSWORD }}
           COSIGN_KEY: ${{ secrets.COSIGN_KEY }}
 
       - name: Run GoReleaser

--- a/.goreleaser-stable.yaml
+++ b/.goreleaser-stable.yaml
@@ -46,6 +46,8 @@ release:
 
     This is a stable release of kraftkit.
   name_template: 'v{{ .Version }}'
+  extra_files:
+    - public.key
 
 signs:
   - id: cosign


### PR DESCRIPTION
Currently people have not way to check the signatures even if they wanted. By generating and publishing the public key in the artifacts we ensure that this will be usable.

<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [ ] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [ ] Tested your changes against relevant architectures and platforms;
  - [ ] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->
