### PR TITLE
fix(internal): Add sanity check for empty runtime

### DIFF
--- a/internal/cli/kraft/pkg/packager_kraftfile_runtime.go
+++ b/internal/cli/kraft/pkg/packager_kraftfile_runtime.go
@@ -59,6 +59,9 @@ func (p *packagerKraftfileRuntime) Pack(ctx context.Context, opts *PkgOptions, a
 	if len(opts.Runtime) > 0 {
 		runtimeName = opts.Runtime
 	} else {
+		if opts.Project == nil || opts.Project.Runtime() == nil {
+			return nil, fmt.Errorf("cannot use runtime packager without a project runtime")
+		}
 		runtimeName = opts.Project.Runtime().Name()
 	}
 


### PR DESCRIPTION
There is a slight chance that someone tries to deploy an application without a runtime and it fails. To not show a panic message return an error instead.

Fixes this: https://discord.com/channels/1143564401060872292/1293989891608154193/1293991241972977686

<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [ ] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [ ] Tested your changes against relevant architectures and platforms;
  - [ ] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->
