### PR TITLE
feat: use docker builder if available

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,8 +70,8 @@ CMAKE       ?= cmake
 # Go tools
 GOFUMPT_VERSION    ?= v0.7.0
 GOFUMPT            ?= $(GO) run mvdan.cc/gofumpt@$(GOFUMPT_VERSION)
-GOCILINT_VERSION   ?= v2.0.2
-GOCILINT           ?= $(GO) run github.com/golangci/golangci-lint/cmd/golangci-lint@$(GOCILINT_VERSION)
+GOCILINT_VERSION   ?= v2.4.0
+GOCILINT           ?= $(GO) run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOCILINT_VERSION)
 YTT_VERSION        ?= v0.51.0
 YTT                ?= $(GO) run carvel.dev/ytt/cmd/ytt@$(YTT_VERSION)
 GORELEASER_VERSION ?= v2.7.0

--- a/buildkit/buildkit.go
+++ b/buildkit/buildkit.go
@@ -1,0 +1,3 @@
+// The buildkit package provides various utilities and functions for working
+// with BuildKit.
+package buildkit

--- a/buildkit/buildkit.go
+++ b/buildkit/buildkit.go
@@ -1,3 +1,0 @@
-// The buildkit package provides various utilities and functions for working
-// with BuildKit.
-package buildkit

