### PR TITLE
fix(internal): Print banner and exit on stopped state only

### DIFF
--- a/internal/cli/kraft/cloud/instance/logs/logs.go
+++ b/internal/cli/kraft/cloud/instance/logs/logs.go
@@ -16,6 +16,7 @@ import (
 	"github.com/spf13/cobra"
 
 	kraftcloud "sdk.kraft.cloud"
+	kcinstances "sdk.kraft.cloud/instances"
 
 	"kraftkit.sh/cmdfactory"
 	"kraftkit.sh/config"
@@ -176,17 +177,19 @@ func Logs(ctx context.Context, opts *LogOptions, args ...string) error {
 									errGroup = append(errGroup, err)
 								}
 
-								consumer.Consume(
-									"",
-									fmt.Sprintf("The instance has exited (%s).", inst.DescribeStopReason()),
-									"",
-									"To see more details about why, run:",
-									"",
-									fmt.Sprintf("\tkraft cloud instance get %s", inst.Name),
-									"",
-								)
+								if inst.State == kcinstances.InstanceStateStopped {
+									consumer.Consume(
+										"",
+										fmt.Sprintf("The instance has exited (%s).", inst.DescribeStopReason()),
+										"",
+										"To see more details about why, run:",
+										"",
+										fmt.Sprintf("\tkraft cloud instance get %s", inst.Name),
+										"",
+									)
 
-								return
+									return
+								}
 							} else {
 								continue
 							}
@@ -214,15 +217,17 @@ func Logs(ctx context.Context, opts *LogOptions, args ...string) error {
 								errGroup = append(errGroup, err)
 							}
 
-							consumer.Consume(
-								"",
-								fmt.Sprintf("The instance has exited (%s).", inst.DescribeStopReason()),
-								"",
-								"To see more details about why, run:",
-								"",
-								fmt.Sprintf("\tkraft cloud instance get %s", inst.Name),
-								"",
-							)
+							if inst.State == kcinstances.InstanceStateStopped {
+								consumer.Consume(
+									"",
+									fmt.Sprintf("The instance has exited (%s).", inst.DescribeStopReason()),
+									"",
+									"To see more details about why, run:",
+									"",
+									fmt.Sprintf("\tkraft cloud instance get %s", inst.Name),
+									"",
+								)
+							}
 						}
 						return
 					}


### PR DESCRIPTION
Right now it also exits on the standby state which is more or less most of the use cases we have now

<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [ ] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [ ] Tested your changes against relevant architectures and platforms;
  - [ ] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->
