### PR TITLE
chore(.github): Ignore 'k8s.io/api' bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,6 +19,7 @@ updates:
       # We've not been taking these, and they require a lot of code changes to resolve.
       - dependency-name: "k8s.io/apimachinery"
       - dependency-name: "k8s.io/apiserver"
+      - dependency-name: "k8s.io/api"
       # HACK: pending resolution of https://github.com/containerd/containerd/issues/12493
       - dependency-name: "github.com/opencontainers/runc"
       - dependency-name: "github.com/opencontainers/runtime-spec"


### PR DESCRIPTION
Bumps to this while ignoring the others caused mismatches between the three. Also as of v0.35.0 they added a runtime check to fail if a mismatch happened. Thus we need to also remove this from further bumps.

<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [ ] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [ ] Tested your changes locally.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->
