### PR TITLE
fix(goreleaser): Install to `/usr/bin` instead

### DIFF
--- a/.goreleaser-stable.yaml
+++ b/.goreleaser-stable.yaml
@@ -73,7 +73,7 @@ nfpms:
     maintainer: Alexander Jung <alex@unikraft.io>
     description: Build and use highly customized and ultra-lightweight unikernels.
     license: BSD 3-clause
-    bindir: /usr/local/bin
+    bindir: /usr/bin
     homepage: https://kraftkit.sh
     formats:
       - deb
@@ -94,9 +94,9 @@ nfpms:
       - g++-x86-64-linux-gnu
     contents:
       - src: scripts/kraftld
-        dst: /usr/local/bin/kraftld
-      - src: ./docs/man/
-        dst: /usr/local/share/man/man1/
+        dst: /usr/bin/kraftld
+      - src: docs/man/
+        dst: /usr/share/man/man1/
 
 aurs:
   - homepage: https://kraftkit.sh

--- a/.goreleaser-staging.yaml
+++ b/.goreleaser-staging.yaml
@@ -59,7 +59,7 @@ nfpms:
     maintainer: Alexander Jung <alex@unikraft.io>
     description: Build and use highly customized and ultra-lightweight unikernels.
     license: BSD 3-clause
-    bindir: /usr/local/bin
+    bindir: /usr/bin
     homepage: https://kraftkit.sh
     formats:
       - deb
@@ -80,9 +80,9 @@ nfpms:
       - g++-x86-64-linux-gnu
     contents:
       - src: scripts/kraftld
-        dst: /usr/local/bin/kraftld
-      - src: ./docs/man/
-        dst: /usr/local/share/man/man1/
+        dst: /usr/bin/kraftld
+      - src: docs/man/
+        dst: /usr/share/man/man1/
 
 brews:
   - name: kraftkit-staging


### PR DESCRIPTION
This avoids `/usr/local/bin` as it is missing on systems.

GitHub-Closes: #2133

<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [ ] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [ ] Tested your changes against relevant architectures and platforms;
  - [ ] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->
