### PR TITLE
fix(test): Change used feature to adapt to new metro

### DIFF
--- a/test/e2e/cloud/instance_create_test.go
+++ b/test/e2e/cloud/instance_create_test.go
@@ -2526,7 +2526,7 @@ var _ = Describe("kraft cloud instance create", func() {
 	})
 
 	// '--feature' flag tests
-	When("invoked with standard flags and positional arguments, and the scale to zero feature", func() {
+	When("invoked with standard flags and positional arguments, and the delete-on-stop feature", func() {
 		var instanceNameFull string
 
 		BeforeEach(func() {
@@ -2540,12 +2540,13 @@ var _ = Describe("kraft cloud instance create", func() {
 				"--port", instancePortMap,
 				"--memory", instanceMemory,
 				"--name", instanceNameFull,
-				"--feature", "scale-to-zero",
+				"--feature", "delete-on-stop",
+				"--start",
 				imageName,
 			)
 		})
 
-		It("should enable scale to zero and work", func() {
+		It("should enable delete-on-stop and work", func() {
 			err := cmd.Run()
 			time.Sleep(2 * time.Second)
 			if err != nil {
@@ -2555,7 +2556,7 @@ var _ = Describe("kraft cloud instance create", func() {
 
 			Expect(stderr.String()).To(BeEmpty())
 			Expect(stdout.String()).ToNot(BeEmpty())
-			Expect(stdout.String()).To(MatchRegexp(`"state":"standby"`))
+			Expect(stdout.String()).To(MatchRegexp(`"state":"running"`))
 			Expect(stdout.String()).To(MatchRegexp("\"image\":\"" + strings.SplitN(imageName, ":", 2)[0]))
 			Expect(stdout.String()).To(MatchRegexp("\"memory\":\"" + instanceMemory + " MiB\""))
 


### PR DESCRIPTION
In new versions scale-to-zero is no longer a valid feature to use as it has been made standalone. Use a different feature to test the flag: delete-on-stop

<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [ ] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->
