### PR TITLE
feat(oci): Add util for accessing OCI layer contents

### DIFF
--- a/oci/utils/tarball.go
+++ b/oci/utils/tarball.go
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2025, Unikraft GmbH and The KraftKit Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file expect in compliance with the License.
+package utils
+
+import (
+	"archive/tar"
+	"fmt"
+	"io"
+	"io/fs"
+	"path/filepath"
+)
+
+// OpenFromTarOCILayer returns a reader for the given file from the provided
+// tarball reader.
+func OpenFromTarOCILayer(r io.Reader, path string) (io.Reader, error) {
+	tarPath, err := filepath.Rel("/", path)
+	if err != nil {
+		return nil, fmt.Errorf("could not trim leading separator from path %q: %w", path, err)
+	}
+
+	tr := tar.NewReader(r)
+	for {
+		h, err := tr.Next()
+		if err != nil {
+			if err == io.EOF {
+				break
+			}
+			return nil, fmt.Errorf("could not advance to the next entry in the OCI image layer: %w", err)
+		}
+
+		if h.Name != tarPath {
+			continue
+		}
+
+		if t := h.Typeflag; t != tar.TypeReg {
+			return nil, fmt.Errorf("path is not a regular file")
+		}
+
+		return tr, nil
+	}
+
+	return nil, &fs.PathError{Op: "open", Path: path, Err: fs.ErrNotExist}
+}


### PR DESCRIPTION
This allows for working with layers as raw tarball streams, without
first unpacking to disk and before storing them in containerd.

Signed-off-by: Robert Günzler <robert@unikraft.cloud>

<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

This PR adds a small utility function to access Unikraft image contents from a
tar stream. Before this was only possible if the image was already unpacked on
disk or in containerd's image store.
