### PR TITLE
fix(pkg): Remove unnecessary shellwords parsing

### DIFF
--- a/internal/cli/kraft/pkg/packager_kraftfile_runtime.go
+++ b/internal/cli/kraft/pkg/packager_kraftfile_runtime.go
@@ -11,7 +11,6 @@ import (
 	"os"
 	"strings"
 
-	"github.com/mattn/go-shellwords"
 	"kraftkit.sh/config"
 	"kraftkit.sh/initrd"
 	"kraftkit.sh/internal/cli/kraft/utils"
@@ -417,14 +416,6 @@ func (p *packagerKraftfileRuntime) Pack(ctx context.Context, opts *PkgOptions, a
 			p.args = rootfsArgs
 		} else if p.target != nil && len(p.target.Command()) > 0 {
 			p.args = p.target.Command()
-		}
-	}
-
-	// Only parse arguments if they have been provided.
-	if len(p.args) > 0 {
-		p.args, err = shellwords.Parse(fmt.Sprintf("'%s'", strings.Join(p.args, "' '")))
-		if err != nil {
-			return nil, err
 		}
 	}
 


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [x] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->
This fixes an issue where the arguments list is parsed twice, transforming it into a single-element array and removing inner quotes from the arguments (that should be preserved).
