### PR TITLE
feat: Add sentry and anonymous telemetry support

### DIFF
--- a/.github/workflows/release-stable.yaml
+++ b/.github/workflows/release-stable.yaml
@@ -71,3 +71,13 @@ jobs:
           AUR_KEY: ${{ secrets.AUR_KEY }}
           COSIGN_PASSWORD: ${{ secrets.COSIGN_PASSWORD }}
           COSIGN_KEY: ${{ secrets.COSIGN_KEY }}
+
+      - name: Create Sentry release
+        uses: getsentry/action-release@v1
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
+          SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
+        with:
+          environment: stable
+          version: "${{  github.ref_name }}"

--- a/.github/workflows/release-staging.yaml
+++ b/.github/workflows/release-staging.yaml
@@ -44,3 +44,18 @@ jobs:
             --skip=validate
         env:
           GITHUB_TOKEN: ${{ secrets.GH_PAT }}
+
+      - name: Get staging version
+        id: current-version
+        run: |
+          echo "version=$(git describe)" >> "$GITHUB_OUTPUT"
+
+      - name: Create Sentry release
+        uses: getsentry/action-release@v1
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
+          SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
+        with:
+          environment: staging
+          version: "${{ steps.current-version.outputs.version }}"

--- a/.goreleaser-stable.yaml
+++ b/.goreleaser-stable.yaml
@@ -232,6 +232,7 @@ builds:
       #@ else:
       - -extldflags "-static"
       #@ end
+      - -X {{ .Env.GOMOD }}/internal/cli/kraft.sentryDsn={{ .Env.SENTRY_DSN }}
     tags:
       - containers_image_storage_stub
       - containers_image_openpgp

--- a/.goreleaser-staging.yaml
+++ b/.goreleaser-staging.yaml
@@ -172,6 +172,7 @@ builds:
       #@ else:
       - -extldflags "-static"
       #@ end
+      - -X {{ .Env.GOMOD }}/internal/cli/kraft.sentryDsn={{ .Env.SENTRY_DSN }}
     tags:
       - containers_image_storage_stub
       - containers_image_openpgp

--- a/Makefile
+++ b/Makefile
@@ -183,6 +183,7 @@ $(addprefix $(.PROXY), $(BIN)): TAGS += containers_image_openpgp
 $(addprefix $(.PROXY), $(BIN)): GO_LDFLAGS += -X "$(GOMOD)/internal/version.version=$(VERSION)"
 $(addprefix $(.PROXY), $(BIN)): GO_LDFLAGS += -X "$(GOMOD)/internal/version.commit=$(GIT_SHA)"
 $(addprefix $(.PROXY), $(BIN)): GO_LDFLAGS += -X "$(GOMOD)/internal/version.buildTime=$(shell date)"
+$(addprefix $(.PROXY), $(BIN)): GO_LDFLAGS += -X "$(GOMOD)/internal/cli/kraft.sentryDsn=$(SENTRY_DSN)"
 ifeq ($(STATIC),y)
 $(addprefix $(.PROXY), $(BIN)): GO_LDFLAGS += -extldflags "-static $(XEN_LDFLAGS)"
 else

