### PR TITLE
refactor(cli)!: Switch logger to stderr

### DIFF
--- a/internal/cli/options.go
+++ b/internal/cli/options.go
@@ -114,7 +114,7 @@ func WithDefaultLogger() CliOption {
 		}
 
 		if copts.IOStreams != nil {
-			logger.SetOutput(copts.IOStreams.Out)
+			logger.SetOutput(copts.IOStreams.ErrOut)
 		}
 
 		// Save the logger

--- a/test/e2e/cli/net_create_test.go
+++ b/test/e2e/cli/net_create_test.go
@@ -190,6 +190,8 @@ var _ = Describe("kraft net create", func() {
 
 	When("invoked with one positional argument without a network", func() {
 		BeforeEach(func() {
+			cmd.Args = append(cmd.Args, "--driver", "bridge")
+			cmd.Args = append(cmd.Args, "--network", "172.18.0.1/24")
 			cmd.Args = append(cmd.Args, "t-cr-5")
 		})
 
@@ -228,7 +230,7 @@ var _ = Describe("kraft net create", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(stderrLs.String()).To(BeEmpty())
 			Expect(stdoutLs.String()).To(MatchRegexp(`^NAME[\t ]+NETWORK[\t ]+DRIVER[\t ]+STATUS\n`))
-			Expect(stdoutLs.String()).To(MatchRegexp(`t-cr-5[\t ]+172.18.0.1/16[\t ]+bridge[\t ]+up`))
+			Expect(stdoutLs.String()).To(MatchRegexp(`t-cr-5[\t ]+172.18.0.1/24[\t ]+bridge[\t ]+up`))
 		})
 	})
 })

--- a/test/e2e/cli/net_create_test.go
+++ b/test/e2e/cli/net_create_test.go
@@ -43,8 +43,8 @@ var _ = Describe("kraft net create", func() {
 			err := cmd.Run()
 			Expect(err).To(HaveOccurred())
 
-			Expect(stderr.String()).To(BeEmpty())
-			Expect(stdout.String()).To(MatchRegexp(`^{"level":"error","msg":"accepts 1 arg\(s\), received 0"}\n`))
+			Expect(stdout.String()).To(BeEmpty())
+			Expect(stderr.String()).To(MatchRegexp(`^{"level":"error","msg":"accepts 1 arg\(s\), received 0"}\n`))
 		})
 	})
 
@@ -75,8 +75,8 @@ var _ = Describe("kraft net create", func() {
 			err := cmd.Run()
 			Expect(err).To(HaveOccurred())
 
-			Expect(stderr.String()).To(BeEmpty())
-			Expect(stdout.String()).To(MatchRegexp(`^{"level":"error","msg":"accepts 1 arg\(s\), received 2"}\n$`))
+			Expect(stdout.String()).To(BeEmpty())
+			Expect(stderr.String()).To(MatchRegexp(`^{"level":"error","msg":"accepts 1 arg\(s\), received 2"}\n$`))
 		})
 	})
 
@@ -90,8 +90,8 @@ var _ = Describe("kraft net create", func() {
 			err := cmd.Run()
 			Expect(err).To(HaveOccurred())
 
-			Expect(stderr.String()).To(BeEmpty())
-			Expect(stdout.String()).To(MatchRegexp(`^{"level":"error","msg":"invalid CIDR address: 172\.45\.1\.1"}\n$`))
+			Expect(stdout.String()).To(BeEmpty())
+			Expect(stderr.String()).To(MatchRegexp(`^{"level":"error","msg":"invalid CIDR address: 172\.45\.1\.1"}\n$`))
 		})
 	})
 
