### PR TITLE
fix(run): Check and assign ports after preparing runner

### DIFF
--- a/internal/cli/kraft/run/run.go
+++ b/internal/cli/kraft/run/run.go
@@ -270,12 +270,6 @@ func (opts *RunOptions) Run(ctx context.Context, args []string) error {
 		},
 	}
 
-	// Preemptively assign ports which can return early with an error if they are
-	// already in use.
-	if err := opts.assignPorts(ctx, machine); err != nil {
-		return err
-	}
-
 	var run runner
 	var errs []error
 	runners, err := runners()
@@ -335,6 +329,11 @@ func (opts *RunOptions) Run(ctx context.Context, args []string) error {
 
 	// Prepare the machine specification based on the compatible runner.
 	if err := run.Prepare(ctx, opts, machine, args...); err != nil {
+		return err
+	}
+
+	// Assign ports by checking for conflicts with existing machines.
+	if err := opts.assignPorts(ctx, machine); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

It is no longer possible to preemptively check whether assigned ports are used by the machine controller since this selection happens potentially only late after checking all possible options and potentially only after use selection.  Therefore, migrate this check to after the prepare statement.