--- a/buildkit/connect.go
+++ b/buildkit/connect.go
@@ -1,0 +1,250 @@
+package buildkit
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"runtime/debug"
+	"strings"
+
+	"kraftkit.sh/config"
+	"kraftkit.sh/log"
+
+	"github.com/moby/buildkit/client"
+	"github.com/testcontainers/testcontainers-go"
+	tlog "github.com/testcontainers/testcontainers-go/log"
+	"github.com/testcontainers/testcontainers-go/wait"
+
+	_ "github.com/moby/buildkit/client/connhelper/dockercontainer"
+	_ "github.com/moby/buildkit/client/connhelper/kubepod"
+	_ "github.com/moby/buildkit/client/connhelper/nerdctlcontainer"
+	_ "github.com/moby/buildkit/client/connhelper/podmancontainer"
+	_ "github.com/moby/buildkit/client/connhelper/ssh"
+)
+
+func ConnectToBuildkit(ctx context.Context) (c *client.Client, cleanup func(), rerr error) {
+	var buildkitInfo *client.Info
+
+	// Check if there is a buildkit host configured
+	buildkitAddr := config.G[config.KraftKit](ctx).BuildKitHost
+	if buildkitAddr != "" {
+		c, err := client.New(ctx, buildkitAddr)
+		if err != nil {
+			return nil, nil, fmt.Errorf("creating buildkit client: %w", err)
+		}
+		buildkitInfo, err = c.Info(ctx)
+		if err != nil {
+			return nil, nil, fmt.Errorf("connecting to buildkit client: %w", err)
+		}
+
+		log.G(ctx).Info("using configured buildkit", "addr", buildkitAddr)
+	}
+
+	// If no other buildkits found, create an ephemeral container
+	if c == nil {
+		log.G(ctx).Info("creating ephemeral buildkit container")
+
+		buildkitVersion := getBuildkitVersion(ctx)
+
+		testcontainers.DefaultLoggingHook = testcontainersLoggingHook
+		printf := &testcontainersPrintf{ctx}
+		tlog.SetDefault(printf)
+
+		// Trap any errors with a helpful message for how to use buildkit
+		var connerr error
+		defer func() {
+			if connerr == nil {
+				return
+			}
+
+			log.G(ctx).Warnf("could not connect to BuildKit client '%s' is BuildKit running?", buildkitAddr)
+			log.G(ctx).Warn("")
+			log.G(ctx).Warn("By default, KraftKit will look for a native install which")
+			log.G(ctx).Warn("is located at /run/buildkit/buildkit.sock.  Alternatively, you")
+			log.G(ctx).Warn("can run BuildKit in a container (recommended for macOS users)")
+			log.G(ctx).Warn("which you can do by running:")
+			log.G(ctx).Warn("")
+			log.G(ctx).Warn("  docker run --rm -d --name buildkit --privileged moby/buildkit:" + buildkitVersion)
+			log.G(ctx).Warn("")
+			log.G(ctx).Warn("Depending on your container runtime, you should connect to Buildkit via:")
+			log.G(ctx).Warn("")
+			log.G(ctx).Warn("  export KRAFTKIT_BUILDKIT_HOST=docker-container://buildkit # for docker")
+			log.G(ctx).Warn("or")
+			log.G(ctx).Warn("  export KRAFTKIT_BUILDKIT_HOST=podman-container://buildkit # for podman")
+			log.G(ctx).Warn("")
+			log.G(ctx).Warn("For more usage instructions visit: https://unikraft.org/buildkit")
+			log.G(ctx).Warn("")
+		}()
+
+		// Port 0 means "give me any free port"
+		addr, err := net.ResolveTCPAddr("tcp", ":0")
+		if err != nil {
+			return nil, nil, err
+		}
+		l, err := net.ListenTCP("tcp", addr)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		port := l.Addr().(*net.TCPAddr).Port
+		_ = l.Close()
+
+		buildkitd, err := startBuildkit(ctx, buildkitVersion, port, printf)
+		if err != nil {
+			return nil, nil, fmt.Errorf("creating buildkit container: %w", err)
+		}
+
+		if buildkitd == nil {
+			return nil, nil, fmt.Errorf("could not start ephemeral BuildKit container")
+		}
+
+		cleanup = func() {
+			err := buildkitd.Terminate(ctx)
+			if err != nil && !strings.Contains(err.Error(), "context cancelled") {
+				log.G(ctx).
+					WithError(err).
+					Debug("terminating buildkit container")
+			}
+		}
+		defer func() {
+			if rerr != nil {
+				cleanup()
+			}
+		}()
+
+		buildkitAddr = fmt.Sprintf("tcp://localhost:%d", port)
+
+		c, connerr = client.New(ctx, buildkitAddr)
+		if connerr != nil {
+			return nil, nil, fmt.Errorf("creating container buildkit client: %w", connerr)
+		}
+		buildkitInfo, connerr = c.Info(ctx)
+		if connerr != nil {
+			return nil, nil, fmt.Errorf("connecting to container buildkit client: %w", err)
+		}
+	}
+
+	log.G(ctx).
+		WithField("addr", buildkitAddr).
+		WithField("version", buildkitInfo.BuildkitVersion.Version).
+		Debug("using buildkit")
+	return c, cleanup, nil
+}
+
+func startBuildkit(ctx context.Context, buildkitVersion string, port int, printf *testcontainersPrintf) (testcontainers.Container, error) {
+	// Trap any panics that occur when instantiating BuildKit through the
+	// testcontainers library. This is known happen if Docker is not installed.
+	// For more information see:
+	//
+	// https://github.com/unikraft/kraftkit/issues/2001
+	defer func() {
+		if r := recover(); r != nil {
+			log.G(ctx).Warn("could not start BuildKit ephemeral container")
+			log.G(ctx).Warn("this can be caused by Docker is either not running or inaccessible")
+			log.G(ctx).Warn("")
+			log.G(ctx).Warn("if you think this was caused by something else, please open an issue at:")
+			log.G(ctx).Warn("https://github.com/unikraft/kraftkit/issues")
+		}
+	}()
+	return testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
+		Started: true,
+		Logger:  printf,
+		ContainerRequest: testcontainers.ContainerRequest{
+			AlwaysPullImage: true,
+			Image:           "moby/buildkit:" + buildkitVersion,
+			WaitingFor:      wait.ForLog(fmt.Sprintf("running server on [::]:%d", port)),
+			Privileged:      true,
+			ExposedPorts:    []string{fmt.Sprintf("%d:%d/tcp", port, port)},
+			Cmd:             []string{"--addr", fmt.Sprintf("tcp://0.0.0.0:%d", port)},
+			Mounts: testcontainers.ContainerMounts{
+				{
+					Source: testcontainers.GenericVolumeMountSource{
+						Name: "kraftkit-buildkit-cache",
+					},
+					Target: "/var/lib/buildkit",
+				},
+			},
+		},
+	})
+}
+
+func getBuildkitVersion(ctx context.Context) string {
+	buildkitVersion := "latest"
+	if bi, ok := debug.ReadBuildInfo(); ok {
+		for _, dep := range bi.Deps {
+			if dep.Path == "github.com/moby/buildkit" {
+				buildkitVersion = dep.Version
+				break
+			}
+		}
+		log.G(ctx).Debug("could not determine BuildKit version from module list")
+	}
+	return buildkitVersion
+}
+
+var testcontainersLoggingHook = func(logger tlog.Logger) testcontainers.ContainerLifecycleHooks {
+	shortContainerID := func(c testcontainers.Container) string {
+		return c.GetContainerID()[:12]
+	}
+
+	return testcontainers.ContainerLifecycleHooks{
+		PreCreates: []testcontainers.ContainerRequestHook{
+			func(ctx context.Context, req testcontainers.ContainerRequest) error {
+				logger.Printf("creating container for image %s", req.Image)
+				return nil
+			},
+		},
+		PostCreates: []testcontainers.ContainerHook{
+			func(ctx context.Context, c testcontainers.Container) error {
+				logger.Printf("container created: %s", shortContainerID(c))
+				return nil
+			},
+		},
+		PreStarts: []testcontainers.ContainerHook{
+			func(ctx context.Context, c testcontainers.Container) error {
+				logger.Printf("starting container: %s", shortContainerID(c))
+				return nil
+			},
+		},
+		PostStarts: []testcontainers.ContainerHook{
+			func(ctx context.Context, c testcontainers.Container) error {
+				logger.Printf("container started: %s", shortContainerID(c))
+				return nil
+			},
+		},
+		PreStops: []testcontainers.ContainerHook{
+			func(ctx context.Context, c testcontainers.Container) error {
+				logger.Printf("stopping container: %s", shortContainerID(c))
+				return nil
+			},
+		},
+		PostStops: []testcontainers.ContainerHook{
+			func(ctx context.Context, c testcontainers.Container) error {
+				logger.Printf("container stopped: %s", shortContainerID(c))
+				return nil
+			},
+		},
+		PreTerminates: []testcontainers.ContainerHook{
+			func(ctx context.Context, c testcontainers.Container) error {
+				logger.Printf("terminating container: %s", shortContainerID(c))
+				return nil
+			},
+		},
+		PostTerminates: []testcontainers.ContainerHook{
+			func(ctx context.Context, c testcontainers.Container) error {
+				logger.Printf("container terminated: %s", shortContainerID(c))
+				return nil
+			},
+		},
+	}
+}
+
+type testcontainersPrintf struct {
+	ctx context.Context
+}
+
+func (t *testcontainersPrintf) Printf(format string, v ...any) {
+	if config.G[config.KraftKit](t.ctx).Log.Level == "trace" {
+		log.G(t.ctx).Tracef(format, v...)
+	}
+}

