### PR TITLE
refactor(oci)!: Update oci package constants

### DIFF
--- a/oci/layer.go
+++ b/oci/layer.go
@@ -29,10 +29,7 @@ func NewLayerFromFile(ctx context.Context, mediaType, src, dst string, opts ...L
 	removeAfterSave := false
 
 	switch mediaType {
-	case ocispec.MediaTypeImageLayer,
-		MediaTypeImageKernelGzip,
-		MediaTypeImageKernel:
-
+	case ocispec.MediaTypeImageLayer:
 		tmp, err := os.CreateTemp("", "kraftkit-ociblob*")
 		if err != nil {
 			return nil, err
@@ -41,7 +38,7 @@ func NewLayerFromFile(ctx context.Context, mediaType, src, dst string, opts ...L
 		if err := archive.TarFileTo(ctx,
 			src, dst, tmp.Name(),
 			archive.WithStripTimes(true),
-			archive.WithGzip(mediaType == MediaTypeImageKernelGzip),
+			archive.WithGzip(false),
 		); err != nil {
 			return nil, err
 		}

--- a/oci/mediatypes.go
+++ b/oci/mediatypes.go
@@ -5,13 +5,6 @@
 package oci
 
 const (
-	MediaTypeLayer       = "application/vnd.unikraft.rootfs.diff"
-	MediaTypeImageKernel = "application/vnd.unikraft.image.v1"
-	MediaTypeInitrdCpio  = "application/vnd.unikraft.initrd.v1"
-	MediaTypeConfig      = "application/vnd.unikraft.config.v1"
-
-	MediaTypeLayerGzip       = MediaTypeLayer + "+gzip"
-	MediaTypeImageKernelGzip = MediaTypeImageKernel + "+gzip"
-	MediaTypeInitrdCpioGzip  = MediaTypeInitrdCpio + "+gzip"
-	MediaTypeConfigGzip      = MediaTypeConfig + "+gzip"
+	MediaTypeKernel = "application/vnd.unikraft.kernel.v1"
+	MediaTypeInitrd = "application/vnd.unikraft.initrd.v1"
 )

--- a/oci/wellknown.go
+++ b/oci/wellknown.go
@@ -8,7 +8,9 @@ const (
 	WellKnownKernelPath      = "/unikraft/bin/kernel"
 	WellKnownKernelDbgPath   = "/unikraft/bin/kernel.dbg"
 	WellKnownInitrdPath      = "/unikraft/bin/initrd"
-	WellKnownConfigPath      = "/unikraft/bin/config"
+	WellKnownKConfigPath     = "/unikraft/bin/config"
+	WellKnownConfigPath      = "/unikraft/config.json"
+	WellKnownCmdlinePath     = "/unikraft/cmdline.txt"
 	WellKnownKernelSourceDir = "/unikraft/src"
 	WellKnownAppSourceDir    = "/unikraft/app"
 )


### PR DESCRIPTION
### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

This fixes and refactors the constants for media types and well-known paths in the oci package.
The media types were unused, so we also drop the corresponding code paths. Missing well-known paths for `cmdline.txt` and `config.json` are added.