### PR TITLE
fix(paraprogress): avoid race condition

### DIFF
--- a/tui/paraprogress/process.go
+++ b/tui/paraprogress/process.go
@@ -147,7 +147,7 @@ func (p *Process) Start() tea.Cmd {
 		return nil
 	})
 
-	return tea.Batch(cmds...)
+	return tea.Sequence(cmds...)
 }
 
 // onProgress is called to dynamically inject ProgressMsg into the bubbletea


### PR DESCRIPTION
It seems possible to trigger a weird race condition in which the status is not marked as success/failed, and so the progress spinner never exits. This previously wasn't a problem, since it seems like we would exit when the progress reached 1.0. However, a recent change modifies that.

My *hunch* is that batching all the cmds in start is causing this - these are run in parallel, so could be racy. It seems possible that:
- The process is run
- The process finished and we send StatusMsg = success
- We send StatusMsg = running, resetting the state back to running This means that a process can end up in a running state forever.

This is definitely a *possible* race condition (that's worth fixing), I'm just not 100% sure it's exactly the one Artūrs was seeing.

[Stack trace](https://github.com/user-attachments/files/24107943/message.txt)

The bug appeared between v0.12.3 and v0.12.4, so:

```
$ ❯ git log v0.12.4...v0.12.3 tui/paraprogress
commit 7a3f80a52d6846973a392e1ad58b6cc7a0d005df
Author: Alexander Jung <alex@unikraft.com>
Date:   Sat Nov 1 11:12:49 2025 -0700

    fix(paraprogress): Properly wait for process to finish
    
    Instead of relying on when the progress hits 100% (or 1.0) to
    exit, continue until the process exits.  This change prevents
    the process from prematurely exiting.
    
    Signed-off-by: Alexander Jung <alex@unikraft.com>

commit 336a173a3bc7ac84702d4955105a07907fb9f6d3 (internal/craciunoiuc/fix-new-tui-usage)
Author: Cezar Craciunoiu <cezar.craciunoiu@unikraft.io>
Date:   Mon Oct 20 13:41:27 2025 +0300

    refactor(tui): Adapt timers/spinners to new package format
    
    Signed-off-by: Cezar Craciunoiu <cezar.craciunoiu@unikraft.io>
```

This feels kinda close.

<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

  Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes against relevant architectures and platforms;
  - [x] Ran `make fmt` on your commit series before opening this PR;
  - [x] Updated relevant documentation.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