@@ -105,8 +105,8 @@ var _ = Describe("kraft net create", func() {
 			err := cmd.Run()
 			Expect(err).To(HaveOccurred())
 
-			Expect(stderr.String()).To(BeEmpty())
-			Expect(stdout.String()).To(MatchRegexp(`^{"level":"error","msg":"invalid CIDR address: 172\.45\.2/24"}\n$`))
+			Expect(stdout.String()).To(BeEmpty())
+			Expect(stderr.String()).To(MatchRegexp(`^{"level":"error","msg":"invalid CIDR address: 172\.45\.2/24"}\n$`))
 		})
 	})
 
@@ -120,8 +120,8 @@ var _ = Describe("kraft net create", func() {
 			err := cmd.Run()
 			Expect(err).To(HaveOccurred())
 
-			Expect(stderr.String()).To(BeEmpty())
-			Expect(stdout.String()).To(MatchRegexp(`^{"level":"error","msg":"invalid CIDR address: 1234"}\n$`))
+			Expect(stdout.String()).To(BeEmpty())
+			Expect(stderr.String()).To(MatchRegexp(`^{"level":"error","msg":"invalid CIDR address: 1234"}\n$`))
 		})
 	})
 
@@ -136,8 +136,8 @@ var _ = Describe("kraft net create", func() {
 			err := cmd.Run()
 			Expect(err).To(HaveOccurred())
 
-			Expect(stderr.String()).To(BeEmpty())
-			Expect(stdout.String()).To(MatchRegexp(`^{"level":"error","msg":"unsupported network driver strategy: unknown \(contributions welcome\!\)"}\n$`))
+			Expect(stdout.String()).To(BeEmpty())
+			Expect(stderr.String()).To(MatchRegexp(`^{"level":"error","msg":"unsupported network driver strategy: unknown \(contributions welcome\!\)"}\n$`))
 		})
 	})
 

--- a/test/e2e/cli/net_down_test.go
+++ b/test/e2e/cli/net_down_test.go
@@ -43,8 +43,8 @@ var _ = Describe("kraft net down", func() {
 			err := cmd.Run()
 			Expect(err).To(HaveOccurred())
 
-			Expect(stderr.String()).To(BeEmpty())
-			Expect(stdout.String()).To(MatchRegexp(`^{"level":"error","msg":"accepts 1 arg\(s\), received 0"}\n`))
+			Expect(stdout.String()).To(BeEmpty())
+			Expect(stderr.String()).To(MatchRegexp(`^{"level":"error","msg":"accepts 1 arg\(s\), received 0"}\n`))
 		})
 	})
 
@@ -59,8 +59,8 @@ var _ = Describe("kraft net down", func() {
 			err := cmd.Run()
 			Expect(err).To(HaveOccurred())
 
-			Expect(stderr.String()).To(BeEmpty())
-			Expect(stdout.String()).To(MatchRegexp(`^{"level":"error","msg":"getting bridge t-do-0 failed: Link not found"}\n$`))
+			Expect(stdout.String()).To(BeEmpty())
+			Expect(stderr.String()).To(MatchRegexp(`^{"level":"error","msg":"getting bridge t-do-0 failed: Link not found"}\n$`))
 		})
 	})
 

--- a/test/e2e/cli/net_inspect_test.go
+++ b/test/e2e/cli/net_inspect_test.go
@@ -44,8 +44,8 @@ var _ = Describe("kraft net inspect", func() {
 			err := cmd.Run()
 			Expect(err).To(HaveOccurred())
 
-			Expect(stderr.String()).To(BeEmpty())
-			Expect(stdout.String()).To(MatchRegexp(`^{"level":"error","msg":"accepts 1 arg\(s\), received 0"}\n`))
+			Expect(stdout.String()).To(BeEmpty())
+			Expect(stderr.String()).To(MatchRegexp(`^{"level":"error","msg":"accepts 1 arg\(s\), received 0"}\n`))
 		})
 	})
 
