### PR TITLE
feat: Auxiliary ROM packaging

### DIFF
--- a/initrd/directory.go
+++ b/initrd/directory.go
@@ -190,6 +190,11 @@ func (initrd *directory) Build(ctx context.Context) (string, error) {
 	return initrd.opts.output, nil
 }
 
+// Options implements Initrd.
+func (initrd *directory) Options() InitrdOptions {
+	return initrd.opts
+}
+
 // Env implements Initrd.
 func (initrd *directory) Env() []string {
 	return nil

--- a/initrd/dockerfile.go
+++ b/initrd/dockerfile.go
@@ -765,6 +765,11 @@ func (initrd *dockerfile) Build(ctx context.Context) (string, error) {
 	return initrd.opts.output, nil
 }
 
+// Options implements Initrd.
+func (initrd *dockerfile) Options() InitrdOptions {
+	return initrd.opts
+}
+
 // Env implements Initrd.
 func (initrd *dockerfile) Env() []string {
 	return initrd.env

--- a/initrd/file.go
+++ b/initrd/file.go
@@ -64,6 +64,11 @@ func (initrd *file) Build(_ context.Context) (string, error) {
 	return initrd.path, nil
 }
 
+// Options implements Initrd.
+func (initrd *file) Options() InitrdOptions {
+	return initrd.opts
+}
+
 // Env implements Initrd.
 func (initrd *file) Env() []string {
 	return nil

--- a/initrd/initrd.go
+++ b/initrd/initrd.go
@@ -25,6 +25,9 @@ type Initrd interface {
 	// Build the rootfs and return the location of the result or error.
 	Build(context.Context) (string, error)
 
+	// Options returns the options used to construct this Initrd.
+	Options() InitrdOptions
+
 	// All environment variables that are set within.
 	Env() []string
 

--- a/initrd/ociimage.go
+++ b/initrd/ociimage.go
@@ -338,6 +338,11 @@ func (initrd *ociimage) Build(ctx context.Context) (string, error) {
 	return initrd.opts.output, nil
 }
 
+// Options implements Initrd.
+func (initrd *ociimage) Options() InitrdOptions {
+	return initrd.opts
+}
+
 // Env implements Initrd.
 func (initrd *ociimage) Env() []string {
 	return initrd.env

--- a/initrd/options.go
+++ b/initrd/options.go
@@ -12,6 +12,31 @@ type InitrdOptions struct {
 	workdir  string
 }
 
+// Whether the resulting CPIO archive file should be compressed.
+func (opts InitrdOptions) Compress() bool {
+	return opts.compress
+}
+
+// The output location of the resulting CPIO archive file.
+func (opts InitrdOptions) Output() string {
+	return opts.output
+}
+
+// The cache directory used during the serialization of the initramfs.
+func (opts InitrdOptions) CacheDir() string {
+	return opts.cacheDir
+}
+
+// The architecture of the file contents of binaries in the initramfs.
+func (opts InitrdOptions) Architecture() string {
+	return opts.arch
+}
+
+// The working directory of the initramfs builder.
+func (opts InitrdOptions) Workdir() string {
+	return opts.workdir
+}
+
 type InitrdOption func(*InitrdOptions) error
 
 // WithCompression sets the compression of the resulting CPIO archive file.

--- a/initrd/tarball.go
+++ b/initrd/tarball.go
@@ -284,6 +284,11 @@ func (initrd *tarball) Build(ctx context.Context) (string, error) {
 	return initrd.opts.output, nil
 }
 
+// Options implements Initrd.
+func (initrd *tarball) Options() InitrdOptions {
+	return initrd.opts
+}
+
 // Env implements Initrd.
 func (initrd *tarball) Env() []string {
 	return nil

--- a/internal/cli/kraft/build/build.go
+++ b/internal/cli/kraft/build/build.go
@@ -108,7 +108,7 @@ func Build(ctx context.Context, opts *BuildOptions, args ...string) error {
 		return fmt.Errorf("could not complete build: %w", err)
 	}
 
-	if opts.Rootfs, _, _, err = utils.BuildRootfs(ctx, opts.Workdir, opts.Rootfs, false, (*opts.Target).Architecture().String()); err != nil {
+	if _, _, _, err = utils.BuildRootfs(ctx, opts.Workdir, opts.Rootfs, false, (*opts.Target).Architecture().String()); err != nil {
 		return err
 	}
 

--- a/internal/cli/kraft/build/builder_dockerfile.go
+++ b/internal/cli/kraft/build/builder_dockerfile.go
@@ -8,6 +8,8 @@ import (
 	"context"
 	"fmt"
 	"strings"
+
+	"kraftkit.sh/log"
 )
 
 // builderDockerfile is a builder that only uses a `Dockerfile` to build a
@@ -28,7 +30,9 @@ func (build *builderDockerfile) Buildable(ctx context.Context, opts *BuildOption
 	if opts.Project == nil {
 		// Do not capture the the project is not initialized, as we can still build
 		// the unikernel using the Dockerfile provided with the `--rootfs`.
-		_ = opts.initProject(ctx)
+		if err := opts.initProject(ctx); err != nil {
+			log.G(ctx).WithError(err).Warn("could not initialize project")
+		}
 	}
 
 	if opts.Project != nil && opts.Project.Rootfs() != "" && opts.Rootfs == "" {

--- a/internal/cli/kraft/cloud/deploy/deployer_rootfs.go
+++ b/internal/cli/kraft/cloud/deploy/deployer_rootfs.go
@@ -11,6 +11,7 @@ import (
 	kcinstances "sdk.kraft.cloud/instances"
 	kcservices "sdk.kraft.cloud/services"
 
+	"kraftkit.sh/log"
 	"kraftkit.sh/unikraft/app"
 	"kraftkit.sh/unikraft/arch"
 	"kraftkit.sh/unikraft/plat"
@@ -34,7 +35,9 @@ func (deployer *deployerRootfs) Deployable(ctx context.Context, opts *DeployOpti
 	if opts.Project == nil {
 		// Do not capture the the project is not initialized, as we can still build
 		// the unikernel using the Dockerfile provided with the `--rootfs`.
-		_ = opts.initProject(ctx)
+		if err := opts.initProject(ctx); err != nil {
+			log.G(ctx).WithError(err).Warn("could not initialize project")
+		}
 	}
 
 	if opts.Project != nil && opts.Project.Rootfs() != "" && opts.Rootfs == "" {

--- a/internal/cli/kraft/pkg/packager_cli_kernel.go
+++ b/internal/cli/kraft/pkg/packager_cli_kernel.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	"kraftkit.sh/config"
+	"kraftkit.sh/initrd"
 	"kraftkit.sh/internal/cli/kraft/utils"
 	"kraftkit.sh/log"
 	"kraftkit.sh/pack"
@@ -64,7 +65,8 @@ func (p *packagerCliKernel) Pack(ctx context.Context, opts *PkgOptions, args ...
 
 	var cmds []string
 	var envs []string
-	if _, cmds, envs, err = utils.BuildRootfs(ctx, opts.Workdir, opts.Rootfs, opts.Compress, targ.Architecture().String()); err != nil {
+	var rootfs initrd.Initrd
+	if rootfs, cmds, envs, err = utils.BuildRootfs(ctx, opts.Workdir, opts.Rootfs, opts.Compress, targ.Architecture().String()); err != nil {
 		return nil, fmt.Errorf("could not build rootfs: %w", err)
 	}
 
@@ -103,13 +105,18 @@ func (p *packagerCliKernel) Pack(ctx context.Context, opts *PkgOptions, args ...
 			opts.Platform+"/"+opts.Architecture,
 			func(ctx context.Context) error {
 				popts := append(opts.packopts,
+					packmanager.PackArchitecture(targ.Architecture()),
+					packmanager.PackPlatform(targ.Platform()),
 					packmanager.PackArgs(opts.Args...),
-					packmanager.PackInitrd(opts.Rootfs),
-					packmanager.PackKConfig(!opts.NoKConfig),
+					packmanager.PackInitrd(rootfs),
 					packmanager.PackName(opts.Name),
 					packmanager.PackOutput(opts.Output),
 					packmanager.PackLabels(labels),
 				)
+
+				if !opts.NoKConfig {
+					popts = append(popts, packmanager.PackKConfig(targ.KConfig()))
+				}
 
 				envs := opts.aggregateEnvs()
 				if len(envs) > 0 {

--- a/internal/cli/kraft/pkg/packager_cli_kernel.go
+++ b/internal/cli/kraft/pkg/packager_cli_kernel.go
@@ -64,7 +64,7 @@ func (p *packagerCliKernel) Pack(ctx context.Context, opts *PkgOptions, args ...
 
 	var cmds []string
 	var envs []string
-	if opts.Rootfs, cmds, envs, err = utils.BuildRootfs(ctx, opts.Workdir, opts.Rootfs, opts.Compress, targ.Architecture().String()); err != nil {
+	if _, cmds, envs, err = utils.BuildRootfs(ctx, opts.Workdir, opts.Rootfs, opts.Compress, targ.Architecture().String()); err != nil {
 		return nil, fmt.Errorf("could not build rootfs: %w", err)
 	}
 

--- a/internal/cli/kraft/pkg/packager_kraftfile_runtime.go
+++ b/internal/cli/kraft/pkg/packager_kraftfile_runtime.go
@@ -43,10 +43,6 @@ func (p *packagerKraftfileRuntime) Packagable(ctx context.Context, opts *PkgOpti
 		return false, fmt.Errorf("cannot package without unikraft core specification")
 	}
 
-	if opts.Project.Targets() == nil {
-		return false, fmt.Errorf("cannot package without project targets")
-	}
-
 	if opts.Project.Rootfs() != "" && opts.Rootfs == "" {
 		opts.Rootfs = opts.Project.Rootfs()
 	}
@@ -59,10 +55,6 @@ func (p *packagerKraftfileRuntime) Pack(ctx context.Context, opts *PkgOptions, a
 	var err error
 	var targ target.Target
 	var runtimeName, runtimeVersion string
-
-	if opts.Project.Targets() == nil {
-		return nil, fmt.Errorf("cannot package without project targets")
-	}
 
 	if len(opts.Runtime) > 0 {
 		var ok bool

--- a/internal/cli/kraft/pkg/packager_kraftfile_runtime.go
+++ b/internal/cli/kraft/pkg/packager_kraftfile_runtime.go
@@ -43,8 +43,8 @@ func (p *packagerKraftfileRuntime) Packagable(ctx context.Context, opts *PkgOpti
 		}
 	}
 
-	if opts.Project.Runtime() == nil && len(opts.Project.Rootfs()) == 0 {
-		return false, fmt.Errorf("cannot package without any of runtime or rootfs")
+	if opts.Project.Runtime() == nil && len(opts.Project.Rootfs()) == 0 && len(opts.Project.Roms()) == 0 {
+		return false, fmt.Errorf("cannot package without any of runtime, rootfs or roms")
 	}
 
 	if opts.Project.Rootfs() != "" && opts.Rootfs == "" {
@@ -65,6 +65,7 @@ func (p *packagerKraftfileRuntime) Pack(ctx context.Context, opts *PkgOptions, a
 		packKConfig      kconfig.KeyValueMap
 		packCmds         []string
 		packEnv          []string
+		packRoms         []string
 		packArgs         []string
 		packRootfs       initrd.Initrd
 		packArchitecture arch.Architecture
@@ -411,6 +412,14 @@ func (p *packagerKraftfileRuntime) Pack(ctx context.Context, opts *PkgOptions, a
 		}
 	}
 
+	if opts.Project != nil {
+		packRoms = opts.Project.Roms()
+	} else if len(opts.Roms) > 0 {
+		packRoms = opts.Roms
+	} else if targ != nil && len(targ.Roms()) > 0 {
+		packRoms = targ.Roms()
+	}
+
 	var labels map[string]string
 	if opts.Project != nil {
 		labels = opts.Project.Labels()
@@ -458,6 +467,12 @@ func (p *packagerKraftfileRuntime) Pack(ctx context.Context, opts *PkgOptions, a
 				if packRootfs != nil {
 					popts = append(popts,
 						packmanager.PackInitrd(packRootfs),
+					)
+				}
+
+				if len(packRoms) > 0 {
+					popts = append(popts,
+						packmanager.PackRoms(packRoms...),
 					)
 				}
 

--- a/internal/cli/kraft/pkg/packager_kraftfile_runtime.go
+++ b/internal/cli/kraft/pkg/packager_kraftfile_runtime.go
@@ -28,7 +28,21 @@ import (
 	"kraftkit.sh/unikraft/target"
 )
 
-type packagerKraftfileRuntime struct{}
+type packagerKraftfileRuntime struct {
+	name    string
+	version string
+	target  target.Target
+
+	// Packaging options
+	kernel       string
+	kconfig      kconfig.KeyValueMap
+	args         []string
+	env          []string
+	roms         []string
+	rootfs       initrd.Initrd
+	architecture arch.Architecture
+	platform     plat.Platform
+}
 
 // String implements fmt.Stringer.
 func (p *packagerKraftfileRuntime) String() string {
@@ -56,42 +70,28 @@ func (p *packagerKraftfileRuntime) Packagable(ctx context.Context, opts *PkgOpti
 
 // Pack implements packager.
 func (p *packagerKraftfileRuntime) Pack(ctx context.Context, opts *PkgOptions, args ...string) ([]pack.Package, error) {
-	var (
-		err              error
-		runtimeName      string
-		runtimeVersion   string
-		targ             target.Target
-		packKernel       string
-		packKConfig      kconfig.KeyValueMap
-		packCmds         []string
-		packEnv          []string
-		packRoms         []string
-		packArgs         []string
-		packRootfs       initrd.Initrd
-		packArchitecture arch.Architecture
-		packPlatform     plat.Platform
-	)
+	var err error
 
 	if len(opts.Runtime) > 0 {
 		var ok bool
-		runtimeName, runtimeVersion, ok = strings.Cut(opts.Runtime, ":")
+		p.name, p.version, ok = strings.Cut(opts.Runtime, ":")
 		if !ok {
-			runtimeVersion = "latest"
+			p.version = "latest"
 		}
 	} else if opts.Project != nil && opts.Project.Runtime() != nil {
-		runtimeName = opts.Project.Runtime().Name()
+		p.name = opts.Project.Runtime().Name()
 	} else if opts.Name != "" {
 		var ok bool
-		runtimeName, runtimeVersion, ok = strings.Cut(opts.Name, ":")
+		p.name, p.version, ok = strings.Cut(opts.Name, ":")
 		if !ok {
-			runtimeVersion = "latest"
+			p.version = "latest"
 		}
 	} else {
 		return nil, fmt.Errorf("no name specified: ")
 	}
 
 	if opts.Platform == "kraftcloud" || (opts.Project.Runtime().Platform() != nil && opts.Project.Runtime().Platform().Name() == "kraftcloud") {
-		runtimeName = utils.RewrapAsKraftCloudPackage(runtimeName)
+		p.name = utils.RewrapAsKraftCloudPackage(p.name)
 	}
 
 	var targets []target.Target
@@ -100,17 +100,17 @@ func (p *packagerKraftfileRuntime) Pack(ctx context.Context, opts *PkgOptions, a
 		targets = opts.Project.Targets()
 
 		if opts.Project.Runtime() != nil {
-			runtimeVersion = opts.Project.Runtime().Version()
+			p.version = opts.Project.Runtime().Version()
 		}
 	}
 
 	qopts := []packmanager.QueryOption{
-		packmanager.WithName(runtimeName),
-		packmanager.WithVersion(runtimeVersion),
+		packmanager.WithName(p.name),
+		packmanager.WithVersion(p.version),
 	}
 
 	if len(targets) == 1 {
-		targ = targets[0]
+		p.target = targets[0]
 	} else if len(targets) > 1 {
 		// Filter project targets by any provided CLI options
 		targets = target.Filter(
@@ -125,13 +125,13 @@ func (p *packagerKraftfileRuntime) Pack(ctx context.Context, opts *PkgOptions, a
 			return nil, fmt.Errorf("could not detect any project targets based on plat=\"%s\" arch=\"%s\"", opts.Platform, opts.Architecture)
 
 		case len(targets) == 1:
-			targ = targets[0]
+			p.target = targets[0]
 
 		case config.G[config.KraftKit](ctx).NoPrompt && len(targets) > 1:
 			return nil, fmt.Errorf("could not determine what to run based on provided CLI arguments")
 
 		default:
-			targ, err = target.Select(targets)
+			p.target, err = target.Select(targets)
 			if err != nil {
 				return nil, fmt.Errorf("could not select target: %v", err)
 			}
@@ -142,16 +142,16 @@ func (p *packagerKraftfileRuntime) Pack(ctx context.Context, opts *PkgOptions, a
 	var packs []pack.Package
 	var kconfigs []string
 
-	if targ != nil {
-		for _, kc := range targ.KConfig() {
+	if p.target != nil {
+		for _, kc := range p.target.KConfig() {
 			kconfigs = append(kconfigs, kc.String())
 		}
 
 		if opts.Platform == "" {
-			opts.Platform = targ.Platform().Name()
+			opts.Platform = p.target.Platform().Name()
 		}
 		if opts.Architecture == "" {
-			opts.Architecture = targ.Architecture().Name()
+			opts.Architecture = p.target.Architecture().Name()
 		}
 	}
 
@@ -168,8 +168,8 @@ func (p *packagerKraftfileRuntime) Pack(ctx context.Context, opts *PkgOptions, a
 		processtree.NewProcessTreeItem(
 			fmt.Sprintf(
 				"searching for %s:%s",
-				runtimeName,
-				runtimeVersion,
+				p.name,
+				p.version,
 			),
 			"",
 			func(ctx context.Context) error {
@@ -207,30 +207,30 @@ func (p *packagerKraftfileRuntime) Pack(ctx context.Context, opts *PkgOptions, a
 		if len(opts.Platform) > 0 && len(opts.Architecture) > 0 {
 			return nil, fmt.Errorf(
 				"could not find runtime '%s:%s' (%s/%s)",
-				runtimeName,
-				runtimeVersion,
+				p.name,
+				p.version,
 				opts.Platform,
 				opts.Architecture,
 			)
 		} else if len(opts.Architecture) > 0 {
 			return nil, fmt.Errorf(
 				"could not find runtime '%s:%s' with '%s' architecture",
-				runtimeName,
-				runtimeVersion,
+				p.name,
+				p.version,
 				opts.Architecture,
 			)
 		} else if len(opts.Platform) > 0 {
 			return nil, fmt.Errorf(
 				"could not find runtime '%s:%s' with '%s' platform",
-				runtimeName,
-				runtimeVersion,
+				p.name,
+				p.version,
 				opts.Platform,
 			)
 		} else {
 			return nil, fmt.Errorf(
 				"could not find runtime %s:%s",
-				runtimeName,
-				runtimeVersion,
+				p.name,
+				p.version,
 			)
 		}
 	} else if len(packs) == 1 {
@@ -238,7 +238,7 @@ func (p *packagerKraftfileRuntime) Pack(ctx context.Context, opts *PkgOptions, a
 	} else if len(packs) > 1 {
 		// If a target has been previously selected, we can use this to filter the
 		// returned list of packages based on its platform and architecture.
-		if targ != nil {
+		if p.target != nil {
 			found := []pack.Package{}
 
 			for _, p := range packs {
@@ -252,7 +252,7 @@ func (p *packagerKraftfileRuntime) Pack(ctx context.Context, opts *PkgOptions, a
 			// platform, prompt with available set of packages.
 			if len(found) == 0 {
 				if !config.G[config.KraftKit](ctx).NoPrompt {
-					log.G(ctx).Warnf("could not find package '%s:%s' based on %s/%s", runtimeName, opts.Project.Runtime().Version(), opts.Platform, opts.Architecture)
+					log.G(ctx).Warnf("could not find package '%s:%s' based on %s/%s", p.name, opts.Project.Runtime().Version(), opts.Platform, opts.Architecture)
 					p, err := selection.Select[pack.Package]("select alternative package with same name to continue", packs...)
 					if err != nil {
 						return nil, fmt.Errorf("could not select package: %w", err)
@@ -260,13 +260,13 @@ func (p *packagerKraftfileRuntime) Pack(ctx context.Context, opts *PkgOptions, a
 
 					selected = p
 				} else {
-					return nil, fmt.Errorf("could not find package '%s:%s' based on %s/%s but %d others found but prompting has been disabled", runtimeName, opts.Project.Runtime().Version(), opts.Platform, opts.Architecture, len(packs))
+					return nil, fmt.Errorf("could not find package '%s:%s' based on %s/%s but %d others found but prompting has been disabled", p.name, opts.Project.Runtime().Version(), opts.Platform, opts.Architecture, len(packs))
 				}
 			} else if len(found) == 1 {
 				selected = &found[0]
 			} else { // > 1
 				if !config.G[config.KraftKit](ctx).NoPrompt {
-					log.G(ctx).Infof("found %d packages named '%s:%s' based on %s/%s", len(found), runtimeName, opts.Project.Runtime().Version(), opts.Platform, opts.Architecture)
+					log.G(ctx).Infof("found %d packages named '%s:%s' based on %s/%s", len(found), p.name, opts.Project.Runtime().Version(), opts.Platform, opts.Architecture)
 					p, err := selection.Select[pack.Package]("select package to continue", found...)
 					if err != nil {
 						return nil, fmt.Errorf("could not select package: %w", err)
@@ -274,7 +274,7 @@ func (p *packagerKraftfileRuntime) Pack(ctx context.Context, opts *PkgOptions, a
 
 					selected = p
 				} else {
-					return nil, fmt.Errorf("found %d packages named '%s:%s' based on %s/%s but prompting has been disabled", len(found), runtimeName, opts.Project.Runtime().Version(), opts.Platform, opts.Architecture)
+					return nil, fmt.Errorf("found %d packages named '%s:%s' based on %s/%s but prompting has been disabled", len(found), p.name, opts.Project.Runtime().Version(), opts.Platform, opts.Architecture)
 				}
 			}
 		} else {
@@ -353,17 +353,17 @@ func (p *packagerKraftfileRuntime) Pack(ctx context.Context, opts *PkgOptions, a
 		// target.Target.  This demonstrates that the implementing package can
 		// resolve application kernels.
 		var ok bool
-		targ, ok = runtime.(target.Target)
+		p.target, ok = runtime.(target.Target)
 		if !ok {
 			return nil, fmt.Errorf("package does not convert to target")
 		}
 
-		opts.Platform = targ.Platform().Name()
-		opts.Architecture = targ.Architecture().Name()
-		packKernel = targ.Kernel()
-		packKConfig = targ.KConfig()
-		packArchitecture = targ.Architecture()
-		packPlatform = targ.Platform()
+		opts.Platform = p.target.Platform().Name()
+		opts.Architecture = p.target.Architecture().Name()
+		p.kernel = p.target.Kernel()
+		p.kconfig = p.target.KConfig()
+		p.architecture = p.target.Architecture()
+		p.platform = p.target.Platform()
 	} else {
 		if len(opts.Platform) == 0 {
 			return nil, fmt.Errorf("no platform specified: required when no runtime is specified")
@@ -372,22 +372,23 @@ func (p *packagerKraftfileRuntime) Pack(ctx context.Context, opts *PkgOptions, a
 			return nil, fmt.Errorf("no architecture specified: required when no runtime is specified")
 		}
 
-		packArchitecture = arch.NewArchitectureFromOptions(
+		p.architecture = arch.NewArchitectureFromOptions(
 			arch.WithName(opts.Architecture),
 		)
-		packPlatform = plat.NewPlatformFromOptions(
+		p.platform = plat.NewPlatformFromOptions(
 			plat.WithName(opts.Platform),
 		)
 
 		log.G(ctx).Warn("no kernel detected: packaging without - this may produce unexpected results")
 	}
 
-	if packRootfs, packCmds, packEnv, err = utils.BuildRootfs(ctx, opts.Workdir, opts.Rootfs, opts.Compress, packArchitecture.String()); err != nil {
+	var rootfsArgs []string
+	if p.rootfs, rootfsArgs, p.env, err = utils.BuildRootfs(ctx, opts.Workdir, opts.Rootfs, opts.Compress, p.architecture.String()); err != nil {
 		return nil, fmt.Errorf("could not build rootfs: %w", err)
 	}
 
-	if packEnv != nil {
-		packEnv = append(opts.Env, packEnv...)
+	if p.env != nil {
+		p.env = append(opts.Env, p.env...)
 	} else {
 		opts.Env = opts.Env
 	}
@@ -396,28 +397,28 @@ func (p *packagerKraftfileRuntime) Pack(ctx context.Context, opts *PkgOptions, a
 	// that have been included in the package.
 	if len(opts.Args) == 0 {
 		if opts.Project != nil && len(opts.Project.Command()) > 0 {
-			packArgs = opts.Project.Command()
-		} else if packCmds != nil {
-			packArgs = packCmds
-		} else if targ != nil && len(targ.Command()) > 0 {
-			packArgs = targ.Command()
+			p.args = opts.Project.Command()
+		} else if rootfsArgs != nil {
+			p.args = rootfsArgs
+		} else if p.target != nil && len(p.target.Command()) > 0 {
+			p.args = p.target.Command()
 		}
 	}
 
 	// Only parse arguments if they have been provided.
-	if len(packArgs) > 0 {
-		packArgs, err = shellwords.Parse(fmt.Sprintf("'%s'", strings.Join(packArgs, "' '")))
+	if len(p.args) > 0 {
+		p.args, err = shellwords.Parse(fmt.Sprintf("'%s'", strings.Join(p.args, "' '")))
 		if err != nil {
 			return nil, err
 		}
 	}
 
 	if opts.Project != nil {
-		packRoms = opts.Project.Roms()
+		p.roms = opts.Project.Roms()
 	} else if len(opts.Roms) > 0 {
-		packRoms = opts.Roms
-	} else if targ != nil && len(targ.Roms()) > 0 {
-		packRoms = targ.Roms()
+		p.roms = opts.Roms
+	} else if p.target != nil && len(p.target.Roms()) > 0 {
+		p.roms = p.target.Roms()
 	}
 
 	var labels map[string]string
@@ -447,42 +448,42 @@ func (p *packagerKraftfileRuntime) Pack(ctx context.Context, opts *PkgOptions, a
 
 		processtree.NewProcessTreeItem(
 			"packaging "+opts.Name,
-			packPlatform.Name()+"/"+packArchitecture.Name(),
+			p.platform.Name()+"/"+p.architecture.Name(),
 			func(ctx context.Context) error {
 				popts := append(opts.packopts,
-					packmanager.PackArgs(packArgs...),
-					packmanager.PackArchitecture(packArchitecture),
-					packmanager.PackPlatform(packPlatform),
+					packmanager.PackArgs(p.args...),
+					packmanager.PackArchitecture(p.architecture),
+					packmanager.PackPlatform(p.platform),
 					packmanager.PackName(opts.Name),
 					packmanager.PackOutput(opts.Output),
 					packmanager.PackLabels(labels),
 				)
 
-				if len(packKernel) > 0 {
+				if len(p.kernel) > 0 {
 					popts = append(popts,
-						packmanager.PackKernel(packKernel),
+						packmanager.PackKernel(p.kernel),
 					)
 				}
 
-				if packRootfs != nil {
+				if p.rootfs != nil {
 					popts = append(popts,
-						packmanager.PackInitrd(packRootfs),
+						packmanager.PackInitrd(p.rootfs),
 					)
 				}
 
-				if len(packRoms) > 0 {
+				if len(p.roms) > 0 {
 					popts = append(popts,
-						packmanager.PackRoms(packRoms...),
+						packmanager.PackRoms(p.roms...),
 					)
 				}
 
-				if !opts.NoKConfig && packKConfig != nil {
+				if !opts.NoKConfig && p.kconfig != nil {
 					popts = append(popts,
-						packmanager.PackKConfig(packKConfig),
+						packmanager.PackKConfig(p.kconfig),
 					)
 				}
 
-				if ukversion, ok := packKConfig.Get(unikraft.UK_FULLVERSION); ok {
+				if ukversion, ok := p.kconfig.Get(unikraft.UK_FULLVERSION); ok {
 					popts = append(popts,
 						packmanager.PackWithKernelVersion(ukversion.Value),
 					)
@@ -495,7 +496,7 @@ func (p *packagerKraftfileRuntime) Pack(ctx context.Context, opts *PkgOptions, a
 					popts = append(popts, packmanager.PackWithEnvs(opts.Env))
 				}
 
-				more, err := opts.pm.Pack(ctx, targ, popts...)
+				more, err := opts.pm.Pack(ctx, p.target, popts...)
 				if err != nil {
 					return err
 				}

--- a/internal/cli/kraft/pkg/packager_kraftfile_runtime.go
+++ b/internal/cli/kraft/pkg/packager_kraftfile_runtime.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/mattn/go-shellwords"
 	"kraftkit.sh/config"
+	"kraftkit.sh/initrd"
 	"kraftkit.sh/internal/cli/kraft/utils"
 	"kraftkit.sh/log"
 	"kraftkit.sh/pack"
@@ -332,7 +333,8 @@ func (p *packagerKraftfileRuntime) Pack(ctx context.Context, opts *PkgOptions, a
 
 	var cmds []string
 	var envs []string
-	if _, cmds, envs, err = utils.BuildRootfs(ctx, opts.Workdir, opts.Rootfs, opts.Compress, targ.Architecture().String()); err != nil {
+	var packRootfs initrd.Initrd
+	if packRootfs, cmds, envs, err = utils.BuildRootfs(ctx, opts.Workdir, opts.Rootfs, opts.Compress, targ.Architecture().String()); err != nil {
 		return nil, fmt.Errorf("could not build rootfs: %w", err)
 	}
 
@@ -393,12 +395,24 @@ func (p *packagerKraftfileRuntime) Pack(ctx context.Context, opts *PkgOptions, a
 			func(ctx context.Context) error {
 				popts := append(opts.packopts,
 					packmanager.PackArgs(args...),
-					packmanager.PackInitrd(opts.Rootfs),
-					packmanager.PackKConfig(!opts.NoKConfig),
+					packmanager.PackArchitecture(targ.Architecture()),
+					packmanager.PackPlatform(targ.Platform()),
 					packmanager.PackName(opts.Name),
 					packmanager.PackOutput(opts.Output),
 					packmanager.PackLabels(labels),
 				)
+
+				if packRootfs != nil {
+					popts = append(popts,
+						packmanager.PackInitrd(packRootfs),
+					)
+				}
+
+				if !opts.NoKConfig && targ.KConfig() != nil {
+					popts = append(popts,
+						packmanager.PackKConfig(targ.KConfig()),
+					)
+				}
 
 				if ukversion, ok := targ.KConfig().Get(unikraft.UK_FULLVERSION); ok {
 					popts = append(popts,

--- a/internal/cli/kraft/pkg/packager_kraftfile_runtime.go
+++ b/internal/cli/kraft/pkg/packager_kraftfile_runtime.go
@@ -332,7 +332,7 @@ func (p *packagerKraftfileRuntime) Pack(ctx context.Context, opts *PkgOptions, a
 
 	var cmds []string
 	var envs []string
-	if opts.Rootfs, cmds, envs, err = utils.BuildRootfs(ctx, opts.Workdir, opts.Rootfs, opts.Compress, targ.Architecture().String()); err != nil {
+	if _, cmds, envs, err = utils.BuildRootfs(ctx, opts.Workdir, opts.Rootfs, opts.Compress, targ.Architecture().String()); err != nil {
 		return nil, fmt.Errorf("could not build rootfs: %w", err)
 	}
 

--- a/internal/cli/kraft/pkg/packager_kraftfile_runtime.go
+++ b/internal/cli/kraft/pkg/packager_kraftfile_runtime.go
@@ -15,6 +15,7 @@ import (
 	"kraftkit.sh/config"
 	"kraftkit.sh/initrd"
 	"kraftkit.sh/internal/cli/kraft/utils"
+	"kraftkit.sh/kconfig"
 	"kraftkit.sh/log"
 	"kraftkit.sh/pack"
 	"kraftkit.sh/packmanager"
@@ -22,6 +23,8 @@ import (
 	"kraftkit.sh/tui/processtree"
 	"kraftkit.sh/tui/selection"
 	"kraftkit.sh/unikraft"
+	"kraftkit.sh/unikraft/arch"
+	"kraftkit.sh/unikraft/plat"
 	"kraftkit.sh/unikraft/target"
 )
 
@@ -40,8 +43,8 @@ func (p *packagerKraftfileRuntime) Packagable(ctx context.Context, opts *PkgOpti
 		}
 	}
 
-	if opts.Project.Runtime() == nil {
-		return false, fmt.Errorf("cannot package without unikraft core specification")
+	if opts.Project.Runtime() == nil && len(opts.Project.Rootfs()) == 0 {
+		return false, fmt.Errorf("cannot package without any of runtime or rootfs")
 	}
 
 	if opts.Project.Rootfs() != "" && opts.Rootfs == "" {
@@ -53,9 +56,20 @@ func (p *packagerKraftfileRuntime) Packagable(ctx context.Context, opts *PkgOpti
 
 // Pack implements packager.
 func (p *packagerKraftfileRuntime) Pack(ctx context.Context, opts *PkgOptions, args ...string) ([]pack.Package, error) {
-	var err error
-	var targ target.Target
-	var runtimeName, runtimeVersion string
+	var (
+		err              error
+		runtimeName      string
+		runtimeVersion   string
+		targ             target.Target
+		packKernel       string
+		packKConfig      kconfig.KeyValueMap
+		packCmds         []string
+		packEnv          []string
+		packArgs         []string
+		packRootfs       initrd.Initrd
+		packArchitecture arch.Architecture
+		packPlatform     plat.Platform
+	)
 
 	if len(opts.Runtime) > 0 {
 		var ok bool
@@ -63,11 +77,16 @@ func (p *packagerKraftfileRuntime) Pack(ctx context.Context, opts *PkgOptions, a
 		if !ok {
 			runtimeVersion = "latest"
 		}
-	} else {
-		if opts.Project == nil || opts.Project.Runtime() == nil {
-			return nil, fmt.Errorf("cannot use runtime packager without a project runtime")
-		}
+	} else if opts.Project != nil && opts.Project.Runtime() != nil {
 		runtimeName = opts.Project.Runtime().Name()
+	} else if opts.Name != "" {
+		var ok bool
+		runtimeName, runtimeVersion, ok = strings.Cut(opts.Name, ":")
+		if !ok {
+			runtimeVersion = "latest"
+		}
+	} else {
+		return nil, fmt.Errorf("no name specified: ")
 	}
 
 	if opts.Platform == "kraftcloud" || (opts.Project.Runtime().Platform() != nil && opts.Project.Runtime().Platform().Name() == "kraftcloud") {
@@ -78,7 +97,10 @@ func (p *packagerKraftfileRuntime) Pack(ctx context.Context, opts *PkgOptions, a
 
 	if opts.Project != nil {
 		targets = opts.Project.Targets()
-		runtimeVersion = opts.Project.Runtime().Version()
+
+		if opts.Project.Runtime() != nil {
+			runtimeVersion = opts.Project.Runtime().Version()
+		}
 	}
 
 	qopts := []packmanager.QueryOption{
@@ -180,7 +202,7 @@ func (p *packagerKraftfileRuntime) Pack(ctx context.Context, opts *PkgOptions, a
 		return nil, err
 	}
 
-	if len(packs) == 0 {
+	if len(packs) == 0 && !opts.NoKernel {
 		if len(opts.Platform) > 0 && len(opts.Architecture) > 0 {
 			return nil, fmt.Errorf(
 				"could not find runtime '%s:%s' (%s/%s)",
@@ -262,103 +284,128 @@ func (p *packagerKraftfileRuntime) Pack(ctx context.Context, opts *PkgOptions, a
 		}
 	}
 
-	runtime := *selected
-	pulled, _, _ := runtime.PulledAt(ctx)
+	if selected != nil {
+		runtime := *selected
+		pulled, _, _ := runtime.PulledAt(ctx)
 
-	// Temporarily save the runtime package.
-	if err := runtime.Save(ctx); err != nil {
-		return nil, fmt.Errorf("could not save runtime package: %w", err)
-	}
+		// Temporarily save the runtime package.
+		if err := runtime.Save(ctx); err != nil {
+			return nil, fmt.Errorf("could not save runtime package: %w", err)
+		}
 
-	// Remove the cached runtime package reference if it was not previously
-	// pulled.
-	if !pulled && opts.NoPull {
+		// Remove the cached runtime package reference if it was not previously
+		// pulled.
+		if !pulled && opts.NoPull {
+			defer func() {
+				if err := runtime.Delete(ctx); err != nil {
+					log.G(ctx).Tracef("could not delete intermediate runtime package: %s", err.Error())
+				}
+			}()
+		}
+
+		if !pulled && !opts.NoPull {
+			paramodel, err := paraprogress.NewParaProgress(
+				ctx,
+				[]*paraprogress.Process{paraprogress.NewProcess(
+					fmt.Sprintf("pulling %s", runtime.String()),
+					func(ctx context.Context, w func(progress float64)) error {
+						popts := []pack.PullOption{}
+						if log.LoggerTypeFromString(config.G[config.KraftKit](ctx).Log.Type) == log.FANCY {
+							popts = append(popts, pack.WithPullProgressFunc(w))
+						}
+
+						return runtime.Pull(
+							ctx,
+							popts...,
+						)
+					},
+				)},
+				paraprogress.IsParallel(false),
+				paraprogress.WithRenderer(
+					log.LoggerTypeFromString(config.G[config.KraftKit](ctx).Log.Type) != log.FANCY,
+				),
+				paraprogress.WithFailFast(true),
+			)
+			if err != nil {
+				return nil, err
+			}
+
+			if err := paramodel.Start(); err != nil {
+				return nil, err
+			}
+		}
+
+		// Create a temporary directory we can use to store the artifacts from
+		// pulling and extracting the identified package.
+		tempDir, err := os.MkdirTemp("", "kraft-pkg-")
+		if err != nil {
+			return nil, fmt.Errorf("could not create temporary directory: %w", err)
+		}
+
 		defer func() {
-			if err := runtime.Delete(ctx); err != nil {
-				log.G(ctx).Tracef("could not delete intermediate runtime package: %s", err.Error())
+			if err := os.RemoveAll(tempDir); err != nil {
+				log.G(ctx).Debugf("could not delete temporary directory: %s", err.Error())
 			}
 		}()
-	}
 
-	if !pulled && !opts.NoPull {
-		paramodel, err := paraprogress.NewParaProgress(
-			ctx,
-			[]*paraprogress.Process{paraprogress.NewProcess(
-				fmt.Sprintf("pulling %s", runtime.String()),
-				func(ctx context.Context, w func(progress float64)) error {
-					popts := []pack.PullOption{}
-					if log.LoggerTypeFromString(config.G[config.KraftKit](ctx).Log.Type) == log.FANCY {
-						popts = append(popts, pack.WithPullProgressFunc(w))
-					}
+		// Crucially, the catalog should return an interface that also implements
+		// target.Target.  This demonstrates that the implementing package can
+		// resolve application kernels.
+		var ok bool
+		targ, ok = runtime.(target.Target)
+		if !ok {
+			return nil, fmt.Errorf("package does not convert to target")
+		}
 
-					return runtime.Pull(
-						ctx,
-						popts...,
-					)
-				},
-			)},
-			paraprogress.IsParallel(false),
-			paraprogress.WithRenderer(
-				log.LoggerTypeFromString(config.G[config.KraftKit](ctx).Log.Type) != log.FANCY,
-			),
-			paraprogress.WithFailFast(true),
+		opts.Platform = targ.Platform().Name()
+		opts.Architecture = targ.Architecture().Name()
+		packKernel = targ.Kernel()
+		packKConfig = targ.KConfig()
+		packArchitecture = targ.Architecture()
+		packPlatform = targ.Platform()
+	} else {
+		if len(opts.Platform) == 0 {
+			return nil, fmt.Errorf("no platform specified: required when no runtime is specified")
+		}
+		if len(opts.Architecture) == 0 {
+			return nil, fmt.Errorf("no architecture specified: required when no runtime is specified")
+		}
+
+		packArchitecture = arch.NewArchitectureFromOptions(
+			arch.WithName(opts.Architecture),
 		)
-		if err != nil {
-			return nil, err
-		}
+		packPlatform = plat.NewPlatformFromOptions(
+			plat.WithName(opts.Platform),
+		)
 
-		if err := paramodel.Start(); err != nil {
-			return nil, err
-		}
+		log.G(ctx).Warn("no kernel detected: packaging without - this may produce unexpected results")
 	}
 
-	// Create a temporary directory we can use to store the artifacts from
-	// pulling and extracting the identified package.
-	tempDir, err := os.MkdirTemp("", "kraft-pkg-")
-	if err != nil {
-		return nil, fmt.Errorf("could not create temporary directory: %w", err)
-	}
-
-	defer func() {
-		os.RemoveAll(tempDir)
-	}()
-
-	// Crucially, the catalog should return an interface that also implements
-	// target.Target.  This demonstrates that the implementing package can
-	// resolve application kernels.
-	targ, ok := runtime.(target.Target)
-	if !ok {
-		return nil, fmt.Errorf("package does not convert to target")
-	}
-
-	var cmds []string
-	var envs []string
-	var packRootfs initrd.Initrd
-	if packRootfs, cmds, envs, err = utils.BuildRootfs(ctx, opts.Workdir, opts.Rootfs, opts.Compress, targ.Architecture().String()); err != nil {
+	if packRootfs, packCmds, packEnv, err = utils.BuildRootfs(ctx, opts.Workdir, opts.Rootfs, opts.Compress, packArchitecture.String()); err != nil {
 		return nil, fmt.Errorf("could not build rootfs: %w", err)
 	}
 
-	if envs != nil {
-		opts.Env = append(opts.Env, envs...)
+	if packEnv != nil {
+		packEnv = append(opts.Env, packEnv...)
+	} else {
+		opts.Env = opts.Env
 	}
 
 	// If no arguments have been specified, use the ones which are default and
 	// that have been included in the package.
 	if len(opts.Args) == 0 {
 		if opts.Project != nil && len(opts.Project.Command()) > 0 {
-			opts.Args = opts.Project.Command()
-		} else if cmds != nil {
-			opts.Args = cmds
-		} else if len(targ.Command()) > 0 {
-			opts.Args = targ.Command()
+			packArgs = opts.Project.Command()
+		} else if packCmds != nil {
+			packArgs = packCmds
+		} else if targ != nil && len(targ.Command()) > 0 {
+			packArgs = targ.Command()
 		}
 	}
 
-	args = []string{}
-
 	// Only parse arguments if they have been provided.
-	if len(opts.Args) > 0 {
-		args, err = shellwords.Parse(fmt.Sprintf("'%s'", strings.Join(opts.Args, "' '")))
+	if len(packArgs) > 0 {
+		packArgs, err = shellwords.Parse(fmt.Sprintf("'%s'", strings.Join(packArgs, "' '")))
 		if err != nil {
 			return nil, err
 		}
@@ -391,16 +438,22 @@ func (p *packagerKraftfileRuntime) Pack(ctx context.Context, opts *PkgOptions, a
 
 		processtree.NewProcessTreeItem(
 			"packaging "+opts.Name,
-			targ.Platform().Name()+"/"+targ.Architecture().Name(),
+			packPlatform.Name()+"/"+packArchitecture.Name(),
 			func(ctx context.Context) error {
 				popts := append(opts.packopts,
-					packmanager.PackArgs(args...),
-					packmanager.PackArchitecture(targ.Architecture()),
-					packmanager.PackPlatform(targ.Platform()),
+					packmanager.PackArgs(packArgs...),
+					packmanager.PackArchitecture(packArchitecture),
+					packmanager.PackPlatform(packPlatform),
 					packmanager.PackName(opts.Name),
 					packmanager.PackOutput(opts.Output),
 					packmanager.PackLabels(labels),
 				)
+
+				if len(packKernel) > 0 {
+					popts = append(popts,
+						packmanager.PackKernel(packKernel),
+					)
+				}
 
 				if packRootfs != nil {
 					popts = append(popts,
@@ -408,13 +461,13 @@ func (p *packagerKraftfileRuntime) Pack(ctx context.Context, opts *PkgOptions, a
 					)
 				}
 
-				if !opts.NoKConfig && targ.KConfig() != nil {
+				if !opts.NoKConfig && packKConfig != nil {
 					popts = append(popts,
-						packmanager.PackKConfig(targ.KConfig()),
+						packmanager.PackKConfig(packKConfig),
 					)
 				}
 
-				if ukversion, ok := targ.KConfig().Get(unikraft.UK_FULLVERSION); ok {
+				if ukversion, ok := packKConfig.Get(unikraft.UK_FULLVERSION); ok {
 					popts = append(popts,
 						packmanager.PackWithKernelVersion(ukversion.Value),
 					)

--- a/internal/cli/kraft/pkg/packager_kraftfile_runtime.go
+++ b/internal/cli/kraft/pkg/packager_kraftfile_runtime.go
@@ -481,12 +481,12 @@ func (p *packagerKraftfileRuntime) Pack(ctx context.Context, opts *PkgOptions, a
 					popts = append(popts,
 						packmanager.PackKConfig(p.kconfig),
 					)
-				}
 
-				if ukversion, ok := p.kconfig.Get(unikraft.UK_FULLVERSION); ok {
-					popts = append(popts,
-						packmanager.PackWithKernelVersion(ukversion.Value),
-					)
+					if ukversion, ok := p.kconfig.Get(unikraft.UK_FULLVERSION); ok {
+						popts = append(popts,
+							packmanager.PackWithKernelVersion(ukversion.Value),
+						)
+					}
 				}
 
 				envs := opts.aggregateEnvs()

--- a/internal/cli/kraft/pkg/packager_kraftfile_unikraft.go
+++ b/internal/cli/kraft/pkg/packager_kraftfile_unikraft.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/mattn/go-shellwords"
 	"kraftkit.sh/config"
+	"kraftkit.sh/initrd"
 	"kraftkit.sh/internal/cli/kraft/utils"
 	"kraftkit.sh/log"
 	"kraftkit.sh/pack"
@@ -93,7 +94,7 @@ func (p *packagerKraftfileUnikraft) Pack(ctx context.Context, opts *PkgOptions, 
 	for _, targ := range selected {
 		var cmds []string
 		var envs []string
-		rootfs := opts.Rootfs
+		var rootfs initrd.Initrd
 
 		// Reset the rootfs, such that it is not packaged as an initrd if it is
 		// already embedded inside of the kernel.
@@ -102,9 +103,7 @@ func (p *packagerKraftfileUnikraft) Pack(ctx context.Context, opts *PkgOptions, 
 			"CONFIG_LIBVFSCORE_AUTOMOUNT_EINITRD",
 			"CONFIG_LIBVFSCORE_AUTOMOUNT_CI_EINITRD",
 		) {
-			rootfs = ""
-		} else {
-			if _, cmds, envs, err = utils.BuildRootfs(ctx, opts.Workdir, rootfs, opts.Compress, targ.Architecture().String()); err != nil {
+			if rootfs, cmds, envs, err = utils.BuildRootfs(ctx, opts.Workdir, opts.Rootfs, opts.Compress, targ.Architecture().String()); err != nil {
 				return nil, fmt.Errorf("could not build rootfs: %w", err)
 			}
 		}
@@ -161,13 +160,18 @@ func (p *packagerKraftfileUnikraft) Pack(ctx context.Context, opts *PkgOptions, 
 			targ.Architecture().Name()+"/"+targ.Platform().Name(),
 			func(ctx context.Context) error {
 				popts := append(baseopts,
+					packmanager.PackArchitecture(targ.Architecture()),
+					packmanager.PackPlatform(targ.Platform()),
 					packmanager.PackArgs(cmdShellArgs...),
 					packmanager.PackInitrd(rootfs),
-					packmanager.PackKConfig(!opts.NoKConfig),
 					packmanager.PackName(opts.Name),
 					packmanager.PackOutput(opts.Output),
 					packmanager.PackLabels(labels),
 				)
+
+				if !opts.NoKConfig {
+					popts = append(popts, packmanager.PackKConfig(targ.KConfig()))
+				}
 
 				if ukversion, ok := targ.KConfig().Get(unikraft.UK_FULLVERSION); ok {
 					popts = append(popts,

--- a/internal/cli/kraft/pkg/packager_kraftfile_unikraft.go
+++ b/internal/cli/kraft/pkg/packager_kraftfile_unikraft.go
@@ -104,7 +104,7 @@ func (p *packagerKraftfileUnikraft) Pack(ctx context.Context, opts *PkgOptions, 
 		) {
 			rootfs = ""
 		} else {
-			if rootfs, cmds, envs, err = utils.BuildRootfs(ctx, opts.Workdir, rootfs, opts.Compress, targ.Architecture().String()); err != nil {
+			if _, cmds, envs, err = utils.BuildRootfs(ctx, opts.Workdir, rootfs, opts.Compress, targ.Architecture().String()); err != nil {
 				return nil, fmt.Errorf("could not build rootfs: %w", err)
 			}
 		}

--- a/internal/cli/kraft/pkg/pkg.go
+++ b/internal/cli/kraft/pkg/pkg.go
@@ -47,6 +47,7 @@ type PkgOptions struct {
 	Labels       []string                  `local:"true" long:"label" short:"l" usage:"Set labels to be packed into the package (k=v)"`
 	Name         string                    `local:"true" long:"name" short:"n" usage:"Specify the name of the package"`
 	NoKConfig    bool                      `local:"true" long:"no-kconfig" usage:"Do not include target .config as metadata"`
+	NoKernel     bool                      `local:"true" long:"no-kernel" usage:"Allow packaging without a kernel image"`
 	NoPull       bool                      `local:"true" long:"no-pull" usage:"Do not pull package dependencies before packaging"`
 	Output       string                    `local:"true" long:"output" short:"o" usage:"Save the package at the following output"`
 	Platform     string                    `local:"true" long:"plat" short:"p" usage:"Filter the creation of the package by platform of known targets (fc/qemu/xen/kraftcloud)"`

--- a/internal/cli/kraft/pkg/pkg.go
+++ b/internal/cli/kraft/pkg/pkg.go
@@ -53,6 +53,7 @@ type PkgOptions struct {
 	Platform     string                    `local:"true" long:"plat" short:"p" usage:"Filter the creation of the package by platform of known targets (fc/qemu/xen/kraftcloud)"`
 	Project      app.Application           `noattribute:"true"`
 	Push         bool                      `local:"true" long:"push" short:"P" usage:"Push the package on if successfully packaged"`
+	Roms         []string                  `local:"true" long:"rom" short:"R" usage:"Specify a path to an auxiliary ROM to include in the package"`
 	Rootfs       string                    `local:"true" long:"rootfs" usage:"Specify a path to use as root file system (can be volume or initramfs)"`
 	Runtime      string                    `local:"true" long:"runtime" short:"r" usage:"Set the runtime to use for the package"`
 	Strategy     packmanager.MergeStrategy `noattribute:"true"`

--- a/internal/cli/kraft/utils/rootfs.go
+++ b/internal/cli/kraft/utils/rootfs.go
@@ -19,9 +19,9 @@ import (
 
 // BuildRootfs generates a rootfs based on the provided working directory and
 // the rootfs entrypoint for the provided target(s).
-func BuildRootfs(ctx context.Context, workdir, rootfs string, compress bool, arch string) (string, []string, []string, error) {
+func BuildRootfs(ctx context.Context, workdir, rootfs string, compress bool, arch string) (initrd.Initrd, []string, []string, error) {
 	if rootfs == "" {
-		return "", nil, nil, nil
+		return nil, nil, nil, nil
 	}
 
 	var processes []*processtree.ProcessTreeItem
@@ -45,7 +45,7 @@ func BuildRootfs(ctx context.Context, workdir, rootfs string, compress bool, arc
 		initrd.WithCompression(compress),
 	)
 	if err != nil {
-		return "", nil, nil, fmt.Errorf("could not initialize initramfs builder: %w", err)
+		return nil, nil, nil, fmt.Errorf("could not initialize initramfs builder: %w", err)
 	}
 
 	processes = append(processes,
@@ -77,12 +77,12 @@ func BuildRootfs(ctx context.Context, workdir, rootfs string, compress bool, arc
 		processes...,
 	)
 	if err != nil {
-		return "", nil, nil, err
+		return nil, nil, nil, err
 	}
 
 	if err := model.Start(); err != nil {
-		return "", nil, nil, err
+		return nil, nil, nil, err
 	}
 
-	return rootfs, cmds, envs, nil
+	return ramfs, cmds, envs, nil
 }

--- a/oci/manager.go
+++ b/oci/manager.go
@@ -226,17 +226,17 @@ func (manager *OCIManager) update(ctx context.Context, auths map[string]config.A
 
 // Pack implements packmanager.PackageManager
 func (manager *OCIManager) Pack(ctx context.Context, entity component.Component, opts ...packmanager.PackOption) ([]pack.Package, error) {
-	targ, ok := entity.(target.Target)
-	if !ok {
-		return nil, fmt.Errorf("entity is not Unikraft target")
-	}
-
 	ctx, handle, err := manager.handle(ctx)
 	if err != nil {
 		return nil, err
 	}
 
-	pkg, err := NewPackageFromTarget(ctx, handle, targ, opts...)
+	var pkg pack.Package
+	if targ, ok := entity.(target.Target); ok {
+		pkg, err = NewPackageFromTarget(ctx, handle, targ, opts...)
+	} else {
+		pkg, err = NewPackage(ctx, handle, opts...)
+	}
 	if err != nil {
 		return nil, err
 	}

--- a/oci/manifest.go
+++ b/oci/manifest.go
@@ -301,6 +301,28 @@ func (manifest *Manifest) SetKernelDbg(ctx context.Context, path string) error {
 	return nil
 }
 
+// AddRom includes an auxiliary read-only memory blob into the manifest.
+func (manifest *Manifest) AddRom(ctx context.Context, path string) error {
+	log.G(ctx).
+		WithField("src", path).
+		Debug("including rom")
+
+	layer, err := NewLayerFromFile(ctx,
+		MediaTypeRom,
+		path,
+		"",
+	)
+	if err != nil {
+		return fmt.Errorf("could build layer from file: %w", err)
+	}
+
+	if _, err := manifest.AddLayer(ctx, layer); err != nil {
+		return err
+	}
+
+	return nil
+}
+
 // SetLabel sets a label of the image with the provided key.
 func (manifest *Manifest) SetLabel(_ context.Context, key, val string) {
 	if manifest.config.Config.Labels == nil {

--- a/oci/mediatypes.go
+++ b/oci/mediatypes.go
@@ -7,4 +7,5 @@ package oci
 const (
 	MediaTypeKernel = "application/vnd.unikraft.kernel.v1"
 	MediaTypeInitrd = "application/vnd.unikraft.initrd.v1"
+	MediaTypeRom    = "application/vnd.unikraft.rom.v1"
 )

--- a/oci/pack.go
+++ b/oci/pack.go
@@ -71,7 +71,9 @@ type ociPackage struct {
 	kernelDbg string
 	initrd    initrd.Initrd
 	command   []string
+	env       []string
 	labels    map[string]string
+	popts     *packmanager.PackOptions
 
 	original *ociPackage
 }
@@ -86,11 +88,6 @@ var (
 func NewPackageFromTarget(ctx context.Context, handle handler.Handler, targ target.Target, opts ...packmanager.PackOption) (pack.Package, error) {
 	var err error
 
-	popts := packmanager.NewPackOptions()
-	for _, opt := range opts {
-		opt(popts)
-	}
-
 	// Initialize the ociPackage by copying over target.Target attributes
 	ocipack := ociPackage{
 		arch:      targ.Architecture(),
@@ -99,9 +96,50 @@ func NewPackageFromTarget(ctx context.Context, handle handler.Handler, targ targ
 		initrd:    targ.Initrd(),
 		kernel:    targ.Kernel(),
 		kernelDbg: targ.KernelDbg(),
-		command:   popts.Args(),
-		labels:    popts.Labels(),
+		command:   targ.Command(),
 		handle:    handle,
+		popts:     packmanager.NewPackOptions(),
+	}
+
+	for _, opt := range opts {
+		opt(ocipack.popts)
+	}
+
+	if ocipack.popts.Name() == "" {
+		return nil, fmt.Errorf("cannot create package without name")
+	}
+	ocipack.ref, err = name.ParseReference(
+		ocipack.popts.Name(),
+		name.WithDefaultRegistry(DefaultRegistry),
+		name.WithDefaultTag(DefaultTag),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("could not parse image reference: %w", err)
+	}
+
+	if ocipack.popts.Architecture() != nil {
+		ocipack.arch = ocipack.popts.Architecture()
+	}
+	if ocipack.popts.Platform() != nil {
+		ocipack.plat = ocipack.popts.Platform()
+	}
+	if ocipack.popts.KConfig() != nil {
+		ocipack.kconfig = ocipack.popts.KConfig()
+	}
+	if ocipack.popts.Initrd() != nil {
+		ocipack.initrd = ocipack.popts.Initrd()
+	}
+	if ocipack.popts.Kernel() != "" {
+		ocipack.kernel = ocipack.popts.Kernel()
+	}
+	if ocipack.popts.KernelDbg() != "" {
+		ocipack.kernelDbg = ocipack.popts.KernelDbg()
+	}
+	if len(ocipack.popts.Args()) > 0 {
+		ocipack.command = ocipack.popts.Args()
+	}
+	if len(ocipack.popts.Env()) > 0 {
+		ocipack.env = ocipack.popts.Env()
 	}
 
 	// It is possible that `NewPackageFromTarget` is called with an existing
@@ -114,17 +152,13 @@ func NewPackageFromTarget(ctx context.Context, handle handler.Handler, targ targ
 		ocipack.original = original
 	}
 
-	if popts.Name() == "" {
-		return nil, fmt.Errorf("cannot create package without name")
-	}
-	ocipack.ref, err = name.ParseReference(
-		popts.Name(),
-		name.WithDefaultRegistry(DefaultRegistry),
-		name.WithDefaultTag(DefaultTag),
-	)
-	if err != nil {
-		return nil, fmt.Errorf("could not parse image reference: %w", err)
-	}
+	return ocipack.build(ctx)
+}
+
+// build is an internal method used to build the package based on the ociPackage
+// attributes and the provided PackOptions from a public constructor.
+func (ocipack *ociPackage) build(ctx context.Context) (*ociPackage, error) {
+	var err error
 
 	// Prepare a new manifest which contains the individual components of the
 	// target, including the kernel image.
@@ -147,14 +181,14 @@ func NewPackageFromTarget(ctx context.Context, handle handler.Handler, targ targ
 		}
 	}
 
-	if popts.KernelDbg() && len(ocipack.KernelDbg()) > 0 {
+	if len(ocipack.KernelDbg()) > 0 {
 		if err := ocipack.manifest.SetKernelDbg(ctx, ocipack.KernelDbg()); err != nil {
 			return nil, err
 		}
 	}
 
-	if popts.Initrd() != "" {
-		if err := ocipack.manifest.SetInitrd(ctx, popts.Initrd()); err != nil {
+	if ocipack.Initrd() != nil {
+		if err := ocipack.manifest.SetInitrd(ctx, ocipack.Initrd().Options().Output()); err != nil {
 			return nil, err
 		}
 	}
@@ -164,7 +198,7 @@ func NewPackageFromTarget(ctx context.Context, handle handler.Handler, targ targ
 	}
 
 	ocipack.manifest.SetAnnotation(ctx, AnnotationName, ocipack.Name())
-	if version := popts.KernelVersion(); len(version) > 0 {
+	if version := ocipack.popts.KernelVersion(); len(version) > 0 {
 		ocipack.manifest.SetAnnotation(ctx, AnnotationKernelVersion, version)
 		ocipack.manifest.SetOSVersion(ctx, version)
 	}
@@ -187,13 +221,13 @@ func NewPackageFromTarget(ctx context.Context, handle handler.Handler, targ targ
 
 	ocipack.manifest.SetOS(ctx, ocipack.Platform().Name())
 	ocipack.manifest.SetArchitecture(ctx, ocipack.Architecture().Name())
-	ocipack.manifest.SetEnv(ctx, popts.Env())
+	ocipack.manifest.SetEnv(ctx, ocipack.env)
 	for _, env := range ocipack.manifest.config.Config.Env {
 		k, v, _ := strings.Cut(env, "=")
 		log.G(ctx).WithField(k, v).Debug("env")
 	}
 
-	switch popts.MergeStrategy() {
+	switch ocipack.popts.MergeStrategy() {
 	case packmanager.StrategyMerge, packmanager.StrategyAbort:
 		ocipack.index, err = NewIndexFromRef(ctx, ocipack.handle, ocipack.ref.Name())
 		if err != nil {
@@ -201,7 +235,7 @@ func NewPackageFromTarget(ctx context.Context, handle handler.Handler, targ targ
 			if err != nil {
 				return nil, fmt.Errorf("could not instantiate new image structure: %w", err)
 			}
-		} else if popts.MergeStrategy() == packmanager.StrategyAbort {
+		} else if ocipack.popts.MergeStrategy() == packmanager.StrategyAbort {
 			return nil, fmt.Errorf("cannot overwrite existing manifest as merge strategy is set to exit on conflict")
 		}
 
@@ -218,7 +252,7 @@ func NewPackageFromTarget(ctx context.Context, handle handler.Handler, targ targ
 		return nil, fmt.Errorf("package merge strategy unset")
 	}
 
-	if popts.MergeStrategy() == packmanager.StrategyAbort && len(ocipack.index.manifests) > 0 {
+	if ocipack.popts.MergeStrategy() == packmanager.StrategyAbort && len(ocipack.index.manifests) > 0 {
 		return nil, fmt.Errorf("cannot continue: reference already exists and merge strategy set to none")
 	}
 
@@ -261,7 +295,7 @@ func NewPackageFromTarget(ctx context.Context, handle handler.Handler, targ targ
 				return nil, fmt.Errorf("could not generate manifest platform checksum for '%s': %w", existingManifest.desc.Digest.String(), err)
 			}
 			if existingManifestChecksum == newManifestChecksum {
-				switch popts.MergeStrategy() {
+				switch ocipack.popts.MergeStrategy() {
 				case packmanager.StrategyAbort:
 					return nil, fmt.Errorf("cannot overwrite existing manifest as merge strategy is set to exit on conflict")
 
@@ -281,7 +315,7 @@ func NewPackageFromTarget(ctx context.Context, handle handler.Handler, targ targ
 		ocipack.index.manifests = manifests
 	}
 
-	if popts.PackKConfig() {
+	if len(ocipack.kconfig) > 0 {
 		log.G(ctx).
 			Debug("including list of kconfig as features")
 
@@ -320,7 +354,7 @@ func NewPackageFromTarget(ctx context.Context, handle handler.Handler, targ targ
 		return nil, fmt.Errorf("could not save index: %w", err)
 	}
 
-	return &ocipack, nil
+	return ocipack, nil
 }
 
 // newPackageFromOCIManifestDigest is an internal method which retrieves the OCI

--- a/oci/pack.go
+++ b/oci/pack.go
@@ -15,6 +15,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -70,6 +71,7 @@ type ociPackage struct {
 	kernel    string
 	kernelDbg string
 	initrd    initrd.Initrd
+	roms      []string
 	command   []string
 	env       []string
 	labels    map[string]string
@@ -98,6 +100,7 @@ func NewPackage(ctx context.Context, handle handler.Handler, opts ...packmanager
 		plat:      popts.Platform(),
 		kconfig:   popts.KConfig(),
 		initrd:    popts.Initrd(),
+		roms:      popts.Roms(),
 		kernel:    popts.Kernel(),
 		kernelDbg: popts.KernelDbg(),
 		command:   popts.Args(),
@@ -133,6 +136,7 @@ func NewPackageFromTarget(ctx context.Context, handle handler.Handler, targ targ
 		plat:      targ.Platform(),
 		kconfig:   targ.KConfig(),
 		initrd:    targ.Initrd(),
+		roms:      targ.Roms(),
 		kernel:    targ.Kernel(),
 		kernelDbg: targ.KernelDbg(),
 		command:   targ.Command(),
@@ -167,6 +171,9 @@ func NewPackageFromTarget(ctx context.Context, handle handler.Handler, targ targ
 	}
 	if ocipack.popts.Initrd() != nil {
 		ocipack.initrd = ocipack.popts.Initrd()
+	}
+	if len(ocipack.popts.Roms()) > 0 {
+		ocipack.roms = ocipack.popts.Roms()
 	}
 	if ocipack.popts.Kernel() != "" {
 		ocipack.kernel = ocipack.popts.Kernel()
@@ -383,6 +390,23 @@ func (ocipack *ociPackage) build(ctx context.Context) (*ociPackage, error) {
 		log.G(ctx).
 			WithField(k, v).
 			Trace("label")
+	}
+
+	// If the merge strategy is set to overwrite, we remove any existing
+	// ROMs from the manifest, as we are going to re-add them.
+	if ocipack.popts.MergeStrategy() == packmanager.StrategyOverwrite {
+		ocipack.manifest.layers = slices.DeleteFunc(ocipack.manifest.layers, func(layer *Layer) bool {
+			return layer.blob.desc.MediaType == MediaTypeRom
+		})
+	}
+
+	for _, rom := range ocipack.Roms() {
+		log.G(ctx).
+			WithField("rom", rom).
+			Trace("layer")
+		if err := ocipack.manifest.AddRom(ctx, rom); err != nil {
+			return nil, fmt.Errorf("could not add ROM '%s' to manifest: %w", rom, err)
+		}
 	}
 
 	if err := ocipack.index.AddManifest(ctx, ocipack.manifest); err != nil {
@@ -1047,6 +1071,11 @@ func (ocipack *ociPackage) KernelDbg() string {
 // Initrd implements unikraft.target.Target
 func (ocipack *ociPackage) Initrd() initrd.Initrd {
 	return ocipack.initrd
+}
+
+// Roms implements unikraft.target.Target
+func (ocipack *ociPackage) Roms() []string {
+	return ocipack.roms
 }
 
 // Command implements unikraft.target.Target

--- a/oci/pack.go
+++ b/oci/pack.go
@@ -159,24 +159,6 @@ func NewPackageFromTarget(ctx context.Context, handle handler.Handler, targ targ
 		}
 	}
 
-	// TODO(nderjung): See below.
-
-	// if popts.PackKernelLibraryObjects() {
-	// 	log.G(ctx).Debug("including kernel library objects")
-	// }
-
-	// if popts.PackKernelLibraryIntermediateObjects() {
-	// 	log.G(ctx).Debug("including kernel library intermediate objects")
-	// }
-
-	// if popts.PackKernelSourceFiles() {
-	// 	log.G(ctx).Debug("including kernel source files")
-	// }
-
-	// if popts.PackAppSourceFiles() {
-	// 	log.G(ctx).Debug("including application source files")
-	// }
-
 	if ocipack.original != nil {
 		ocipack.manifest.config = ocipack.original.manifest.config
 	}

--- a/oci/pack.go
+++ b/oci/pack.go
@@ -83,6 +83,45 @@ var (
 	_ target.Target = (*ociPackage)(nil)
 )
 
+// NewPackage creates a new package based on the provided options.
+func NewPackage(ctx context.Context, handle handler.Handler, opts ...packmanager.PackOption) (pack.Package, error) {
+	var err error
+
+	popts := packmanager.NewPackOptions()
+	for _, opt := range opts {
+		opt(popts)
+	}
+
+	// Initialize the ociPackage by copying over target.Target attributes
+	ocipack := ociPackage{
+		arch:      popts.Architecture(),
+		plat:      popts.Platform(),
+		kconfig:   popts.KConfig(),
+		initrd:    popts.Initrd(),
+		kernel:    popts.Kernel(),
+		kernelDbg: popts.KernelDbg(),
+		command:   popts.Args(),
+		env:       popts.Env(),
+		labels:    popts.Labels(),
+		handle:    handle,
+		popts:     popts,
+	}
+
+	if popts.Name() == "" {
+		return nil, fmt.Errorf("cannot create package without name")
+	}
+	ocipack.ref, err = name.ParseReference(
+		popts.Name(),
+		name.WithDefaultRegistry(DefaultRegistry),
+		name.WithDefaultTag(DefaultTag),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("could not parse image reference: %w", err)
+	}
+
+	return ocipack.build(ctx)
+}
+
 // NewPackageFromTarget generates an OCI implementation of the pack.Package
 // construct based on an input Application and options.
 func NewPackageFromTarget(ctx context.Context, handle handler.Handler, targ target.Target, opts ...packmanager.PackOption) (pack.Package, error) {

--- a/packmanager/pack_options.go
+++ b/packmanager/pack_options.go
@@ -4,15 +4,25 @@
 // You may not use this file except in compliance with the License.
 package packmanager
 
+import (
+	"kraftkit.sh/initrd"
+	"kraftkit.sh/kconfig"
+	"kraftkit.sh/unikraft/arch"
+	"kraftkit.sh/unikraft/plat"
+)
+
 // PackOptions contains the list of options which can be set when packaging a
 // component.
 type PackOptions struct {
 	appSourceFiles bool
+	architecture   arch.Architecture
+	platform       plat.Platform
 	args           []string
 	env            []string
-	initrd         string
-	kconfig        bool
-	kernelDbg      bool
+	initrd         initrd.Initrd
+	kconfig        kconfig.KeyValueMap
+	kernel         string
+	kernelDbg      string
 	kernelVersion  string
 	labels         map[string]string
 	name           string
@@ -34,6 +44,16 @@ func (popts *PackOptions) PackAppSourceFiles() bool {
 	return popts.appSourceFiles
 }
 
+// Architecture returns the architecture of the package.
+func (popts *PackOptions) Architecture() arch.Architecture {
+	return popts.architecture
+}
+
+// Platform returns the platform of the package.
+func (popts *PackOptions) Platform() plat.Platform {
+	return popts.platform
+}
+
 // Args returns the arguments to pass to the kernel.
 func (popts *PackOptions) Args() []string {
 	return popts.args
@@ -44,18 +64,23 @@ func (popts *PackOptions) Env() []string {
 	return popts.env
 }
 
+// Kernel returns the path of the kernel file that should be packaged.
+func (popts *PackOptions) Kernel() string {
+	return popts.kernel
+}
+
 // Initrd returns the path of the initrd file that should be packaged.
-func (popts *PackOptions) Initrd() string {
+func (popts *PackOptions) Initrd() initrd.Initrd {
 	return popts.initrd
 }
 
-// PackKConfig returns whether the .config file should be packaged.
-func (popts *PackOptions) PackKConfig() bool {
+// KConfig returns whether the .config file should be packaged.
+func (popts *PackOptions) KConfig() kconfig.KeyValueMap {
 	return popts.kconfig
 }
 
 // PackKernelDbg returns return whether to package the debug kernel.
-func (popts *PackOptions) KernelDbg() bool {
+func (popts *PackOptions) KernelDbg() string {
 	return popts.kernelDbg
 }
 
@@ -94,6 +119,20 @@ func PackAppSourceFiles(pack bool) PackOption {
 	}
 }
 
+// PackArchitecture sets the architecture of the package.
+func PackArchitecture(architecture arch.Architecture) PackOption {
+	return func(popts *PackOptions) {
+		popts.architecture = architecture
+	}
+}
+
+// PackPlatform sets the platform of the package.
+func PackPlatform(platform plat.Platform) PackOption {
+	return func(popts *PackOptions) {
+		popts.platform = platform
+	}
+}
+
 // PackArgs sets the arguments to be passed to the application.
 func PackArgs(args ...string) PackOption {
 	return func(popts *PackOptions) {
@@ -102,23 +141,30 @@ func PackArgs(args ...string) PackOption {
 }
 
 // PackKConfig marks to include the kconfig `.config` file into the package.
-func PackKConfig(kconfig bool) PackOption {
+func PackKConfig(kcfg kconfig.KeyValueMap) PackOption {
 	return func(popts *PackOptions) {
-		popts.kconfig = kconfig
+		popts.kconfig = kcfg
+	}
+}
+
+// PackKernel includes the kernel in the package.
+func PackKernel(kernel string) PackOption {
+	return func(popts *PackOptions) {
+		popts.kernel = kernel
 	}
 }
 
 // PackInitrd includes the provided path to an initrd file in the package.
-func PackInitrd(initrd string) PackOption {
+func PackInitrd(rootfs initrd.Initrd) PackOption {
 	return func(popts *PackOptions) {
-		popts.initrd = initrd
+		popts.initrd = rootfs
 	}
 }
 
 // PackKernelDbg includes the debug kernel in the package.
-func PackKernelDbg(dbg bool) PackOption {
+func PackKernelDbg(kernelDbg string) PackOption {
 	return func(popts *PackOptions) {
-		popts.kernelDbg = dbg
+		popts.kernelDbg = kernelDbg
 	}
 }
 

--- a/packmanager/pack_options.go
+++ b/packmanager/pack_options.go
@@ -20,6 +20,7 @@ type PackOptions struct {
 	args           []string
 	env            []string
 	initrd         initrd.Initrd
+	roms           []string
 	kconfig        kconfig.KeyValueMap
 	kernel         string
 	kernelDbg      string
@@ -72,6 +73,11 @@ func (popts *PackOptions) Kernel() string {
 // Initrd returns the path of the initrd file that should be packaged.
 func (popts *PackOptions) Initrd() initrd.Initrd {
 	return popts.initrd
+}
+
+// Auxiliary read-only memory blobs.
+func (popts *PackOptions) Roms() []string {
+	return popts.roms
 }
 
 // KConfig returns whether the .config file should be packaged.
@@ -158,6 +164,13 @@ func PackKernel(kernel string) PackOption {
 func PackInitrd(rootfs initrd.Initrd) PackOption {
 	return func(popts *PackOptions) {
 		popts.initrd = rootfs
+	}
+}
+
+// PackRoms includes auxiliary read-only memory blobs in the package.
+func PackRoms(roms ...string) PackOption {
+	return func(popts *PackOptions) {
+		popts.roms = roms
 	}
 }
 

--- a/packmanager/pack_options.go
+++ b/packmanager/pack_options.go
@@ -7,20 +7,17 @@ package packmanager
 // PackOptions contains the list of options which can be set when packaging a
 // component.
 type PackOptions struct {
-	appSourceFiles                   bool
-	args                             []string
-	env                              []string
-	initrd                           string
-	kconfig                          bool
-	kernelDbg                        bool
-	kernelLibraryIntermediateObjects bool
-	kernelLibraryObjects             bool
-	kernelSourceFiles                bool
-	kernelVersion                    string
-	labels                           map[string]string
-	name                             string
-	output                           string
-	mergeStrategy                    MergeStrategy
+	appSourceFiles bool
+	args           []string
+	env            []string
+	initrd         string
+	kconfig        bool
+	kernelDbg      bool
+	kernelVersion  string
+	labels         map[string]string
+	name           string
+	output         string
+	mergeStrategy  MergeStrategy
 }
 
 // NewPackOptions returns an instantiated *NewPackOptions with default
@@ -60,22 +57,6 @@ func (popts *PackOptions) PackKConfig() bool {
 // PackKernelDbg returns return whether to package the debug kernel.
 func (popts *PackOptions) KernelDbg() bool {
 	return popts.kernelDbg
-}
-
-// PackKernelLibraryIntermediateObjects returns whether to package intermediate
-// kernel library object files.
-func (popts *PackOptions) PackKernelLibraryIntermediateObjects() bool {
-	return popts.kernelLibraryIntermediateObjects
-}
-
-// PackKernelLibraryObjects returns whether to package kernel library objects.
-func (popts *PackOptions) PackKernelLibraryObjects() bool {
-	return popts.kernelLibraryObjects
-}
-
-// PackKernelSourceFiles returns the whether to package kernel source files.
-func (popts *PackOptions) PackKernelSourceFiles() bool {
-	return popts.kernelSourceFiles
 }
 
 // KernelVersion returns the version of the kernel
@@ -138,30 +119,6 @@ func PackInitrd(initrd string) PackOption {
 func PackKernelDbg(dbg bool) PackOption {
 	return func(popts *PackOptions) {
 		popts.kernelDbg = dbg
-	}
-}
-
-// PackKernelLibraryIntermediateObjects marks to include intermediate library
-// object files, e.g. libnolibc/errno.o
-func PackKernelLibraryIntermediateObjects(pack bool) PackOption {
-	return func(popts *PackOptions) {
-		popts.kernelSourceFiles = pack
-	}
-}
-
-// PackKernelLibraryObjects marks to include library object files, e.g. nolibc.o
-func PackKernelLibraryObjects(pack bool) PackOption {
-	return func(popts *PackOptions) {
-		popts.kernelSourceFiles = pack
-	}
-}
-
-// PackKernelSourceFiles marks that all source files which make up the build
-// from the Unikraft build side are to be included.  Including these files will
-// enable a reproducible build.
-func PackKernelSourceFiles(pack bool) PackOption {
-	return func(popts *PackOptions) {
-		popts.kernelSourceFiles = pack
 	}
 }
 

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -39,6 +39,8 @@ var (
 	SchemaV_06 string
 )
 
+var ErrInvalidSpecVersion = fmt.Errorf("invalid specification version")
+
 // Validate uses the jsonschema to validate the configuration
 func Validate(ctx context.Context, config map[string]interface{}) error {
 	var spec string
@@ -59,13 +61,19 @@ func Validate(ctx context.Context, config map[string]interface{}) error {
 		return fmt.Errorf("could not parse specification version: %w", err)
 	}
 
-	latestVer := semver.MustParse(string(SchemaVersionLatest))
-
-	if specVer.LessThan(latestVer) {
+	var schemaLoader gojsonschema.JSONLoader
+	if specVer.LessThan(SchemaVersionLatest) {
 		log.G(ctx).Warnf("specification in Kraftfile (v%s) version is not latest (v%s)", spec, SchemaVersionLatest)
+	} else if specVer.GreaterThan(SchemaVersionLatest) {
+		log.G(ctx).Warnf("specification version in Kraftfile (v%s) is greater than parsable (v%s)", spec, SchemaVersionLatest)
 	}
 
-	schemaLoader := gojsonschema.NewStringLoader(SchemaV_06)
+	if specVer.Equal(SchemaVersionV0_5) {
+		schemaLoader = gojsonschema.NewStringLoader(SchemaV_05)
+	} else {
+		schemaLoader = gojsonschema.NewStringLoader(SchemaV_06)
+	}
+
 	dataLoader := gojsonschema.NewGoLoader(config)
 
 	result, err := gojsonschema.Validate(schemaLoader, dataLoader)
@@ -174,10 +182,8 @@ func specificity(err gojsonschema.ResultError) int {
 	return len(strings.Split(err.Field(), "."))
 }
 
-type SchemaVersion string
-
-const (
-	SchemaVersionV0_5   = SchemaVersion("0.5")
-	SchemaVersionV0_6   = SchemaVersion("0.6")
+var (
+	SchemaVersionV0_5   = semver.MustParse("v0.5")
+	SchemaVersionV0_6   = semver.MustParse("v0.6")
 	SchemaVersionLatest = SchemaVersionV0_6
 )

--- a/schema/v0.6.json
+++ b/schema/v0.6.json
@@ -37,6 +37,11 @@
 
     "/^rootfs$/": { "type": ["string", "array"] },
 
+    "/^roms$/": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+
     "/^volumes$/": {
       "oneOf": [
         { "type": "string" },

--- a/unikraft/app/application.go
+++ b/unikraft/app/application.go
@@ -64,6 +64,10 @@ type Application interface {
 	// as the root filesystem.  This can either be an initramdisk or a volume.
 	Rootfs() string
 
+	// Auxiliary read-only memory blobs.  Used for arbitrary data which are
+	// mounted at runtime.
+	Roms() []string
+
 	// SetRootfs sets the root filesystem path for the application to the given
 	// value path.
 	SetRootfs(string)
@@ -176,6 +180,7 @@ type application struct {
 	env           target.Env
 	command       []string
 	rootfs        string
+	roms          []string
 	kraftfile     *Kraftfile
 	configuration kconfig.KeyValueMap
 	extensions    component.Extensions
@@ -250,6 +255,10 @@ func (app *application) Targets() []target.Target {
 
 func (app *application) Rootfs() string {
 	return app.rootfs
+}
+
+func (app *application) Roms() []string {
+	return app.roms
 }
 
 func (app *application) SetRootfs(rootfs string) {

--- a/unikraft/app/application_options.go
+++ b/unikraft/app/application_options.go
@@ -127,6 +127,14 @@ func WithRootfs(rootfs string) ApplicationOption {
 	}
 }
 
+// WithRoms sets the application's auxiliary read-only memory blobs.
+func WithRoms(roms ...string) ApplicationOption {
+	return func(ac *application) error {
+		ac.roms = roms
+		return nil
+	}
+}
+
 // WithTemplate sets the application's template
 func WithTemplate(template *template.TemplateConfig) ApplicationOption {
 	return func(ac *application) error {

--- a/unikraft/app/loader.go
+++ b/unikraft/app/loader.go
@@ -69,6 +69,15 @@ func NewApplicationFromInterface(ctx context.Context, iface map[string]interface
 		}
 	}
 
+	romsSectionList := getSectionList(iface, "roms")
+	for _, rom := range romsSectionList {
+		romStr, ok := rom.(string)
+		if !ok {
+			return nil, errors.New("rom must be a string")
+		}
+		app.roms = append(app.roms, romStr)
+	}
+
 	if n, ok := iface["cmd"]; ok {
 		switch v := n.(type) {
 		case string:

--- a/unikraft/app/project.go
+++ b/unikraft/app/project.go
@@ -175,6 +175,7 @@ func NewProjectFromOptions(ctx context.Context, opts ...ProjectOption) (Applicat
 		WithUnikraft(app.unikraft),
 		WithRuntime(app.runtime),
 		WithRootfs(app.rootfs),
+		WithRoms(app.roms...),
 		WithTemplate(app.template),
 		WithCommand(app.command...),
 		WithLabels(app.labels),

--- a/unikraft/target/target.go
+++ b/unikraft/target/target.go
@@ -41,6 +41,9 @@ type Target interface {
 	// Initrd contains the initramfs configuration for this target.
 	Initrd() initrd.Initrd
 
+	// Auxiliary read-only memory blobs for this target.
+	Roms() []string
+
 	// Command is the command-line arguments set for this target.
 	Command() []string
 
@@ -71,6 +74,9 @@ type TargetConfig struct {
 
 	// initrd is the configuration for the initrd.
 	initrd initrd.Initrd
+
+	// auxiliary read-only memory blobs for this target.
+	roms []string
 
 	// command is the command-line arguments set for this target.
 	command []string
@@ -121,6 +127,10 @@ func (tc *TargetConfig) KernelDbg() string {
 
 func (tc *TargetConfig) Initrd() initrd.Initrd {
 	return tc.initrd
+}
+
+func (tc *TargetConfig) Roms() []string {
+	return tc.roms
 }
 
 func (tc *TargetConfig) Type() unikraft.ComponentType {


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

This PR introduces initial support for packaging auxiliary read-only memory blob files (auxiliary ROMs).  These are totally arbitrary files which can be used by an external provider and mounted to the kernel.  It's up to the application to decide what to do with this and provides flexibility in terms of being able to support additional types of usecases beyond a single initramfs.

Right now this can be used in two different ways:

1. Via a `Kraftfile`:
   ```yaml
   spec: v0.6

   runtime: base:latest

   rootfs: ./rootfs

   roms:
   - path/to/blob.bin
   ```

2. Via CLI:
   ```
   kraft pkg \
   --name test:latest \
   --rom path/to/blob.bin \
   [...]
   ```



