### PR TITLE
fix(cloud): Remove unsupported output format `full` from example

### DIFF
--- a/internal/cli/kraft/cloud/service/list/list.go
+++ b/internal/cli/kraft/cloud/service/list/list.go
@@ -37,8 +37,8 @@ func NewCmd() *cobra.Command {
 			# List all service in your account.
 			$ kraft cloud service list
 
-			# List all service in your account in full table format.
-			$ kraft cloud service list -o full
+			# List all service in your account in list format.
+			$ kraft cloud service list -o list
 		`),
 		Annotations: map[string]string{
 			cmdfactory.AnnotationHelpGroup: "kraftcloud-service",


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [x] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->
Running `kraft cloud service list --help` shows the example command `kraft cloud service list -o full`. However, `full` is no longer a valid output format. This PR fixes this by replacing `full` with `list` in the example.
