### PR TITLE
fix(login): Support setting user/token verbatim

### DIFF
--- a/internal/cli/kraft/login/login.go
+++ b/internal/cli/kraft/login/login.go
@@ -81,18 +81,18 @@ func (opts *LoginOptions) Run(ctx context.Context, args []string) error {
 		opts.Token = string(btoken)
 	}
 
-	// Check if the provided token is a base64 encoded string containing both the
-	// username and token
-	if decoded, err := base64.StdEncoding.DecodeString(opts.Token); err == nil && len(decoded) > 0 {
-		split := strings.SplitN(string(decoded), ":", 2)
+	// If only a token was provided, check if it is a base64 encoded string
+	// containing both the username and token.
+	if opts.User == "" && opts.Token != "" {
+		// Check if the provided token is a base64 encoded string containing both the
+		// username and token
+		if decoded, err := base64.StdEncoding.DecodeString(opts.Token); err == nil && len(decoded) > 0 {
+			split := strings.SplitN(string(decoded), ":", 2)
 
-		if len(split) == 2 {
-			if len(opts.User) > 0 {
-				return fmt.Errorf("cannot specify -u|--username with a -t|--token that contains a base64 encoding of a username and token")
+			if len(split) == 2 {
+				opts.User = split[0]
+				opts.Token = split[1]
 			}
-
-			opts.User = split[0]
-			opts.Token = split[1]
 		}
 	}
 


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

In the envent that a user wishes to supply a user and token without the token being base64 decoded to interpret the user, this can change supports removing the mutually exlusivity of `-u` and `-t` flag such that these values can be set verbatim.
