### PR TITLE
fix(internal): Only set options if not set on cli

### DIFF
--- a/internal/cli/kraft/pkg/packager_kraftfile_runtime.go
+++ b/internal/cli/kraft/pkg/packager_kraftfile_runtime.go
@@ -110,8 +110,12 @@ func (p *packagerKraftfileRuntime) Pack(ctx context.Context, opts *PkgOptions, a
 			kconfigs = append(kconfigs, kc.String())
 		}
 
-		opts.Platform = targ.Platform().Name()
-		opts.Architecture = targ.Architecture().Name()
+		if opts.Platform == "" {
+			opts.Platform = targ.Platform().Name()
+		}
+		if opts.Architecture == "" {
+			opts.Architecture = targ.Architecture().Name()
+		}
 	}
 
 	treemodel, err := processtree.NewProcessTree(


### PR DESCRIPTION
Currently the target options override cli options if they are already set. The check ensures that this does not happen.

GitHub-Fixes: #1913

<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [ ] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [ ] Tested your changes against relevant architectures and platforms;
  - [ ] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->
