### PR TITLE
revert: feat(pkg)!: Deprecate `--no-pull` / `NoPull` option

### DIFF
--- a/internal/cli/kraft/cloud/compose/build/build.go
+++ b/internal/cli/kraft/cloud/compose/build/build.go
@@ -194,6 +194,7 @@ func Build(ctx context.Context, opts *BuildOptions, args ...string) error {
 			Compress:     false,
 			Format:       "oci",
 			Name:         pkgName,
+			NoPull:       true,
 			Platform:     "kraftcloud",
 			Push:         opts.Push,
 			Project:      project,

--- a/internal/cli/kraft/cloud/deploy/deployer_kraftfile_runtime.go
+++ b/internal/cli/kraft/cloud/deploy/deployer_kraftfile_runtime.go
@@ -103,6 +103,7 @@ func (deployer *deployerKraftfileRuntime) Deploy(ctx context.Context, opts *Depl
 		Format:       "oci",
 		Kraftfile:    opts.Kraftfile,
 		Name:         pkgName,
+		NoPull:       true,
 		Platform:     "kraftcloud",
 		Project:      opts.Project,
 		Push:         true,

--- a/internal/cli/kraft/pkg/packager_kraftfile_runtime.go
+++ b/internal/cli/kraft/pkg/packager_kraftfile_runtime.go
@@ -17,6 +17,7 @@ import (
 	"kraftkit.sh/log"
 	"kraftkit.sh/pack"
 	"kraftkit.sh/packmanager"
+	"kraftkit.sh/tui/paraprogress"
 	"kraftkit.sh/tui/processtree"
 	"kraftkit.sh/tui/selection"
 	"kraftkit.sh/unikraft"
@@ -270,12 +271,44 @@ func (p *packagerKraftfileRuntime) Pack(ctx context.Context, opts *PkgOptions, a
 
 	// Remove the cached runtime package reference if it was not previously
 	// pulled.
-	if !pulled {
+	if !pulled && opts.NoPull {
 		defer func() {
 			if err := runtime.Delete(ctx); err != nil {
 				log.G(ctx).Tracef("could not delete intermediate runtime package: %s", err.Error())
 			}
 		}()
+	}
+
+	if !pulled && !opts.NoPull {
+		paramodel, err := paraprogress.NewParaProgress(
+			ctx,
+			[]*paraprogress.Process{paraprogress.NewProcess(
+				fmt.Sprintf("pulling %s", runtime.String()),
+				func(ctx context.Context, w func(progress float64)) error {
+					popts := []pack.PullOption{}
+					if log.LoggerTypeFromString(config.G[config.KraftKit](ctx).Log.Type) == log.FANCY {
+						popts = append(popts, pack.WithPullProgressFunc(w))
+					}
+
+					return runtime.Pull(
+						ctx,
+						popts...,
+					)
+				},
+			)},
+			paraprogress.IsParallel(false),
+			paraprogress.WithRenderer(
+				log.LoggerTypeFromString(config.G[config.KraftKit](ctx).Log.Type) != log.FANCY,
+			),
+			paraprogress.WithFailFast(true),
+		)
+		if err != nil {
+			return nil, err
+		}
+
+		if err := paramodel.Start(); err != nil {
+			return nil, err
+		}
 	}
 
 	// Create a temporary directory we can use to store the artifacts from

--- a/internal/cli/kraft/pkg/pkg.go
+++ b/internal/cli/kraft/pkg/pkg.go
@@ -47,6 +47,7 @@ type PkgOptions struct {
 	Labels       []string                  `local:"true" long:"label" short:"l" usage:"Set labels to be packed into the package (k=v)"`
 	Name         string                    `local:"true" long:"name" short:"n" usage:"Specify the name of the package"`
 	NoKConfig    bool                      `local:"true" long:"no-kconfig" usage:"Do not include target .config as metadata"`
+	NoPull       bool                      `local:"true" long:"no-pull" usage:"Do not pull package dependencies before packaging"`
 	Output       string                    `local:"true" long:"output" short:"o" usage:"Save the package at the following output"`
 	Platform     string                    `local:"true" long:"plat" short:"p" usage:"Filter the creation of the package by platform of known targets (fc/qemu/xen/kraftcloud)"`
 	Project      app.Application           `noattribute:"true"`


### PR DESCRIPTION
This reverts commit 9229ccee606fb0efec999f0ff69be20f023f510c.

When pushing to an internal registry directly we need to pull the runtime (aka official kernels located in harbor) if we want to bump the reference to them in the new package.

<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->
