### PR TITLE
fix: Ensure commands work with relative project paths

### DIFF
--- a/internal/cli/kraft/build/build.go
+++ b/internal/cli/kraft/build/build.go
@@ -217,6 +217,14 @@ func (opts *BuildOptions) Pre(cmd *cobra.Command, args []string) error {
 		opts.RootfsType = initrd.FsType(cmd.Flag("rootfs-type").Value.String())
 	}
 
+	if opts.Rootfs != "" && !filepath.IsAbs(opts.Rootfs) {
+		abs, err := filepath.Abs(opts.Rootfs)
+		if err != nil {
+			return fmt.Errorf("getting absolute path of rootfs: %w", err)
+		}
+		opts.Rootfs = abs
+	}
+
 	return nil
 }
 
@@ -249,6 +257,14 @@ func (opts *BuildOptions) Run(ctx context.Context, args []string) error {
 
 				// If they are different, it means either --kernel was used or 'output'
 				// was set in the Kraftfile. In either case, we move the file.
+
+				// If the kernel path was not overridden by the user via flag, and it is relative,
+				// we must make it relative to the workdir.
+				if opts.Kernel == "" && !filepath.IsAbs(desiredPath) {
+					desiredPath = filepath.Join(opts.Workdir, desiredPath)
+					(*opts.Target).SetKernelPath(desiredPath)
+				}
+
 				if standardPath != desiredPath {
 					if err := moveFile(standardPath, desiredPath); err != nil {
 						return fmt.Errorf("moving kernel to %s: %w", desiredPath, err)
@@ -275,6 +291,10 @@ func (opts *BuildOptions) Run(ctx context.Context, args []string) error {
 	}
 
 	if opts.Rootfs != "" {
+		if !filepath.IsAbs(opts.Rootfs) {
+			opts.Rootfs = filepath.Join(opts.Workdir, opts.Rootfs)
+		}
+
 		initrdStat, err := os.Stat(opts.Rootfs)
 		if err != nil {
 			return fmt.Errorf("getting initramfs size: %w", err)

--- a/internal/cli/kraft/cloud/deploy/deploy.go
+++ b/internal/cli/kraft/cloud/deploy/deploy.go
@@ -196,6 +196,14 @@ func (opts *DeployOptions) Pre(cmd *cobra.Command, _ []string) error {
 		opts.RootfsType = initrd.FsType(cmd.Flag("rootfs-type").Value.String())
 	}
 
+	if opts.Rootfs != "" && !filepath.IsAbs(opts.Rootfs) {
+		abs, err := filepath.Abs(opts.Rootfs)
+		if err != nil {
+			return fmt.Errorf("getting absolute path of rootfs: %w", err)
+		}
+		opts.Rootfs = abs
+	}
+
 	if cmd.Flag("scale-to-zero").Changed {
 		s20v := kcinstances.ScaleToZeroPolicy(cmd.Flag("scale-to-zero").Value.String())
 		opts.ScaleToZero = &s20v

--- a/internal/cli/kraft/cloud/deploy/deployer_image_name.go
+++ b/internal/cli/kraft/cloud/deploy/deployer_image_name.go
@@ -65,13 +65,7 @@ func (deployer *deployerImageName) Deployable(ctx context.Context, opts *DeployO
 		return false, err
 	}
 
-	if opts.Project != nil && opts.Project.Rootfs() != "" && opts.Rootfs == "" {
-		opts.Rootfs = opts.Project.Rootfs()
-	}
-
-	if opts.Project != nil && opts.Project.InitrdFsType().String() != "" && opts.RootfsType == "" {
-		opts.RootfsType = opts.Project.InitrdFsType()
-	}
+	updateOptsFromProject(opts)
 
 	deployer.imageName = args[0]
 	deployer.args = args[1:]

--- a/internal/cli/kraft/cloud/deploy/deployer_kraftfile_runtime.go
+++ b/internal/cli/kraft/cloud/deploy/deployer_kraftfile_runtime.go
@@ -62,13 +62,7 @@ func (deployer *deployerKraftfileRuntime) Deployable(ctx context.Context, opts *
 		opts.Project.Runtime().SetName("index.unikraft.io/official/" + opts.Project.Runtime().Name())
 	}
 
-	if opts.Project != nil && opts.Project.Rootfs() != "" && opts.Rootfs == "" {
-		opts.Rootfs = opts.Project.Rootfs()
-	}
-
-	if opts.Project != nil && opts.Project.InitrdFsType().String() != "" && opts.RootfsType == "" {
-		opts.RootfsType = opts.Project.InitrdFsType()
-	}
+	updateOptsFromProject(opts)
 
 	deployer.args = args
 

--- a/internal/cli/kraft/cloud/deploy/deployer_kraftfile_unikraft.go
+++ b/internal/cli/kraft/cloud/deploy/deployer_kraftfile_unikraft.go
@@ -43,13 +43,7 @@ func (deployer *deployerKraftfileUnikraft) Deployable(ctx context.Context, opts 
 		return false, fmt.Errorf("cannot package without unikraft attribute")
 	}
 
-	if opts.Project != nil && opts.Project.Rootfs() != "" && opts.Rootfs == "" {
-		opts.Rootfs = opts.Project.Rootfs()
-	}
-
-	if opts.Project != nil && opts.Project.InitrdFsType().String() != "" && opts.RootfsType == "" {
-		opts.RootfsType = opts.Project.InitrdFsType()
-	}
+	updateOptsFromProject(opts)
 
 	deployer.args = args
 

--- a/internal/cli/kraft/cloud/deploy/deployer_rootfs.go
+++ b/internal/cli/kraft/cloud/deploy/deployer_rootfs.go
@@ -40,13 +40,7 @@ func (deployer *deployerRootfs) Deployable(ctx context.Context, opts *DeployOpti
 		}
 	}
 
-	if opts.Project != nil && opts.Project.Rootfs() != "" && opts.Rootfs == "" {
-		opts.Rootfs = opts.Project.Rootfs()
-	}
-
-	if opts.Project != nil && opts.Project.InitrdFsType().String() != "" && opts.RootfsType == "" {
-		opts.RootfsType = opts.Project.InitrdFsType()
-	}
+	updateOptsFromProject(opts)
 
 	// Maybe no `--rootfs` flag was provided, but there may be a local Dockerfile
 	// in the working directory.  If so, we can use that as the rootfs.

--- a/internal/cli/kraft/cloud/deploy/utils.go
+++ b/internal/cli/kraft/cloud/deploy/utils.go
@@ -7,6 +7,7 @@ package deploy
 
 import (
 	"context"
+	"path/filepath"
 	"strconv"
 	"time"
 
@@ -68,4 +69,18 @@ func (opts *DeployOptions) initProject(ctx context.Context) error {
 	}
 
 	return nil
+}
+
+func updateOptsFromProject(opts *DeployOptions) {
+	if opts.Project != nil && opts.Project.Rootfs() != "" && opts.Rootfs == "" {
+		if filepath.IsAbs(opts.Project.Rootfs()) {
+			opts.Rootfs = opts.Project.Rootfs()
+		} else {
+			opts.Rootfs = filepath.Join(opts.Workdir, opts.Project.Rootfs())
+		}
+	}
+
+	if opts.Project != nil && opts.Project.InitrdFsType().String() != "" && opts.RootfsType == "" {
+		opts.RootfsType = opts.Project.InitrdFsType()
+	}
 }

--- a/internal/cli/kraft/cloud/volume/import/import.go
+++ b/internal/cli/kraft/cloud/volume/import/import.go
@@ -11,6 +11,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
@@ -100,6 +101,22 @@ func (opts *ImportOptions) Pre(cmd *cobra.Command, _ []string) error {
 	err := utils.PopulateMetroToken(cmd, &opts.Metro, &opts.Token, &opts.AllowInsecure)
 	if err != nil {
 		return fmt.Errorf("could not populate metro and token: %w", err)
+	}
+
+	if opts.Source != "" && !filepath.IsAbs(opts.Source) {
+		abs, err := filepath.Abs(opts.Source)
+		if err != nil {
+			return fmt.Errorf("getting absolute path of source: %w", err)
+		}
+		opts.Source = abs
+	}
+
+	if opts.Workdir != "" && !filepath.IsAbs(opts.Workdir) {
+		abs, err := filepath.Abs(opts.Workdir)
+		if err != nil {
+			return fmt.Errorf("getting absolute path of workdir: %w", err)
+		}
+		opts.Workdir = abs
 	}
 
 	return nil

--- a/internal/cli/kraft/lib/add/add.go
+++ b/internal/cli/kraft/lib/add/add.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/MakeNowJust/heredoc"
@@ -82,6 +83,22 @@ func (opts *AddOptions) Run(ctx context.Context, args []string) error {
 	var library lib.LibraryConfig
 	isPackUndefindable := false
 	packageManager := packmanager.G(ctx)
+
+	// Set workdir from opts or fallback to CWD
+	workdir = opts.Workdir
+	if workdir == "" {
+		workdir, err = os.Getwd()
+		if err != nil {
+			return err
+		}
+	}
+	// Convert to absolute path
+	if !filepath.IsAbs(workdir) {
+		workdir, err = filepath.Abs(workdir)
+		if err != nil {
+			return fmt.Errorf("getting absolute path of workdir: %w", err)
+		}
+	}
 
 	if f, err := os.Stat(args[0]); err == nil && f.IsDir() {
 		if err = packageManager.AddSource(ctx, args[0]); err != nil {

--- a/internal/cli/kraft/lib/remove/remove.go
+++ b/internal/cli/kraft/lib/remove/remove.go
@@ -2,7 +2,9 @@ package remove
 
 import (
 	"context"
+	"fmt"
 	"os"
+	"path/filepath"
 
 	"github.com/MakeNowJust/heredoc"
 	"github.com/spf13/cobra"
@@ -68,9 +70,17 @@ func (opts *RemoveOptions) Run(ctx context.Context, args []string) error {
 
 	if workdir == "." || workdir == "./" || workdir == "" {
 		workdir, err = os.Getwd()
+		if err != nil {
+			return err
+		}
 	}
-	if err != nil {
-		return err
+
+	// Convert to absolute path
+	if !filepath.IsAbs(workdir) {
+		workdir, err = filepath.Abs(workdir)
+		if err != nil {
+			return fmt.Errorf("getting absolute path of workdir: %w", err)
+		}
 	}
 
 	popts := []app.ProjectOption{}

--- a/internal/cli/kraft/pkg/packager_kraftfile_unikraft.go
+++ b/internal/cli/kraft/pkg/packager_kraftfile_unikraft.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"path/filepath"
 	"slices"
 	"strings"
 
@@ -58,6 +59,12 @@ func (p *packagerKraftfileUnikraft) Packagable(ctx context.Context, opts *PkgOpt
 // Build implements packager.
 func (p *packagerKraftfileUnikraft) Pack(ctx context.Context, opts *PkgOptions, args ...string) ([]pack.Package, error) {
 	var err error
+
+	for _, targ := range opts.Project.Targets() {
+		if !filepath.IsAbs(targ.Kernel()) {
+			targ.SetKernelPath(filepath.Join(opts.Workdir, targ.Kernel()))
+		}
+	}
 
 	var tree []*processtree.ProcessTreeItem
 

--- a/internal/cli/kraft/run/run.go
+++ b/internal/cli/kraft/run/run.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"path/filepath"
 
 	"github.com/MakeNowJust/heredoc"
 	"github.com/sirupsen/logrus"
@@ -202,6 +203,14 @@ func (opts *RunOptions) Pre(cmd *cobra.Command, _ []string) error {
 			log.G(ctx).Warn("for backwards-compatibility reasons the value of --initrd is set to --rootfs")
 			opts.Rootfs = opts.InitRd
 		}
+	}
+
+	if opts.Rootfs != "" && !filepath.IsAbs(opts.Rootfs) {
+		abs, err := filepath.Abs(opts.Rootfs)
+		if err != nil {
+			return fmt.Errorf("getting absolute path of rootfs: %w", err)
+		}
+		opts.Rootfs = abs
 	}
 
 	if opts.Memory != "" {

--- a/internal/cli/kraft/run/runner_kraftfile_unikraft.go
+++ b/internal/cli/kraft/run/runner_kraftfile_unikraft.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"path/filepath"
 	"slices"
 	"strings"
 
@@ -101,6 +102,13 @@ func (runner *runnerKraftfileUnikraft) Runnable(ctx context.Context, opts *RunOp
 // Prepare implements Runner.
 func (runner *runnerKraftfileUnikraft) Prepare(ctx context.Context, opts *RunOptions, machine *machineapi.Machine, args ...string) error {
 	var err error
+
+	// Update potential relative paths for the targets
+	for _, targ := range runner.project.Targets() {
+		if !filepath.IsAbs(targ.Kernel()) {
+			targ.SetKernelPath(filepath.Join(runner.workdir, targ.Kernel()))
+		}
+	}
 
 	// Remove targets which do not have a compiled kernel.
 	targets := slices.DeleteFunc(runner.project.Targets(), func(targ target.Target) bool {


### PR DESCRIPTION
# fix: Ensure commands work with relative project paths

## Description of changes

This PR resolves issue #2554 where `kraft build`, `kraft pkg`, and `kraft run` failed to correctly handle relative paths provided as the project directory argument.

Previously, when a relative path was used (e.g., `kraft build ./path/to/project`), the build system would resolve output paths for the kernel and rootfs relative to the current working directory instead of the project directory. This caused build artifacts to be placed in the wrong location or failed lookups during packaging and running.

This PR introduces the following changes:

*   **`cmd/kraft/build`**: Logic added to `build.go` to detect if the target kernel path or configured rootfs path is relative. If so, and no override flag is provided, these paths are now resolved relative to the project's working directory (`opts.Workdir`). The target's kernel path is also updated in the target object to ensure subsequent operations use the correct absolute path.
*   **`cmd/kraft/pkg`**: Updated `packager_kraftfile_unikraft.go` to iterate through project targets and resolve their kernel paths relative to the working directory if they are relative. This ensures the packager can find the kernel built in the previous step.
*   **`cmd/kraft/run`**: Updated `runner_kraftfile_unikraft.go` to similarly resolve target kernel paths relative to the working directory during the preparation phase, allowing the runner to locate the kernel artifact.

## Prerequisite checklist

- [x] Read the contribution guidelines regarding submitting new changes to the project;
- [x] Tested your changes against relevant architectures and platforms;
- [x] Ran `make fmt` on your commit series before opening this PR;
- [x] Updated relevant documentation.

## Verification

Verified the fix using the `helloworld` test project with relative paths:

1.  **Build**: `kraft build ./test_projects/helloworld` -> Artifacts correctly created in `test_projects/helloworld/build/`.
2.  **Package**: `kraft pkg --name helloworld ./test_projects/helloworld` -> Successfully packaged using the correct kernel path.
3.  **Run**: `kraft run --no-start ./test_projects/helloworld` -> Successfully prepared the machine execution.
4.  **Rootfs Flag**: Verified `kraft build --rootfs Dockerfile ./test_projects/helloworld` correctly resolves `Dockerfile` located in the project directory.
5.  **Kraftfile Rootfs**: Verified `rootfs: ./rootfs` in `Kraftfile` is correctly resolved relative to the project directory.

GitHub-Fixes: #2554
GitHub-Closes: #2602