@@ -60,8 +60,8 @@ var _ = Describe("kraft net inspect", func() {
 			err := cmd.Run()
 			Expect(err).To(HaveOccurred())
 
-			Expect(stderr.String()).To(BeEmpty())
-			Expect(stdout.String()).To(MatchRegexp(`^{"level":"error","msg":"no such network: t-in-0"}\n$`))
+			Expect(stdout.String()).To(BeEmpty())
+			Expect(stderr.String()).To(MatchRegexp(`^{"level":"error","msg":"no such network: t-in-0"}\n$`))
 		})
 	})
 

--- a/test/e2e/cli/net_ls_test.go
+++ b/test/e2e/cli/net_ls_test.go
@@ -47,8 +47,8 @@ var _ = Describe("kraft net ls", func() {
 			err := cmd.Run()
 			Expect(err).To(HaveOccurred())
 
-			Expect(stderr.String()).To(BeEmpty())
-			Expect(stdout.String()).To(MatchRegexp(`^{"level":"error","msg":"unknown command \\"test\\" for \\"kraft net list\\""}`))
+			Expect(stdout.String()).To(BeEmpty())
+			Expect(stderr.String()).To(MatchRegexp(`^{"level":"error","msg":"unknown command \\"test\\" for \\"kraft net list\\""}`))
 		})
 	})
 

--- a/test/e2e/cli/net_rm_test.go
+++ b/test/e2e/cli/net_rm_test.go
@@ -43,8 +43,8 @@ var _ = Describe("kraft net rm", func() {
 			err := cmd.Run()
 			Expect(err).To(HaveOccurred())
 
-			Expect(stderr.String()).To(BeEmpty())
-			Expect(stdout.String()).To(MatchRegexp(`^{"level":"error","msg":"accepts 1 arg\(s\), received 0"}\n`))
+			Expect(stdout.String()).To(BeEmpty())
+			Expect(stderr.String()).To(MatchRegexp(`^{"level":"error","msg":"accepts 1 arg\(s\), received 0"}\n`))
 		})
 	})
 
@@ -58,8 +58,8 @@ var _ = Describe("kraft net rm", func() {
 			err := cmd.Run()
 			Expect(err).To(HaveOccurred())
 
-			Expect(stderr.String()).To(BeEmpty())
-			Expect(stdout.String()).To(MatchRegexp(`^{"level":"error","msg":"accepts 1 arg\(s\), received 2"}\n$`))
+			Expect(stdout.String()).To(BeEmpty())
+			Expect(stderr.String()).To(MatchRegexp(`^{"level":"error","msg":"accepts 1 arg\(s\), received 2"}\n$`))
 		})
 	})
 
@@ -139,8 +139,8 @@ var _ = Describe("kraft net rm", func() {
 			err := cmd.Run()
 			Expect(err).To(HaveOccurred())
 
-			Expect(stderr.String()).To(BeEmpty())
-			Expect(stdout.String()).To(MatchRegexp(`^{"level":"error","msg":"getting bridge t-rm-1 failed: Link not found"}\n$`))
+			Expect(stdout.String()).To(BeEmpty())
+			Expect(stderr.String()).To(MatchRegexp(`^{"level":"error","msg":"getting bridge t-rm-1 failed: Link not found"}\n$`))
 		})
 	})
 })

--- a/test/e2e/cli/net_up_test.go
+++ b/test/e2e/cli/net_up_test.go
@@ -43,8 +43,8 @@ var _ = Describe("kraft net up", func() {
 			err := cmd.Run()
 			Expect(err).To(HaveOccurred())
 
-			Expect(stderr.String()).To(BeEmpty())
-			Expect(stdout.String()).To(MatchRegexp(`^{"level":"error","msg":"accepts 1 arg\(s\), received 0"}\n`))
+			Expect(stdout.String()).To(BeEmpty())
+			Expect(stderr.String()).To(MatchRegexp(`^{"level":"error","msg":"accepts 1 arg\(s\), received 0"}\n`))
 		})
 	})
 
