### PR TITLE
fix(buildkit): regression in buildkit default address

### DIFF
--- a/buildkit/connect.go
+++ b/buildkit/connect.go
@@ -15,6 +15,7 @@ import (
 	"kraftkit.sh/log"
 
 	"github.com/moby/buildkit/client"
+	bkappdefaults "github.com/moby/buildkit/util/appdefaults"
 	dockerclient "github.com/moby/moby/client"
 	"github.com/testcontainers/testcontainers-go"
 	tlog "github.com/testcontainers/testcontainers-go/log"
@@ -42,43 +43,35 @@ func ConnectToBuildkit(ctx context.Context) (c *client.Client, cleanup func(), r
 		if err != nil {
 			return nil, nil, fmt.Errorf("connecting to buildkit client: %w", err)
 		}
-
 		log.G(ctx).Info("using configured buildkit", "addr", buildkitAddr)
 	}
 
-	// Check if the docker buildkit host can be used
-	// see logic from https://github.com/docker/buildx/blob/master/driver/docker/driver.go
+	// Check if the default buildkit socket is available
 	if c == nil {
-		opt, ok := dockerBuildkit(ctx, nil)
-		if ok {
-			var err error
-			c, err = client.New(ctx, "", opt...)
-			if err != nil {
-				return nil, nil, fmt.Errorf("creating docker buildkit client: %w", err)
-			}
-			buildkitInfo, err = c.Info(ctx)
-			if err != nil {
-				return nil, nil, fmt.Errorf("connecting to docker buildkit client: %w", err)
-			}
+		var err error
+		c, err = client.New(ctx, bkappdefaults.Address)
+		if err != nil {
+			return nil, nil, fmt.Errorf("creating default buildkit client: %w", err)
+		}
+		buildkitInfo, err = c.Info(ctx)
+		if err != nil {
+			c.Close()
+			c = nil
+		}
+		if c != nil {
+			log.G(ctx).Info("using default buildkit socket")
+		}
+	}
 
-			// we need features that are *only* supported when the containerd
-			// snapshotter is enabled :(
-			var hasCtrdSnapshotter bool
-			workers, _ := c.ListWorkers(ctx)
-			for _, w := range workers {
-				if _, ok := w.Labels["org.mobyproject.buildkit.worker.snapshotter"]; ok {
-					hasCtrdSnapshotter = true
-				}
-			}
-			if !hasCtrdSnapshotter {
-				err = c.Close()
-				c = nil
-				log.G(ctx).Debug("closing docker buildkit client due to incompatible snapshotter", "error", err)
-			}
-
-			if c != nil {
-				log.G(ctx).Info("using docker buildkit")
-			}
+	// Check if the docker buildkit host can be used
+	if c == nil {
+		var err error
+		c, buildkitInfo, err = dockerBuildkit(ctx)
+		if err != nil {
+			return nil, nil, err
+		}
+		if c != nil {
+			log.G(ctx).Info("using docker buildkit")
 		}
 	}
 
@@ -162,7 +155,7 @@ func ConnectToBuildkit(ctx context.Context) (c *client.Client, cleanup func(), r
 		}
 		buildkitInfo, connerr = c.Info(ctx)
 		if connerr != nil {
-			return nil, nil, fmt.Errorf("connecting to container buildkit client: %w", err)
+			return nil, nil, fmt.Errorf("connecting to buildkit client: %w", connerr)
 		}
 	}
 
@@ -173,15 +166,16 @@ func ConnectToBuildkit(ctx context.Context) (c *client.Client, cleanup func(), r
 	return c, cleanup, nil
 }
 
-func dockerBuildkit(ctx context.Context, d dockerclient.APIClient) ([]client.ClientOpt, bool) {
+// see logic from https://github.com/docker/buildx/blob/master/driver/docker/driver.go
+func dockerBuildkit(ctx context.Context) (*client.Client, *client.Info, error) {
 	d, err := dockerclient.New(dockerclient.FromEnv)
 	if err != nil {
-		return nil, false
+		return nil, nil, nil
 	}
 
 	_, err = d.ServerVersion(ctx, dockerclient.ServerVersionOptions{})
 	if err != nil {
-		return nil, false
+		return nil, nil, nil
 	}
 
 	opts := []client.ClientOpt{
@@ -191,7 +185,33 @@ func dockerBuildkit(ctx context.Context, d dockerclient.APIClient) ([]client.Cli
 			return d.DialHijack(ctx, "/session", proto, meta)
 		}),
 	}
-	return opts, true
+
+	c, err := client.New(ctx, "", opts...)
+	if err != nil {
+		return nil, nil, fmt.Errorf("creating docker buildkit client: %w", err)
+	}
+
+	// we need features that are *only* supported when the containerd
+	// snapshotter is enabled :(
+	var hasCtrdSnapshotter bool
+	workers, err := c.ListWorkers(ctx)
+	if err != nil {
+		return nil, nil, c.Close()
+	}
+	for _, w := range workers {
+		if _, ok := w.Labels["org.mobyproject.buildkit.worker.snapshotter"]; ok {
+			hasCtrdSnapshotter = true
+		}
+	}
+	if !hasCtrdSnapshotter {
+		return nil, nil, c.Close()
+	}
+
+	info, err := c.Info(ctx)
+	if err != nil {
+		return nil, nil, c.Close()
+	}
+	return c, info, nil
 }
 
 func startBuildkit(ctx context.Context, buildkitVersion string, port int, printf *testcontainersPrintf) (testcontainers.Container, error) {

--- a/buildkit/connect.go
+++ b/buildkit/connect.go
@@ -253,17 +253,15 @@ func startBuildkit(ctx context.Context, buildkitVersion string, port int, printf
 }
 
 func getBuildkitVersion(ctx context.Context) string {
-	buildkitVersion := "latest"
 	if bi, ok := debug.ReadBuildInfo(); ok {
 		for _, dep := range bi.Deps {
 			if dep.Path == "github.com/moby/buildkit" {
-				buildkitVersion = dep.Version
-				break
+				return dep.Version
 			}
 		}
-		log.G(ctx).Debug("could not determine BuildKit version from module list")
 	}
-	return buildkitVersion
+	log.G(ctx).Debug("could not determine BuildKit version from module list")
+	return "latest"
 }
 
 var testcontainersLoggingHook = func(logger tlog.Logger) testcontainers.ContainerLifecycleHooks {

--- a/buildkit/connect.go
+++ b/buildkit/connect.go
@@ -43,7 +43,7 @@ func ConnectToBuildkit(ctx context.Context) (c *client.Client, cleanup func(), r
 		if err != nil {
 			return nil, nil, fmt.Errorf("connecting to buildkit client: %w", err)
 		}
-		log.G(ctx).Info("using configured buildkit", "addr", buildkitAddr)
+		log.G(ctx).WithField("addr", buildkitAddr).Info("using configured buildkit")
 	}
 
 	// Check if the default buildkit socket is available
@@ -77,9 +77,10 @@ func ConnectToBuildkit(ctx context.Context) (c *client.Client, cleanup func(), r
 
 	// If no other buildkits found, create an ephemeral container
 	if c == nil {
-		log.G(ctx).Info("creating ephemeral buildkit container")
-
 		buildkitVersion := getBuildkitVersion(ctx)
+		log.G(ctx).
+			WithField("version", buildkitVersion).
+			Info("creating ephemeral buildkit container")
 
 		testcontainers.DefaultLoggingHook = testcontainersLoggingHook
 		printf := &testcontainersPrintf{ctx}


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [x] Updated relevant documentation.

### Description of changes

See individual commits for more detail.

This PR fixes the regression introduced in https://github.com/unikraft/kraftkit/pull/2575 - we need to connect to `/run/buildkit/buildkitd.sock` if it's available. This was being *implicitly* done - this adds it explicitly.

The behavior is still slightly different (from before #2575). If `KRAFTKIT_BUILDKIT_HOST` is set, then we don't allow a silent failure. All the other options (e.g. `/run/buildkit/buildkitd.sock`, and the builtin docker buildkit) should fail gracefully, until there are no more options left.

We also fix some logging weirdness that made debugging this a bit harder than it needed to be.