### PR TITLE
fix(run): Correct runner lookup key in runnersByName

### DIFF
--- a/internal/cli/kraft/run/runner.go
+++ b/internal/cli/kraft/run/runner.go
@@ -66,7 +66,7 @@ func runnersByName() (map[string]runner, error) {
 	}
 	ret := make(map[string]runner, len(runners))
 	for _, runner := range runners {
-		ret[runner.String()] = runner
+		ret[runner.Name()] = runner
 	}
 	return ret, nil
 }


### PR DESCRIPTION
fix(run): Correct runner lookup key in runnersByName

### Prerequisite checklist

  - [x] Tested your changes locally.

### Description of changes

This PR fixes a bug in how runners are looked up by name, which prevented the `--as` flag from working correctly with built-in runners (like `kernel`).

**The Issue:**
The `runnersByName` map was invalid because it was keying runners by their human-readable description (`runner.String()`) instead of their short identifier (`runner.Name()`).
However, the `kraft run` logic (and the `--as` flag validation) expects to look up runners by their short name (e.g., "kernel", "linuxu").

**The Result:**
1. Running `kraft run --as=kernel ...` would fail with `unknown runner: kernel` because "kernel" was not in the map key set.
2. The error message would list verbose descriptions (e.g., `run the '.' kernel binary...`) as choices instead of the short names.

**The Fix:**
Changed the key generation in `runnersByName` to use `runner.Name()` instead of `runner.String()`.

**Verification:**
- Validated that `kraft run --as=kernel ...` now correctly selects the kernel runner and proceeds to execution.
- Validated that `kraft run --as=invalid ...` now displays a clean list of valid short names in the error message.