@@ -59,8 +59,8 @@ var _ = Describe("kraft net up", func() {
 			err := cmd.Run()
 			Expect(err).To(HaveOccurred())
 
-			Expect(stderr.String()).To(BeEmpty())
-			Expect(stdout.String()).To(MatchRegexp(`^{"level":"error","msg":"getting bridge t-up-0 failed: Link not found"}\n$`))
+			Expect(stdout.String()).To(BeEmpty())
+			Expect(stderr.String()).To(MatchRegexp(`^{"level":"error","msg":"getting bridge t-up-0 failed: Link not found"}\n$`))
 		})
 	})
 

--- a/test/e2e/cli/pkg_source_test.go
+++ b/test/e2e/cli/pkg_source_test.go
@@ -219,7 +219,7 @@ var _ = Describe("kraft pkg source", func() {
 					fmt.Print(cmd.DumpError(stdout, stderr, err))
 				}
 				Expect(err).ToNot(HaveOccurred())
-				Expect(stderr.String()).To(BeEmpty())
+				Expect(stdout.String()).To(BeEmpty())
 
 				// Calculate config file hash
 				bytes, err := os.ReadFile(cfg.Path())
@@ -244,10 +244,10 @@ var _ = Describe("kraft pkg source", func() {
 					fmt.Print(cmd.DumpError(stdout, stderr, err))
 				}
 				Expect(err).ToNot(HaveOccurred())
-				Expect(stderr.String()).To(BeEmpty())
+				Expect(stdout.String()).To(BeEmpty())
 
-				// Check warning message exists in stdout
-				Expect(stdout.String()).To(MatchRegexp(`^{"level":"warning","msg":"manifest already saved: https://manifests\.kraftkit\.sh/index\.yaml"}\n$`))
+				// Check warning message exists in stderr
+				Expect(stderr.String()).To(MatchRegexp(`^{"level":"warning","msg":"manifest already saved: https://manifests\.kraftkit\.sh/index\.yaml"}\n$`))
 
 				// Check if the config file was not modified
 				newBytes, err := os.ReadFile(cfg.Path())
@@ -274,7 +274,7 @@ var _ = Describe("kraft pkg source", func() {
 					fmt.Print(cmd.DumpError(stdout, stderr, err))
 				}
 				Expect(err).ToNot(HaveOccurred())
-				Expect(stderr.String()).To(BeEmpty())
+				Expect(stdout.String()).To(BeEmpty())
 
 				// Read the config file
 				osFile, err := os.Open(cfg.Path())
@@ -327,8 +327,8 @@ var _ = Describe("kraft pkg source", func() {
 				Expect(cfgMapUnikernelManifests[1]).To(Equal("https://example2.com"))
 				Expect(cfgMapUnikernelManifests[2]).To(Equal("https://example3.com"))
 
-				// Check if stdout is empty
-				Expect(stdout.String()).To(BeEmpty())
+				// Check if stderr is empty
+				Expect(stderr.String()).To(BeEmpty())
 			})
 		})
 
@@ -343,7 +343,7 @@ var _ = Describe("kraft pkg source", func() {
 					fmt.Print(cmd.DumpError(stdout, stderr, err))
 				}
 				Expect(err).ToNot(HaveOccurred())
-				Expect(stderr.String()).To(BeEmpty())
+				Expect(stdout.String()).To(BeEmpty())
 
 				// Read the config file
 				osFile, err := os.Open(cfg.Path())
@@ -395,7 +395,7 @@ var _ = Describe("kraft pkg source", func() {
 				Expect(cfgMapUnikernelManifests[0]).To(Equal("https://example.com"))
 
 				// Check if stdout contains the warning message
-				Expect(stdout.String()).To(MatchRegexp(`^{"level":"warning","msg":"manifest already saved: https://example\.com"}\n$`))
+				Expect(stderr.String()).To(MatchRegexp(`^{"level":"warning","msg":"manifest already saved: https://example\.com"}\n$`))
 			})
 		})
 	})

