### PR TITLE
fix(initrd): Use `stat` as a more robust mechanic for checking a file

### DIFF
--- a/initrd/file.go
+++ b/initrd/file.go
@@ -6,6 +6,7 @@ package initrd
 
 import (
 	"context"
+	"fmt"
 	"os"
 )
 
@@ -17,11 +18,13 @@ type file struct {
 // NewFromFile accepts an input file which already represents a CPIO archive and
 // is provided as a mechanism for satisfying the Initrd interface.
 func NewFromFile(_ context.Context, path string, opts ...InitrdOption) (Initrd, error) {
-	fi, err := os.Open(path)
+	stat, err := os.Stat(path)
 	if err != nil {
 		return nil, err
 	}
-	defer fi.Close()
+	if stat.IsDir() {
+		return nil, fmt.Errorf("path %s is a directory, not a file", path)
+	}
 
 	initrd := file{
 		opts: InitrdOptions{},


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

This would also pass for other types, especially directories, which is problematic, as this is also an initrd-provider.
