### PR TITLE
feat: Add support for exporting (OCI) packages

### DIFF
--- a/archive/archive.go
+++ b/archive/archive.go
@@ -211,8 +211,6 @@ func TarDirWriter(ctx context.Context, root, prefix string, tw *tar.Writer, opts
 			return err
 		}
 
-		dst = filepath.ToSlash(filepath.Join(prefix, dst))
-
-		return TarFileWriter(ctx, filepath.Join(root, path), dst, tw, opts...)
+		return TarFileWriter(ctx, path, filepath.ToSlash(filepath.Join(prefix, dst)), tw, opts...)
 	})
 }

--- a/internal/cli/kraft/pkg/export/export.go
+++ b/internal/cli/kraft/pkg/export/export.go
@@ -1,0 +1,173 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2025, Unikraft GmbH and The KraftKit Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+
+package export
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/MakeNowJust/heredoc"
+	"github.com/spf13/cobra"
+	"kraftkit.sh/cmdfactory"
+	"kraftkit.sh/config"
+	"kraftkit.sh/log"
+	"kraftkit.sh/pack"
+	"kraftkit.sh/packmanager"
+	"kraftkit.sh/tui/paraprogress"
+	"kraftkit.sh/tui/processtree"
+)
+
+type ExportOptions struct {
+	Architecture string `long:"arch" short:"m" usage:"Specify the desired architecture"`
+	Format       string `long:"as" short:"M" usage:"Force the packaging despite possible conflicts" default:"auto"`
+	Output       string `long:"output" short:"o" usage:"Set the location to export the package to"`
+	Platform     string `long:"plat" short:"p" usage:"Specify the desired platform"`
+	Update       bool   `long:"update" short:"u" usage:"Fetch the latest information about components and pull if not present"`
+}
+
+// Export the package to a specified location.
+func Info(ctx context.Context, opts *ExportOptions, args ...string) error {
+	if opts == nil {
+		opts = &ExportOptions{}
+	}
+
+	return opts.Run(ctx, args)
+}
+
+func New() *cobra.Command {
+	cmd, err := cmdfactory.New(&ExportOptions{}, cobra.Command{
+		Short:   "Export a package",
+		Use:     "export [FLAGS] PACKAGE",
+		Aliases: []string{"e"},
+		Long: heredoc.Doc(`
+			Export a package to a specified location. The meaning of "export" is
+			up to the implementing package, but it should be a representation of the
+			package that can be used by other tools or processes.
+		`),
+		Args: cmdfactory.ExactArgs(1, "package name not specified"),
+		Example: heredoc.Doc(`
+			# Exports the NGINX OCI package to a tarball.
+			$ kraft pkg export unikraft.org/nginx:1.15 -M oci -o ./output.tar.gz
+		`),
+		Annotations: map[string]string{
+			cmdfactory.AnnotationHelpGroup: "pkg",
+		},
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	return cmd
+}
+
+func (opts *ExportOptions) Run(ctx context.Context, args []string) error {
+	ctx, err := packmanager.WithDefaultUmbrellaManagerInContext(ctx)
+	if err != nil {
+		return err
+	}
+
+	parallel := !config.G[config.KraftKit](ctx).NoParallel
+	norender := log.LoggerTypeFromString(config.G[config.KraftKit](ctx).Log.Type) != log.FANCY
+	pm := packmanager.G(ctx)
+
+	// Force a particular package manager
+	if len(opts.Format) > 0 && opts.Format != "auto" {
+		pm, err = pm.From(pack.PackageFormat(opts.Format))
+		if err != nil {
+			return err
+		}
+	}
+
+	var searches []*processtree.ProcessTreeItem
+	var packs []pack.Package
+
+	for _, arg := range args {
+		search := processtree.NewProcessTreeItem(
+			fmt.Sprintf("finding %s", arg), "",
+			func(ctx context.Context) error {
+				more, err := pm.Catalog(ctx,
+					packmanager.WithArchitecture(opts.Architecture),
+					packmanager.WithLocal(true),
+					packmanager.WithName(arg),
+					packmanager.WithPlatform(opts.Platform),
+					packmanager.WithRemote(opts.Update),
+				)
+				if err != nil {
+					return err
+				}
+
+				if len(more) == 0 {
+					return fmt.Errorf("could not find: %s", arg)
+				}
+
+				packs = append(packs, more...)
+
+				return nil
+			},
+		)
+
+		searches = append(searches, search)
+	}
+
+	treemodel, err := processtree.NewProcessTree(
+		ctx,
+		[]processtree.ProcessTreeOption{
+			processtree.IsParallel(parallel),
+			processtree.WithRenderer(norender),
+			processtree.WithFailFast(false),
+			processtree.WithHideOnSuccess(true),
+		},
+		searches...,
+	)
+	if err != nil {
+		return err
+	}
+
+	if err := treemodel.Start(); err != nil {
+		return fmt.Errorf("could not complete search: %v", err)
+	}
+
+	if len(packs) == 0 {
+		return fmt.Errorf("could not find package(s): %v", args)
+	}
+
+	if len(packs) > 1 {
+		options := make([]string, len(packs))
+		for i, p := range packs {
+			options[i] = p.ID()
+		}
+		return fmt.Errorf("too many options: %v", options)
+	}
+
+	if opts.Update {
+		proc := paraprogress.NewProcess(
+			fmt.Sprintf("pulling %s", packs[0]),
+			func(ctx context.Context, w func(progress float64)) error {
+				return packs[0].Pull(
+					ctx,
+					pack.WithPullProgressFunc(w),
+				)
+			},
+		)
+
+		paramodel, err := paraprogress.NewParaProgress(
+			ctx,
+			[]*paraprogress.Process{proc},
+			paraprogress.IsParallel(parallel),
+			paraprogress.WithRenderer(norender),
+			paraprogress.WithFailFast(true),
+		)
+		if err != nil {
+			return err
+		}
+
+		if err := paramodel.Start(); err != nil {
+			return fmt.Errorf("could not pull all components: %v", err)
+		}
+	}
+
+	return packs[0].Export(ctx, opts.Output)
+}

--- a/internal/cli/kraft/pkg/pkg.go
+++ b/internal/cli/kraft/pkg/pkg.go
@@ -24,6 +24,7 @@ import (
 	"kraftkit.sh/cmdfactory"
 	"kraftkit.sh/packmanager"
 
+	"kraftkit.sh/internal/cli/kraft/pkg/export"
 	"kraftkit.sh/internal/cli/kraft/pkg/info"
 	"kraftkit.sh/internal/cli/kraft/pkg/list"
 	"kraftkit.sh/internal/cli/kraft/pkg/pull"
@@ -269,6 +270,7 @@ func NewCmd() *cobra.Command {
 		panic(err)
 	}
 
+	cmd.AddCommand(export.New())
 	cmd.AddCommand(info.New())
 	cmd.AddCommand(list.NewCmd())
 	cmd.AddCommand(pull.NewCmd())

--- a/manifest/pack.go
+++ b/manifest/pack.go
@@ -211,6 +211,11 @@ func (mp mpack) Save(ctx context.Context) error {
 	return nil
 }
 
+// Format implements pack.Package
+func (mp mpack) Export(_ context.Context, _ string) error {
+	return fmt.Errorf("not implemented")
+}
+
 func (mp mpack) Format() pack.PackageFormat {
 	return ManifestFormat
 }

--- a/oci/handler/containerd.go
+++ b/oci/handler/containerd.go
@@ -15,6 +15,7 @@ import (
 	"fmt"
 	"io"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/containerd/containerd"
@@ -200,6 +201,48 @@ func (handle *ContainerdHandler) DeleteDigest(ctx context.Context, dgst digest.D
 	}()
 
 	return handle.client.ContentStore().Delete(ctx, dgst)
+}
+
+type readerAtWrapper struct {
+	r   content.ReaderAt
+	off int64
+	mu  sync.Mutex
+}
+
+func (w *readerAtWrapper) Read(p []byte) (int, error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	if w.off >= w.r.Size() {
+		return 0, io.EOF
+	}
+
+	n, err := w.r.ReadAt(p, w.off)
+	w.off += int64(n)
+	return n, err
+}
+
+func (w *readerAtWrapper) Close() error {
+	return w.r.Close()
+}
+
+// ReadDigest implements DigestReader.
+func (handle *ContainerdHandler) ReadDigest(ctx context.Context, dgst digest.Digest) (io.ReadCloser, error) {
+	ctx, done, err := handle.lease(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	defer func() {
+		err = combineErrors(err, done(ctx))
+	}()
+
+	readerAt, err := handle.client.ContentStore().ReaderAt(ctx, ocispec.Descriptor{Digest: dgst})
+	if err != nil {
+		return nil, err
+	}
+
+	return &readerAtWrapper{r: readerAt}, nil
 }
 
 // SaveDescriptor implements DescriptorSaver.

--- a/oci/handler/directory.go
+++ b/oci/handler/directory.go
@@ -639,6 +639,27 @@ func (handle *DirectoryHandler) DeleteDigest(ctx context.Context, dgst digest.Di
 	return nil
 }
 
+// ReadDigest implements DigestReader.
+func (handle *DirectoryHandler) ReadDigest(ctx context.Context, dgst digest.Digest) (io.ReadCloser, error) {
+	digestPath := filepath.Join(
+		handle.path,
+		DirectoryHandlerDigestsDir,
+		dgst.Algorithm().String(),
+		dgst.Encoded(),
+	)
+
+	if _, err := os.Stat(digestPath); err != nil {
+		return nil, fmt.Errorf("could not find digest '%s': %w", dgst.String(), err)
+	}
+
+	file, err := os.Open(digestPath)
+	if err != nil {
+		return nil, fmt.Errorf("could not open digest '%s': %w", dgst.String(), err)
+	}
+
+	return file, nil
+}
+
 // SaveDescriptor implements DescriptorSaver.
 func (handle *DirectoryHandler) SaveDescriptor(ctx context.Context, ref string, desc ocispec.Descriptor, reader io.Reader, onProgress func(float64)) error {
 	blobPath := filepath.Join(

--- a/oci/handler/handler.go
+++ b/oci/handler/handler.go
@@ -24,6 +24,12 @@ type DigestPuller interface {
 	PullDigest(ctx context.Context, mediaType, fullref string, dgst digest.Digest, plat *ocispec.Platform, onProgress func(float64)) error
 }
 
+type DigestReader interface {
+	// ReadDigest retrieves the provided digest and returns an io.ReadCloser
+	// which can be used to read the contents of the digest.
+	ReadDigest(context.Context, digest.Digest) (io.ReadCloser, error)
+}
+
 type DescriptorSaver interface {
 	// SaveDescriptor accepts an optional name reference which represents
 	// descriptor (but this is not always necessary and can be left blank if the
@@ -82,6 +88,7 @@ type Handler interface {
 	DigestPuller
 	DigestLister
 	DigestDeleter
+	DigestReader
 	DescriptorSaver
 	DescriptorPusher
 	ManifestLister

--- a/oci/pack.go
+++ b/oci/pack.go
@@ -11,6 +11,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	golog "log"
 	"net/http"
 	"os"
@@ -33,6 +34,7 @@ import (
 	"golang.org/x/sync/errgroup"
 	"oras.land/oras-go/v2/content"
 
+	"kraftkit.sh/archive"
 	"kraftkit.sh/config"
 	"kraftkit.sh/initrd"
 	"kraftkit.sh/internal/set"
@@ -1016,6 +1018,146 @@ func (ocipack *ociPackage) Save(ctx context.Context) error {
 	}
 
 	return nil
+}
+
+// Export implements pack.Package
+func (ocipack *ociPackage) Export(ctx context.Context, path string) error {
+	if ocipack.manifest == nil || ocipack.manifest.manifest == nil {
+		return fmt.Errorf("no manifest available to export")
+	}
+
+	// Create a temporary directory for the OCI layout
+	tempDir, err := os.MkdirTemp("", "oci-export-*")
+	if err != nil {
+		return fmt.Errorf("failed to create temporary directory: %w", err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	// Create the OCI layout file
+	ociLayoutPath := filepath.Join(tempDir, "oci-layout")
+	ociLayout := map[string]interface{}{
+		"imageLayoutVersion": "1.0.0",
+	}
+	ociLayoutData, err := json.Marshal(ociLayout)
+	if err != nil {
+		return fmt.Errorf("failed to marshal oci-layout: %w", err)
+	}
+	if err := os.WriteFile(ociLayoutPath, ociLayoutData, 0o644); err != nil {
+		return fmt.Errorf("failed to write oci-layout file: %w", err)
+	}
+
+	// Create blobs directory
+	blobsDir := filepath.Join(tempDir, "blobs")
+	if err := os.MkdirAll(blobsDir, 0o755); err != nil {
+		return fmt.Errorf("failed to create blobs directory: %w", err)
+	}
+
+	// Get the OCI manifest
+	manifest := ocipack.manifest.manifest
+
+	// Export image configuration blob
+	configDigest := manifest.Config.Digest
+	configAlgo := configDigest.Algorithm().String()
+	configHash := configDigest.Encoded()
+
+	configBlobDir := filepath.Join(blobsDir, configAlgo)
+	if err := os.MkdirAll(configBlobDir, 0o755); err != nil {
+		return fmt.Errorf("failed to create config blob directory: %w", err)
+	}
+
+	configPath := filepath.Join(configBlobDir, configHash)
+	configData, err := json.Marshal(ocipack.manifest.config)
+	if err != nil {
+		return fmt.Errorf("failed to resolve image config: %w", err)
+	}
+
+	if err := os.WriteFile(configPath, configData, 0o644); err != nil {
+		return fmt.Errorf("failed to write config file: %w", err)
+	}
+
+	// Export layer blobs
+	for _, layer := range ocipack.manifest.manifest.Layers {
+		layerDigest := layer.Digest
+		layerAlgo := layerDigest.Algorithm().String()
+		layerHash := layerDigest.Encoded()
+
+		layerBlobDir := filepath.Join(blobsDir, layerAlgo)
+		if err := os.MkdirAll(layerBlobDir, 0o755); err != nil {
+			return fmt.Errorf("failed to create layer blob directory: %w", err)
+		}
+
+		layerPath := filepath.Join(layerBlobDir, layerHash)
+
+		// Check if layer file already exists (avoid duplicates)
+		if _, err := os.Stat(layerPath); err == nil {
+			continue
+		}
+
+		layerData, err := ocipack.handle.ReadDigest(ctx, layerDigest)
+		if err != nil {
+			return fmt.Errorf("failed to resolve layer '%s' content: %w", layerDigest.String(), err)
+		}
+
+		dst, err := os.Create(layerPath)
+		if err != nil {
+			return fmt.Errorf("failed to create file: %v", err)
+		}
+
+		defer dst.Close()
+
+		if _, err := io.Copy(dst, layerData); err != nil {
+			return fmt.Errorf("failed to copy: %v", err)
+		}
+	}
+
+	// Export manifest blob
+	manifestData, err := json.Marshal(manifest)
+	if err != nil {
+		return fmt.Errorf("failed to marshal manifest: %w", err)
+	}
+
+	manifestDigest := digest.FromBytes(manifestData)
+	manifestAlgo := manifestDigest.Algorithm().String()
+	manifestHash := manifestDigest.Encoded()
+
+	manifestBlobDir := filepath.Join(blobsDir, manifestAlgo)
+	if err := os.MkdirAll(manifestBlobDir, 0o755); err != nil {
+		return fmt.Errorf("failed to create manifest blob directory: %w", err)
+	}
+
+	manifestBlobPath := filepath.Join(manifestBlobDir, manifestHash)
+	if err := os.WriteFile(manifestBlobPath, manifestData, 0o644); err != nil {
+		return fmt.Errorf("failed to write manifest blob: %w", err)
+	}
+
+	indexData, err := ocipack.handle.ReadDigest(ctx, ocipack.index.desc.Digest)
+	if err != nil {
+		return fmt.Errorf("failed to resolve layer '%s' content: %w", ocipack.index.desc.Digest.String(), err)
+	}
+
+	indexPath := filepath.Join(tempDir, "index.json")
+	dst, err := os.Create(indexPath)
+	if err != nil {
+		return fmt.Errorf("failed to create file: %v", err)
+	}
+
+	defer dst.Close()
+
+	if _, err := io.Copy(dst, indexData); err != nil {
+		return fmt.Errorf("failed to copy: %v", err)
+	}
+
+	// Create tarball from the OCI layout directory
+	log.G(ctx).WithFields(logrus.Fields{
+		"dest": path,
+	}).Debug("creating export tarball")
+
+	// Create all parent directories if they do not exist.
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return fmt.Errorf("creating parent directories for tarball: %w", err)
+	}
+
+	return archive.TarDir(ctx, tempDir, "", path)
 }
 
 // Pull implements pack.Package

--- a/oci/pack.go
+++ b/oci/pack.go
@@ -862,7 +862,18 @@ func (ocipack *ociPackage) Pull(ctx context.Context, opts ...pack.PullOption) er
 	}
 
 	// The digest for index has now changed following a pull.  Figure out the new
-	// manifest by using the
+	// manifest by using the platform checksum to identify the correct manifest.
+	index, err := ocipack.handle.ResolveIndex(ctx, ocipack.imageRef())
+	if err != nil {
+		return fmt.Errorf("could not resolve index after pull: %w", err)
+	}
+	ocipack.index, err = NewIndexFromSpec(ctx, ocipack.handle, index)
+	if err != nil {
+		return fmt.Errorf("could not instantiate index from spec: %w", err)
+	}
+
+	// Calculate the platform checksum for the existing manifest, and compare
+	// against the manifests which are now available in the index.
 	existingChecksum, err := ociutils.PlatformChecksum(ocipack.imageRef(), ocipack.manifest.desc.Platform)
 	if err != nil {
 		return fmt.Errorf("calculating checksum for '%s': %w", ocipack.imageRef(), err)

--- a/pack/package.go
+++ b/pack/package.go
@@ -49,6 +49,12 @@ type Package interface {
 	// Save the state of package.
 	Save(context.Context) error
 
+	// Export the package to a specified location.  It's up to the implementing
+	// package to decide what "export" means, but it should be a
+	// representation of the package that can be used by other tools or
+	// processes.
+	Export(context.Context, string) error
+
 	// Deletes package available locally.
 	Delete(context.Context) error
 

--- a/unikraft/runtime/runtime_pack.go
+++ b/unikraft/runtime/runtime_pack.go
@@ -165,6 +165,15 @@ func (runtime *Runtime) Save(ctx context.Context) error {
 	return runtime.pack.Save(ctx)
 }
 
+// Export implements kraftkit.sh/pack.Package
+func (runtime *Runtime) Export(ctx context.Context, path string) error {
+	if runtime.pack == nil {
+		return fmt.Errorf("cannot export an empty package")
+	}
+
+	return runtime.pack.Export(ctx, path)
+}
+
 // Format implements kraftkit.sh/unikraft.component.Component
 func (runtime *Runtime) Format() pack.PackageFormat {
 	return runtime.pack.Format()


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

This PR introduces support for exporting packages via a new `Export` interface and `kraft pkg export` subcommand.

For now, the only implemented package manager is the OCI package manager which exports the target package into a tarball OCI bundle.

It can be used via the CLI:

```bash
kraft pkg export --arch x86_64 --plat qemu unikraft.org/nginx:1.15 -o ./output.tar.gz
```

Or via the Go SDK:
```go
ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
defer cancel()

// Set up logrus logger.
logger := logrus.StandardLogger()

// Set the log level to trace.
logger.Level = logrus.TraceLevel

// Save logger to context.
ctx = log.WithLogger(ctx, logger)

// Set up the OCI package manager.
ociman, err := oci.NewOCIManager(ctx,
	oci.WithDirectory(ctx, cachedir),
)
if err != nil {
	panic(err)
}

found, err := ociman.Catalog(ctx,
	packmanager.WithName("unikraft.org/nginx:latest"),
)
if err != nil {
	panic(err)
}

if len(found) == 0 {
	panic("package not found")
}

if len(found) > 1 {
	panic("multiple packages found")
}

found[0].Export(ctx, "./output.tar.gz")

```