--- a/test/e2e/cli/pkg_unsource_test.go
+++ b/test/e2e/cli/pkg_unsource_test.go
@@ -45,7 +45,7 @@ var _ = Describe("kraft pkg unsource", func() {
 					fmt.Print(cmd.DumpError(stdout, stderr, err))
 				}
 				Expect(err).ToNot(HaveOccurred())
-				Expect(stderr.String()).To(BeEmpty())
+				Expect(stdout.String()).To(BeEmpty())
 
 				// Read the config file
 				osFile, err := os.Open(cfg.Path())
@@ -86,8 +86,8 @@ var _ = Describe("kraft pkg unsource", func() {
 				_, ok := cfgMap["unikraft"].(map[string]interface{})
 				Expect(ok).To(BeFalse())
 
-				// Check if stdout is empty
-				Expect(stdout.String()).To(MatchRegexp(`^{"level":"warning","msg":"manifest not found: https://manifests\.kraftkit\.sh/index\.yaml"}\n$`))
+				// Check if stderr contains a log message
+				Expect(stderr.String()).To(MatchRegexp(`^{"level":"warning","msg":"manifest not found: https://manifests\.kraftkit\.sh/index\.yaml"}\n$`))
 			})
 		})
 
@@ -115,7 +115,7 @@ var _ = Describe("kraft pkg unsource", func() {
 					fmt.Print(cmd.DumpError(stdout, stderr, err))
 				}
 				Expect(err).ToNot(HaveOccurred())
-				Expect(stderr.String()).To(BeEmpty())
+				Expect(stdout.String()).To(BeEmpty())
 
 				// Read the config file
 				osFile, err := os.Open(cfg.Path())
@@ -163,8 +163,8 @@ var _ = Describe("kraft pkg unsource", func() {
 				// Check if the default manifests are removed
 				Expect(cfgMapUnikernelManifests).To(HaveLen(0))
 
-				// Check if stdout is empty
-				Expect(stdout.String()).To(MatchRegexp(`^{"level":"warning","msg":"manifest not found: https://manifests\.kraftkit\.sh/index\.yaml"}\n$`))
+				// Check if stderr to contain a log message
+				Expect(stderr.String()).To(MatchRegexp(`^{"level":"warning","msg":"manifest not found: https://manifests\.kraftkit\.sh/index\.yaml"}\n$`))
 			})
 		})
 
@@ -192,7 +192,7 @@ var _ = Describe("kraft pkg unsource", func() {
 					fmt.Print(cmd.DumpError(stdout, stderr, err))
 				}
 				Expect(err).ToNot(HaveOccurred())
-				Expect(stderr.String()).To(BeEmpty())
+				Expect(stdout.String()).To(BeEmpty())
 
 				// Read the config file
 				osFile, err := os.Open(cfg.Path())
@@ -240,8 +240,8 @@ var _ = Describe("kraft pkg unsource", func() {
 				// Check if the default manifests are still there
 				Expect(cfgMapUnikernelManifests).To(HaveLen(0))
 
-				// Check if stdout contains the warning
-				Expect(stdout.String()).To(MatchRegexp(`^{"level":"warning","msg":"manifest not found: https://example\.com"}\n$`))
+				// Check if stderr contains the warning
+				Expect(stderr.String()).To(MatchRegexp(`^{"level":"warning","msg":"manifest not found: https://example\.com"}\n$`))
 			})
 		})
 	})
