### PR TITLE
refactor!: Decoupling cli code with native uknet.netDevip structure

### DIFF
--- a/api/network/v1alpha1/network.go
+++ b/api/network/v1alpha1/network.go
@@ -1,0 +1,16 @@
+package v1alpha1
+
+import (
+	"kraftkit.sh/unikraft/export/v0/uknetdev"
+)
+
+func ParseNetwork(networkAttr *NetworkAttr) (uknetdev.NetdevIp, error) {
+	return uknetdev.NetdevIp{
+		CIDR:     networkAttr.CIDR,
+		Gateway:  networkAttr.Gateway,
+		DNS0:     networkAttr.DNS0,
+		DNS1:     networkAttr.DNS1,
+		Hostname: networkAttr.Hostname,
+		Domain:   networkAttr.Domain,
+	}, nil
+}

--- a/api/network/v1alpha1/network.zip.go
+++ b/api/network/v1alpha1/network.zip.go
@@ -19,6 +19,27 @@ type (
 	NetworkList = zip.ObjectList[NetworkSpec, NetworkStatus]
 )
 
+// NetworkAttr abstracts the uknetdev.NetdevIp fields 
+type NetworkAttr struct {
+	// IPv4 address in CIDR notation, which includes the subnet.
+	CIDR string
+
+	// Gateway IPv4 address.
+	Gateway string
+
+	// IPv4 address of the primary DNS server.
+	DNS0 string
+
+	// IPv4 address of the secondary DNS server.
+	DNS1 string
+
+	// Hostname of the IPv4 address.
+	Hostname string
+
+	// Domain/Search suffix for IPv4 address.
+	Domain string
+}
+
 // NetworkSpec contains the desired behavior of the network.
 type NetworkSpec struct {
 	// Driver is the name of the implementing strategy.

--- a/internal/cli/kraft/compose/create/create.go
+++ b/internal/cli/kraft/compose/create/create.go
@@ -38,7 +38,6 @@ import (
 	mnetwork "kraftkit.sh/machine/network"
 	mplatform "kraftkit.sh/machine/platform"
 	mvolume "kraftkit.sh/machine/volume"
-	"kraftkit.sh/unikraft/export/v0/uknetdev"
 )
 
 type CreateOptions struct {
@@ -498,13 +497,18 @@ func createService(ctx context.Context, project *compose.Project, service types.
 		dns1 = service.DNS[1]
 	}
 	for name, network := range service.Networks {
-		arg := uknetdev.NetdevIp{
+		networkAttr := networkapi.NetworkAttr{
 			CIDR:     network.Ipv4Address,
 			DNS0:     dns0,
 			DNS1:     dns1,
 			Hostname: service.Hostname,
 			Domain:   service.DomainName,
 		}
+		arg, err := networkapi.ParseNetwork(&networkAttr)
+		if err != nil {
+			return err
+		}
+
 		networks = append(networks, fmt.Sprintf("%s:%s", project.Networks[name].Name, arg.String()))
 	}
 

--- a/machine/firecracker/v1alpha1.go
+++ b/machine/firecracker/v1alpha1.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	machinev1alpha1 "kraftkit.sh/api/machine/v1alpha1"
+	networkapi "kraftkit.sh/api/network/v1alpha1"
 	"kraftkit.sh/config"
 	"kraftkit.sh/exec"
 	"kraftkit.sh/internal/logtail"
@@ -295,16 +296,21 @@ watch:
 				}); err != nil {
 					return machine, err
 				}
+				networkAttr := networkapi.NetworkAttr{
+					CIDR:     iface.Spec.CIDR,
+					Gateway:  iface.Spec.Gateway,
+					DNS0:     iface.Spec.DNS0,
+					DNS1:     iface.Spec.DNS1,
+					Hostname: iface.Spec.Hostname,
+					Domain:   iface.Spec.Domain,
+				}
+				netdevIp, err := networkapi.ParseNetwork(&networkAttr)
+				if err != nil {
+					return machine, err
+				}
 
 				kernelArgs = append(kernelArgs,
-					uknetdev.NewParamIp().WithValue(uknetdev.NetdevIp{
-						CIDR:     iface.Spec.CIDR,
-						Gateway:  iface.Spec.Gateway,
-						DNS0:     iface.Spec.DNS0,
-						DNS1:     iface.Spec.DNS1,
-						Hostname: iface.Spec.Hostname,
-						Domain:   iface.Spec.Domain,
-					}),
+					uknetdev.NewParamIp().WithValue(netdevIp),
 				)
 
 				// Increment the host network ID for additional interfaces.

--- a/machine/qemu/v1alpha1.go
+++ b/machine/qemu/v1alpha1.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	machinev1alpha1 "kraftkit.sh/api/machine/v1alpha1"
+	networkapi "kraftkit.sh/api/network/v1alpha1"
 	"kraftkit.sh/config"
 	"kraftkit.sh/exec"
 	"kraftkit.sh/internal/logtail"
@@ -295,16 +296,22 @@ func (service *machineV1alpha1Service) Create(ctx context.Context, machine *mach
 						Downscript: "no", // Disable execution
 					}),
 				)
