### PR TITLE
feat: Introduce tarball manifest provider

### DIFF
--- a/archive/options.go
+++ b/archive/options.go
@@ -6,6 +6,7 @@ package archive
 
 type UnarchiveOptions struct {
 	stripComponents int
+	stripIfOnlyDir  bool
 }
 
 type UnarchiveOption func(uo *UnarchiveOptions) error
@@ -17,6 +18,14 @@ func StripComponents(sc int) UnarchiveOption {
 		}
 
 		uo.stripComponents = sc
+		return nil
+	}
+}
+
+// If there exists only one top-level directory, strip it.
+func StripIfSingleTopLevelDir() UnarchiveOption {
+	return func(uo *UnarchiveOptions) error {
+		uo.stripIfOnlyDir = true
 		return nil
 	}
 }

--- a/manifest/provider.go
+++ b/manifest/provider.go
@@ -72,6 +72,17 @@ func NewProvider(ctx context.Context, path string, mopts ...ManifestOption) (Pro
 		return provider, nil
 	}
 
+	log.G(ctx).WithFields(logrus.Fields{
+		"path": path,
+	}).Trace("trying tarball provider")
+	provider, err = NewTarballProvider(ctx, path, mopts...)
+	if err == nil {
+		log.G(ctx).WithFields(logrus.Fields{
+			"path": path,
+		}).Trace("using tarball provider")
+		return provider, nil
+	}
+
 	// First attempt to detect whether the provided input is a Git repository.  If
 	// it is, it could potentially be from GitHub as well.
 	log.G(ctx).WithFields(logrus.Fields{

--- a/manifest/tarball.go
+++ b/manifest/tarball.go
@@ -1,0 +1,117 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2022, Unikraft GmbH and The KraftKit Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+
+package manifest
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"kraftkit.sh/archive"
+	"kraftkit.sh/pack"
+	"kraftkit.sh/unikraft"
+	"kraftkit.sh/unikraft/app"
+)
+
+type TarballProvider struct {
+	typ   unikraft.ComponentType
+	name  string
+	path  string
+	mopts *ManifestOptions
+}
+
+func NewTarballProvider(ctx context.Context, path string, opts ...ManifestOption) (Provider, error) {
+	if ok, err := archive.IsTarGz(path); !ok {
+		return nil, fmt.Errorf("'%s' is not a tarball: %w", path, err)
+	}
+
+	// Determine the type preemptively
+	n := strings.TrimSuffix(path, ".tar.gz")
+	n = filepath.Base(n)
+	t, n, _, err := unikraft.GuessTypeNameVersion(n)
+	if err != nil || t == unikraft.ComponentTypeUnknown {
+		for _, f := range app.DefaultFileNames {
+			if f, err := os.Stat(filepath.Join(path, f)); err == nil && f.Size() > 0 {
+				t = unikraft.ComponentTypeApp
+				break
+			}
+		}
+	}
+
+	if t == unikraft.ComponentTypeUnknown {
+		return nil, fmt.Errorf("unknown type for tarball: %s", path)
+	}
+
+	return &TarballProvider{
+		typ:   t,
+		name:  n,
+		path:  path,
+		mopts: NewManifestOptions(opts...),
+	}, nil
+}
+
+func (provider TarballProvider) Manifests() ([]*Manifest, error) {
+	return []*Manifest{
+		{
+			Type:     provider.typ,
+			Name:     provider.name,
+			Provider: provider,
+			Origin:   provider.path,
+			Channels: []ManifestChannel{
+				{
+					Name:     "default",
+					Default:  true,
+					Resource: provider.path,
+				},
+			},
+		},
+	}, nil
+}
+
+func (provider TarballProvider) PullManifest(ctx context.Context, manifest *Manifest, opts ...pack.PullOption) error {
+	popts, err := pack.NewPullOptions(opts...)
+	if err != nil {
+		return err
+	}
+
+	if len(popts.Workdir()) == 0 {
+		return fmt.Errorf("cannot pull without without working directory")
+	}
+
+	// The directory provider only has one channel, exploit this knowledge
+	if len(manifest.Channels) != 1 {
+		return fmt.Errorf("cannot determine channel for directory provider")
+	}
+
+	local, err := unikraft.PlaceComponent(
+		popts.Workdir(),
+		manifest.Type,
+		manifest.Name,
+	)
+	if err != nil {
+		return fmt.Errorf("could not place component package: %s", err)
+	}
+
+	if err := archive.UntarGz(provider.path, local, archive.StripIfSingleTopLevelDir()); err != nil {
+		return fmt.Errorf("could not untar: %s: %w", provider.path, err)
+	}
+
+	return nil
+}
+
+func (provider TarballProvider) DeleteManifest(context.Context) error {
+	return nil
+}
+
+func (provider TarballProvider) String() string {
+	return "tarball"
+}
+
+func (provider TarballProvider) MarshalJSON() ([]byte, error) {
+	return []byte(`"tarball"`), nil
+}

--- a/unikraft/component/component.go
+++ b/unikraft/component/component.go
@@ -115,7 +115,7 @@ func urlHasVersion(u *url.URL) string {
 func parseStringProp(entry string) map[string]interface{} {
 	component := make(map[string]interface{})
 
-	if f, err := os.Stat(entry); err == nil && f.IsDir() {
+	if f, err := os.Stat(entry); err == nil && (f.Mode().IsRegular() || f.Mode().IsDir()) {
 		component["source"] = entry
 	} else if u, err := url.Parse(entry); err == nil && u.Host != "" {
 		component["source"] = entry


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

This PR series introduces a new "manifest provider" which handles accessing source code, in this case from tarballs.  It makes accessing sources in the following format of a `Kraftfile` possible:

```yaml
spec: v0.6

name: http-c

unikraft:
  source: ./unikraft.tar.gz

libraries:
  lwip:
    source: ./lib-lwip.tar.gz

targets:
- qemu/x86_64
```