--- a/buildkit/connect.go
+++ b/buildkit/connect.go
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2025, Unikraft GmbH and The KraftKit Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
 package buildkit
 
 import (
@@ -11,6 +15,7 @@ import (
 	"kraftkit.sh/log"
 
 	"github.com/moby/buildkit/client"
+	dockerclient "github.com/moby/moby/client"
 	"github.com/testcontainers/testcontainers-go"
 	tlog "github.com/testcontainers/testcontainers-go/log"
 	"github.com/testcontainers/testcontainers-go/wait"
@@ -28,7 +33,8 @@ func ConnectToBuildkit(ctx context.Context) (c *client.Client, cleanup func(), r
 	// Check if there is a buildkit host configured
 	buildkitAddr := config.G[config.KraftKit](ctx).BuildKitHost
 	if buildkitAddr != "" {
-		c, err := client.New(ctx, buildkitAddr)
+		var err error
+		c, err = client.New(ctx, buildkitAddr)
 		if err != nil {
 			return nil, nil, fmt.Errorf("creating buildkit client: %w", err)
 		}
@@ -38,6 +44,42 @@ func ConnectToBuildkit(ctx context.Context) (c *client.Client, cleanup func(), r
 		}
 
 		log.G(ctx).Info("using configured buildkit", "addr", buildkitAddr)
+	}
+
+	// Check if the docker buildkit host can be used
+	// see logic from https://github.com/docker/buildx/blob/master/driver/docker/driver.go
+	if c == nil {
+		opt, ok := dockerBuildkit(ctx, nil)
+		if ok {
+			var err error
+			c, err = client.New(ctx, "", opt...)
+			if err != nil {
+				return nil, nil, fmt.Errorf("creating docker buildkit client: %w", err)
+			}
+			buildkitInfo, err = c.Info(ctx)
+			if err != nil {
+				return nil, nil, fmt.Errorf("connecting to docker buildkit client: %w", err)
+			}
+
+			// we need features that are *only* supported when the containerd
+			// snapshotter is enabled :(
+			var hasCtrdSnapshotter bool
+			workers, _ := c.ListWorkers(ctx)
+			for _, w := range workers {
+				if _, ok := w.Labels["org.mobyproject.buildkit.worker.snapshotter"]; ok {
+					hasCtrdSnapshotter = true
+				}
+			}
+			if !hasCtrdSnapshotter {
+				err = c.Close()
+				c = nil
+				log.G(ctx).Debug("closing docker buildkit client due to incompatible snapshotter", "error", err)
+			}
+
+			if c != nil {
+				log.G(ctx).Info("using docker buildkit")
+			}
+		}
 	}
 
 	// If no other buildkits found, create an ephemeral container
@@ -129,6 +171,27 @@ func ConnectToBuildkit(ctx context.Context) (c *client.Client, cleanup func(), r
 		WithField("version", buildkitInfo.BuildkitVersion.Version).
 		Debug("using buildkit")
 	return c, cleanup, nil
+}
+
+func dockerBuildkit(ctx context.Context, d dockerclient.APIClient) ([]client.ClientOpt, bool) {
+	d, err := dockerclient.New(dockerclient.FromEnv)
+	if err != nil {
+		return nil, false
+	}
+
+	_, err = d.ServerVersion(ctx, dockerclient.ServerVersionOptions{})
+	if err != nil {
+		return nil, false
+	}
+
+	opts := []client.ClientOpt{
+		client.WithContextDialer(func(context.Context, string) (net.Conn, error) {
+			return d.DialHijack(ctx, "/grpc", "h2c", nil)
+		}), client.WithSessionDialer(func(ctx context.Context, proto string, meta map[string][]string) (net.Conn, error) {
+			return d.DialHijack(ctx, "/session", proto, meta)
+		}),
+	}
+	return opts, true
 }
 
 func startBuildkit(ctx context.Context, buildkitVersion string, port int, printf *testcontainersPrintf) (testcontainers.Container, error) {

--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,7 @@ require (
 	github.com/containerd/nerdctl v1.7.7
 	github.com/containerd/platforms v1.0.0-rc.2
 	github.com/cpuguy83/go-md2man/v2 v2.0.7
-	github.com/cyphar/filepath-securejoin v0.5.1
+	github.com/cyphar/filepath-securejoin v0.6.0
 	github.com/dgraph-io/badger/v3 v3.2103.5
 	github.com/docker/cli v29.0.1+incompatible
 	github.com/docker/docker v28.5.2+incompatible
@@ -52,6 +52,7 @@ require (
 	github.com/mgutz/ansi v0.0.0-20200706080929-d51e80ef957d
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/moby/buildkit v0.25.1
+	github.com/moby/moby/client v0.2.1
 	github.com/muesli/reflow v0.3.0
 	github.com/muesli/termenv v0.16.0
 	github.com/onsi/ginkgo/v2 v2.27.2
@@ -91,6 +92,7 @@ require (
 )
 
 require (
+	cyphar.com/go-pathrs v0.2.1 // indirect
 	dario.cat/mergo v1.0.2 // indirect
 	github.com/AdaLogics/go-fuzz-headers v0.0.0-20240806141605-e8a1dd7889d6 // indirect
 	github.com/AdamKorcz/go-118-fuzz-build v0.0.0-20231105174938-2b5cbb29f3e2 // indirect
@@ -223,6 +225,7 @@ require (
 	github.com/moby/docker-image-spec v1.3.1 // indirect
 	github.com/moby/go-archive v0.1.0 // indirect
 	github.com/moby/locker v1.0.1 // indirect
+	github.com/moby/moby/api v1.52.0 // indirect
 	github.com/moby/patternmatcher v0.6.0 // indirect
 	github.com/moby/sys/capability v0.4.0 // indirect
 	github.com/moby/sys/mountinfo v0.7.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -23,6 +23,8 @@ cloud.google.com/go/pubsub v1.2.0/go.mod h1:jhfEVHT8odbXTkndysNHCcx0awwzvfOlguIA
 cloud.google.com/go/storage v1.0.0/go.mod h1:IhtSnM/ZTZV8YYJWCY8RULGVqBDmpoyjwiyrjsg+URw=
 cloud.google.com/go/storage v1.5.0/go.mod h1:tpKbwo567HUNpVclU5sGELwQWBDZ8gh0ZeosJ0Rtdos=
 cloud.google.com/go/storage v1.6.0/go.mod h1:N7U0C8pVQ/+NIKOBQyamJIeKQKkZ+mxpohlUTyfDhBk=
+cyphar.com/go-pathrs v0.2.1 h1:9nx1vOgwVvX1mNBWDu93+vaceedpbsDqo+XuBGL40b8=
+cyphar.com/go-pathrs v0.2.1/go.mod h1:y8f1EMG7r+hCuFf/rXsKqMJrJAUoADZGNh5/vZPKcGc=
 dario.cat/mergo v1.0.2 h1:85+piFYR1tMbRrLcDwR18y4UKJ3aH1Tbzi24VRW1TK8=
 dario.cat/mergo v1.0.2/go.mod h1:E/hbnu0NxMFBjpMIE34DRGLWqDy0g5FuKDhCb31ngxA=
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
@@ -379,8 +381,8 @@ github.com/creack/pty v1.1.24/go.mod h1:08sCNb52WyoAwi2QDyzUCTgcvVFhUzewun7wtTfv
 github.com/cyberphone/json-canonicalization v0.0.0-20241213102144-19d51d7fe467 h1:uX1JmpONuD549D73r6cgnxyUu18Zb7yHAy5AYU0Pm4Q=
 github.com/cyberphone/json-canonicalization v0.0.0-20241213102144-19d51d7fe467/go.mod h1:uzvlm1mxhHkdfqitSA92i7Se+S9ksOn3a3qmv/kyOCw=
 github.com/cyphar/filepath-securejoin v0.2.2/go.mod h1:FpkQEhXnPnOthhzymB7CGsFk2G9VLXONKD9G7QGMM+4=
-github.com/cyphar/filepath-securejoin v0.5.1 h1:eYgfMq5yryL4fbWfkLpFFy2ukSELzaJOTaUTuh+oF48=
-github.com/cyphar/filepath-securejoin v0.5.1/go.mod h1:Sdj7gXlvMcPZsbhwhQ33GguGLDGQL7h7bg04C/+u9jI=
+github.com/cyphar/filepath-securejoin v0.6.0 h1:BtGB77njd6SVO6VztOHfPxKitJvd/VPT+OFBFMOi1Is=
+github.com/cyphar/filepath-securejoin v0.6.0/go.mod h1:A8hd4EnAeyujCJRrICiOWqjS1AX0a9kM5XL+NwKoYSc=
 github.com/d2g/dhcp4 v0.0.0-20170904100407-a1d1b6c41b1c/go.mod h1:Ct2BUK8SB0YC1SMSibvLzxjeJLnrYEVLULFNiHY9YfQ=
 github.com/d2g/dhcp4client v1.0.0/go.mod h1:j0hNfjhrt2SxUOw55nL0ATM/z4Yt3t2Kd1mW34z5W5s=
 github.com/d2g/dhcp4server v0.0.0-20181031114812-7d4a0a7f59a5/go.mod h1:Eo87+Kg/IX2hfWJfwxMzLyuSZyxSoAug2nGa1G2QAi8=
@@ -928,6 +930,10 @@ github.com/moby/go-archive v0.1.0 h1:Kk/5rdW/g+H8NHdJW2gsXyZ7UnzvJNOy6VKJqueWdcQ
 github.com/moby/go-archive v0.1.0/go.mod h1:G9B+YoujNohJmrIYFBpSd54GTUB4lt9S+xVQvsJyFuo=
 github.com/moby/locker v1.0.1 h1:fOXqR41zeveg4fFODix+1Ch4mj/gT0NE1XJbp/epuBg=
 github.com/moby/locker v1.0.1/go.mod h1:S7SDdo5zpBK84bzzVlKr2V0hz+7x9hWbYC/kq7oQppc=
+github.com/moby/moby/api v1.52.0 h1:00BtlJY4MXkkt84WhUZPRqt5TvPbgig2FZvTbe3igYg=
+github.com/moby/moby/api v1.52.0/go.mod h1:8mb+ReTlisw4pS6BRzCMts5M49W5M7bKt1cJy/YbAqc=
+github.com/moby/moby/client v0.2.1 h1:1Grh1552mvv6i+sYOdY+xKKVTvzJegcVMhuXocyDz/k=
+github.com/moby/moby/client v0.2.1/go.mod h1:O+/tw5d4a1Ha/ZA/tPxIZJapJRUS6LNZ1wiVRxYHyUE=
 github.com/moby/patternmatcher v0.6.0 h1:GmP9lR19aU5GqSSFko+5pRqHi+Ohk1O69aFiKkVGiPk=
 github.com/moby/patternmatcher v0.6.0/go.mod h1:hDPoyOpDY7OrrMDLaYoY3hf52gNCR/YOUYxkhApJIxc=
 github.com/moby/sys/atomicwriter v0.1.0 h1:kw5D/EqkBwsBFi0ss9v1VG3wIkVhzGvLklJ+w3A14Sw=
@@ -1905,6 +1911,8 @@ k8s.io/utils v0.0.0-20250604170112-4c0f3b243397 h1:hwvWFiBzdWw1FhfY1FooPn3kzWuJ8
 k8s.io/utils v0.0.0-20250604170112-4c0f3b243397/go.mod h1:OLgZIPagt7ERELqWJFomSt595RzquPNLL48iOWgYOg0=
 oras.land/oras-go/v2 v2.6.0 h1:X4ELRsiGkrbeox69+9tzTu492FMUu7zJQW6eJU+I2oc=
 oras.land/oras-go/v2 v2.6.0/go.mod h1:magiQDfG6H1O9APp+rOsvCPcW1GD2MM7vgnKY0Y+u1o=
+pgregory.net/rapid v1.2.0 h1:keKAYRcjm+e1F0oAuU5F5+YPAWcyxNNRK2wud503Gnk=
+pgregory.net/rapid v1.2.0/go.mod h1:PY5XlDGj0+V1FCq0o192FdRhpKHGTRIWBgqjDBTrq04=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
 rsc.io/quote/v3 v3.1.0/go.mod h1:yEA65RcK8LyAZtP9Kv3t0HmxON59tX3rD+tICJqUlj0=
 rsc.io/sampler v1.3.0/go.mod h1:T1hPZKmBbMNahiBKFy5HrXp6adAjACjK9JXDnKaTXpA=

--- a/initrd/dockerfile.go
+++ b/initrd/dockerfile.go
@@ -9,16 +9,15 @@ import (
 	"encoding/csv"
 	"fmt"
 	"io"
-	"net"
 	"os"
 	"path/filepath"
-	"runtime/debug"
 	"strings"
 
 	"golang.org/x/sync/errgroup"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	"kraftkit.sh/buildkit"
 	"kraftkit.sh/cmdfactory"
 	"kraftkit.sh/config"
 	"kraftkit.sh/fs/cpio"
@@ -35,9 +34,6 @@ import (
 	"github.com/moby/buildkit/session/secrets/secretsprovider"
 	"github.com/moby/buildkit/session/sshforward/sshprovider"
 	"github.com/moby/buildkit/util/progress/progressui"
-	"github.com/testcontainers/testcontainers-go"
-	tlog "github.com/testcontainers/testcontainers-go/log"
-	"github.com/testcontainers/testcontainers-go/wait"
 
 	_ "github.com/moby/buildkit/client/connhelper/dockercontainer"
 	_ "github.com/moby/buildkit/client/connhelper/kubepod"
@@ -89,73 +85,6 @@ func init() {
 				"Supply secrets when building Dockerfile",
 			),
 		)
-	}
-}
-
-var testcontainersLoggingHook = func(logger tlog.Logger) testcontainers.ContainerLifecycleHooks {
-	shortContainerID := func(c testcontainers.Container) string {
-		return c.GetContainerID()[:12]
-	}
-
-	return testcontainers.ContainerLifecycleHooks{
-		PreCreates: []testcontainers.ContainerRequestHook{
-			func(ctx context.Context, req testcontainers.ContainerRequest) error {
-				logger.Printf("creating container for image %s", req.Image)
-				return nil
-			},
-		},
-		PostCreates: []testcontainers.ContainerHook{
-			func(ctx context.Context, c testcontainers.Container) error {
-				logger.Printf("container created: %s", shortContainerID(c))
-				return nil
-			},
-		},
-		PreStarts: []testcontainers.ContainerHook{
-			func(ctx context.Context, c testcontainers.Container) error {
-				logger.Printf("starting container: %s", shortContainerID(c))
-				return nil
-			},
-		},
-		PostStarts: []testcontainers.ContainerHook{
-			func(ctx context.Context, c testcontainers.Container) error {
-				logger.Printf("container started: %s", shortContainerID(c))
-				return nil
-			},
-		},
-		PreStops: []testcontainers.ContainerHook{
-			func(ctx context.Context, c testcontainers.Container) error {
-				logger.Printf("stopping container: %s", shortContainerID(c))
-				return nil
-			},
-		},
-		PostStops: []testcontainers.ContainerHook{
-			func(ctx context.Context, c testcontainers.Container) error {
-				logger.Printf("container stopped: %s", shortContainerID(c))
-				return nil
-			},
-		},
-		PreTerminates: []testcontainers.ContainerHook{
-			func(ctx context.Context, c testcontainers.Container) error {
-				logger.Printf("terminating container: %s", shortContainerID(c))
-				return nil
-			},
-		},
-		PostTerminates: []testcontainers.ContainerHook{
-			func(ctx context.Context, c testcontainers.Container) error {
-				logger.Printf("container terminated: %s", shortContainerID(c))
-				return nil
-			},
-		},
-	}
-}
-
-type testcontainersPrintf struct {
-	ctx context.Context
-}
-
-func (t *testcontainersPrintf) Printf(format string, v ...interface{}) {
-	if config.G[config.KraftKit](t.ctx).Log.Level == "trace" {
-		log.G(t.ctx).Tracef(format, v...)
 	}
 }
 
@@ -216,43 +145,6 @@ func (initrd *dockerfile) Name() string {
 	return "Dockerfile"
 }
 
-func startBuildkit(ctx context.Context, buildkitVersion string, port int, printf *testcontainersPrintf) (testcontainers.Container, error) {
-	// Trap any panics that occur when instantiating BuildKit through the
-	// testcontainers library. This is known happen if Docker is not installed.
-	// For more information see:
-	//
-	// https://github.com/unikraft/kraftkit/issues/2001
-	defer func() {
-		if r := recover(); r != nil {
-			log.G(ctx).Warn("could not start BuildKit ephemeral container")
-			log.G(ctx).Warn("this can be caused by Docker is either not running or inaccessible")
-			log.G(ctx).Warn("")
-			log.G(ctx).Warn("if you think this was caused by something else, please open an issue at:")
-			log.G(ctx).Warn("https://github.com/unikraft/kraftkit/issues")
-		}
-	}()
-	return testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
-		Started: true,
-		Logger:  printf,
-		ContainerRequest: testcontainers.ContainerRequest{
-			AlwaysPullImage: true,
-			Image:           "moby/buildkit:" + buildkitVersion,
-			WaitingFor:      wait.ForLog(fmt.Sprintf("running server on [::]:%d", port)),
-			Privileged:      true,
-			ExposedPorts:    []string{fmt.Sprintf("%d:%d/tcp", port, port)},
-			Cmd:             []string{"--addr", fmt.Sprintf("tcp://0.0.0.0:%d", port)},
-			Mounts: testcontainers.ContainerMounts{
-				{
-					Source: testcontainers.GenericVolumeMountSource{
-						Name: "kraftkit-buildkit-cache",
-					},
-					Target: "/var/lib/buildkit",
-				},
-			},
-		},
-	})
-}
-
 // Build implements Initrd.
 func (initrd *dockerfile) Build(ctx context.Context) (string, error) {
 	if initrd.opts.output == "" {
@@ -278,95 +170,13 @@ func (initrd *dockerfile) Build(ctx context.Context) (string, error) {
 	defer ociOutput.Close()
 	defer os.RemoveAll(ociOutput.Name())
 
-	buildkitAddr := config.G[config.KraftKit](ctx).BuildKitHost
-	c, _ := client.New(ctx, buildkitAddr)
-	buildKitInfo, connerr := c.Info(ctx)
-	if connerr != nil {
-		log.G(ctx).Info("creating ephemeral buildkit container")
-
-		buildkitVersion := "latest"
-		if bi, ok := debug.ReadBuildInfo(); ok {
-			for _, dep := range bi.Deps {
-				if dep.Path == "github.com/moby/buildkit" {
-					buildkitVersion = dep.Version
-					break
-				}
-			}
-			log.G(ctx).Debug("could not determine BuildKit version from module list")
-		}
-
-		testcontainers.DefaultLoggingHook = testcontainersLoggingHook
-		printf := &testcontainersPrintf{ctx}
-		tlog.SetDefault(printf)
-
-		// Trap any errors with a helpful message for how to use buildkit
-		defer func() {
-			if connerr == nil {
-				return
-			}
-
-			log.G(ctx).Warnf("could not connect to BuildKit client '%s' is BuildKit running?", buildkitAddr)
-			log.G(ctx).Warn("")
-			log.G(ctx).Warn("By default, KraftKit will look for a native install which")
-			log.G(ctx).Warn("is located at /run/buildkit/buildkit.sock.  Alternatively, you")
-			log.G(ctx).Warn("can run BuildKit in a container (recommended for macOS users)")
-			log.G(ctx).Warn("which you can do by running:")
-			log.G(ctx).Warn("")
-			log.G(ctx).Warn("  docker run --rm -d --name buildkit --privileged moby/buildkit:" + buildkitVersion)
-			log.G(ctx).Warn("")
-			log.G(ctx).Warn("Depending on your container runtime, you should connect to Buildkit via:")
-			log.G(ctx).Warn("")
-			log.G(ctx).Warn("  export KRAFTKIT_BUILDKIT_HOST=docker-container://buildkit # for docker")
-			log.G(ctx).Warn("or")
-			log.G(ctx).Warn("  export KRAFTKIT_BUILDKIT_HOST=podman-container://buildkit # for podman")
-			log.G(ctx).Warn("")
-			log.G(ctx).Warn("For more usage instructions visit: https://unikraft.org/buildkit")
-			log.G(ctx).Warn("")
-		}()
-
-		// Port 0 means "give me any free port"
-		addr, err := net.ResolveTCPAddr("tcp", ":0")
-		if err != nil {
-			return "", err
-		}
-		l, err := net.ListenTCP("tcp", addr)
-		if err != nil {
-			return "", err
-		}
-
-		port := l.Addr().(*net.TCPAddr).Port
-		_ = l.Close()
-
-		buildkitd, err := startBuildkit(ctx, buildkitVersion, port, printf)
-		if err != nil {
-			return "", fmt.Errorf("creating buildkit container: %w", err)
-		}
-
-		if buildkitd == nil {
-			return "", fmt.Errorf("could not start ephemeral BuildKit container")
-		}
-
-		defer func() {
-			if err := buildkitd.Terminate(ctx); err != nil && !strings.Contains(err.Error(), "context cancelled") {
-				log.G(ctx).
-					WithError(err).
-					Debug("terminating buildkit container")
-			}
-		}()
-
-		buildkitAddr = fmt.Sprintf("tcp://localhost:%d", port)
-
-		c, _ = client.New(ctx, buildkitAddr)
-		buildKitInfo, connerr = c.Info(ctx)
-		if err != nil {
-			return "", fmt.Errorf("connecting to container buildkit client: %w", err)
-		}
+	c, cleanup, err := buildkit.ConnectToBuildkit(ctx)
+	if err != nil {
+		return "", fmt.Errorf("could not connect to buildkit: %w", err)
 	}
-
-	log.G(ctx).
-		WithField("addr", buildkitAddr).
-		WithField("version", buildKitInfo.BuildkitVersion.Version).
-		Debug("using buildkit")
+	if cleanup != nil {
+		defer cleanup()
+	}
 
 	var cacheExports []client.CacheOptionsEntry
 	if len(initrd.opts.cacheDir) > 0 {


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [x] Updated relevant documentation.

### Description of changes

Splits out buildkit connection code to a new package, and additionally tries to connect to the default docker daemon! This avoids spinning up things with testcontainers, which we can aim to completely rip-out long term (by using `buildx`).

This is just a first step, but should be a good start!