@@ -380,7 +380,7 @@ var _ = Describe("kraft pkg unsource", func() {
 					fmt.Print(cmd.DumpError(stdout, stderr, err))
 				}
 				Expect(err).ToNot(HaveOccurred())
-				Expect(stderr.String()).To(BeEmpty())
+				Expect(stdout.String()).To(BeEmpty())
 
 				// Read the config file
 				osFile, err := os.Open(cfg.Path())
@@ -429,8 +429,8 @@ var _ = Describe("kraft pkg unsource", func() {
 				Expect(cfgMapUnikernelManifests).To(HaveLen(1))
 				Expect(cfgMapUnikernelManifests[0]).To(Equal("https://example3.com"))
 
-				// Check if stdout has a warning
-				Expect(stdout.String()).To(MatchRegexp(`^{"level":"warning","msg":"manifest not found: https://example2\.com"}\n$`))
+				// Check if stderr has a warning
+				Expect(stderr.String()).To(MatchRegexp(`^{"level":"warning","msg":"manifest not found: https://example2\.com"}\n$`))
 			})
 		})
 	})

--- a/test/e2e/cli/pkg_update_test.go
+++ b/test/e2e/cli/pkg_update_test.go
@@ -53,9 +53,9 @@ var _ = Describe("kraft pkg", func() {
 				}
 				Expect(err).ToNot(HaveOccurred())
 
-				Expect(stderr.String()).To(BeEmpty())
-				Expect(stdout.String()).To(MatchRegexp(`{"level":"info","msg":"updating manifest index"}`))
-				Expect(stdout.String()).To(MatchRegexp(`{"level":"info","msg":"updating oci index"}`))
+				Expect(stdout.String()).To(BeEmpty())
+				Expect(stderr.String()).To(MatchRegexp(`{"level":"info","msg":"updating manifest index"}`))
+				Expect(stderr.String()).To(MatchRegexp(`{"level":"info","msg":"updating oci index"}`))
 
 				Expect(manifestsPath).To(ContainFiles("index.yaml", "unikraft.yaml"))
 				Expect(manifestsPath).To(ContainDirectories("libs"))

--- a/test/e2e/cli/version_test.go
+++ b/test/e2e/cli/version_test.go
@@ -73,8 +73,8 @@ var _ = Describe("kraft version", func() {
 			Expect(err).To(HaveOccurred())
 			Expect(err).To(MatchError("exit status 1"))
 
-			Expect(stderr.String()).To(BeEmpty())
-			Expect(stdout.String()).To(MatchRegexp(
+			Expect(stdout.String()).To(BeEmpty())
+			Expect(stderr.String()).To(MatchRegexp(
 				`^{"level":"error","msg":"unknown command \\"some-arg\\" for \\"kraft version\\""}\n$`,
 			))
 		})

--- a/test/e2e/framework/cmd/cmd.go
+++ b/test/e2e/framework/cmd/cmd.go
@@ -7,7 +7,6 @@ package cmd
 
 import (
 	"bytes"
-	"errors"
 	"fmt"
 	"io"
 	"os/exec"
@@ -80,27 +79,6 @@ func NewKraftPrivileged(stdout, stderr *IOStream, cfgPath string) *Cmd {
 // reports.
 type Cmd struct {
 	*exec.Cmd
-}
-
-// Run runs the command, and automatically injects the output to stderr in the
-// returned ExitError, in case such an error occurs.
-// It is similar to (*exec.Cmd).Output, but allows the command to have stdout
-// explicitly set.
-func (c *Cmd) Run() error {
-	if err := c.Cmd.Run(); err != nil {
-		if ee := (&exec.ExitError{}); errors.As(err, &ee) {
-			if r, ok := c.Cmd.Stderr.(io.Reader); ok {
-				b, re := io.ReadAll(r)
-				if re != nil {
-					return fmt.Errorf("%w. Additionally, while reading stderr: %w", err, re)
-				}
-				ee.Stderr = b
-				return &ExitError{ExitError: ee}
-			}
-		}
-	}
-
-	return nil
 }
 
 // DumpError is a common method used across command executions which is


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

This is a common UNIX design pattern that logs should be emitted to stderr instead of stdout.  Reserve stdout for program outputs instead.  This makes piping between invocations of kraft and other programs less painful.
