### PR TITLE
ci: group dependabot updates together

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,10 @@ version: 2
 updates:
 
   - package-ecosystem: gomod
-    directory: /
+    directories:
+      - /
+      - /tools/protoc-gen-go-netconn
+      - /tools/go-generate-qemu-devices
     target-branch: staging
     schedule:
       interval: weekly
@@ -12,26 +15,11 @@ updates:
     commit-message:
       prefix: gomod # Prefix messages with
       include: scope # List all updated dependencies
-  - package-ecosystem: gomod
-    directory: /tools/go-generate-qemu-devices
-    target-branch: staging
-    schedule:
-      interval: weekly
-      day: sunday
-      time: '09:00'
-    commit-message:
-      prefix: gomod # Prefix messages with
-      include: scope # List all updated dependencies
-  - package-ecosystem: gomod
-    directory: /tools/protoc-gen-go-netconn
-    target-branch: staging
-    schedule:
-      interval: weekly
-      day: sunday
-      time: '09:00'
-    commit-message:
-      prefix: gomod # Prefix messages with
-      include: scope # List all updated dependencies
+    groups:
+      go-deps:
+        applies-to: version-updates
+        patterns:
+          - "*"
 
   - package-ecosystem: github-actions
     directory: /


### PR DESCRIPTION
Having lots of little PRs is very annoying. We should group them together.

<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [x] Updated relevant documentation.
