### PR TITLE
fix(unikraft): Deep copy library list to avoid altering

### DIFF
--- a/unikraft/app/application.go
+++ b/unikraft/app/application.go
@@ -236,7 +236,10 @@ func (app *application) Libraries(ctx context.Context) (map[string]*lib.LibraryC
 		return nil, err
 	}
 
-	libs := app.libraries
+	libs := map[string]*lib.LibraryConfig{}
+	for key, lib := range app.libraries {
+		libs[key] = lib
+	}
 
 	for _, uklib := range uklibs {
 		libs[uklib.Name()] = uklib


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [ ] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [ ] Tested your changes against relevant architectures and platforms;
  - [ ] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

Previously, if a call to this was made the saved list of libraries would then contain all internal libraries, apart from external ones. This results then in broken make builds due to incorrectly including too many libraries that should not be included.