### PR TITLE
fix(cloud): Append env from Kraftfile on deploy

### DIFF
--- a/internal/cli/kraft/cloud/deploy/deployer_kraftfile_runtime.go
+++ b/internal/cli/kraft/cloud/deploy/deployer_kraftfile_runtime.go
@@ -105,6 +105,14 @@ func (deployer *deployerKraftfileRuntime) Deploy(ctx context.Context, opts *Depl
 		)
 	}
 
+	if opts.Project != nil && opts.Project.Env() != nil {
+		var projectEnv []string
+		for k, v := range opts.Project.Env() {
+			projectEnv = append(projectEnv, fmt.Sprintf("%s=%s", k, v))
+		}
+		opts.Env = append(projectEnv, opts.Env...)
+	}
+
 	packs, err := pkg.Pkg(ctx, &pkg.PkgOptions{
 		Architecture:   "x86_64",
 		Compress:       opts.Compress,

--- a/unikraft/app/project_options.go
+++ b/unikraft/app/project_options.go
@@ -98,8 +98,11 @@ func (popts *ProjectOptions) RelativePath(path string) string {
 
 // LookupConfig provides a lookup function for config variables
 func (popts *ProjectOptions) LookupConfig(key string) (string, bool) {
-	v, ok := popts.kconfig[key]
-	return v.Value, ok
+	if v, ok := popts.kconfig[key]; ok {
+		return v.Value, true
+	}
+
+	return os.LookupEnv(key)
 }
 
 // SetProjectName sets the project name along with whether the name is set


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [x] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->
This fixes the ability to pass environment variables to instances when using the `kraft cloud deploy` command. It allows syntax with interpolation of the following form:

```Kraftfile
env:
  SPECIFIED: VALUE1
  INTERPOLATED: ${VALUE2:-DEFAULT}
```
