### PR TITLE
fix(iostreams): Translation of ANSI escape on Windows for stderr

### DIFF
--- a/iostreams/iostreams.go
+++ b/iostreams/iostreams.go
@@ -71,7 +71,7 @@ type IOStreams struct {
 
 	In     fileReader
 	Out    FileWriter
-	ErrOut io.Writer
+	ErrOut FileWriter
 
 	terminalTheme string
 
@@ -429,10 +429,21 @@ func System() *IOStreams {
 		}
 	}
 
+	var stderr FileWriter = os.Stderr
+	// On Windows with no virtual terminal processing support, translate ANSI escape
+	// sequences to console syscalls.
+	if colorableStderr := colorable.NewColorable(os.Stderr); colorableStderr != os.Stderr {
+		// Ensure that the file descriptor of the original stderr is preserved.
+		stderr = &fdWriter{
+			fd:     os.Stderr.Fd(),
+			Writer: colorableStderr,
+		}
+	}
+
 	io := &IOStreams{
 		In:           os.Stdin,
 		Out:          stdout,
-		ErrOut:       colorable.NewColorable(os.Stderr),
+		ErrOut:       stderr,
 		pagerCommand: os.Getenv("PAGER"),
 		term:         &terminal,
 	}

--- a/iostreams/iostreams.go
+++ b/iostreams/iostreams.go
@@ -52,7 +52,7 @@ type FileWriter interface {
 	Fd() uintptr
 }
 
-type fileReader interface {
+type FileReader interface {
 	io.ReadCloser
 	Fd() uintptr
 }
@@ -69,7 +69,7 @@ type Terminal interface {
 type IOStreams struct {
 	term Terminal
 
-	In     fileReader
+	In     FileReader
 	Out    FileWriter
 	ErrOut FileWriter
 
@@ -158,7 +158,7 @@ func (s *IOStreams) SetOut(out FileWriter) {
 	s.Out = out
 }
 
-func (s *IOStreams) SetIn(in fileReader) {
+func (s *IOStreams) SetIn(in FileReader) {
 	s.In = in
 }
 

--- a/tui/processtree/processtree.go
+++ b/tui/processtree/processtree.go
@@ -148,7 +148,7 @@ func NewProcessTree(ctx context.Context, opts []ProcessTreeOption, tree ...*Proc
 		}
 
 		ios.Out = iostreams.NewNoTTYWriter(item, iostreams.G(ctx).Out.Fd())
-		ios.ErrOut = item
+		ios.ErrOut = iostreams.NewNoTTYWriter(item, iostreams.G(ctx).ErrOut.Fd())
 		ios.In = iostreams.G(ctx).In
 		ictx = iostreams.WithIOStreams(ictx, ios)
 
@@ -189,7 +189,7 @@ func (pti *ProcessTreeItem) Write(p []byte) (int, error) {
 	return len(p), nil
 }
 
-func (pti *ProcessTreeItem) Fd() int {
+func (pti *ProcessTreeItem) Fd() uintptr {
 	return 0
 }
 


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->