+				networkAttr := networkapi.NetworkAttr{
+					CIDR:     iface.Spec.CIDR,
+					Gateway:  network.Gateway,
+					DNS0:     iface.Spec.DNS0,
+					DNS1:     iface.Spec.DNS1,
+					Hostname: iface.Spec.Hostname,
+					Domain:   iface.Spec.Domain,
+				}
+
+				netdevIp, err := networkapi.ParseNetwork(&networkAttr)
+				if err != nil {
+					return machine, err
+				}
 
 				kernelArgs = append(kernelArgs,
-					uknetdev.NewParamIp().WithValue(uknetdev.NetdevIp{
-						CIDR:     iface.Spec.CIDR,
-						Gateway:  network.Gateway,
-						DNS0:     iface.Spec.DNS0,
-						DNS1:     iface.Spec.DNS1,
-						Hostname: iface.Spec.Hostname,
-						Domain:   iface.Spec.Domain,
-					}),
+					uknetdev.NewParamIp().WithValue(netdevIp),
 				)
 			}
 		}

--- a/machine/xen/v1alpha1.go
+++ b/machine/xen/v1alpha1.go
@@ -36,6 +36,8 @@ import (
 	"kraftkit.sh/unikraft/export/v0/ukargparse"
 	"kraftkit.sh/unikraft/export/v0/uknetdev"
 	"kraftkit.sh/unikraft/export/v0/vfscore"
+	networkapi "kraftkit.sh/api/network/v1alpha1"
+
 
 	"xenbits.xenproject.org/git-http/xen.git/tools/golang/xenlight"
 )
@@ -172,15 +174,20 @@ func (service *machineV1alpha1Service) Create(ctx context.Context, machine *mach
 				nic.Mac = xenlight.Mac([]byte(mac))
 
 				cfg.Nics = append(cfg.Nics, *nic)
+				networkAttr := networkapi.NetworkAttr{
+					CIDR:     iface.Spec.CIDR,
+					Gateway:  network.Gateway,
+					DNS0:     iface.Spec.DNS0,
+					DNS1:     iface.Spec.DNS1,
+					Hostname: iface.Spec.Hostname,
+					Domain:   iface.Spec.Domain,
+				}
+				netdevIp, err := networkapi.ParseNetwork(&networkAttr)
+				if err != nil {
+					return machine, err 
+				}
 				kernelArgs = append(kernelArgs,
-					uknetdev.NewParamIp().WithValue(uknetdev.NetdevIp{
-						CIDR:     iface.Spec.CIDR,
-						Gateway:  network.Gateway,
-						DNS0:     iface.Spec.DNS0,
-						DNS1:     iface.Spec.DNS1,
-						Hostname: iface.Spec.Hostname,
-						Domain:   iface.Spec.Domain,
-					}),
+					uknetdev.NewParamIp().WithValue(netdevIp),
 				)
 				i++
 			}


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [ ] Tested your changes against relevant architectures and platforms;
  - [ ] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
--> 
- Introduces a new structure NetworkAttr to handle the job uknet.netDevIp was doing
- In the issue it was mentioned to deal with the network string , although from the flow I deduced that we are not directly filling these fields from the user given cli responses unlike port, I may be wrong here, direct me if thats the case!
