### PR TITLE
feat: Introduce support for supplying `--env-file` in compose

### DIFF
--- a/compose/project.go
+++ b/compose/project.go
@@ -40,7 +40,7 @@ var DefaultFileNames = []string{
 
 // NewProjectFromComposeFile loads a compose file and returns a project. If no
 // compose file is specified, it will look for one in the current directory.
-func NewProjectFromComposeFile(ctx context.Context, workdir, composefile string) (*Project, error) {
+func NewProjectFromComposeFile(ctx context.Context, workdir, composefile string, opts ...cli.ProjectOptionsFn) (*Project, error) {
 	if composefile == "" {
 		for _, file := range DefaultFileNames {
 			fullpath := filepath.Join(workdir, file)
@@ -62,6 +62,7 @@ func NewProjectFromComposeFile(ctx context.Context, workdir, composefile string)
 
 	options, err := cli.NewProjectOptions(
 		[]string{fullpath},
+		opts...,
 	)
 	if err != nil {
 		return nil, err

--- a/internal/cli/kraft/cloud/compose/build/build.go
+++ b/internal/cli/kraft/cloud/compose/build/build.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 
 	"github.com/MakeNowJust/heredoc"
+	composespec "github.com/compose-spec/compose-go/v2/cli"
 	"github.com/spf13/cobra"
 
 	kraftcloud "sdk.kraft.cloud"
@@ -33,8 +34,9 @@ import (
 
 type BuildOptions struct {
 	Auth        *config.AuthConfig    `noattribute:"true"`
-	Composefile string                `noattribute:"true"`
 	Client      kraftcloud.KraftCloud `noattribute:"true"`
+	Composefile string                `noattribute:"true"`
+	EnvFile     string                `noattribute:"true"`
 	Metro       string                `noattribute:"true"`
 	Project     *compose.Project      `noattribute:"true"`
 	Push        bool                  `long:"push" usage:"Push the built service images"`
@@ -102,7 +104,11 @@ func Build(ctx context.Context, opts *BuildOptions, args ...string) error {
 			return err
 		}
 
-		opts.Project, err = compose.NewProjectFromComposeFile(ctx, workdir, opts.Composefile)
+		opts.Project, err = compose.NewProjectFromComposeFile(ctx,
+			workdir,
+			opts.Composefile,
+			composespec.WithEnvFiles(opts.EnvFile),
+		)
 		if err != nil {
 			return err
 		}

--- a/internal/cli/kraft/cloud/compose/compose.go
+++ b/internal/cli/kraft/cloud/compose/compose.go
@@ -28,6 +28,7 @@ import (
 
 type ComposeOptions struct {
 	Composefile string `long:"file" usage:"Set the Compose file."`
+	EnvFile     string `long:"env-file" usage:"Set the environment file."`
 }
 
 func NewCmd() *cobra.Command {

--- a/internal/cli/kraft/cloud/compose/down/down.go
+++ b/internal/cli/kraft/cloud/compose/down/down.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 
 	"github.com/MakeNowJust/heredoc"
+	composespec "github.com/compose-spec/compose-go/v2/cli"
 	"github.com/spf13/cobra"
 
 	kraftcloud "sdk.kraft.cloud"
@@ -28,6 +29,7 @@ type DownOptions struct {
 	Auth        *config.AuthConfig    `noattribute:"true"`
 	Client      kraftcloud.KraftCloud `noattribute:"true"`
 	Composefile string                `noattribute:"true"`
+	EnvFile     string                `noattribute:"true"`
 	Metro       string                `noattribute:"true"`
 	Project     *compose.Project      `noattribute:"true"`
 	Token       string                `noattribute:"true"`
@@ -88,7 +90,11 @@ func (opts *DownOptions) Run(ctx context.Context, args []string) error {
 			return err
 		}
 
-		opts.Project, err = compose.NewProjectFromComposeFile(ctx, workdir, opts.Composefile)
+		opts.Project, err = compose.NewProjectFromComposeFile(ctx,
+			workdir,
+			opts.Composefile,
+			composespec.WithEnvFiles(opts.EnvFile),
+		)
 		if err != nil {
 			return err
 		}

--- a/internal/cli/kraft/cloud/compose/list/list.go
+++ b/internal/cli/kraft/cloud/compose/list/list.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 
 	"github.com/MakeNowJust/heredoc"
+	composespec "github.com/compose-spec/compose-go/v2/cli"
 	"github.com/spf13/cobra"
 
 	"kraftkit.sh/cmdfactory"
@@ -23,6 +24,7 @@ import (
 
 type ListOptions struct {
 	Composefile string `noattribute:"true"`
+	EnvFile     string `noattribute:"true"`
 	Output      string `long:"output" short:"o" usage:"Set output format. Options: table,yaml,json,list,raw" default:"table"`
 	Token       string `noattribute:"true"`
 }
@@ -64,7 +66,11 @@ func (opts *ListOptions) Run(ctx context.Context, args []string) error {
 		workdir = args[0]
 	}
 
-	project, err := compose.NewProjectFromComposeFile(ctx, workdir, opts.Composefile)
+	project, err := compose.NewProjectFromComposeFile(ctx,
+		workdir,
+		opts.Composefile,
+		composespec.WithEnvFiles(opts.EnvFile),
+	)
 	if err != nil {
 		return err
 	}

--- a/internal/cli/kraft/cloud/compose/logs/logs.go
+++ b/internal/cli/kraft/cloud/compose/logs/logs.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 
 	"github.com/MakeNowJust/heredoc"
+	composespec "github.com/compose-spec/compose-go/v2/cli"
 	"github.com/spf13/cobra"
 
 	kraftcloud "sdk.kraft.cloud"
@@ -27,6 +28,7 @@ type LogsOptions struct {
 	Auth        *config.AuthConfig    `noattribute:"true"`
 	Client      kraftcloud.KraftCloud `noattribute:"true"`
 	Composefile string                `noattribute:"true"`
+	EnvFile     string                `noattribute:"true"`
 	Follow      bool                  `long:"follow" short:"f" usage:"Follow log output"`
 	Metro       string                `noattribute:"true"`
 	Output      string                `long:"output" short:"o" usage:"Set output format. Options: table,yaml,json,list,raw" default:"table"`
@@ -99,7 +101,11 @@ func Logs(ctx context.Context, opts *LogsOptions, args ...string) error {
 	}
 
 	if opts.Project == nil {
-		opts.Project, err = compose.NewProjectFromComposeFile(ctx, workdir, opts.Composefile)
+		opts.Project, err = compose.NewProjectFromComposeFile(ctx,
+			workdir,
+			opts.Composefile,
+			composespec.WithEnvFiles(opts.EnvFile),
+		)
 		if err != nil {
 			return err
 		}

--- a/internal/cli/kraft/cloud/compose/ps/ps.go
+++ b/internal/cli/kraft/cloud/compose/ps/ps.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 
 	"github.com/MakeNowJust/heredoc"
+	composespec "github.com/compose-spec/compose-go/v2/cli"
 	"github.com/spf13/cobra"
 
 	kraftcloud "sdk.kraft.cloud"
@@ -27,6 +28,7 @@ type PsOptions struct {
 	Auth        *config.AuthConfig    `noattribute:"true"`
 	Client      kraftcloud.KraftCloud `noattribute:"true"`
 	Composefile string                `noattribute:"true"`
+	EnvFile     string                `noattribute:"true"`
 	Metro       string                `noattribute:"true"`
 	Output      string                `long:"output" short:"o" usage:"Set output format. Options: table,yaml,json,list,raw" default:"table"`
 	Project     *compose.Project      `noattribute:"true"`
@@ -84,7 +86,11 @@ func (opts *PsOptions) Run(ctx context.Context, args []string) error {
 			return err
 		}
 
-		opts.Project, err = compose.NewProjectFromComposeFile(ctx, workdir, opts.Composefile)
+		opts.Project, err = compose.NewProjectFromComposeFile(ctx,
+			workdir,
+			opts.Composefile,
+			composespec.WithEnvFiles(opts.EnvFile),
+		)
 		if err != nil {
 			return err
 		}

--- a/internal/cli/kraft/cloud/compose/push/push.go
+++ b/internal/cli/kraft/cloud/compose/push/push.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 
 	"github.com/MakeNowJust/heredoc"
+	composespec "github.com/compose-spec/compose-go/v2/cli"
 	"github.com/dustin/go-humanize"
 	"github.com/spf13/cobra"
 
@@ -31,6 +32,7 @@ type PushOptions struct {
 	Auth        *config.AuthConfig           `noattribute:"true"`
 	Client      kcinstances.InstancesService `noattribute:"true"`
 	Composefile string                       `noattribute:"true"`
+	EnvFile     string                       `noattribute:"true"`
 	Metro       string                       `noattribute:"true"`
 	Project     *compose.Project             `noattribute:"true"`
 	Token       string                       `noattribute:"true"`
@@ -79,7 +81,11 @@ func Push(ctx context.Context, opts *PushOptions, args ...string) error {
 	}
 
 	if opts.Project == nil {
-		opts.Project, err = compose.NewProjectFromComposeFile(ctx, workdir, opts.Composefile)
+		opts.Project, err = compose.NewProjectFromComposeFile(ctx,
+			workdir,
+			opts.Composefile,
+			composespec.WithEnvFiles(opts.EnvFile),
+		)
 		if err != nil {
 			return err
 		}

--- a/internal/cli/kraft/cloud/compose/start/start.go
+++ b/internal/cli/kraft/cloud/compose/start/start.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/MakeNowJust/heredoc"
+	composespec "github.com/compose-spec/compose-go/v2/cli"
 	"github.com/spf13/cobra"
 
 	kraftcloud "sdk.kraft.cloud"
@@ -28,6 +29,7 @@ type StartOptions struct {
 	Auth        *config.AuthConfig    `noattribute:"true"`
 	Client      kraftcloud.KraftCloud `noattribute:"true"`
 	Composefile string                `noattribute:"true"`
+	EnvFile     string                `noattribute:"true"`
 	Metro       string                `noattribute:"true"`
 	Project     *compose.Project      `noattribute:"true"`
 	Token       string                `noattribute:"true"`
@@ -93,7 +95,11 @@ func (opts *StartOptions) Run(ctx context.Context, args []string) error {
 			return err
 		}
 
-		opts.Project, err = compose.NewProjectFromComposeFile(ctx, workdir, opts.Composefile)
+		opts.Project, err = compose.NewProjectFromComposeFile(ctx,
+			workdir,
+			opts.Composefile,
+			composespec.WithEnvFiles(opts.EnvFile),
+		)
 		if err != nil {
 			return err
 		}

--- a/internal/cli/kraft/cloud/compose/stop/stop.go
+++ b/internal/cli/kraft/cloud/compose/stop/stop.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/MakeNowJust/heredoc"
+	composespec "github.com/compose-spec/compose-go/v2/cli"
 	"github.com/spf13/cobra"
 
 	kraftcloud "sdk.kraft.cloud"
@@ -30,6 +31,7 @@ type StopOptions struct {
 	Client       kraftcloud.KraftCloud `noattribute:"true"`
 	Composefile  string                `noattribute:"true"`
 	DrainTimeout time.Duration         `long:"drain-timeout" short:"d" usage:"Timeout for the instance to stop (ms/s/m/h)"`
+	EnvFile      string                `noattribute:"true"`
 	Force        bool                  `long:"force" short:"f" usage:"Force stop the instance(s)"`
 	Metro        string                `noattribute:"true"`
 	Project      *compose.Project      `noattribute:"true"`
@@ -103,7 +105,11 @@ func (opts *StopOptions) Run(ctx context.Context, args []string) error {
 			return err
 		}
 
-		opts.Project, err = compose.NewProjectFromComposeFile(ctx, workdir, opts.Composefile)
+		opts.Project, err = compose.NewProjectFromComposeFile(ctx,
+			workdir,
+			opts.Composefile,
+			composespec.WithEnvFiles(opts.EnvFile),
+		)
 		if err != nil {
 			return err
 		}

--- a/internal/cli/kraft/cloud/compose/up/up.go
+++ b/internal/cli/kraft/cloud/compose/up/up.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/MakeNowJust/heredoc"
+	composespec "github.com/compose-spec/compose-go/v2/cli"
 	"github.com/dustin/go-humanize"
 	"github.com/spf13/cobra"
 
@@ -41,6 +42,7 @@ type UpOptions struct {
 	Client           kraftcloud.KraftCloud    `noattribute:"true"`
 	Composefile      string                   `noattribute:"true"`
 	Detach           bool                     `local:"true" long:"detach" short:"d" usage:"Run the services in the background"`
+	EnvFile          string                   `noattribute:"true"`
 	Metro            string                   `noattribute:"true"`
 	NoStart          bool                     `noattribute:"true"`
 	NoBuild          bool                     `local:"true" long:"no-build" usage:"Do not build the services before starting them"`
@@ -136,7 +138,11 @@ func Up(ctx context.Context, opts *UpOptions, args ...string) error {
 			return err
 		}
 
-		opts.Project, err = compose.NewProjectFromComposeFile(ctx, workdir, opts.Composefile)
+		opts.Project, err = compose.NewProjectFromComposeFile(ctx,
+			workdir,
+			opts.Composefile,
+			composespec.WithEnvFiles(opts.EnvFile),
+		)
 		if err != nil {
 			return err
 		}

--- a/internal/cli/kraft/compose/build/build.go
+++ b/internal/cli/kraft/compose/build/build.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"os"
 
+	composespec "github.com/compose-spec/compose-go/v2/cli"
 	"github.com/compose-spec/compose-go/v2/types"
 	"github.com/spf13/cobra"
 
@@ -24,6 +25,7 @@ import (
 
 type BuildOptions struct {
 	composefile string
+	EnvFile     string `noattribute:"true"`
 }
 
 func NewCmd() *cobra.Command {
@@ -63,7 +65,11 @@ func (opts *BuildOptions) Run(ctx context.Context, args []string) error {
 		return err
 	}
 
-	project, err := compose.NewProjectFromComposeFile(ctx, workdir, opts.composefile)
+	project, err := compose.NewProjectFromComposeFile(ctx,
+		workdir,
+		opts.composefile,
+		composespec.WithEnvFiles(opts.EnvFile),
+	)
 	if err != nil {
 		return err
 	}

--- a/internal/cli/kraft/compose/compose.go
+++ b/internal/cli/kraft/compose/compose.go
@@ -30,6 +30,7 @@ import (
 
 type ComposeOptions struct {
 	Composefile string `long:"file" short:"f" usage:"Set the Compose file."`
+	EnvFile     string `long:"env-file" usage:"Set the environment file."`
 }
 
 func NewCmd() *cobra.Command {

--- a/internal/cli/kraft/compose/create/create.go
+++ b/internal/cli/kraft/compose/create/create.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 
 	"github.com/MakeNowJust/heredoc"
+	composespec "github.com/compose-spec/compose-go/v2/cli"
 	"github.com/compose-spec/compose-go/v2/types"
 	"github.com/spf13/cobra"
 
@@ -42,6 +43,7 @@ import (
 
 type CreateOptions struct {
 	Composefile   string `noattribute:"true"`
+	EnvFile       string `noattribute:"true"`
 	RemoveOrphans bool   `long:"remove-orphans" usage:"Remove machines for services not defined in the Compose file"`
 }
 
@@ -88,7 +90,11 @@ func (opts *CreateOptions) Run(ctx context.Context, args []string) error {
 		return err
 	}
 
-	project, err := compose.NewProjectFromComposeFile(ctx, workdir, opts.Composefile)
+	project, err := compose.NewProjectFromComposeFile(ctx,
+		workdir,
+		opts.Composefile,
+		composespec.WithEnvFiles(opts.EnvFile),
+	)
 	if err != nil {
 		return err
 	}

--- a/internal/cli/kraft/compose/down/down.go
+++ b/internal/cli/kraft/compose/down/down.go
@@ -10,6 +10,7 @@ import (
 	"os"
 
 	"github.com/MakeNowJust/heredoc"
+	composespec "github.com/compose-spec/compose-go/v2/cli"
 	"github.com/compose-spec/compose-go/v2/types"
 
 	"github.com/spf13/cobra"
@@ -29,7 +30,8 @@ import (
 
 type DownOptions struct {
 	composefile   string
-	RemoveOrphans bool `long:"remove-orphans" usage:"Remove machines for services not defined in the Compose file."`
+	EnvFile       string `noattribute:"true"`
+	RemoveOrphans bool   `long:"remove-orphans" usage:"Remove machines for services not defined in the Compose file."`
 }
 
 func NewCmd() *cobra.Command {
@@ -74,7 +76,11 @@ func (opts *DownOptions) Run(ctx context.Context, args []string) error {
 	if err != nil {
 		return err
 	}
-	project, err := compose.NewProjectFromComposeFile(ctx, workdir, opts.composefile)
+	project, err := compose.NewProjectFromComposeFile(ctx,
+		workdir,
+		opts.composefile,
+		composespec.WithEnvFiles(opts.EnvFile),
+	)
 	if err != nil {
 		return err
 	}

--- a/internal/cli/kraft/compose/logs/logs.go
+++ b/internal/cli/kraft/compose/logs/logs.go
@@ -9,26 +9,23 @@ import (
 	"context"
 	"os"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
-	machineapi "kraftkit.sh/api/machine/v1alpha1"
-
+	composespec "github.com/compose-spec/compose-go/v2/cli"
 	"github.com/spf13/cobra"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	machineapi "kraftkit.sh/api/machine/v1alpha1"
 
 	"kraftkit.sh/cmdfactory"
 	"kraftkit.sh/compose"
 	kernellogs "kraftkit.sh/internal/cli/kraft/logs"
 	"kraftkit.sh/log"
-
 	mplatform "kraftkit.sh/machine/platform"
-
 	"kraftkit.sh/packmanager"
 )
 
 type LogsOptions struct {
-	Follow bool `long:"follow" usage:"Follow log output"`
-
 	Composefile string `noattribute:"true"`
+	EnvFile     string `noattribute:"true"`
+	Follow      bool   `long:"follow" usage:"Follow log output"`
 }
 
 func NewCmd() *cobra.Command {
@@ -69,7 +66,11 @@ func (opts *LogsOptions) Run(ctx context.Context, args []string) error {
 		return err
 	}
 
-	project, err := compose.NewProjectFromComposeFile(ctx, workdir, opts.Composefile)
+	project, err := compose.NewProjectFromComposeFile(ctx,
+		workdir,
+		opts.Composefile,
+		composespec.WithEnvFiles(opts.EnvFile),
+	)
 	if err != nil {
 		return err
 	}

--- a/internal/cli/kraft/compose/pause/pause.go
+++ b/internal/cli/kraft/compose/pause/pause.go
@@ -9,6 +9,7 @@ import (
 	"os"
 
 	"github.com/MakeNowJust/heredoc"
+	composespec "github.com/compose-spec/compose-go/v2/cli"
 	"github.com/spf13/cobra"
 
 	"kraftkit.sh/cmdfactory"
@@ -23,6 +24,7 @@ import (
 
 type PauseOptions struct {
 	composefile string
+	EnvFile     string `noattribute:"true"`
 }
 
 func NewCmd() *cobra.Command {
@@ -67,7 +69,11 @@ func (opts *PauseOptions) Run(ctx context.Context, args []string) error {
 		return err
 	}
 
-	project, err := compose.NewProjectFromComposeFile(ctx, workdir, opts.composefile)
+	project, err := compose.NewProjectFromComposeFile(ctx,
+		workdir,
+		opts.composefile,
+		composespec.WithEnvFiles(opts.EnvFile),
+	)
 	if err != nil {
 		return err
 	}

--- a/internal/cli/kraft/compose/ps/ps.go
+++ b/internal/cli/kraft/compose/ps/ps.go
@@ -10,18 +10,20 @@ import (
 	"os"
 
 	"github.com/MakeNowJust/heredoc"
+	composespec "github.com/compose-spec/compose-go/v2/cli"
 	"github.com/spf13/cobra"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	composeapi "kraftkit.sh/api/compose/v1"
 	"kraftkit.sh/cmdfactory"
 	"kraftkit.sh/compose"
-
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	composeapi "kraftkit.sh/api/compose/v1"
 	pslist "kraftkit.sh/internal/cli/kraft/ps"
 	"kraftkit.sh/log"
 	"kraftkit.sh/packmanager"
 )
 
 type PsOptions struct {
+	EnvFile string `noattribute:"true"`
 	Long    bool   `long:"long" short:"l" usage:"Show more information"`
 	Orphans bool   `long:"orphans" usage:"Include orphaned services (default: true)" default:"true"`
 	Output  string `long:"output" short:"o" usage:"Set output format. Options: table,yaml,json,list" default:"table"`
@@ -74,7 +76,11 @@ func (opts *PsOptions) Run(ctx context.Context, args []string) error {
 	if err != nil {
 		return err
 	}
-	project, err := compose.NewProjectFromComposeFile(ctx, workdir, opts.composefile)
+	project, err := compose.NewProjectFromComposeFile(ctx,
+		workdir,
+		opts.composefile,
+		composespec.WithEnvFiles(opts.EnvFile),
+	)
 	if err != nil {
 		return err
 	}

--- a/internal/cli/kraft/compose/pull/pull.go
+++ b/internal/cli/kraft/compose/pull/pull.go
@@ -10,11 +10,12 @@ import (
 	"os"
 
 	"github.com/MakeNowJust/heredoc"
+	composespec "github.com/compose-spec/compose-go/v2/cli"
 	"github.com/spf13/cobra"
+
 	"kraftkit.sh/cmdfactory"
 	"kraftkit.sh/compose"
 	"kraftkit.sh/internal/cli/kraft/compose/utils"
-
 	pkgpull "kraftkit.sh/internal/cli/kraft/pkg/pull"
 	"kraftkit.sh/log"
 	"kraftkit.sh/packmanager"
@@ -22,6 +23,7 @@ import (
 
 type PullOptions struct {
 	composefile string
+	EnvFile     string `noattribute:"true"`
 }
 
 func NewCmd() *cobra.Command {
@@ -67,7 +69,11 @@ func (opts *PullOptions) Run(ctx context.Context, args []string) error {
 		return err
 	}
 
-	project, err := compose.NewProjectFromComposeFile(ctx, workdir, opts.composefile)
+	project, err := compose.NewProjectFromComposeFile(ctx,
+		workdir,
+		opts.composefile,
+		composespec.WithEnvFiles(opts.EnvFile),
+	)
 	if err != nil {
 		return err
 	}

--- a/internal/cli/kraft/compose/push/push.go
+++ b/internal/cli/kraft/compose/push/push.go
@@ -10,10 +10,11 @@ import (
 	"os"
 
 	"github.com/MakeNowJust/heredoc"
+	composespec "github.com/compose-spec/compose-go/v2/cli"
 	"github.com/spf13/cobra"
+
 	"kraftkit.sh/cmdfactory"
 	"kraftkit.sh/compose"
-
 	pkgpush "kraftkit.sh/internal/cli/kraft/pkg/push"
 	"kraftkit.sh/log"
 	"kraftkit.sh/packmanager"
@@ -21,6 +22,7 @@ import (
 
 type PushOptions struct {
 	composefile string
+	EnvFile     string `noattribute:"true"`
 }
 
 func NewCmd() *cobra.Command {
@@ -66,7 +68,11 @@ func (opts *PushOptions) Run(ctx context.Context, args []string) error {
 		return err
 	}
 
-	project, err := compose.NewProjectFromComposeFile(ctx, workdir, opts.composefile)
+	project, err := compose.NewProjectFromComposeFile(ctx,
+		workdir,
+		opts.composefile,
+		composespec.WithEnvFiles(opts.EnvFile),
+	)
 	if err != nil {
 		return err
 	}

--- a/internal/cli/kraft/compose/start/start.go
+++ b/internal/cli/kraft/compose/start/start.go
@@ -9,6 +9,7 @@ import (
 	"os"
 
 	"github.com/MakeNowJust/heredoc"
+	composespec "github.com/compose-spec/compose-go/v2/cli"
 	"github.com/spf13/cobra"
 
 	"kraftkit.sh/cmdfactory"
@@ -23,6 +24,7 @@ import (
 
 type StartOptions struct {
 	Composefile string `noattribute:"true"`
+	EnvFile     string `noattribute:"true"`
 }
 
 func NewCmd() *cobra.Command {
@@ -67,7 +69,11 @@ func (opts *StartOptions) Run(ctx context.Context, args []string) error {
 		return err
 	}
 
-	project, err := compose.NewProjectFromComposeFile(ctx, workdir, opts.Composefile)
+	project, err := compose.NewProjectFromComposeFile(ctx,
+		workdir,
+		opts.Composefile,
+		composespec.WithEnvFiles(opts.EnvFile),
+	)
 	if err != nil {
 		return err
 	}

--- a/internal/cli/kraft/compose/stop/stop.go
+++ b/internal/cli/kraft/compose/stop/stop.go
@@ -9,6 +9,7 @@ import (
 	"os"
 
 	"github.com/MakeNowJust/heredoc"
+	composespec "github.com/compose-spec/compose-go/v2/cli"
 	"github.com/spf13/cobra"
 
 	"kraftkit.sh/cmdfactory"
@@ -23,6 +24,7 @@ import (
 
 type StopOptions struct {
 	Composefile string
+	EnvFile     string `noattribute:"true"`
 }
 
 func NewCmd() *cobra.Command {
@@ -67,7 +69,11 @@ func (opts *StopOptions) Run(ctx context.Context, args []string) error {
 		return err
 	}
 
-	project, err := compose.NewProjectFromComposeFile(ctx, workdir, opts.Composefile)
+	project, err := compose.NewProjectFromComposeFile(ctx,
+		workdir,
+		opts.Composefile,
+		composespec.WithEnvFiles(opts.EnvFile),
+	)
 	if err != nil {
 		return err
 	}

--- a/internal/cli/kraft/compose/unpause/unpause.go
+++ b/internal/cli/kraft/compose/unpause/unpause.go
@@ -9,6 +9,7 @@ import (
 	"os"
 
 	"github.com/MakeNowJust/heredoc"
+	composespec "github.com/compose-spec/compose-go/v2/cli"
 	"github.com/spf13/cobra"
 
 	"kraftkit.sh/cmdfactory"
@@ -23,6 +24,7 @@ import (
 
 type UnpauseOptions struct {
 	Composefile string `noattribute:"true"`
+	EnvFile     string `noattribute:"true"`
 }
 
 func NewCmd() *cobra.Command {
@@ -67,7 +69,11 @@ func (opts *UnpauseOptions) Run(ctx context.Context, args []string) error {
 		return err
 	}
 
-	project, err := compose.NewProjectFromComposeFile(ctx, workdir, opts.Composefile)
+	project, err := compose.NewProjectFromComposeFile(ctx,
+		workdir,
+		opts.Composefile,
+		composespec.WithEnvFiles(opts.EnvFile),
+	)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This commit introduces support to all compose subcommands (both
in the local and cloud) for supplying an alternative environmental
variables file (i.e. other than `.env`) via the flag `--env-file`.
This increases compatibility with existing compose-based CLI tools
like `docker`.

Signed-off-by: Alexander Jung <alex@unikraft.io>

<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [ ] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [ ] Tested your changes against relevant architectures and platforms;
  - [ ] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->
