### PR TITLE
fix(initrd): Fix path resolution of cpio archive in initrd init

### DIFF
--- a/initrd/file.go
+++ b/initrd/file.go
@@ -19,14 +19,6 @@ type file struct {
 // NewFromFile accepts an input file which already represents a CPIO archive and
 // is provided as a mechanism for satisfying the Initrd interface.
 func NewFromFile(_ context.Context, path string, opts ...InitrdOption) (Initrd, error) {
-	stat, err := os.Stat(path)
-	if err != nil {
-		return nil, err
-	}
-	if stat.IsDir() {
-		return nil, fmt.Errorf("path %s is a directory, not a file", path)
-	}
-
 	initrd := file{
 		opts: InitrdOptions{},
 		path: path,
@@ -40,6 +32,14 @@ func NewFromFile(_ context.Context, path string, opts ...InitrdOption) (Initrd, 
 
 	if !filepath.IsAbs(initrd.path) {
 		initrd.path = filepath.Join(initrd.opts.workdir, initrd.path)
+	}
+
+	stat, err := os.Stat(initrd.path)
+	if err != nil {
+		return nil, err
+	}
+	if stat.IsDir() {
+		return nil, fmt.Errorf("path %s is a directory, not a file", initrd.path)
 	}
 
 	absDest, err := filepath.Abs(filepath.Clean(initrd.opts.output))


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [ x ] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [ x ] Tested your changes against relevant architectures and platforms;
  - [ x ] Ran `make fmt` on your commit series before opening this PR;
  - [  ] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

Fix a bug related to relative path handling of `initrd`'s cpio build source.
