### PR TITLE
fix: More fixes for erofs usage

### DIFF
--- a/initrd/options.go
+++ b/initrd/options.go
@@ -93,11 +93,7 @@ func WithOutput(output string) InitrdOption {
 // WithOutputType sets the output type of the resulting root filesystem.
 func WithOutputType(fsType FsType) InitrdOption {
 	return func(opts *InitrdOptions) error {
-		if fsType == FsType("") {
-			opts.fsType = FsTypeCpio
-		} else {
-			opts.fsType = fsType
-		}
+		opts.fsType = fsType
 		return nil
 	}
 }

--- a/initrd/options.go
+++ b/initrd/options.go
@@ -93,7 +93,11 @@ func WithOutput(output string) InitrdOption {
 // WithOutputType sets the output type of the resulting root filesystem.
 func WithOutputType(fsType FsType) InitrdOption {
 	return func(opts *InitrdOptions) error {
-		opts.fsType = fsType
+		if fsType == FsType("") {
+			opts.fsType = FsTypeCpio
+		} else {
+			opts.fsType = fsType
+		}
 		return nil
 	}
 }

--- a/internal/cli/kraft/build/build.go
+++ b/internal/cli/kraft/build/build.go
@@ -128,6 +128,7 @@ func Build(ctx context.Context, opts *BuildOptions, args ...string) error {
 	// and the packaging step may perform a build of the rootfs again.  Ultimately
 	// this prevents re-builds.
 	opts.Project.SetRootfs(opts.Rootfs)
+	opts.Project.SetInitrdFsType(opts.RootfsType)
 
 	err = build.Build(ctx, opts, args...)
 	if err != nil {

--- a/internal/cli/kraft/build/build.go
+++ b/internal/cli/kraft/build/build.go
@@ -53,7 +53,7 @@ type BuildOptions struct {
 	Project        app.Application `noattribute:"true"`
 	Rootfs         string          `long:"rootfs" usage:"Specify a path to use as root file system (can be volume or initramfs)"`
 	RootfsType     initrd.FsType   `noattribute:"true"`
-	KeepFileOwners bool            `noattribute:"true"`
+	KeepFileOwners bool            `local:"true" long:"keep-file-owners" usage:"Keep file owners (user:group) in the rootfs (false sets 'root:root')"`
 	SaveBuildLog   string          `long:"build-log" usage:"Use the specified file to save the output from the build"`
 	Target         *target.Target  `noattribute:"true"`
 	TargetName     string          `long:"target" short:"t" usage:"Build a particular known target"`
@@ -200,6 +200,12 @@ func (opts *BuildOptions) Pre(cmd *cobra.Command, args []string) error {
 	}
 
 	cmd.SetContext(ctx)
+
+	if cmd.Flag("rootfs-type").Changed && cmd.Flag("rootfs-type").Value.String() != "" {
+		opts.RootfsType = initrd.FsType(cmd.Flag("rootfs-type").Value.String())
+	} else {
+		opts.RootfsType = initrd.FsTypeCpio
+	}
 
 	return nil
 }

--- a/internal/cli/kraft/build/build.go
+++ b/internal/cli/kraft/build/build.go
@@ -81,6 +81,10 @@ func Build(ctx context.Context, opts *BuildOptions, args ...string) error {
 		}
 	}
 
+	if opts.Project != nil && opts.Project.InitrdFsType().String() != "" && opts.RootfsType == "" {
+		opts.RootfsType = opts.Project.InitrdFsType()
+	}
+
 	opts.statistics = map[string]string{}
 
 	var build builder
@@ -204,8 +208,6 @@ func (opts *BuildOptions) Pre(cmd *cobra.Command, args []string) error {
 
 	if cmd.Flag("rootfs-type").Changed && cmd.Flag("rootfs-type").Value.String() != "" {
 		opts.RootfsType = initrd.FsType(cmd.Flag("rootfs-type").Value.String())
-	} else {
-		opts.RootfsType = initrd.FsTypeCpio
 	}
 
 	return nil

--- a/internal/cli/kraft/build/builder_dockerfile.go
+++ b/internal/cli/kraft/build/builder_dockerfile.go
@@ -39,6 +39,10 @@ func (build *builderDockerfile) Buildable(ctx context.Context, opts *BuildOption
 		opts.Rootfs = opts.Project.Rootfs()
 	}
 
+	if opts.Project != nil && opts.Project.InitrdFsType().String() != "" && opts.RootfsType == "" {
+		opts.RootfsType = opts.Project.InitrdFsType()
+	}
+
 	// TODO(nderjung): This is a very naiive check and should be improved,
 	// potentially using an external library which parses the Dockerfile syntax.
 	// In most cases, however, the Dockerfile is usually named `Dockerfile`.

--- a/internal/cli/kraft/build/builder_kraftfile_runtime.go
+++ b/internal/cli/kraft/build/builder_kraftfile_runtime.go
@@ -45,6 +45,10 @@ func (build *builderKraftfileRuntime) Buildable(ctx context.Context, opts *Build
 		opts.Rootfs = opts.Project.Rootfs()
 	}
 
+	if opts.Project.InitrdFsType().String() != "" && opts.RootfsType == "" {
+		opts.RootfsType = opts.Project.InitrdFsType()
+	}
+
 	return true, nil
 }
 

--- a/internal/cli/kraft/build/builder_kraftfile_unikraft.go
+++ b/internal/cli/kraft/build/builder_kraftfile_unikraft.go
@@ -53,8 +53,12 @@ func (build *builderKraftfileUnikraft) Buildable(ctx context.Context, opts *Buil
 		return false, fmt.Errorf("cannot build without unikraft core specification")
 	}
 
-	if opts.Rootfs == "" {
+	if opts.Project != nil && opts.Project.Rootfs() != "" && opts.Rootfs == "" {
 		opts.Rootfs = opts.Project.Rootfs()
+	}
+
+	if opts.Project != nil && opts.Project.InitrdFsType().String() != "" && opts.RootfsType == "" {
+		opts.RootfsType = opts.Project.InitrdFsType()
 	}
 
 	return true, nil

--- a/internal/cli/kraft/cloud/compose/build/build.go
+++ b/internal/cli/kraft/cloud/compose/build/build.go
@@ -22,6 +22,7 @@ import (
 	"kraftkit.sh/cmdfactory"
 	"kraftkit.sh/compose"
 	"kraftkit.sh/config"
+	"kraftkit.sh/initrd"
 	"kraftkit.sh/internal/cli/kraft/build"
 	"kraftkit.sh/internal/cli/kraft/cloud/utils"
 	"kraftkit.sh/internal/cli/kraft/pkg"
@@ -33,16 +34,18 @@ import (
 )
 
 type BuildOptions struct {
-	AllowInsecure bool                  `noattribute:"true"`
-	Auth          *config.AuthConfig    `noattribute:"true"`
-	Client        kraftcloud.KraftCloud `noattribute:"true"`
-	Composefile   string                `noattribute:"true"`
-	EnvFile       string                `noattribute:"true"`
-	Metro         string                `noattribute:"true"`
-	Project       *compose.Project      `noattribute:"true"`
-	Push          bool                  `long:"push" usage:"Push the built service images"`
-	Runtimes      []string              `long:"runtime" usage:"Alternative runtime to use when packaging a service"`
-	Token         string                `noattribute:"true"`
+	AllowInsecure  bool                  `noattribute:"true"`
+	Auth           *config.AuthConfig    `noattribute:"true"`
+	Client         kraftcloud.KraftCloud `noattribute:"true"`
+	Composefile    string                `noattribute:"true"`
+	EnvFile        string                `noattribute:"true"`
+	Metro          string                `noattribute:"true"`
+	Project        *compose.Project      `noattribute:"true"`
+	Push           bool                  `long:"push" usage:"Push the built service images"`
+	Runtimes       []string              `long:"runtime" usage:"Alternative runtime to use when packaging a service"`
+	RootfsType     initrd.FsType         `noattribute:"true"`
+	KeepFileOwners bool                  `local:"true" long:"keep-file-owners" usage:"Keep file owners (user:group) in the rootfs (false sets 'root:root')"`
+	Token          string                `noattribute:"true"`
 }
 
 func NewCmd() *cobra.Command {
@@ -71,6 +74,15 @@ func NewCmd() *cobra.Command {
 	if err != nil {
 		panic(err)
 	}
+
+	cmd.Flags().Var(
+		cmdfactory.NewEnumFlag[initrd.FsType](
+			initrd.FsTypes(),
+			initrd.FsTypeCpio,
+		),
+		"rootfs-type",
+		"Set the type of the format of the rootfs (cpio/erofs)",
+	)
 
 	return cmd
 }
@@ -192,15 +204,17 @@ func Build(ctx context.Context, opts *BuildOptions, args ...string) error {
 		}
 
 		popts := &pkg.PkgOptions{
-			Architecture: "x86_64",
-			Compress:     false,
-			Format:       "oci",
-			Name:         pkgName,
-			NoPull:       false,
-			Platform:     "kraftcloud",
-			Push:         opts.Push,
-			Project:      project,
-			Strategy:     packmanager.StrategyOverwrite,
+			Architecture:   "x86_64",
+			Compress:       false,
+			Format:         "oci",
+			Name:           pkgName,
+			NoPull:         false,
+			Platform:       "kraftcloud",
+			Push:           opts.Push,
+			Project:        project,
+			Strategy:       packmanager.StrategyOverwrite,
+			RootfsType:     opts.RootfsType,
+			KeepFileOwners: opts.KeepFileOwners,
 		}
 
 		// If no build context can be determined, assume a build via a unikernel
@@ -358,6 +372,12 @@ func (opts *BuildOptions) Pre(cmd *cobra.Command, args []string) error {
 
 	if cmd.Flag("env-file").Changed {
 		opts.EnvFile = cmd.Flag("env-file").Value.String()
+	}
+
+	if cmd.Flag("rootfs-type").Changed && cmd.Flag("rootfs-type").Value.String() != "" {
+		opts.RootfsType = initrd.FsType(cmd.Flag("rootfs-type").Value.String())
+	} else {
+		opts.RootfsType = initrd.FsTypeCpio
 	}
 
 	return nil

--- a/internal/cli/kraft/cloud/compose/build/build.go
+++ b/internal/cli/kraft/cloud/compose/build/build.go
@@ -376,8 +376,6 @@ func (opts *BuildOptions) Pre(cmd *cobra.Command, args []string) error {
 
 	if cmd.Flag("rootfs-type").Changed && cmd.Flag("rootfs-type").Value.String() != "" {
 		opts.RootfsType = initrd.FsType(cmd.Flag("rootfs-type").Value.String())
-	} else {
-		opts.RootfsType = initrd.FsTypeCpio
 	}
 
 	return nil

--- a/internal/cli/kraft/cloud/compose/up/up.go
+++ b/internal/cli/kraft/cloud/compose/up/up.go
@@ -27,6 +27,7 @@ import (
 	"kraftkit.sh/cmdfactory"
 	"kraftkit.sh/compose"
 	"kraftkit.sh/config"
+	"kraftkit.sh/initrd"
 	"kraftkit.sh/internal/cli/kraft/cloud/compose/build"
 	"kraftkit.sh/internal/cli/kraft/cloud/instance/create"
 	"kraftkit.sh/internal/cli/kraft/cloud/instance/get"
@@ -52,6 +53,8 @@ type UpOptions struct {
 	RolloutQualifier *create.RolloutQualifier `noattribute:"true"`
 	RolloutWait      time.Duration            `local:"true" long:"rollout-wait" usage:"Time to wait before performing rolling out action (ms/s/m/h)" default:"10s"`
 	Runtimes         []string                 `long:"runtime" usage:"Alternative runtime to use when packaging a service"`
+	RootfsType       initrd.FsType            `noattribute:"true"`
+	KeepFileOwners   bool                     `local:"true" long:"keep-file-owners" usage:"Keep file owners (user:group) in the rootfs (false sets 'root:root')"`
 	Token            string                   `noattribute:"true"`
 	Wait             time.Duration            `local:"true" long:"wait" short:"w" usage:"Timeout to wait for the instance to start (ms/s/m/h)"`
 }
@@ -90,6 +93,15 @@ func NewCmd() *cobra.Command {
 		panic(err)
 	}
 
+	cmd.Flags().Var(
+		cmdfactory.NewEnumFlag[initrd.FsType](
+			initrd.FsTypes(),
+			initrd.FsTypeCpio,
+		),
+		"rootfs-type",
+		"Set the type of the format of the rootfs (cpio/erofs)",
+	)
+
 	return cmd
 }
 
@@ -112,6 +124,12 @@ func (opts *UpOptions) Pre(cmd *cobra.Command, args []string) error {
 
 	if cmd.Flag("env-file").Changed {
 		opts.EnvFile = cmd.Flag("env-file").Value.String()
+	}
+
+	if cmd.Flag("rootfs-type").Changed && cmd.Flag("rootfs-type").Value.String() != "" {
+		opts.RootfsType = initrd.FsType(cmd.Flag("rootfs-type").Value.String())
+	} else {
+		opts.RootfsType = initrd.FsTypeCpio
 	}
 
 	return nil
@@ -178,14 +196,16 @@ func Up(ctx context.Context, opts *UpOptions, args ...string) error {
 	if !opts.NoBuild {
 		// Build all services if the build flag is set.
 		if err := build.Build(ctx, &build.BuildOptions{
-			Auth:        opts.Auth,
-			Client:      opts.Client,
-			Composefile: opts.Composefile,
-			Metro:       opts.Metro,
-			Project:     opts.Project,
-			Runtimes:    opts.Runtimes,
-			Token:       opts.Token,
-			Push:        true,
+			Auth:           opts.Auth,
+			Client:         opts.Client,
+			Composefile:    opts.Composefile,
+			Metro:          opts.Metro,
+			Project:        opts.Project,
+			Runtimes:       opts.Runtimes,
+			RootfsType:     opts.RootfsType,
+			KeepFileOwners: opts.KeepFileOwners,
+			Token:          opts.Token,
+			Push:           true,
 		}, args...); err != nil {
 			return err
 		}

--- a/internal/cli/kraft/cloud/compose/up/up.go
+++ b/internal/cli/kraft/cloud/compose/up/up.go
@@ -128,8 +128,6 @@ func (opts *UpOptions) Pre(cmd *cobra.Command, args []string) error {
 
 	if cmd.Flag("rootfs-type").Changed && cmd.Flag("rootfs-type").Value.String() != "" {
 		opts.RootfsType = initrd.FsType(cmd.Flag("rootfs-type").Value.String())
-	} else {
-		opts.RootfsType = initrd.FsTypeCpio
 	}
 
 	return nil

--- a/internal/cli/kraft/cloud/deploy/deploy.go
+++ b/internal/cli/kraft/cloud/deploy/deploy.go
@@ -194,8 +194,6 @@ func (opts *DeployOptions) Pre(cmd *cobra.Command, _ []string) error {
 
 	if cmd.Flag("rootfs-type").Changed && cmd.Flag("rootfs-type").Value.String() != "" {
 		opts.RootfsType = initrd.FsType(cmd.Flag("rootfs-type").Value.String())
-	} else {
-		opts.RootfsType = initrd.FsTypeCpio
 	}
 
 	if cmd.Flag("scale-to-zero").Changed {

--- a/internal/cli/kraft/cloud/deploy/deployer_image_name.go
+++ b/internal/cli/kraft/cloud/deploy/deployer_image_name.go
@@ -65,6 +65,14 @@ func (deployer *deployerImageName) Deployable(ctx context.Context, opts *DeployO
 		return false, err
 	}
 
+	if opts.Project != nil && opts.Project.Rootfs() != "" && opts.Rootfs == "" {
+		opts.Rootfs = opts.Project.Rootfs()
+	}
+
+	if opts.Project != nil && opts.Project.InitrdFsType().String() != "" && opts.RootfsType == "" {
+		opts.RootfsType = opts.Project.InitrdFsType()
+	}
+
 	deployer.imageName = args[0]
 	deployer.args = args[1:]
 

--- a/internal/cli/kraft/cloud/deploy/deployer_kraftfile_runtime.go
+++ b/internal/cli/kraft/cloud/deploy/deployer_kraftfile_runtime.go
@@ -62,6 +62,14 @@ func (deployer *deployerKraftfileRuntime) Deployable(ctx context.Context, opts *
 		opts.Project.Runtime().SetName("index.unikraft.io/official/" + opts.Project.Runtime().Name())
 	}
 
+	if opts.Project != nil && opts.Project.Rootfs() != "" && opts.Rootfs == "" {
+		opts.Rootfs = opts.Project.Rootfs()
+	}
+
+	if opts.Project != nil && opts.Project.InitrdFsType().String() != "" && opts.RootfsType == "" {
+		opts.RootfsType = opts.Project.InitrdFsType()
+	}
+
 	deployer.args = args
 
 	return true, nil

--- a/internal/cli/kraft/cloud/deploy/deployer_kraftfile_unikraft.go
+++ b/internal/cli/kraft/cloud/deploy/deployer_kraftfile_unikraft.go
@@ -9,7 +9,6 @@ import (
 	kcinstances "sdk.kraft.cloud/instances"
 	kcservices "sdk.kraft.cloud/services"
 
-	"kraftkit.sh/initrd"
 	"kraftkit.sh/internal/cli/kraft/build"
 )
 
@@ -42,10 +41,6 @@ func (deployer *deployerKraftfileUnikraft) Deployable(ctx context.Context, opts 
 
 	if opts.Project.Unikraft(ctx) == nil {
 		return false, fmt.Errorf("cannot package without unikraft attribute")
-	}
-
-	if opts.RootfsType == initrd.FsTypeErofs {
-		return false, fmt.Errorf("Unikraft does not currently have support for erofs initrds (contributions welcome!)")
 	}
 
 	deployer.args = args

--- a/internal/cli/kraft/cloud/deploy/deployer_kraftfile_unikraft.go
+++ b/internal/cli/kraft/cloud/deploy/deployer_kraftfile_unikraft.go
@@ -43,6 +43,14 @@ func (deployer *deployerKraftfileUnikraft) Deployable(ctx context.Context, opts 
 		return false, fmt.Errorf("cannot package without unikraft attribute")
 	}
 
+	if opts.Project != nil && opts.Project.Rootfs() != "" && opts.Rootfs == "" {
+		opts.Rootfs = opts.Project.Rootfs()
+	}
+
+	if opts.Project != nil && opts.Project.InitrdFsType().String() != "" && opts.RootfsType == "" {
+		opts.RootfsType = opts.Project.InitrdFsType()
+	}
+
 	deployer.args = args
 
 	return true, nil

--- a/internal/cli/kraft/cloud/deploy/deployer_rootfs.go
+++ b/internal/cli/kraft/cloud/deploy/deployer_rootfs.go
@@ -44,6 +44,10 @@ func (deployer *deployerRootfs) Deployable(ctx context.Context, opts *DeployOpti
 		opts.Rootfs = opts.Project.Rootfs()
 	}
 
+	if opts.Project != nil && opts.Project.InitrdFsType().String() != "" && opts.RootfsType == "" {
+		opts.RootfsType = opts.Project.InitrdFsType()
+	}
+
 	// Maybe no `--rootfs` flag was provided, but there may be a local Dockerfile
 	// in the working directory.  If so, we can use that as the rootfs.
 

--- a/internal/cli/kraft/pkg/packager_dockerfile.go
+++ b/internal/cli/kraft/pkg/packager_dockerfile.go
@@ -32,6 +32,10 @@ func (p *packagerDockerfile) Packagable(ctx context.Context, opts *PkgOptions, a
 		opts.Rootfs = opts.Project.Rootfs()
 	}
 
+	if opts.Project != nil && opts.Project.InitrdFsType().String() != "" && opts.RootfsType == "" {
+		opts.RootfsType = opts.Project.InitrdFsType()
+	}
+
 	// TODO(nderjung): This is a very naiive check and should be improved,
 	// potentially using an external library which parses the Dockerfile syntax.
 	// In most cases, however, the Dockerfile is usually named `Dockerfile`.

--- a/internal/cli/kraft/pkg/packager_kraftfile_runtime.go
+++ b/internal/cli/kraft/pkg/packager_kraftfile_runtime.go
@@ -65,6 +65,10 @@ func (p *packagerKraftfileRuntime) Packagable(ctx context.Context, opts *PkgOpti
 		opts.Rootfs = opts.Project.Rootfs()
 	}
 
+	if opts.Project.InitrdFsType().String() != "" && opts.RootfsType == "" {
+		opts.RootfsType = opts.Project.InitrdFsType()
+	}
+
 	return true, nil
 }
 

--- a/internal/cli/kraft/pkg/packager_kraftfile_unikraft.go
+++ b/internal/cli/kraft/pkg/packager_kraftfile_unikraft.go
@@ -48,6 +48,10 @@ func (p *packagerKraftfileUnikraft) Packagable(ctx context.Context, opts *PkgOpt
 		opts.Rootfs = opts.Project.Rootfs()
 	}
 
+	if opts.Project.InitrdFsType().String() != "" && opts.RootfsType == "" {
+		opts.RootfsType = opts.Project.InitrdFsType()
+	}
+
 	return true, nil
 }
 

--- a/internal/cli/kraft/pkg/pkg.go
+++ b/internal/cli/kraft/pkg/pkg.go
@@ -324,8 +324,6 @@ func (opts *PkgOptions) Pre(cmd *cobra.Command, args []string) error {
 	opts.Strategy = packmanager.MergeStrategy(cmd.Flag("strategy").Value.String())
 	if cmd.Flag("rootfs-type").Changed && cmd.Flag("rootfs-type").Value.String() != "" {
 		opts.RootfsType = initrd.FsType(cmd.Flag("rootfs-type").Value.String())
-	} else {
-		opts.RootfsType = initrd.FsTypeCpio
 	}
 
 	return nil

--- a/internal/cli/kraft/run/run.go
+++ b/internal/cli/kraft/run/run.go
@@ -163,8 +163,6 @@ func (opts *RunOptions) Pre(cmd *cobra.Command, _ []string) error {
 	opts.hostMode = mplatform.SystemUnknown
 	if cmd.Flag("rootfs-type").Changed && cmd.Flag("rootfs-type").Value.String() != "" {
 		opts.RootfsType = initrd.FsType(cmd.Flag("rootfs-type").Value.String())
-	} else {
-		opts.RootfsType = initrd.FsTypeCpio
 	}
 
 	if opts.RunAs == "" || !set.NewStringSet("kernel", "project").Contains(opts.RunAs) {

--- a/internal/cli/kraft/run/runner_kraftfile_runtime.go
+++ b/internal/cli/kraft/run/runner_kraftfile_runtime.go
@@ -81,6 +81,14 @@ func (runner *runnerKraftfileRuntime) Runnable(ctx context.Context, opts *RunOpt
 		return false, fmt.Errorf("cannot run project without runtime directive")
 	}
 
+	if runner.project != nil && runner.project.Rootfs() != "" && opts.Rootfs == "" {
+		opts.Rootfs = runner.project.Rootfs()
+	}
+
+	if runner.project != nil && runner.project.InitrdFsType().String() != "" && opts.RootfsType == "" {
+		opts.RootfsType = runner.project.InitrdFsType()
+	}
+
 	return true, nil
 }
 

--- a/internal/cli/kraft/run/runner_kraftfile_unikraft.go
+++ b/internal/cli/kraft/run/runner_kraftfile_unikraft.go
@@ -87,6 +87,14 @@ func (runner *runnerKraftfileUnikraft) Runnable(ctx context.Context, opts *RunOp
 		return false, fmt.Errorf("cannot run project build without unikraft")
 	}
 
+	if runner.project != nil && runner.project.Rootfs() != "" && opts.Rootfs == "" {
+		opts.Rootfs = runner.project.Rootfs()
+	}
+
+	if runner.project != nil && runner.project.InitrdFsType().String() != "" && opts.RootfsType == "" {
+		opts.RootfsType = runner.project.InitrdFsType()
+	}
+
 	return true, nil
 }
 

--- a/internal/cli/kraft/run/utils.go
+++ b/internal/cli/kraft/run/utils.go
@@ -354,14 +354,14 @@ func (opts *RunOptions) prepareRootfs(ctx context.Context, machine *machineapi.M
 	// If the user has supplied an initram path, set this now, this overrides any
 	// preparation and is considered higher priority compared to what has been set
 	// prior to this point.
-	if opts.Rootfs == "" || machine.Status.InitrdPath != "" {
+	if opts.Rootfs == "" || machine.Status.InitrdPath != "" || opts.RootfsType == "" {
 		return nil
 	}
 
 	machine.Status.InitrdPath = filepath.Join(
 		opts.workdir,
 		unikraft.BuildDir,
-		fmt.Sprintf(initrd.DefaultInitramfsArchFileName, machine.Spec.Architecture, opts.RootfsType.String()),
+		fmt.Sprintf(initrd.DefaultInitramfsArchFileName, machine.Spec.Architecture, opts.RootfsType),
 	)
 
 	ramfs, err := initrd.New(ctx,

--- a/internal/cli/kraft/utils/rootfs.go
+++ b/internal/cli/kraft/utils/rootfs.go
@@ -20,7 +20,7 @@ import (
 // BuildRootfs generates a rootfs based on the provided working directory and
 // the rootfs entrypoint for the provided target(s).
 func BuildRootfs(ctx context.Context, workdir, rootfs string, compress, keepOwners bool, arch string, fsType initrd.FsType) (initrd.Initrd, []string, []string, error) {
-	if rootfs == "" {
+	if rootfs == "" || fsType == "" {
 		return nil, nil, nil, nil
 	}
 
@@ -34,7 +34,7 @@ func BuildRootfs(ctx context.Context, workdir, rootfs string, compress, keepOwne
 		initrd.WithOutput(filepath.Join(
 			workdir,
 			unikraft.BuildDir,
-			fmt.Sprintf(initrd.DefaultInitramfsArchFileName, arch, fsType.String()),
+			fmt.Sprintf(initrd.DefaultInitramfsArchFileName, arch, fsType),
 		)),
 		initrd.WithCacheDir(filepath.Join(
 			workdir,

--- a/schema/v0.6.json
+++ b/schema/v0.6.json
@@ -35,7 +35,17 @@
       "additionalProperties": true
     },
 
-    "/^rootfs$/": { "type": ["string", "array"] },
+    "/^rootfs$/": {
+      "oneOf": [
+        { "type": "string" },
+        {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/rootfs"
+          }
+        }
+      ]
+    },
 
     "/^roms$/": {
       "type": "array",
@@ -152,6 +162,15 @@
         "source": { "type": "string" },
         "version": { "type": [ "string", "number" ] },
         "kconfig": { "$ref": "#/definitions/list_or_dict" }
+      }
+    },
+
+    "rootfs": {
+      "id": "#/definitions/rootfs",
+      "type": [ "object" ],
+      "properties": {
+        "source": { "type": "string" },
+        "type": { "type": "string" }
       }
     },
 

--- a/tools/github-action/build.go
+++ b/tools/github-action/build.go
@@ -31,7 +31,7 @@ func (opts *GithubAction) build(ctx context.Context) error {
 			initrd.WithOutput(filepath.Join(
 				opts.Workdir,
 				unikraft.BuildDir,
-				fmt.Sprintf(initrd.DefaultInitramfsArchFileName, opts.target.Architecture().String(), opts.RootfsType.String()),
+				fmt.Sprintf(initrd.DefaultInitramfsArchFileName, opts.target.Architecture().String(), opts.RootfsType),
 			)),
 			initrd.WithCacheDir(filepath.Join(
 				opts.Workdir,
@@ -39,7 +39,7 @@ func (opts *GithubAction) build(ctx context.Context) error {
 				"rootfs-cache",
 			)),
 			initrd.WithArchitecture(opts.target.Architecture().String()),
-			initrd.WithOutputType(opts.RootfsType),
+			initrd.WithOutputType(initrd.FsType(opts.RootfsType)),
 		)
 		if err != nil {
 			return fmt.Errorf("could not prepare initramfs: %w", err)

--- a/tools/github-action/pack.go
+++ b/tools/github-action/pack.go
@@ -83,8 +83,8 @@ func (opts *GithubAction) aggregateEnvs() []string {
 
 // BuildRootfs generates a rootfs based on the provided working directory and
 // the rootfs entrypoint for the provided target(s).
-func (opts *GithubAction) buildRootfs(ctx context.Context, workdir, rootfs string, compress bool, arch string) (initrd.Initrd, []string, []string, error) {
-	if rootfs == "" {
+func (opts *GithubAction) buildRootfs(ctx context.Context, workdir, rootfs string, compress bool, arch string, fsType initrd.FsType) (initrd.Initrd, []string, []string, error) {
+	if rootfs == "" || fsType == "" {
 		return nil, nil, nil, nil
 	}
 
@@ -97,7 +97,7 @@ func (opts *GithubAction) buildRootfs(ctx context.Context, workdir, rootfs strin
 		initrd.WithOutput(filepath.Join(
 			workdir,
 			unikraft.BuildDir,
-			fmt.Sprintf(initrd.DefaultInitramfsArchFileName, arch, initrd.FsTypeCpio.String()),
+			fmt.Sprintf(initrd.DefaultInitramfsArchFileName, arch, fsType),
 		)),
 		initrd.WithCacheDir(filepath.Join(
 			workdir,
@@ -105,6 +105,7 @@ func (opts *GithubAction) buildRootfs(ctx context.Context, workdir, rootfs strin
 			"rootfs-cache",
 		)),
 		initrd.WithArchitecture(arch),
+		initrd.WithOutputType(fsType),
 		initrd.WithCompression(compress),
 	)
 	if err != nil {
@@ -139,6 +140,10 @@ func (opts *GithubAction) packagableUnikraft(ctx context.Context) (bool, error) 
 		opts.Rootfs = opts.project.Rootfs()
 	}
 
+	if opts.project.InitrdFsType().String() != "" && opts.RootfsType == "" {
+		opts.RootfsType = opts.project.InitrdFsType().String()
+	}
+
 	return true, nil
 }
 
@@ -157,6 +162,10 @@ func (opts *GithubAction) packagableRuntime(ctx context.Context) (bool, error) {
 		opts.Rootfs = opts.project.Rootfs()
 	}
 
+	if opts.project.InitrdFsType().String() != "" && opts.RootfsType == "" {
+		opts.RootfsType = opts.project.InitrdFsType().String()
+	}
+
 	return true, nil
 }
 
@@ -169,6 +178,10 @@ func (opts *GithubAction) packagableDockerfile(ctx context.Context) (bool, error
 
 	if opts.project != nil && opts.project.Rootfs() != "" && opts.Rootfs == "" {
 		opts.Rootfs = opts.project.Rootfs()
+	}
+
+	if opts.project != nil && opts.project.InitrdFsType().String() != "" && opts.RootfsType == "" {
+		opts.RootfsType = opts.project.InitrdFsType().String()
 	}
 
 	// TODO(nderjung): This is a very naiive check and should be improved,
@@ -454,7 +467,7 @@ func (opts *GithubAction) packRuntime(ctx context.Context, output string, format
 	var cmds []string
 	var rootfsEnvs []string
 	var rootfs initrd.Initrd
-	if rootfs, cmds, rootfsEnvs, err = opts.buildRootfs(ctx, opts.Workdir, opts.Rootfs, false, targ.Architecture().String()); err != nil {
+	if rootfs, cmds, rootfsEnvs, err = opts.buildRootfs(ctx, opts.Workdir, opts.Rootfs, false, targ.Architecture().String(), initrd.FsType(opts.RootfsType)); err != nil {
 		return fmt.Errorf("could not build rootfs: %w", err)
 	}
 

--- a/unikraft/app/application.go
+++ b/unikraft/app/application.go
@@ -68,6 +68,12 @@ type Application interface {
 	// mounted at runtime.
 	Roms() []string
 
+	// InitrdFsType returns the type of root filesystem to be used during runtime.
+	InitrdFsType() initrd.FsType
+
+	// SetInitrdFsType sets the type of root filesystem to be used during runtime.
+	SetInitrdFsType(initrd.FsType)
+
 	// SetRootfs sets the root filesystem path for the application to the given
 	// value path.
 	SetRootfs(string)
@@ -170,6 +176,7 @@ type application struct {
 	workingDir    string
 	filename      string
 	outDir        string
+	fsType        initrd.FsType
 	template      *template.TemplateConfig
 	runtime       *runtime.Runtime
 	unikraft      *core.UnikraftConfig
@@ -266,6 +273,14 @@ func (app *application) Roms() []string {
 
 func (app *application) SetRootfs(rootfs string) {
 	app.rootfs = rootfs
+}
+
+func (app *application) SetInitrdFsType(fsType initrd.FsType) {
+	app.fsType = fsType
+}
+
+func (app *application) InitrdFsType() initrd.FsType {
+	return app.fsType
 }
 
 func (app *application) Command() []string {
@@ -602,7 +617,7 @@ func (app *application) Configure(ctx context.Context, tc target.Target, extra k
 			"CONFIG_LIBPOSIX_VFS_FSTAB_EINITRD_PATH",
 			filepath.Join(
 				app.outDir,
-				fmt.Sprintf(initrd.DefaultInitramfsArchFileName, tc.Architecture().String(), initrd.FsTypeCpio.String()),
+				fmt.Sprintf(initrd.DefaultInitramfsArchFileName, tc.Architecture().String(), app.InitrdFsType()),
 			),
 		)
 	}

--- a/unikraft/app/application_options.go
+++ b/unikraft/app/application_options.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"kraftkit.sh/initrd"
 	"kraftkit.sh/kconfig"
 	"kraftkit.sh/unikraft"
 	"kraftkit.sh/unikraft/app/volume"
@@ -123,6 +124,14 @@ func WithRuntime(rt *runtime.Runtime) ApplicationOption {
 func WithRootfs(rootfs string) ApplicationOption {
 	return func(ac *application) error {
 		ac.rootfs = rootfs
+		return nil
+	}
+}
+
+// WithFsType sets the application's rootfs filesystem type
+func WithFsType(fsType initrd.FsType) ApplicationOption {
+	return func(ac *application) error {
+		ac.fsType = fsType
 		return nil
 	}
 }

--- a/unikraft/app/loader.go
+++ b/unikraft/app/loader.go
@@ -26,6 +26,7 @@ import (
 	interp "github.com/compose-spec/compose-go/interpolation"
 	"github.com/pkg/errors"
 	"gopkg.in/yaml.v2"
+	"kraftkit.sh/initrd"
 	"kraftkit.sh/unikraft"
 )
 
@@ -63,9 +64,37 @@ func NewApplicationFromInterface(ctx context.Context, iface map[string]interface
 	}
 
 	if n, ok := iface["rootfs"]; ok {
-		app.rootfs, ok = n.(string)
-		if !ok {
-			return nil, errors.New("rootfs must be a string")
+		switch n.(type) {
+		case string:
+			app.rootfs = n.(string)
+			app.fsType = initrd.FsTypeCpio
+		case interface{}:
+			rootfsMap := getSectionMap(iface, "rootfs")
+			if rootfsMap == nil {
+				return nil, errors.New("rootfs must be a mapping or a string")
+			}
+
+			if t, ok := rootfsMap["type"]; ok {
+				fsTypeStr, ok := t.(string)
+				if !ok {
+					return nil, errors.New("rootfs type must be a string")
+				}
+				app.fsType = initrd.FsType(strings.ToLower(fsTypeStr))
+			} else {
+				app.fsType = initrd.FsTypeCpio
+			}
+
+			if s, ok := rootfsMap["source"]; ok {
+				sourceStr, ok := s.(string)
+				if !ok {
+					return nil, errors.New("rootfs source must be a string")
+				}
+				app.rootfs = sourceStr
+			} else {
+				return nil, errors.New("rootfs source must be specified")
+			}
+		default:
+			return nil, errors.New("rootfs must be a mapping or a string")
 		}
 	}
 

--- a/unikraft/app/project.go
+++ b/unikraft/app/project.go
@@ -175,6 +175,7 @@ func NewProjectFromOptions(ctx context.Context, opts ...ProjectOption) (Applicat
 		WithUnikraft(app.unikraft),
 		WithRuntime(app.runtime),
 		WithRootfs(app.rootfs),
+		WithFsType(app.fsType),
 		WithRoms(app.roms...),
 		WithTemplate(app.template),
 		WithCommand(app.command...),


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [ ] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [ ] Tested your changes against relevant architectures and platforms;
  - [ ] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

The added functionality allows you to do:
```
rootfs:
  source: ./Dockerfile
  type: erofs
```
The `type` field being optional.

whilst also keeping the old (which has `cpio` as the default type)
```
rootfs: ./Dockerfile
```

This is overwritten by the cli flag.