### PR TITLE
fix(internal): Build rootfs if no embedded initrd found

### DIFF
--- a/internal/cli/kraft/pkg/packager_kraftfile_unikraft.go
+++ b/internal/cli/kraft/pkg/packager_kraftfile_unikraft.go
@@ -102,7 +102,7 @@ func (p *packagerKraftfileUnikraft) Pack(ctx context.Context, opts *PkgOptions, 
 
 		// Reset the rootfs, such that it is not packaged as an initrd if it is
 		// already embedded inside of the kernel.
-		if opts.Project.KConfig().AnyYes(
+		if opts.Project.KConfig().AllNoOrUnset(
 			"CONFIG_LIBVFSCORE_ROOTFS_EINITRD", // Deprecated
 			"CONFIG_LIBVFSCORE_AUTOMOUNT_EINITRD",
 			"CONFIG_LIBVFSCORE_AUTOMOUNT_CI_EINITRD",


### PR DESCRIPTION
This ensures that when packaging we pack an initrd if we build code and we don't use embedded initrd, or if we don't use it in general.

<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [ ] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [ ] Tested your changes against relevant architectures and platforms;
  - [ ] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

cc @andreittr