### PR TITLE
fix(internal): Load env vars from file when specified

### DIFF
--- a/internal/cli/kraft/cloud/compose/build/build.go
+++ b/internal/cli/kraft/cloud/compose/build/build.go
@@ -104,10 +104,16 @@ func Build(ctx context.Context, opts *BuildOptions, args ...string) error {
 			return err
 		}
 
+		var envFiles []string
+		if opts.EnvFile != "" {
+			envFiles = append(envFiles, opts.EnvFile)
+		}
+
 		opts.Project, err = compose.NewProjectFromComposeFile(ctx,
 			workdir,
 			opts.Composefile,
-			composespec.WithEnvFiles(opts.EnvFile),
+			composespec.WithEnvFiles(envFiles...),
+			composespec.WithDotEnv,
 		)
 		if err != nil {
 			return err
@@ -335,6 +341,10 @@ func (opts *BuildOptions) Pre(cmd *cobra.Command, args []string) error {
 
 	if cmd.Flag("file").Changed {
 		opts.Composefile = cmd.Flag("file").Value.String()
+	}
+
+	if cmd.Flag("env-file").Changed {
+		opts.EnvFile = cmd.Flag("env-file").Value.String()
 	}
 
 	return nil

--- a/internal/cli/kraft/cloud/compose/down/down.go
+++ b/internal/cli/kraft/cloud/compose/down/down.go
@@ -90,10 +90,16 @@ func (opts *DownOptions) Run(ctx context.Context, args []string) error {
 			return err
 		}
 
+		var envFiles []string
+		if opts.EnvFile != "" {
+			envFiles = append(envFiles, opts.EnvFile)
+		}
+
 		opts.Project, err = compose.NewProjectFromComposeFile(ctx,
 			workdir,
 			opts.Composefile,
-			composespec.WithEnvFiles(opts.EnvFile),
+			composespec.WithEnvFiles(envFiles...),
+			composespec.WithDotEnv,
 		)
 		if err != nil {
 			return err

--- a/internal/cli/kraft/cloud/compose/list/list.go
+++ b/internal/cli/kraft/cloud/compose/list/list.go
@@ -66,10 +66,16 @@ func (opts *ListOptions) Run(ctx context.Context, args []string) error {
 		workdir = args[0]
 	}
 
+	var envFiles []string
+	if opts.EnvFile != "" {
+		envFiles = append(envFiles, opts.EnvFile)
+	}
+
 	project, err := compose.NewProjectFromComposeFile(ctx,
 		workdir,
 		opts.Composefile,
-		composespec.WithEnvFiles(opts.EnvFile),
+		composespec.WithEnvFiles(envFiles...),
+		composespec.WithDotEnv,
 	)
 	if err != nil {
 		return err

--- a/internal/cli/kraft/cloud/compose/logs/logs.go
+++ b/internal/cli/kraft/cloud/compose/logs/logs.go
@@ -72,6 +72,10 @@ func (opts *LogsOptions) Pre(cmd *cobra.Command, args []string) error {
 		opts.Composefile = cmd.Flag("file").Value.String()
 	}
 
+	if cmd.Flag("env-file").Changed {
+		opts.EnvFile = cmd.Flag("env-file").Value.String()
+	}
+
 	return nil
 }
 
@@ -101,10 +105,16 @@ func Logs(ctx context.Context, opts *LogsOptions, args ...string) error {
 	}
 
 	if opts.Project == nil {
+		var envFiles []string
+		if opts.EnvFile != "" {
+			envFiles = append(envFiles, opts.EnvFile)
+		}
+
 		opts.Project, err = compose.NewProjectFromComposeFile(ctx,
 			workdir,
 			opts.Composefile,
-			composespec.WithEnvFiles(opts.EnvFile),
+			composespec.WithEnvFiles(envFiles...),
+			composespec.WithDotEnv,
 		)
 		if err != nil {
 			return err

--- a/internal/cli/kraft/cloud/compose/ps/ps.go
+++ b/internal/cli/kraft/cloud/compose/ps/ps.go
@@ -86,10 +86,16 @@ func (opts *PsOptions) Run(ctx context.Context, args []string) error {
 			return err
 		}
 
+		var envFiles []string
+		if opts.EnvFile != "" {
+			envFiles = append(envFiles, opts.EnvFile)
+		}
+
 		opts.Project, err = compose.NewProjectFromComposeFile(ctx,
 			workdir,
 			opts.Composefile,
-			composespec.WithEnvFiles(opts.EnvFile),
+			composespec.WithEnvFiles(envFiles...),
+			composespec.WithDotEnv,
 		)
 		if err != nil {
 			return err

--- a/internal/cli/kraft/cloud/compose/push/push.go
+++ b/internal/cli/kraft/cloud/compose/push/push.go
@@ -81,10 +81,16 @@ func Push(ctx context.Context, opts *PushOptions, args ...string) error {
 	}
 
 	if opts.Project == nil {
+		var envFiles []string
+		if opts.EnvFile != "" {
+			envFiles = append(envFiles, opts.EnvFile)
+		}
+
 		opts.Project, err = compose.NewProjectFromComposeFile(ctx,
 			workdir,
 			opts.Composefile,
-			composespec.WithEnvFiles(opts.EnvFile),
+			composespec.WithEnvFiles(envFiles...),
+			composespec.WithDotEnv,
 		)
 		if err != nil {
 			return err
@@ -191,6 +197,10 @@ func (opts *PushOptions) Pre(cmd *cobra.Command, args []string) error {
 
 	if cmd.Flag("file").Changed {
 		opts.Composefile = cmd.Flag("file").Value.String()
+	}
+
+	if cmd.Flag("env-file").Changed {
+		opts.EnvFile = cmd.Flag("env-file").Value.String()
 	}
 
 	return nil

--- a/internal/cli/kraft/cloud/compose/start/start.go
+++ b/internal/cli/kraft/cloud/compose/start/start.go
@@ -70,6 +70,10 @@ func (opts *StartOptions) Pre(cmd *cobra.Command, args []string) error {
 		opts.Composefile = cmd.Flag("file").Value.String()
 	}
 
+	if cmd.Flag("env-file").Changed {
+		opts.EnvFile = cmd.Flag("env-file").Value.String()
+	}
+
 	return nil
 }
 
@@ -95,10 +99,16 @@ func (opts *StartOptions) Run(ctx context.Context, args []string) error {
 			return err
 		}
 
+		var envFiles []string
+		if opts.EnvFile != "" {
+			envFiles = append(envFiles, opts.EnvFile)
+		}
+
 		opts.Project, err = compose.NewProjectFromComposeFile(ctx,
 			workdir,
 			opts.Composefile,
-			composespec.WithEnvFiles(opts.EnvFile),
+			composespec.WithEnvFiles(envFiles...),
+			composespec.WithDotEnv,
 		)
 		if err != nil {
 			return err

--- a/internal/cli/kraft/cloud/compose/stop/stop.go
+++ b/internal/cli/kraft/cloud/compose/stop/stop.go
@@ -80,6 +80,10 @@ func (opts *StopOptions) Pre(cmd *cobra.Command, args []string) error {
 		opts.Composefile = cmd.Flag("file").Value.String()
 	}
 
+	if cmd.Flag("env-file").Changed {
+		opts.EnvFile = cmd.Flag("env-file").Value.String()
+	}
+
 	return nil
 }
 
@@ -105,10 +109,16 @@ func (opts *StopOptions) Run(ctx context.Context, args []string) error {
 			return err
 		}
 
+		var envFiles []string
+		if opts.EnvFile != "" {
+			envFiles = append(envFiles, opts.EnvFile)
+		}
+
 		opts.Project, err = compose.NewProjectFromComposeFile(ctx,
 			workdir,
 			opts.Composefile,
-			composespec.WithEnvFiles(opts.EnvFile),
+			composespec.WithEnvFiles(envFiles...),
+			composespec.WithDotEnv,
 		)
 		if err != nil {
 			return err

--- a/internal/cli/kraft/cloud/compose/up/up.go
+++ b/internal/cli/kraft/cloud/compose/up/up.go
@@ -109,6 +109,10 @@ func (opts *UpOptions) Pre(cmd *cobra.Command, args []string) error {
 		opts.Composefile = cmd.Flag("file").Value.String()
 	}
 
+	if cmd.Flag("env-file").Changed {
+		opts.EnvFile = cmd.Flag("env-file").Value.String()
+	}
+
 	return nil
 }
 
@@ -138,10 +142,16 @@ func Up(ctx context.Context, opts *UpOptions, args ...string) error {
 			return err
 		}
 
+		var envFiles []string
+		if opts.EnvFile != "" {
+			envFiles = append(envFiles, opts.EnvFile)
+		}
+
 		opts.Project, err = compose.NewProjectFromComposeFile(ctx,
 			workdir,
 			opts.Composefile,
-			composespec.WithEnvFiles(opts.EnvFile),
+			composespec.WithEnvFiles(envFiles...),
+			composespec.WithDotEnv,
 		)
 		if err != nil {
 			return err

--- a/internal/cli/kraft/compose/build/build.go
+++ b/internal/cli/kraft/compose/build/build.go
@@ -55,6 +55,10 @@ func (opts *BuildOptions) Pre(cmd *cobra.Command, _ []string) error {
 		opts.composefile = cmd.Flag("file").Value.String()
 	}
 
+	if cmd.Flag("env-file").Changed {
+		opts.EnvFile = cmd.Flag("env-file").Value.String()
+	}
+
 	log.G(cmd.Context()).WithField("composefile", opts.composefile).Debug("using")
 	return nil
 }
@@ -65,10 +69,16 @@ func (opts *BuildOptions) Run(ctx context.Context, args []string) error {
 		return err
 	}
 
+	var envFiles []string
+	if opts.EnvFile != "" {
+		envFiles = append(envFiles, opts.EnvFile)
+	}
+
 	project, err := compose.NewProjectFromComposeFile(ctx,
 		workdir,
 		opts.composefile,
-		composespec.WithEnvFiles(opts.EnvFile),
+		composespec.WithEnvFiles(envFiles...),
+		composespec.WithDotEnv,
 	)
 	if err != nil {
 		return err

--- a/internal/cli/kraft/compose/create/create.go
+++ b/internal/cli/kraft/compose/create/create.go
@@ -80,6 +80,10 @@ func (opts *CreateOptions) Pre(cmd *cobra.Command, _ []string) error {
 		opts.Composefile = cmd.Flag("file").Value.String()
 	}
 
+	if cmd.Flag("env-file").Changed {
+		opts.EnvFile = cmd.Flag("env-file").Value.String()
+	}
+
 	log.G(cmd.Context()).WithField("composefile", opts.Composefile).Debug("using")
 	return nil
 }
@@ -90,10 +94,16 @@ func (opts *CreateOptions) Run(ctx context.Context, args []string) error {
 		return err
 	}
 
+	var envFiles []string
+	if opts.EnvFile != "" {
+		envFiles = append(envFiles, opts.EnvFile)
+	}
+
 	project, err := compose.NewProjectFromComposeFile(ctx,
 		workdir,
 		opts.Composefile,
-		composespec.WithEnvFiles(opts.EnvFile),
+		composespec.WithEnvFiles(envFiles...),
+		composespec.WithDotEnv,
 	)
 	if err != nil {
 		return err

--- a/internal/cli/kraft/compose/down/down.go
+++ b/internal/cli/kraft/compose/down/down.go
@@ -67,6 +67,10 @@ func (opts *DownOptions) Pre(cmd *cobra.Command, _ []string) error {
 		opts.composefile = cmd.Flag("file").Value.String()
 	}
 
+	if cmd.Flag("env-file").Changed {
+		opts.EnvFile = cmd.Flag("env-file").Value.String()
+	}
+
 	log.G(cmd.Context()).WithField("composefile", opts.composefile).Debug("using")
 	return nil
 }
@@ -76,10 +80,16 @@ func (opts *DownOptions) Run(ctx context.Context, args []string) error {
 	if err != nil {
 		return err
 	}
+	var envFiles []string
+	if opts.EnvFile != "" {
+		envFiles = append(envFiles, opts.EnvFile)
+	}
+
 	project, err := compose.NewProjectFromComposeFile(ctx,
 		workdir,
 		opts.composefile,
-		composespec.WithEnvFiles(opts.EnvFile),
+		composespec.WithEnvFiles(envFiles...),
+		composespec.WithDotEnv,
 	)
 	if err != nil {
 		return err

--- a/internal/cli/kraft/compose/logs/logs.go
+++ b/internal/cli/kraft/compose/logs/logs.go
@@ -55,6 +55,10 @@ func (opts *LogsOptions) Pre(cmd *cobra.Command, _ []string) error {
 		opts.Composefile = cmd.Flag("file").Value.String()
 	}
 
+	if cmd.Flag("env-file").Changed {
+		opts.EnvFile = cmd.Flag("env-file").Value.String()
+	}
+
 	log.G(cmd.Context()).WithField("composefile", opts.Composefile).Debug("using")
 
 	return nil
@@ -66,10 +70,16 @@ func (opts *LogsOptions) Run(ctx context.Context, args []string) error {
 		return err
 	}
 
+	var envFiles []string
+	if opts.EnvFile != "" {
+		envFiles = append(envFiles, opts.EnvFile)
+	}
+
 	project, err := compose.NewProjectFromComposeFile(ctx,
 		workdir,
 		opts.Composefile,
-		composespec.WithEnvFiles(opts.EnvFile),
+		composespec.WithEnvFiles(envFiles...),
+		composespec.WithDotEnv,
 	)
 	if err != nil {
 		return err

--- a/internal/cli/kraft/compose/pause/pause.go
+++ b/internal/cli/kraft/compose/pause/pause.go
@@ -59,6 +59,10 @@ func (opts *PauseOptions) Pre(cmd *cobra.Command, _ []string) error {
 		opts.composefile = cmd.Flag("file").Value.String()
 	}
 
+	if cmd.Flag("env-file").Changed {
+		opts.EnvFile = cmd.Flag("env-file").Value.String()
+	}
+
 	log.G(cmd.Context()).WithField("composefile", opts.composefile).Debug("using")
 	return nil
 }
@@ -69,10 +73,16 @@ func (opts *PauseOptions) Run(ctx context.Context, args []string) error {
 		return err
 	}
 
+	var envFiles []string
+	if opts.EnvFile != "" {
+		envFiles = append(envFiles, opts.EnvFile)
+	}
+
 	project, err := compose.NewProjectFromComposeFile(ctx,
 		workdir,
 		opts.composefile,
-		composespec.WithEnvFiles(opts.EnvFile),
+		composespec.WithEnvFiles(envFiles...),
+		composespec.WithDotEnv,
 	)
 	if err != nil {
 		return err

--- a/internal/cli/kraft/compose/ps/ps.go
+++ b/internal/cli/kraft/compose/ps/ps.go
@@ -67,6 +67,10 @@ func (opts *PsOptions) Pre(cmd *cobra.Command, _ []string) error {
 		opts.composefile = cmd.Flag("file").Value.String()
 	}
 
+	if cmd.Flag("env-file").Changed {
+		opts.EnvFile = cmd.Flag("env-file").Value.String()
+	}
+
 	log.G(cmd.Context()).WithField("composefile", opts.composefile).Debug("using")
 	return nil
 }
@@ -76,10 +80,16 @@ func (opts *PsOptions) Run(ctx context.Context, args []string) error {
 	if err != nil {
 		return err
 	}
+	var envFiles []string
+	if opts.EnvFile != "" {
+		envFiles = append(envFiles, opts.EnvFile)
+	}
+
 	project, err := compose.NewProjectFromComposeFile(ctx,
 		workdir,
 		opts.composefile,
-		composespec.WithEnvFiles(opts.EnvFile),
+		composespec.WithEnvFiles(envFiles...),
+		composespec.WithDotEnv,
 	)
 	if err != nil {
 		return err

--- a/internal/cli/kraft/compose/pull/pull.go
+++ b/internal/cli/kraft/compose/pull/pull.go
@@ -59,6 +59,10 @@ func (opts *PullOptions) Pre(cmd *cobra.Command, _ []string) error {
 		opts.composefile = cmd.Flag("file").Value.String()
 	}
 
+	if cmd.Flag("env-file").Changed {
+		opts.EnvFile = cmd.Flag("env-file").Value.String()
+	}
+
 	log.G(cmd.Context()).WithField("composefile", opts.composefile).Debug("using")
 	return nil
 }
@@ -69,10 +73,16 @@ func (opts *PullOptions) Run(ctx context.Context, args []string) error {
 		return err
 	}
 
+	var envFiles []string
+	if opts.EnvFile != "" {
+		envFiles = append(envFiles, opts.EnvFile)
+	}
+
 	project, err := compose.NewProjectFromComposeFile(ctx,
 		workdir,
 		opts.composefile,
-		composespec.WithEnvFiles(opts.EnvFile),
+		composespec.WithEnvFiles(envFiles...),
+		composespec.WithDotEnv,
 	)
 	if err != nil {
 		return err

--- a/internal/cli/kraft/compose/push/push.go
+++ b/internal/cli/kraft/compose/push/push.go
@@ -58,6 +58,10 @@ func (opts *PushOptions) Pre(cmd *cobra.Command, _ []string) error {
 		opts.composefile = cmd.Flag("file").Value.String()
 	}
 
+	if cmd.Flag("env-file").Changed {
+		opts.EnvFile = cmd.Flag("env-file").Value.String()
+	}
+
 	log.G(cmd.Context()).WithField("composefile", opts.composefile).Debug("using")
 	return nil
 }
@@ -68,10 +72,16 @@ func (opts *PushOptions) Run(ctx context.Context, args []string) error {
 		return err
 	}
 
+	var envFiles []string
+	if opts.EnvFile != "" {
+		envFiles = append(envFiles, opts.EnvFile)
+	}
+
 	project, err := compose.NewProjectFromComposeFile(ctx,
 		workdir,
 		opts.composefile,
-		composespec.WithEnvFiles(opts.EnvFile),
+		composespec.WithEnvFiles(envFiles...),
+		composespec.WithDotEnv,
 	)
 	if err != nil {
 		return err

--- a/internal/cli/kraft/compose/start/start.go
+++ b/internal/cli/kraft/compose/start/start.go
@@ -59,6 +59,10 @@ func (opts *StartOptions) Pre(cmd *cobra.Command, _ []string) error {
 		opts.Composefile = cmd.Flag("file").Value.String()
 	}
 
+	if cmd.Flag("env-file").Changed {
+		opts.EnvFile = cmd.Flag("env-file").Value.String()
+	}
+
 	log.G(cmd.Context()).WithField("composefile", opts.Composefile).Debug("using")
 	return nil
 }
@@ -69,10 +73,16 @@ func (opts *StartOptions) Run(ctx context.Context, args []string) error {
 		return err
 	}
 
+	var envFiles []string
+	if opts.EnvFile != "" {
+		envFiles = append(envFiles, opts.EnvFile)
+	}
+
 	project, err := compose.NewProjectFromComposeFile(ctx,
 		workdir,
 		opts.Composefile,
-		composespec.WithEnvFiles(opts.EnvFile),
+		composespec.WithEnvFiles(envFiles...),
+		composespec.WithDotEnv,
 	)
 	if err != nil {
 		return err

--- a/internal/cli/kraft/compose/stop/stop.go
+++ b/internal/cli/kraft/compose/stop/stop.go
@@ -59,6 +59,10 @@ func (opts *StopOptions) Pre(cmd *cobra.Command, _ []string) error {
 		opts.Composefile = cmd.Flag("file").Value.String()
 	}
 
+	if cmd.Flag("env-file").Changed {
+		opts.EnvFile = cmd.Flag("env-file").Value.String()
+	}
+
 	log.G(cmd.Context()).WithField("composefile", opts.Composefile).Debug("using")
 	return nil
 }
@@ -69,10 +73,16 @@ func (opts *StopOptions) Run(ctx context.Context, args []string) error {
 		return err
 	}
 
+	var envFiles []string
+	if opts.EnvFile != "" {
+		envFiles = append(envFiles, opts.EnvFile)
+	}
+
 	project, err := compose.NewProjectFromComposeFile(ctx,
 		workdir,
 		opts.Composefile,
-		composespec.WithEnvFiles(opts.EnvFile),
+		composespec.WithEnvFiles(envFiles...),
+		composespec.WithDotEnv,
 	)
 	if err != nil {
 		return err

--- a/internal/cli/kraft/compose/unpause/unpause.go
+++ b/internal/cli/kraft/compose/unpause/unpause.go
@@ -59,6 +59,10 @@ func (opts *UnpauseOptions) Pre(cmd *cobra.Command, _ []string) error {
 		opts.Composefile = cmd.Flag("file").Value.String()
 	}
 
+	if cmd.Flag("env-file").Changed {
+		opts.EnvFile = cmd.Flag("env-file").Value.String()
+	}
+
 	log.G(cmd.Context()).WithField("composefile", opts.Composefile).Debug("using")
 	return nil
 }
@@ -69,10 +73,16 @@ func (opts *UnpauseOptions) Run(ctx context.Context, args []string) error {
 		return err
 	}
 
+	var envFiles []string
+	if opts.EnvFile != "" {
+		envFiles = append(envFiles, opts.EnvFile)
+	}
+
 	project, err := compose.NewProjectFromComposeFile(ctx,
 		workdir,
 		opts.Composefile,
-		composespec.WithEnvFiles(opts.EnvFile),
+		composespec.WithEnvFiles(envFiles...),
+		composespec.WithDotEnv,
 	)
 	if err != nil {
 		return err


### PR DESCRIPTION
By default it uses '.env' if found. If '--env-file' is specified then use that instead of it.

<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [ ] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [ ] Tested your changes against relevant architectures and platforms;
  - [ ] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->
