### PR TITLE
fix(kraft): Do not force splitting of environmental variables at CLI

### DIFF
--- a/internal/cli/kraft/build/build.go
+++ b/internal/cli/kraft/build/build.go
@@ -35,7 +35,7 @@ type BuildOptions struct {
 	All          bool            `long:"all" usage:"Build all targets"`
 	Architecture string          `long:"arch" short:"m" usage:"Filter the creation of the build by architecture of known targets (x86_64/arm64/arm)"`
 	DotConfig    string          `long:"config" short:"c" usage:"Override the path to the KConfig .config file"`
-	Env          []string        `long:"env" short:"e" usage:"Set environment variables to be built in the unikernel"`
+	Env          []string        `long:"env" short:"e" usage:"Set environment variables to be built in the unikernel" split:"false"`
 	ForcePull    bool            `long:"force-pull" usage:"Force pulling packages before building"`
 	Jobs         int             `long:"jobs" short:"j" usage:"Allow N jobs at once"`
 	KernelDbg    bool            `long:"dbg" usage:"Build the debuggable (symbolic) kernel image instead of the stripped image"`

--- a/internal/cli/kraft/cloud/deploy/deploy.go
+++ b/internal/cli/kraft/cloud/deploy/deploy.go
@@ -42,7 +42,7 @@ type DeployOptions struct {
 	Domain              []string                       `local:"true" long:"domain" short:"d" usage:"Set the domain names for the service"`
 	DotConfig           string                         `long:"config" short:"c" usage:"Override the path to the KConfig .config file"`
 	Entrypoint          types.ShellCommand             `local:"true" long:"entrypoint" usage:"Set the entrypoint for the instance"`
-	Env                 []string                       `local:"true" long:"env" short:"e" usage:"Environmental variables"`
+	Env                 []string                       `local:"true" long:"env" short:"e" usage:"Environmental variables" split:"false"`
 	Features            []string                       `local:"true" long:"feature" usage:"Specify the special features to enable"`
 	Follow              bool                           `local:"true" long:"follow" short:"f" usage:"Follow the logs of the instance"`
 	ForcePull           bool                           `long:"force-pull" usage:"Force pulling packages before building"`

--- a/internal/cli/kraft/cloud/instance/create/create.go
+++ b/internal/cli/kraft/cloud/instance/create/create.go
@@ -38,7 +38,7 @@ type CreateOptions struct {
 	Auth                *config.AuthConfig             `noattribute:"true"`
 	Client              kraftcloud.KraftCloud          `noattribute:"true"`
 	Certificate         []string                       `local:"true" long:"certificate" short:"c" usage:"Set the certificates to use for the service"`
-	Env                 []string                       `local:"true" long:"env" short:"e" usage:"Environmental variables"`
+	Env                 []string                       `local:"true" long:"env" short:"e" usage:"Environmental variables" split:"false"`
 	Features            []string                       `local:"true" long:"feature" short:"f" usage:"List of features to enable"`
 	Domain              []string                       `local:"true" long:"domain" short:"d" usage:"The domain names to use for the service"`
 	Image               string                         `noattribute:"true"`

--- a/internal/cli/kraft/pkg/pkg.go
+++ b/internal/cli/kraft/pkg/pkg.go
@@ -39,7 +39,7 @@ type PkgOptions struct {
 	Args         []string                  `local:"true" long:"args" short:"a" usage:"Pass arguments that will be part of the running kernel's command line"`
 	Compress     bool                      `local:"true" long:"compress" short:"c" usage:"Compress the initrd package (experimental)"`
 	Dbg          bool                      `local:"true" long:"dbg" usage:"Package the debuggable (symbolic) kernel image instead of the stripped image"`
-	Env          []string                  `local:"true" long:"env" short:"e" usage:"Set environment variables to be packed into the package"`
+	Env          []string                  `local:"true" long:"env" short:"e" usage:"Set environment variables to be packed into the package" split:"false"`
 	Force        bool                      `local:"true" long:"force-format" usage:"Force the use of a packaging handler format"`
 	Format       string                    `local:"true" long:"as" short:"M" usage:"Force the packaging despite possible conflicts" default:"oci"`
 	Kernel       string                    `local:"true" long:"kernel" short:"k" usage:"Override the path to the unikernel image"`

--- a/internal/cli/kraft/run/run.go
+++ b/internal/cli/kraft/run/run.go
@@ -33,7 +33,7 @@ type RunOptions struct {
 	Architecture  string   `long:"arch" short:"m" usage:"Set the architecture"`
 	Detach        bool     `long:"detach" short:"d" usage:"Run unikernel in background"`
 	DisableAccel  bool     `long:"disable-acceleration" short:"W" usage:"Disable acceleration of CPU (usually enables TCG)"`
-	Env           []string `long:"env" short:"e" usage:"Set environment variables, int the format key[=value]"`
+	Env           []string `long:"env" short:"e" usage:"Set environment variables, int the format key[=value]" split:"false"`
 	InitRd        string   `long:"initrd" usage:"Use the specified initrd (readonly)" hidden:"true"`
 	IP            string   `long:"ip" usage:"Assign the provided IP address"`
 	KernelArgs    []string `long:"kernel-arg" short:"a" usage:"Set additional kernel arguments"`


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

Env vars can contain arbitrary values, including `,` which is by default split by the cmdfactory.  Prevent this inherent functionality by setting the `split` struct tag to `false`.  This allows for now using `,` in an environmental variable without it being mangled.
