### PR TITLE
fix(app): Prioritize project targets over template targets

### DIFF
--- a/unikraft/app/application.go
+++ b/unikraft/app/application.go
@@ -289,11 +289,13 @@ func (app *application) MergeTemplate(ctx context.Context, merge Application) (A
 		}
 	}
 
-	// TODO(nderjung): This entire method and procedure needs to be re-thought to
-	// be better extensible.  For now, it is unused.  We can safely cast this:
-	app.targets = []*target.TargetConfig{}
-	for _, t := range merge.Targets() {
-		app.targets = append(app.targets, t.(*target.TargetConfig))
+	// Only merge targets if the application has no targets, aka prioritize the
+	// application's targets over the template's targets.
+	if len(app.targets) == 0 {
+		app.targets = []*target.TargetConfig{}
+		for _, t := range merge.Targets() {
+			app.targets = append(app.targets, t.(*target.TargetConfig))
+		}
 	}
 
 	for id, ext := range merge.Extensions() {


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

Do not merge template targets.  If a user specifies a template in their `Kraftfile` and supply a list of `targets`, they expect there to only be those targets in _their_ specified list. Adopting the targets from the template would mean that programmatically we'd have to search for our target or specify a name, which makes the process more cumbersome.

