### PR TITLE
feat(import): Add port argument for custom connections

### DIFF
--- a/internal/cli/kraft/cloud/volume/import/import.go
+++ b/internal/cli/kraft/cloud/volume/import/import.go
@@ -39,6 +39,7 @@ type ImportOptions struct {
 	Metro string             `noattribute:"true"`
 
 	VolimportImage string `local:"true" long:"image" usage:"Volume import image to use" default:"official/utils/volimport:1.0"`
+	Port           int    `local:"true" long:"port" short:"p" usage:"Custom port to connect to the volume import service instance on" default:"42069"`
 	Force          bool   `local:"true" long:"force" short:"f" usage:"Force import, even if it might fail"`
 	Source         string `local:"true" long:"source" short:"s" usage:"Path to the data source (directory, Dockerfile, Docker link, cpio file)" default:"."`
 	Timeout        uint64 `local:"true" long:"timeout" short:"t" usage:"Timeout for the import process in seconds when unresponsive" default:"10"`
@@ -48,7 +49,6 @@ type ImportOptions struct {
 
 const (
 	volimportImageOld string = "official/utils/volimport:latest"
-	volimportPort     uint16 = 42069
 )
 
 func NewCmd() *cobra.Command {
@@ -68,6 +68,9 @@ func NewCmd() *cobra.Command {
 
 			# Import data from a local cpio file "path/to/file" to a volume named "my-volume"
 			$ kraft cloud volume import --source path/to/file --volume my-volume
+
+			# Import data from a local cpio file "path/to/file" to a volume named "my-volume" on the port 10000
+			$ kraft cloud volume import --source path/to/file --volume my-volume --port 10000
 		`),
 		Annotations: map[string]string{
 			cmdfactory.AnnotationHelpGroup: "kraftcloud-volume",
@@ -87,6 +90,10 @@ func (opts *ImportOptions) Pre(cmd *cobra.Command, _ []string) error {
 
 	if opts.VolimportImage == volimportImageOld {
 		return fmt.Errorf("the image %q is deprecated, please use the default and update KraftKit to the latest version", volimportImageOld)
+	}
+
+	if opts.Port < 1024 || opts.Port > 65535 {
+		return fmt.Errorf("port must be between 1024 and 65535")
 	}
 
 	if finfo, err := os.Stat(opts.Source); err == nil && (!finfo.IsDir() && !strings.HasSuffix(opts.Source, "Dockerfile")) {
@@ -169,7 +176,7 @@ func importVolumeData(ctx context.Context, opts *ImportOptions) (retErr error) {
 			if authStr, err = utils.GenRandAuth(); err != nil {
 				return fmt.Errorf("generating random authentication string: %w", err)
 			}
-			instID, instFQDN, err = runVolimport(ctx, icli, opts.VolimportImage, volUUID, authStr, opts.Timeout)
+			instID, instFQDN, err = runVolimport(ctx, icli, opts.VolimportImage, volUUID, authStr, opts.Timeout, opts.Port)
 			return err
 		},
 	)
@@ -190,7 +197,7 @@ func importVolumeData(ctx context.Context, opts *ImportOptions) (retErr error) {
 	if log.LoggerTypeFromString(config.G[config.KraftKit](ctx).Log.Type) == log.FANCY {
 		paraprogress, err := paraProgress(ctx, fmt.Sprintf("Importing data (%s)", humanize.IBytes(uint64(cpioSize))),
 			func(ctx context.Context, callback func(float64)) (retErr error) {
-				instAddr := instFQDN + ":" + strconv.FormatUint(uint64(volimportPort), 10)
+				instAddr := instFQDN + ":" + strconv.FormatUint(uint64(opts.Port), 10)
 				conn, err := tls.Dial("tcp4", instAddr, nil)
 				if err != nil {
 					return fmt.Errorf("connecting to volume data import instance send port: %w", err)
@@ -211,7 +218,7 @@ func importVolumeData(ctx context.Context, opts *ImportOptions) (retErr error) {
 			return err
 		}
 	} else {
-		instAddr := instFQDN + ":" + strconv.FormatUint(uint64(volimportPort), 10)
+		instAddr := instFQDN + ":" + strconv.FormatUint(uint64(opts.Port), 10)
 		conn, err := tls.Dial("tcp4", instAddr, nil)
 		if err != nil {
 			return fmt.Errorf("connecting to volume data import instance send port: %w", err)

--- a/internal/cli/kraft/cloud/volume/import/volimport.go
+++ b/internal/cli/kraft/cloud/volume/import/volimport.go
@@ -16,6 +16,10 @@ import (
 	kcvolumes "sdk.kraft.cloud/volumes"
 )
 
+const (
+	volimportPort uint16 = 42069
+)
+
 // volumeSanityCheck verifies that the given volume is suitable for import.
 func volumeSanityCheck(ctx context.Context, cli kcvolumes.VolumesService, volID string, dataSize int64) (volUUID string, volSize int64, err error) {
 	getvolResp, err := cli.Get(ctx, volID)
@@ -35,7 +39,7 @@ func volumeSanityCheck(ctx context.Context, cli kcvolumes.VolumesService, volID 
 }
 
 // runVolimport spawns a volume data import instance with the given volume attached.
-func runVolimport(ctx context.Context, cli kcinstances.InstancesService, image, volUUID, authStr string, timeoutS uint64) (instID, fqdn string, err error) {
+func runVolimport(ctx context.Context, cli kcinstances.InstancesService, image, volUUID, authStr string, timeoutS uint64, servicePort int) (instID, fqdn string, err error) {
 	args := []string{
 		"volimport",
 		"-p", strconv.FormatUint(uint64(volimportPort), 10),
@@ -49,7 +53,7 @@ func runVolimport(ctx context.Context, cli kcinstances.InstancesService, image, 
 		Args:     args,
 		ServiceGroup: &kcinstances.CreateRequestServiceGroup{
 			Services: []kcservices.CreateRequestService{{
-				Port:            int(volimportPort),
+				Port:            servicePort,
 				DestinationPort: ptr(int(volimportPort)),
 				Handlers:        []kcservices.Handler{kcservices.HandlerTLS},
 			}},


### PR DESCRIPTION
Connections to certain ports can be restricted. Add option to set the port of the service group of the volimport service instance.

<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [ ] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [ ] Tested your changes against relevant architectures and platforms;
  - [ ] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->
