### PR TITLE
fix(run): Do not run lightweight check for project validty

### DIFF
--- a/internal/cli/kraft/run/runner_kraftfile_runtime.go
+++ b/internal/cli/kraft/run/runner_kraftfile_runtime.go
@@ -62,10 +62,6 @@ func (runner *runnerKraftfileRuntime) Runnable(ctx context.Context, opts *RunOpt
 		}
 	}
 
-	if !app.IsWorkdirInitialized(opts.workdir) {
-		return false, fmt.Errorf("path is not project: %s", opts.workdir)
-	}
-
 	popts := []app.ProjectOption{
 		app.WithProjectWorkdir(opts.workdir),
 	}

--- a/internal/cli/kraft/run/runner_kraftfile_unikraft.go
+++ b/internal/cli/kraft/run/runner_kraftfile_unikraft.go
@@ -65,10 +65,6 @@ func (runner *runnerKraftfileUnikraft) Runnable(ctx context.Context, opts *RunOp
 		}
 	}
 
-	if !app.IsWorkdirInitialized(runner.workdir) {
-		return false, fmt.Errorf("path is not project: %s", runner.workdir)
-	}
-
 	popts := []app.ProjectOption{
 		app.WithProjectWorkdir(runner.workdir),
 	}


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

The full check occurs shortly after within `NewProjectFromOptions` and so this check is redundant.  Further still, since the check looks for default `Kraftfile` names, specifying an alternative name would result in this check to fail.  The alternative name, is however, handled correctly subsequently and passed into `NewProjectFromOptions`.

GitHub-Fixes: #1969
