### PR TITLE
fix(drain): Remove incorrect set of aliases

### DIFF
--- a/internal/cli/kraft/cloud/service/drain/drain.go
+++ b/internal/cli/kraft/cloud/service/drain/drain.go
@@ -31,10 +31,9 @@ type DrainOptions struct {
 
 func NewCmd() *cobra.Command {
 	cmd, err := cmdfactory.New(&DrainOptions{}, cobra.Command{
-		Short:   "Drain instances in a service",
-		Use:     "drain [FLAGS] [NAME|UUID [NAME|UUID]...]",
-		Args:    cobra.ArbitraryArgs,
-		Aliases: []string{"delete", "del", "rm"},
+		Short: "Drain instances in a service",
+		Use:   "drain [FLAGS] [NAME|UUID [NAME|UUID]...]",
+		Args:  cobra.ArbitraryArgs,
 		Example: heredoc.Doc(`
 			# Drain a service from your account by UUID.
 			$ kraft cloud service drain fd1684ea-7970-4994-92d6-61dcc7905f2b


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

Not only are these aliases incorrect but they resulted in undefined behaviour which when attempting to use the (same) set of alises set for the `remove` subcommand.

