### PR TITLE
refactor(run): Better plat/arch selection

### DIFF
--- a/internal/cli/kraft/run/runner_kraftfile_unikraft.go
+++ b/internal/cli/kraft/run/runner_kraftfile_unikraft.go
@@ -107,8 +107,8 @@ func (runner *runnerKraftfileUnikraft) Prepare(ctx context.Context, opts *RunOpt
 	// Filter project targets by any provided CLI options
 	targets = target.Filter(
 		targets,
-		opts.Architecture,
-		opts.platform.String(),
+		"",
+		"",
 		opts.Target,
 	)
 
@@ -130,6 +130,21 @@ func (runner *runnerKraftfileUnikraft) Prepare(ctx context.Context, opts *RunOpt
 			return fmt.Errorf("could not select target: %v", err)
 		}
 	}
+
+	opts.Platform = t.Platform().String()
+	if err := opts.detectAndSetHostPlatform(ctx); err != nil {
+		return fmt.Errorf("could not detect platform: %w", err)
+	}
+
+	opts.Architecture = t.Architecture().String()
+	if err := opts.detectAndSetHostArchitecture(ctx); err != nil {
+		return fmt.Errorf("could not detect architecture: %w", err)
+	}
+
+	log.G(ctx).
+		WithField("arch", opts.Architecture).
+		WithField("plat", opts.Platform).
+		Info("using")
 
 	// Provide a meaningful name
 	targetName := t.Name()

--- a/internal/cli/kraft/run/runner_linuxu.go
+++ b/internal/cli/kraft/run/runner_linuxu.go
@@ -125,6 +125,18 @@ func (runner *runnerLinuxu) Prepare(ctx context.Context, opts *RunOptions, machi
 		opts.Platform = "qemu"
 	}
 
+	if opts.Platform == "" || opts.Platform == "auto" {
+		if err := opts.detectAndSetHostPlatform(ctx); err != nil {
+			return fmt.Errorf("could not detect host platform: %w", err)
+		}
+	}
+
+	if opts.Architecture == "" || opts.Architecture == "auto" {
+		if err := opts.detectAndSetHostArchitecture(ctx); err != nil {
+			return fmt.Errorf("could not detect host architecture: %w", err)
+		}
+	}
+
 	loader, err := runtime.NewRuntime(ctx, opts.Runtime,
 		runtime.WithPlatform(opts.Platform),
 		runtime.WithArchitecture(opts.Architecture),


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

This PR refactors and generally improves the selection process for targets and/or packages during the invocation of `kraft run`. This begins with breaking up `discoverMachineController` into two seperate methods for detecting the platform and the architecture. Broadly, this, along with migrating the call to these methods to later stages, allows for the various runners to make a wider search before narrowing into the host's plat/arch combo.  This is done in order to 1). provide the user the option to select from the various plat/arch combinations if the host does not match and 2). in the case where the user is working with multiple builds in their project, to always all them to select these when no flags are present.  Previously, the embedded functionality would always just default to the host's plat/arch but this might not always be appropriate given what the user is trying to do.

