### PR TITLE
fix(initrd): Remove check to allow different formats

### DIFF
--- a/initrd/file.go
+++ b/initrd/file.go
@@ -6,10 +6,7 @@ package initrd
 
 import (
 	"context"
-	"io"
 	"os"
-
-	"kraftkit.sh/cpio"
 )
 
 type file struct {
@@ -24,7 +21,6 @@ func NewFromFile(_ context.Context, path string, opts ...InitrdOption) (Initrd, 
 	if err != nil {
 		return nil, err
 	}
-
 	defer fi.Close()
 
 	initrd := file{
@@ -38,26 +34,12 @@ func NewFromFile(_ context.Context, path string, opts ...InitrdOption) (Initrd, 
 		}
 	}
 
-	reader := cpio.NewReader(fi)
-
-	// Iterate through the files in the archive.
-	for {
-		_, _, err := reader.Next()
-		if err == io.EOF {
-			// end of cpio archive
-			break
-		}
-		if err != nil {
-			return nil, err
-		}
-	}
-
 	return &initrd, nil
 }
 
 // Build implements Initrd.
 func (initrd *file) Name() string {
-	return "CPIO file"
+	return "file"
 }
 
 // Build implements Initrd.


### PR DESCRIPTION
By removing the check we allow for other types of initrds also.

Tested by @marcrittinghaus 

<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [ ] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [ ] Tested your changes against relevant architectures and platforms;
  - [ ] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->
