### PR TITLE
fix(buildenvs): Set the `--platform` when build `base` target

### DIFF
--- a/buildenvs/Makefile
+++ b/buildenvs/Makefile
@@ -79,6 +79,7 @@ base: _WITH_CACHE      := --no-cache
 endif
 base:
 	$(DOCKER) build \
+		--platform $(PLATFORM) \
 		--build-arg GO_VERSION=$(GO_VERSION) \
 		--build-arg KRAFTKIT_VERSION=$(KRAFTKIT_VERSION) \
 		--build-arg QEMU_VERSION=$(QEMU_VERSION) \


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

Currently the only supported platform is x86_64.  Running this command on an arm64 machine results in a failed build.  This change ensures it will correctly build.
