### PR TITLE
refactor(oci)!: Add `handle` to `NewPackageFromTarget` signature

### DIFF
--- a/oci/manager.go
+++ b/oci/manager.go
@@ -232,7 +232,12 @@ func (manager *OCIManager) Pack(ctx context.Context, entity component.Component,
 		return nil, fmt.Errorf("entity is not Unikraft target")
 	}
 
-	pkg, err := NewPackageFromTarget(ctx, targ, opts...)
+	ctx, handle, err := manager.handle(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	pkg, err := NewPackageFromTarget(ctx, handle, targ, opts...)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

Previously the `NewPackageFromTarget` would attempt to seed this by looking at KraftKit's configuration.  Instead, pass this directly as a required argument.  Since this is only used in one place, it is a small refactor. However, this ultimately allows the for the OCI package manager to be instantiated with its manager options, i.e. `WithDirectory` or `WithContainerd` and thus the handler can be used during packaging without having to re-read configuration.
