### PR TITLE
fix(net): Update alias for inspect command

### DIFF
--- a/internal/cli/kraft/net/inspect/inspect.go
+++ b/internal/cli/kraft/net/inspect/inspect.go
@@ -27,7 +27,7 @@ func NewCmd() *cobra.Command {
 	cmd, err := cmdfactory.New(&InspectOptions{}, cobra.Command{
 		Short:   "Inspect a machine network",
 		Use:     "inspect NETWORK",
-		Aliases: []string{"list"},
+		Aliases: []string{"show"},
 		Args:    cobra.ExactArgs(1),
 		Long:    "Inspect a machine network.",
 		Example: heredoc.Doc(`


### PR DESCRIPTION
# fix(net): Update alias for inspect command

## Description
This PR resolves an issue where `kraft net list -h` displayed the help message for the `inspect` command instead of the `list` command.

## Motivation and Context
The `inspect` command was registered with the alias `list`:
```go
Aliases: []string{"list"},
```
This caused a conflict with the actual `list` subcommand of `kraft net`. When running `kraft net list`, the CLI framework (cobra) matched the alias of `inspect` (or caused ambiguity), leading to incorrect help output and potential confusion.

## Changes
- Changed the alias of the `inspect` command from `list` to `show` in `internal/cli/kraft/net/inspect/inspect.go`.

## Verification
- Verified that `kraft net list -h` now correctly displays:
  ```text
  List machine networks.

  USAGE
    kraft net list [FLAGS]
  ```
- Verified that `kraft net show` works as an alias for `inspect`.
- Ran `make fmt` to ensure coding style compliance.

## Checklist
- [x] Test your changes against relevant architectures and platforms;
- [x] Ran make fmt on your commit series before opening this PR;
- [x] Update relevant documentation (Help message updates automatically).
