### PR TITLE
fix(app): Add safe type assertions in Kraftfile parsing

### DIFF
--- a/unikraft/app/project.go
+++ b/unikraft/app/project.go
@@ -104,11 +104,19 @@ func NewProjectFromOptions(ctx context.Context, opts ...ProjectOption) (Applicat
 
 	iface = groupXFieldsIntoExtensions(iface)
 	if n, ok := iface["name"]; ok {
-		name = n.(string)
+		nameStr, ok := n.(string)
+		if !ok {
+			return nil, fmt.Errorf("malformed Kraftfile: 'name' field must be a string, got %T", n)
+		}
+		name = nameStr
 	}
 
 	if n, ok := iface["outdir"]; ok {
-		name = n.(string)
+		outdirStr, ok := n.(string)
+		if !ok {
+			return nil, fmt.Errorf("malformed Kraftfile: 'outdir' field must be a string, got %T", n)
+		}
+		outdir = outdirStr
 	}
 
 	popts.kraftfile.config = iface

--- a/unikraft/app/transform.go
+++ b/unikraft/app/transform.go
@@ -149,7 +149,11 @@ func transformMappingOrList(mappingOrList interface{}, sep string, allowNil bool
 	case []interface{}:
 		result := make(map[string]interface{})
 		for _, value := range value {
-			key, val := transformValueToMapEntry(value.(string), sep, allowNil)
+			strValue, ok := value.(string)
+			if !ok {
+				return nil, errors.Errorf("malformed Kraftfile: expected string in list, got %T", value)
+			}
+			key, val := transformValueToMapEntry(strValue, sep, allowNil)
 			result[key] = val
 		}
 		return result, nil

--- a/unikraft/app/volume/transform.go
+++ b/unikraft/app/volume/transform.go
@@ -38,16 +38,32 @@ func TransformFromSchema(ctx context.Context, data interface{}) (interface{}, er
 		for key, prop := range entry {
 			switch key {
 			case "driver":
-				volume.driver = prop.(string)
+				driverStr, ok := prop.(string)
+				if !ok {
+					return nil, fmt.Errorf("malformed Kraftfile: 'volumes.driver' must be a string, got %T", prop)
+				}
+				volume.driver = driverStr
 
 			case "source":
-				volume.source = prop.(string)
+				sourceStr, ok := prop.(string)
+				if !ok {
+					return nil, fmt.Errorf("malformed Kraftfile: 'volumes.source' must be a string, got %T", prop)
+				}
+				volume.source = sourceStr
 
 			case "destination":
-				volume.destination = prop.(string)
+				destStr, ok := prop.(string)
+				if !ok {
+					return nil, fmt.Errorf("malformed Kraftfile: 'volumes.destination' must be a string, got %T", prop)
+				}
+				volume.destination = destStr
 
 			case "readonly":
-				volume.readOnly = prop.(bool)
+				readOnlyBool, ok := prop.(bool)
+				if !ok {
+					return nil, fmt.Errorf("malformed Kraftfile: 'volumes.readonly' must be a boolean, got %T", prop)
+				}
+				volume.readOnly = readOnlyBool
 
 			}
 		}

--- a/unikraft/component/component.go
+++ b/unikraft/component/component.go
@@ -74,7 +74,11 @@ func TranslateFromSchema(props interface{}) (map[string]interface{}, error) {
 				}
 
 			case "source":
-				for k, v := range parseStringProp(prop.(string)) {
+				sourceStr, ok := prop.(string)
+				if !ok {
+					return nil, fmt.Errorf("component 'source' must be a string, got %T", prop)
+				}
+				for k, v := range parseStringProp(sourceStr) {
 					component[k] = v
 				}
 

--- a/unikraft/core/transform.go
+++ b/unikraft/core/transform.go
@@ -6,6 +6,7 @@ package core
 
 import (
 	"context"
+	"fmt"
 	"os"
 
 	"kraftkit.sh/kconfig"
@@ -34,7 +35,10 @@ func TransformFromSchema(ctx context.Context, props interface{}) (interface{}, e
 	}
 
 	if source, ok := c["source"]; ok {
-		core.source = source.(string)
+		core.source, ok = source.(string)
+		if !ok {
+			return nil, fmt.Errorf("core 'source' must be a string, got %T", source)
+		}
 
 		// If the provided source is a directory on the host, set the "path" to this
 		// value.  The "path" is the location on disk where the microlibrary will
@@ -51,11 +55,17 @@ func TransformFromSchema(ctx context.Context, props interface{}) (interface{}, e
 	}
 
 	if version, ok := c["version"]; ok {
-		core.version = version.(string)
+		core.version, ok = version.(string)
+		if !ok {
+			return nil, fmt.Errorf("core 'version' must be a string, got %T", version)
+		}
 	}
 
 	if kconf, ok := c["kconfig"]; ok {
-		core.kconfig = kconf.(kconfig.KeyValueMap)
+		core.kconfig, ok = kconf.(kconfig.KeyValueMap)
+		if !ok {
+			return nil, fmt.Errorf("core 'kconfig' must be a mapping, got %T", kconf)
+		}
 	}
 
 	return core, nil

--- a/unikraft/lib/transform.go
+++ b/unikraft/lib/transform.go
@@ -39,7 +39,10 @@ func TransformFromSchema(ctx context.Context, name string, props interface{}) (L
 	}
 
 	if source, ok := c["source"]; ok {
-		lib.source = source.(string)
+		lib.source, ok = source.(string)
+		if !ok {
+			return lib, fmt.Errorf("library 'source' must be a string, got %T", source)
+		}
 
 		// If the provided source is a directory on the host, set the "path" to this
 		// value.  The "path" is the location on disk where the microlibrary will
@@ -56,11 +59,17 @@ func TransformFromSchema(ctx context.Context, name string, props interface{}) (L
 	}
 
 	if version, ok := c["version"]; ok {
-		lib.version = version.(string)
+		lib.version, ok = version.(string)
+		if !ok {
+			return lib, fmt.Errorf("library 'version' must be a string, got %T", version)
+		}
 	}
 
 	if kconf, ok := c["kconfig"]; ok {
-		lib.kconfig = kconf.(kconfig.KeyValueMap)
+		lib.kconfig, ok = kconf.(kconfig.KeyValueMap)
+		if !ok {
+			return lib, fmt.Errorf("library 'kconfig' must be a mapping, got %T", kconf)
+		}
 	}
 
 	return lib, nil

--- a/unikraft/runtime/transform.go
+++ b/unikraft/runtime/transform.go
@@ -53,15 +53,24 @@ func TransformFromSchema(ctx context.Context, props interface{}) (interface{}, e
 		}
 
 		if source, ok := c["source"]; ok {
-			runtime.source = source.(string)
+			runtime.source, ok = source.(string)
+			if !ok {
+				return nil, fmt.Errorf("runtime 'source' must be a string, got %T", source)
+			}
 		}
 
 		if version, ok := c["version"]; ok {
-			runtime.version = version.(string)
+			runtime.version, ok = version.(string)
+			if !ok {
+				return nil, fmt.Errorf("runtime 'version' must be a string, got %T", version)
+			}
 		}
 
 		if kconf, ok := c["kconfig"]; ok {
-			runtime.kconfig = kconf.(kconfig.KeyValueMap)
+			runtime.kconfig, ok = kconf.(kconfig.KeyValueMap)
+			if !ok {
+				return nil, fmt.Errorf("runtime 'kconfig' must be a mapping, got %T", kconf)
+			}
 		}
 	}
 

--- a/unikraft/target/transform.go
+++ b/unikraft/target/transform.go
@@ -50,7 +50,11 @@ func TransformFromSchema(ctx context.Context, data interface{}) (interface{}, er
 		for key, prop := range value {
 			switch key {
 			case "name":
-				t.name = prop.(string)
+				name, ok := prop.(string)
+				if !ok {
+					return nil, fmt.Errorf("target 'name' must be a string, got %T", prop)
+				}
+				t.name = name
 
 			case "architecture", "arch":
 				architecture, err := arch.TransformFromSchema(ctx, prop)
@@ -61,7 +65,10 @@ func TransformFromSchema(ctx context.Context, data interface{}) (interface{}, er
 				t.architecture = architecture.(arch.ArchitectureConfig)
 
 			case "platform", "plat":
-				p := prop.(string)
+				p, ok := prop.(string)
+				if !ok {
+					return nil, fmt.Errorf("target 'platform' must be a string, got %T", prop)
+				}
 				if strings.Contains(p, "/") {
 					split := strings.SplitN(p, "/", 2)
 					p = split[0]
@@ -82,7 +89,11 @@ func TransformFromSchema(ctx context.Context, data interface{}) (interface{}, er
 				t.platform = platform.(plat.PlatformConfig)
 
 			case "kernel":
-				t.name = prop.(string)
+				kernel, ok := prop.(string)
+				if !ok {
+					return nil, fmt.Errorf("target 'kernel' must be a string, got %T", prop)
+				}
+				t.name = kernel
 
 			case "kconfig":
 				switch tprop := prop.(type) {
@@ -96,7 +107,11 @@ func TransformFromSchema(ctx context.Context, data interface{}) (interface{}, er
 				}
 
 			case "output":
-				t.kernel = prop.(string)
+				output, ok := prop.(string)
+				if !ok {
+					return nil, fmt.Errorf("target 'output' must be a string, got %T", prop)
+				}
+				t.kernel = output
 			}
 		}
 	default:

--- a/unikraft/template/transform.go
+++ b/unikraft/template/transform.go
@@ -6,6 +6,7 @@ package template
 
 import (
 	"context"
+	"fmt"
 	"os"
 
 	"kraftkit.sh/kconfig"
@@ -34,7 +35,10 @@ func TransformFromSchema(ctx context.Context, props interface{}) (interface{}, e
 	}
 
 	if source, ok := c["source"]; ok {
-		template.source = source.(string)
+		template.source, ok = source.(string)
+		if !ok {
+			return nil, fmt.Errorf("template 'source' must be a string, got %T", source)
+		}
 
 		// If the provided source is a directory on the host, set the "path" to this
 		// value.  The "path" is the location on disk where the microlibrary will
@@ -51,15 +55,24 @@ func TransformFromSchema(ctx context.Context, props interface{}) (interface{}, e
 	}
 
 	if name, ok := c["name"]; ok {
-		template.name = name.(string)
+		template.name, ok = name.(string)
+		if !ok {
+			return nil, fmt.Errorf("template 'name' must be a string, got %T", name)
+		}
 	}
 
 	if version, ok := c["version"]; ok {
-		template.version = version.(string)
+		template.version, ok = version.(string)
+		if !ok {
+			return nil, fmt.Errorf("template 'version' must be a string, got %T", version)
+		}
 	}
 
 	if kconf, ok := c["kconfig"]; ok {
-		template.kconfig = kconf.(kconfig.KeyValueMap)
+		template.kconfig, ok = kconf.(kconfig.KeyValueMap)
+		if !ok {
+			return nil, fmt.Errorf("template 'kconfig' must be a mapping, got %T", kconf)
+		}
 	}
 
 	return template, nil


### PR DESCRIPTION
# fix(app): Add safe type assertions in Kraftfile parsing

## Description

This PR fixes issue #38 by replacing unsafe type assertions with safe checks that return descriptive error messages instead of panicking when parsing malformed Kraftfiles.

### Before
```
panic: interface conversion: interface {} is int, not string
```

### After
```
W  could not initialize project error=malformed Kraftfile: 'name' field must be a string, got int
E  could not determine what or how to build from the given context
```

## Changes

| File | Fix |
|------|-----|
| `unikraft/app/project.go` | name, outdir field assertions |
| `unikraft/app/transform.go` | list element assertions |
| `unikraft/app/volume/transform.go` | volume property assertions |
| `unikraft/component/component.go` | source field assertion |
| `unikraft/core/transform.go` | source, version, kconfig |
| `unikraft/lib/transform.go` | source, version, kconfig |
| `unikraft/runtime/transform.go` | source, version, kconfig |
| `unikraft/target/transform.go` | name, platform, kernel, output |
| `unikraft/template/transform.go` | source, name, version, kconfig |

## Checklist

- [x] Test changes against relevant architectures and platforms
- [x] Ran `gofumpt` on commit series before opening this PR

## Testing

Tested with malformed Kraftfiles containing invalid types:
- `name: 123` → Returns helpful error message
- `volumes.source: 123` → Returns helpful error message  
- `targets.platform: 123` → Returns helpful error message

Fixes #38