--- a/config/config.go
+++ b/config/config.go
@@ -15,23 +15,24 @@ type AuthConfig struct {
 }
 
 type KraftKit struct {
-	NoPrompt       bool   `yaml:"no_prompt" env:"KRAFTKIT_NO_PROMPT" long:"no-prompt" usage:"Do not prompt for user interaction" default:"false"`
-	NoParallel     bool   `yaml:"no_parallel" env:"KRAFTKIT_NO_PARALLEL" long:"no-parallel" usage:"Do not run internal tasks in parallel" default:"false"`
-	NoEmojis       bool   `yaml:"no_emojis" env:"KRAFTKIT_NO_EMOJIS" long:"no-emojis" usage:"Do not use emojis in any console output" default:"true"`
-	NoCheckUpdates bool   `yaml:"no_check_updates" env:"KRAFTKIT_NO_CHECK_UPDATES" long:"no-check-updates" usage:"Do not check for updates" default:"false"`
-	NoColor        bool   `yaml:"no_color" env:"KRAFTKIT_NO_COLOR" long:"no-color" usage:"Disable color output"`
-	NoWarnSudo     bool   `yaml:"no_warn_sudo" env:"KRAFTKIT_NO_WARN_SUDO" long:"no-warn-sudo" usage:"Do not warn on running via sudo" default:"false"`
-	Editor         string `yaml:"editor" env:"KRAFTKIT_EDITOR" long:"editor" usage:"Set the text editor to open when prompt to edit a file"`
-	GitProtocol    string `yaml:"git_protocol" env:"KRAFTKIT_GIT_PROTOCOL" long:"git-protocol" usage:"Preferred Git protocol to use" default:"https"`
-	Pager          string `yaml:"pager,omitempty" env:"KRAFTKIT_PAGER" long:"pager" usage:"System pager to pipe output to" default:"cat"`
-	Qemu           string `yaml:"qemu,omitempty" env:"KRAFTKIT_QEMU" long:"qemu" usage:"Path to QEMU executable" default:""`
-	HTTPUnixSocket string `yaml:"http_unix_socket,omitempty" env:"KRAFTKIT_HTTP_UNIX_SOCKET" long:"http-unix-sock" usage:"When making HTTP(S) connections, pipe requests via this shared socket"`
-	RuntimeDir     string `yaml:"runtime_dir" env:"KRAFTKIT_RUNTIME_DIR" long:"runtime-dir" usage:"Directory for placing runtime files (e.g. pidfiles)"`
-	DefaultPlat    string `yaml:"default_plat" env:"KRAFTKIT_DEFAULT_PLAT" usage:"The default platform to use when invoking platform-specific code" noattribute:"true"`
-	DefaultArch    string `yaml:"default_arch" env:"KRAFTKIT_DEFAULT_ARCH" usage:"The default architecture to use when invoking architecture-specific code" noattribute:"true"`
-	ContainerdAddr string `yaml:"containerd_addr,omitempty" env:"KRAFTKIT_CONTAINERD_ADDR" long:"containerd-addr" usage:"Address of containerd daemon socket" default:""`
-	EventsPidFile  string `yaml:"events_pidfile" env:"KRAFTKIT_EVENTS_PIDFILE" long:"events-pid-file" usage:"Events process ID used when running multiple unikernels"`
-	BuildKitHost   string `yaml:"buildkit_host" env:"KRAFTKIT_BUILDKIT_HOST" long:"buildkit-host" usage:"Path to the buildkit host" default:""`
+	NoPrompt                  bool   `yaml:"no_prompt" env:"KRAFTKIT_NO_PROMPT" long:"no-prompt" usage:"Do not prompt for user interaction" default:"false"`
+	NoParallel                bool   `yaml:"no_parallel" env:"KRAFTKIT_NO_PARALLEL" long:"no-parallel" usage:"Do not run internal tasks in parallel" default:"false"`
+	NoEmojis                  bool   `yaml:"no_emojis" env:"KRAFTKIT_NO_EMOJIS" long:"no-emojis" usage:"Do not use emojis in any console output" default:"true"`
+	NoCheckUpdates            bool   `yaml:"no_check_updates" env:"KRAFTKIT_NO_CHECK_UPDATES" long:"no-check-updates" usage:"Do not check for updates" default:"false"`
+	NoColor                   bool   `yaml:"no_color" env:"KRAFTKIT_NO_COLOR" long:"no-color" usage:"Disable color output"`
+	NoWarnSudo                bool   `yaml:"no_warn_sudo" env:"KRAFTKIT_NO_WARN_SUDO" long:"no-warn-sudo" usage:"Do not warn on running via sudo" default:"false"`
+	Editor                    string `yaml:"editor" env:"KRAFTKIT_EDITOR" long:"editor" usage:"Set the text editor to open when prompt to edit a file"`
+	GitProtocol               string `yaml:"git_protocol" env:"KRAFTKIT_GIT_PROTOCOL" long:"git-protocol" usage:"Preferred Git protocol to use" default:"https"`
+	Pager                     string `yaml:"pager,omitempty" env:"KRAFTKIT_PAGER" long:"pager" usage:"System pager to pipe output to" default:"cat"`
+	Qemu                      string `yaml:"qemu,omitempty" env:"KRAFTKIT_QEMU" long:"qemu" usage:"Path to QEMU executable" default:""`
+	HTTPUnixSocket            string `yaml:"http_unix_socket,omitempty" env:"KRAFTKIT_HTTP_UNIX_SOCKET" long:"http-unix-sock" usage:"When making HTTP(S) connections, pipe requests via this shared socket"`
+	RuntimeDir                string `yaml:"runtime_dir" env:"KRAFTKIT_RUNTIME_DIR" long:"runtime-dir" usage:"Directory for placing runtime files (e.g. pidfiles)"`
+	DefaultPlat               string `yaml:"default_plat" env:"KRAFTKIT_DEFAULT_PLAT" usage:"The default platform to use when invoking platform-specific code" noattribute:"true"`
+	DefaultArch               string `yaml:"default_arch" env:"KRAFTKIT_DEFAULT_ARCH" usage:"The default architecture to use when invoking architecture-specific code" noattribute:"true"`
+	ContainerdAddr            string `yaml:"containerd_addr,omitempty" env:"KRAFTKIT_CONTAINERD_ADDR" long:"containerd-addr" usage:"Address of containerd daemon socket" default:""`
+	EventsPidFile             string `yaml:"events_pidfile" env:"KRAFTKIT_EVENTS_PIDFILE" long:"events-pid-file" usage:"Events process ID used when running multiple unikernels"`
+	BuildKitHost              string `yaml:"buildkit_host" env:"KRAFTKIT_BUILDKIT_HOST" long:"buildkit-host" usage:"Path to the buildkit host" default:""`
+	CollectAnonymousTelemetry bool   `yaml:"collect_anonymous_telemetry" env:"KRAFTKIT_COLLECT_ANONYMOUS_TELEMETRY" long:"collect-anonymous-telemetry" usage:"Collect anonymous telemetry" default:"false"`
 
 	Paths struct {
 		Plugins   string `yaml:"plugins,omitempty" env:"KRAFTKIT_PATHS_PLUGINS" long:"plugins-dir" usage:"Path to KraftKit plugin directory"`

--- a/config/manager.go
+++ b/config/manager.go
@@ -5,10 +5,12 @@
 package config
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"os/signal"
 	"reflect"
+	"strconv"
 	"strings"
 	"syscall"
 )
@@ -112,6 +114,117 @@ func (cm *ConfigManager[C]) Write(merge bool) error {
 	for _, f := range cm.Feeders {
 		if err := f.Write(cm.Config, merge); err != nil {
 			return err
+		}
+	}
+
+	return nil
+}
+
+// convertType attempts to convert an arbitrary value to a target reflect.Type.
+func convertType(value any, targetType reflect.Type) (reflect.Value, error) {
+	val := reflect.ValueOf(value)
+
+	if val.Type().AssignableTo(targetType) {
+		return val, nil
+	}
+
+	switch targetType.Kind() {
+	case reflect.String:
+		return reflect.ValueOf(fmt.Sprintf("%v", value)), nil
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		switch v := value.(type) {
+		case string:
+			if intVal, err := strconv.ParseInt(v, 10, 64); err == nil {
+				return reflect.ValueOf(intVal).Convert(targetType), nil
+			}
+		case float64:
+			return reflect.ValueOf(int64(v)).Convert(targetType), nil
+		case bool:
+			if v {
+				return reflect.ValueOf(int64(1)).Convert(targetType), nil
+			}
+			return reflect.ValueOf(int64(0)).Convert(targetType), nil
+		}
+	case reflect.Float32, reflect.Float64:
+		switch v := value.(type) {
+		case string:
+			if floatVal, err := strconv.ParseFloat(v, 64); err == nil {
+				return reflect.ValueOf(floatVal).Convert(targetType), nil
+			}
+		case int:
+			return reflect.ValueOf(float64(v)).Convert(targetType), nil
+		case bool:
+			if v {
+				return reflect.ValueOf(float64(1.0)).Convert(targetType), nil
+			}
+			return reflect.ValueOf(float64(0.0)).Convert(targetType), nil
+		}
+	case reflect.Bool:
+		switch v := value.(type) {
+		case string:
+			if b, err := strconv.ParseBool(v); err == nil {
+				return reflect.ValueOf(b), nil
+			}
+		case int, int64:
+			return reflect.ValueOf(v != 0), nil
+		case float64:
+			return reflect.ValueOf(v != 0.0), nil
+		}
+	}
+
+	return reflect.Value{}, errors.New("unsupported type conversion")
+}
+
+// getYAMLTag extracts the YAML tag from a struct field.
+func getYAMLTag(field reflect.StructField, ok bool) string {
+	if !ok {
+		return ""
+	}
+	tag := field.Tag.Get("yaml")
+	if tag == "" {
+		return field.Name
+	}
+	return strings.Split(tag, ",")[0]
+}
+
+// Set updates any field in the config struct using a dot-separated key.
+func (cm *ConfigManager[C]) Set(key string, val any) error {
+	v := reflect.ValueOf(cm.Config)
+	if v.Kind() != reflect.Ptr || v.Elem().Kind() != reflect.Struct {
+		return errors.New("cfg must be a pointer to a struct")
+	}
+
+	v = v.Elem() // Dereference the pointer
+	keys := strings.Split(key, ".")
+
+	for i, k := range keys {
+		field := v.FieldByNameFunc(func(f string) bool {
+			return getYAMLTag(v.Type().FieldByName(f)) == k
+		})
+
+		if !field.IsValid() {
+			return errors.New("invalid key: " + k)
+		}
+
+		if i == len(keys)-1 {
+			if !field.CanSet() {
+				return errors.New("cannot set field: " + k)
+			}
+			convertedVal, err := convertType(val, field.Type())
+			if err != nil {
+				return err
+			}
+			field.Set(convertedVal)
+			return nil
+		}
+
+		if field.Kind() == reflect.Ptr {
+			if field.IsNil() {
+				field.Set(reflect.New(field.Type().Elem()))
+			}
+			v = field.Elem()
+		} else {
+			v = field
 		}
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -36,6 +36,7 @@ require (
 	github.com/erikh/ping v0.0.0-20141209185752-d731d249e12a
 	github.com/firecracker-microvm/firecracker-go-sdk v1.0.0
 	github.com/fsnotify/fsnotify v1.8.0
+	github.com/getsentry/sentry-go v0.31.1
 	github.com/go-git/go-git/v5 v5.13.2
 	github.com/gobwas/glob v0.2.3
 	github.com/google/go-containerregistry v0.20.3

--- a/go.sum
+++ b/go.sum
@@ -470,6 +470,8 @@ github.com/fxamacker/cbor/v2 v2.7.0/go.mod h1:pxXPTn3joSm21Gbwsv0w9OSA2y1HFR9qXE
 github.com/gabriel-vasile/mimetype v1.4.8 h1:FfZ3gj38NjllZIeJAmMhr+qKL8Wu+nOoI3GqacKw1NM=
 github.com/gabriel-vasile/mimetype v1.4.8/go.mod h1:ByKUIKGjh1ODkGM1asKUbQZOLGrPjydw3hYPU2YU9t8=
 github.com/garyburd/redigo v0.0.0-20150301180006-535138d7bcd7/go.mod h1:NR3MbYisc3/PwhQ00EMzDiPmrwpPxAn5GI05/YaO1SY=
+github.com/getsentry/sentry-go v0.31.1 h1:ELVc0h7gwyhnXHDouXkhqTFSO5oslsRDk0++eyE0KJ4=
+github.com/getsentry/sentry-go v0.31.1/go.mod h1:CYNcMMz73YigoHljQRG+qPF+eMq8gG72XcGN/p71BAY=
 github.com/ghodss/yaml v0.0.0-20150909031657-73d445a93680/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/gliderlabs/ssh v0.3.8 h1:a4YXD1V7xMF9g5nTkdfnja3Sxy1PVDCj1Zg4Wb8vY6c=
@@ -998,6 +1000,8 @@ github.com/pelletier/go-toml v1.9.5/go.mod h1:u1nR/EPcESfeI/szUZKdtJ0xRNbUoANCko
 github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR/tNboyR3/BZd58JJSHlUSCU=
 github.com/pierrec/lz4/v4 v4.1.21 h1:yOVMLb6qSIDP67pl/5F7RepeKYu/VmTyEXvuMI5d9mQ=
 github.com/pierrec/lz4/v4 v4.1.21/go.mod h1:gZWDp/Ze/IJXGXf23ltt2EXimqmTUXEy0GFuRQyBid4=
+github.com/pingcap/errors v0.11.4 h1:lFuQV/oaUMGcD2tqt+01ROSmJs75VG1ToEOkZIZ4nE4=
+github.com/pingcap/errors v0.11.4/go.mod h1:Oi8TUi2kEtXXLMJk9l1cGmz20kV3TaQ0usTwv5KuLY8=
 github.com/pjbgf/sha1cd v0.3.2 h1:a9wb0bp1oC2TGwStyn0Umc/IGKQnEgF0vVaZ8QF8eo4=
 github.com/pjbgf/sha1cd v0.3.2/go.mod h1:zQWigSxVmsHEZow5qaLtPYxpcKMMQpa09ixqBxuCS6A=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
@@ -1326,6 +1330,8 @@ go.opentelemetry.io/proto/otlp v1.3.1 h1:TrMUixzpM0yuc/znrFTP9MMRh8trP93mkCiDVeX
 go.opentelemetry.io/proto/otlp v1.3.1/go.mod h1:0X1WI4de4ZsLrrJNLAQbFeLCm3T7yBkR0XqQ7niQU+8=
 go.uber.org/atomic v1.3.2/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
 go.uber.org/atomic v1.4.0/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
+go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
+go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
 go.uber.org/multierr v1.1.0/go.mod h1:wR5kodmAFQ0UK8QlbwjlSNy0Z68gJhDJUG5sjR94q/0=
 go.uber.org/multierr v1.11.0 h1:blXXJkSxSSfBVBlC76pxqeO+LN3aDfLQo+309xJstO0=
 go.uber.org/multierr v1.11.0/go.mod h1:20+QtiLqy0Nd6FdQB9TLXag12DsQkrbs3htMFfDN80Y=

--- a/internal/cli/kraft/kraft.go
+++ b/internal/cli/kraft/kraft.go
@@ -7,12 +7,18 @@ package kraft
 
 import (
 	"context"
+	"encoding/base64"
 	"fmt"
 	"os"
+	"runtime/debug"
 	"runtime/pprof"
+	"strings"
+	"time"
 
 	"github.com/MakeNowJust/heredoc"
+	"github.com/getsentry/sentry-go"
 	"github.com/rancher/wrangler/pkg/signals"
+	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 
@@ -136,6 +142,9 @@ func (k *KraftOptions) Run(_ context.Context, args []string) error {
 	return pflag.ErrHelp
 }
 
+// The Sentry DSN to use for anonymous telemetry.
+var sentryDsn = ""
+
 func Main(args []string) int {
 	cmd := NewCmd()
 	ctx := signals.SetupSignalContext()
@@ -176,9 +185,7 @@ func Main(args []string) int {
 	}
 
 	// Set up the config manager in the context if it is available
-	if copts.ConfigManager != nil {
-		ctx = config.WithConfigManager(ctx, copts.ConfigManager)
-	}
+	ctx = config.WithConfigManager(ctx, copts.ConfigManager)
 
 	// Hydrate KraftCloud configuration
 	if newCtx, err := config.HydrateKraftCloudAuthInContext(ctx); err == nil {
@@ -186,9 +193,60 @@ func Main(args []string) int {
 	}
 
 	// Set up the logger in the context if it is available
-	if copts.Logger != nil {
-		ctx = log.WithLogger(ctx, copts.Logger)
+	ctx = log.WithLogger(ctx, copts.Logger)
+
+	// Add the kraftkit version to the debug logs
+	log.G(ctx).
+		WithField("version", kitversion.Version()).
+		Debugf("kraftkit")
+
+	collectTelemetry := sentryDsn != "" && config.G[config.KraftKit](ctx).CollectAnonymousTelemetry
+
+	if collectTelemetry {
+		sentryDsn, err := base64.StdEncoding.DecodeString(sentryDsn)
+		if err != nil {
+			collectTelemetry = false
+		} else {
+			if err := sentry.Init(sentry.ClientOptions{
+				Dsn:              string(sentryDsn),
+				Release:          kitversion.Version(),
+				TracesSampleRate: 1.0,
+			}); err != nil {
+				log.G(ctx).Debugf("could not initialize sentry: %v", err)
+			} else {
+				log.G(ctx).Debug("collecting anonymous telemetry - to disable export KRAFTKIT_COLLECT_ANONYMOUS_TELEMETRY=false")
+			}
+		}
 	}
+
+	defer func() {
+		if err := recover(); err != nil {
+			if collectTelemetry {
+				sentry.CurrentHub().RecoverWithContext(ctx, err)
+				sentry.Flush(time.Second * 5)
+			}
+
+			// Use copts.Logger as access to log.G(ctx) may not be available in the
+			// panic state.
+			copts.Logger.Logf(logrus.FatalLevel, "a fatal error occurred: %s", err)
+
+			recoverLevel := logrus.DebugLevel
+			if !collectTelemetry {
+				recoverLevel = logrus.ErrorLevel
+			}
+
+			// Only log the stack trace if the user has opted-out of telemetry such
+			// that they can see the stack trace and report the issue.  Otherwise,
+			// silently log these to the debug level and suggest the user to open an
+			// issue.
+			for _, line := range strings.Split(string(debug.Stack()), "\n") {
+				copts.Logger.Log(recoverLevel, line)
+			}
+			if !collectTelemetry {
+				copts.Logger.Log(logrus.FatalLevel, "please consider opening an issue at: https://github.com/unikraft/kraftkit/issues/new?template=bug_report.yml")
+			}
+		}
+	}()
 
 	// Set up the iostreams in the context if it is available
 	if copts.IOStreams != nil {
@@ -208,9 +266,6 @@ func Main(args []string) int {
 		log.G(ctx).Warn("\texport KRAFTKIT_NO_WARN_SUDO=1")
 		log.G(ctx).Warn("")
 	}
-
-	// Add the kraftkit version to the debug logs
-	log.G(ctx).Debugf("kraftkit %s", kitversion.Version())
 
 	if !config.G[config.KraftKit](ctx).NoCheckUpdates {
 		if err := kitupdate.Check(ctx); err != nil {

--- a/internal/cli/kraft/kraft.go
+++ b/internal/cli/kraft/kraft.go
@@ -44,6 +44,7 @@ import (
 	"kraftkit.sh/internal/cli/kraft/set"
 	"kraftkit.sh/internal/cli/kraft/start"
 	"kraftkit.sh/internal/cli/kraft/stop"
+	"kraftkit.sh/internal/cli/kraft/system"
 	"kraftkit.sh/internal/cli/kraft/unset"
 	"kraftkit.sh/internal/cli/kraft/version"
 	"kraftkit.sh/internal/cli/kraft/volume"
@@ -125,6 +126,7 @@ func NewCmd() *cobra.Command {
 	cmd.AddGroup(&cobra.Group{ID: "misc", Title: "MISCELLANEOUS COMMANDS"})
 	cmd.AddCommand(login.NewCmd())
 	cmd.AddCommand(version.NewCmd())
+	cmd.AddCommand(system.NewCmd())
 	cmd.AddCommand(x.NewCmd())
 
 	return cmd

--- a/internal/cli/kraft/system/set/set.go
+++ b/internal/cli/kraft/system/set/set.go
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2025, Unikraft GmbH and The KraftKit Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+
+package set
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/MakeNowJust/heredoc"
+	"github.com/spf13/cobra"
+
+	"kraftkit.sh/cmdfactory"
+	"kraftkit.sh/config"
+	"kraftkit.sh/log"
+)
+
+type Set struct{}
+
+func NewCmd() *cobra.Command {
+	cmd, err := cmdfactory.New(&Set{}, cobra.Command{
+		Short: "Set a KraftKit configuration option",
+		Use:   "set KEY=VALUE",
+		Args:  cobra.MinimumNArgs(1),
+		Example: heredoc.Doc(`
+			# Change the default log level and log type
+			$ kraft system set log.level=debug log.type=basic
+		`),
+		Annotations: map[string]string{
+			cmdfactory.AnnotationHelpGroup: "misc",
+		},
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	return cmd
+}
+
+func (opts *Set) Run(ctx context.Context, args []string) error {
+	for _, arg := range args {
+		key, val, ok := strings.Cut(arg, "=")
+		if !ok {
+			return errors.New("invalid argument: expected KEY=VALUE")
+		}
+
+		log.G(ctx).
+			WithField(key, val).
+			Info("setting")
+
+		if err := config.M[config.KraftKit](ctx).Set(key, val); err != nil {
+			return fmt.Errorf("could not set configuration option: %w", err)
+		}
+	}
+
+	return config.M[config.KraftKit](ctx).Write(true)
+}

--- a/internal/cli/kraft/system/set/set.go
+++ b/internal/cli/kraft/system/set/set.go
@@ -29,6 +29,9 @@ func NewCmd() *cobra.Command {
 		Example: heredoc.Doc(`
 			# Change the default log level and log type
 			$ kraft system set log.level=debug log.type=basic
+
+			# Enable anonymous telemetry
+			$ kraft system set collect_anonymous_telemetry=true
 		`),
 		Annotations: map[string]string{
 			cmdfactory.AnnotationHelpGroup: "misc",

--- a/internal/cli/kraft/system/system.go
+++ b/internal/cli/kraft/system/system.go
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2025, Unikraft GmbH and The KraftKit Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+
+package system
+
+import (
+	"context"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+
+	"kraftkit.sh/cmdfactory"
+
+	"kraftkit.sh/internal/cli/kraft/system/set"
+)
+
+type System struct{}
+
+func NewCmd() *cobra.Command {
+	cmd, err := cmdfactory.New(&System{}, cobra.Command{
+		Short:   "Manage KraftKit and host system",
+		Use:     "system SUBCOMMAND",
+		Aliases: []string{"sys", "self"},
+		Annotations: map[string]string{
+			cmdfactory.AnnotationHelpGroup:  "misc",
+			cmdfactory.AnnotationHelpHidden: "true",
+		},
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	cmd.AddCommand(set.NewCmd())
+
+	return cmd
+}
+
+func (opts *System) Run(ctx context.Context, args []string) error {
+	return pflag.ErrHelp
+}

--- a/log/formatter.go
+++ b/log/formatter.go
@@ -217,29 +217,29 @@ func (f *TextFormatter) printColored(b *bytes.Buffer, entry *logrus.Entry, keys 
 	var levelText string
 	switch entry.Level {
 	case logrus.InfoLevel:
-		levelText = "i"
+		levelText = " i "
 		levelColor = colorScheme.InfoLevel
 	case logrus.WarnLevel:
-		levelText = "W"
+		levelText = " W "
 		levelColor = colorScheme.WarnLevel
 	case logrus.ErrorLevel:
-		levelText = "E"
+		levelText = " E "
 		levelColor = colorScheme.ErrorLevel
 	case logrus.FatalLevel:
-		levelText = "!"
+		levelText = "<!>"
 		levelColor = colorScheme.FatalLevel
 	case logrus.PanicLevel:
-		levelText = "X"
+		levelText = " X "
 		levelColor = colorScheme.PanicLevel
 	case logrus.TraceLevel:
-		levelText = "T"
+		levelText = " T "
 		levelColor = colorScheme.TraceLevel
 	default:
-		levelText = "D"
+		levelText = " D "
 		levelColor = colorScheme.DebugLevel
 	}
 
-	level := levelColor(fmt.Sprintf(" %1s ", levelText))
+	level := levelColor(levelText)
 	prefix := ""
 	message := entry.Message
 

--- a/tools/webinstall/install.sh
+++ b/tools/webinstall/install.sh
@@ -1698,6 +1698,24 @@ check_autoinstall() {
     _RETVAL="$_cai_auto_install"
 }
 
+# collect_telemetry queries the user as to whether to enable anonymous telemetry
+# and then updates KraftKit's configuration accordingly.
+# Returns:
+# _RETVAL: whether to enable telemetry: y or empty
+collect_telemetry() {
+    _et_telemetry=""
+
+    if prompt_yes_no "Help us make KraftKit better and opt-in to collecting anonymous telemetry? [y/N]: " "n"; then
+        _et_telemetry="y"
+        kraft system set collect_anonymous_telemetry=true
+    else
+        _et_telemetry="n"
+        kraft system set collect_anonymous_telemetry=false
+    fi
+
+    _RETVAL="$_et_telemetry"
+}
+
 # main is the entrypoint of the script.
 # The steps are:
 # 1. Check if we have all the commands we need
@@ -1734,18 +1752,19 @@ main() {
     # Install kraftkit for the given architecture and its dependencies
     install_kraftkit "$_main_arch" "$_main_auto_install"
 
-    # Check if kraft is installed and working
-    kraft -h
-    _main_kraft_ret="$?"
-
     # Install kraftkit completions
     if [ "$HAS_TTY" = "y" ]; then
         install_completions "$_main_arch"
+        collect_telemetry
     fi
 
-    say_ok 'Happy Krafting!'
+    say ''
+    say_ok 'Happy krafting!'
+    say ''
+    say 'Type kraft -h for help'
+    say ''
 
-    return $_main_kraft_ret
+    return 0
 }
 
 

--- a/tools/webinstall/install.sh
+++ b/tools/webinstall/install.sh
@@ -27,7 +27,7 @@ INSTALL_CPUTYPE=${INSTALL_CPUTYPE:-}
 INSTALL_SERVER=${INSTALL_SERVER:-https://get.kraftkit.sh}
 INSTALL_TLS=${INSTALL_TLS:-y}
 DEBUG=${DEBUG:-n}
-NEED_TTY=${NEED_TTY:-y}
+HAS_TTY=${HAS_TTY:-y}
 ASK_SUDO=${ASK_SUDO:-y}
 
 # Commands as variables to make them easier to override
@@ -208,7 +208,7 @@ get_user_response() {
     printf "[?] %s" "$_gur_question"
 
     # Check if we have a tty and read from it if we do
-    if [ "$NEED_TTY" = "y" ]; then
+    if [ "$HAS_TTY" = "y" ]; then
         read -r _gur_read_answer < /dev/tty
     fi
 
@@ -268,7 +268,7 @@ do_cmd() {
             # Check if we have a tty and run with it if we do,
             # otherwise exit with an error
             # This is because sudo requires a tty to input the password
-            if [ "$NEED_TTY" = "y" ]; then
+            if [ "$HAS_TTY" = "y" ]; then
                 # shellcheck disable=SC2002
                 $SUDO sh -c "$@" < /dev/tty
                 ASK_SUDO="n"
@@ -1637,7 +1637,7 @@ install_completions() {
 # arg_parse parses the arguments passed to the script.
 # $@: the arguments to parse
 # Returns:
-# NEED_TTY: whether /dev/tty is needed
+# HAS_TTY: whether /dev/tty is needed
 # Code: 0 on success, 1 on error
 arg_parse() {
     for _agp_arg in "$@"; do
@@ -1668,7 +1668,7 @@ arg_parse() {
                         y)
                             # user wants to skip the prompt --
                             # we don't need /dev/tty
-                            NEED_TTY=n
+                            HAS_TTY=n
                             ;;
                         d)
                             # user wants debugging output
@@ -1716,9 +1716,9 @@ main() {
     need_cmd "$RM"
 
     # Check if we have to use /dev/tty to prompt the user
-    NEED_TTY=y
+    HAS_TTY=y
     arg_parse "$@"
-    say_debug "Parsed arguments: NEED_TTY: $NEED_TTY"
+    say_debug "Parsed arguments: HAS_TTY: $HAS_TTY"
 
     # Detect the architecture and OS of the current machine
     get_architecture || return 1
@@ -1739,7 +1739,7 @@ main() {
     _main_kraft_ret="$?"
 
     # Install kraftkit completions
-    if [ "$NEED_TTY" = "y" ]; then
+    if [ "$HAS_TTY" = "y" ]; then
         install_completions "$_main_arch"
     fi
 


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

In order to support the increasing usage of the tool and better facilitate fixes, introduce Sentry back trace handler into `kraft`.  This is an anonymous usage and opt-in feature which will help the KraftKit maintainers catch panics and provide fixes.

The default value of the new configuration option which enables this functionality is **false/"off"** and can be switched via:
    
- env var: `KRAFTKIT_COLLECT_ANONYMOUS_TELEMETRY`
- config file: `collect_anonymous_telemetry`
- CLI flag: `--collect-anonymous-telemetry`
    
We're introducing the option in order to improve the CLI experience for endusers and tackle panics and handle bug reports in a more systematic and prompt manner.
    
The local build experience totally disables telemetry and it's only included as part of official releases.  This is done because 1). contributors are making iterative updates may encounter higher error-rates during developmenet and 2). local-first development may include changes which are not "official" and therefore not debuggable from a telemetry point-of-view.

