### PR TITLE
fix: Preserve original user's config path when running with sudo

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -139,6 +139,8 @@ jobs:
           KRAFTKIT_NO_WARN_SUDO: true
           KRAFTKIT_NO_CHECK_UPDATES: true
           DOCKER: ''
+          KRAFTKIT_DATA_DIR: /tmp/kraftkit-data
+          KRAFTKIT_STATE_DIR: /tmp/kraftkit-state
         run: make test-e2e DISTDIR="$(go env GOPATH)"/bin
 
   e2e-cloud-cli:

--- a/config/config_file.go
+++ b/config/config_file.go
@@ -27,12 +27,9 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log"
 	"os"
-	"os/user"
 	"path/filepath"
 	"runtime"
-	"strconv"
 	"syscall"
 )
 
@@ -44,114 +41,6 @@ const (
 	APP_DATA            = "AppData"
 	LOCAL_APP_DATA      = "LocalAppData"
 )
-
-// sudoUserInfo contains information about the original user when running under sudo.
-type sudoUserInfo struct {
-	HomeDir string
-	UID     int
-	GID     int
-}
-
-// getSudoUserInfo returns information about the original user when running under sudo.
-// Returns nil if not running under sudo or if the original user cannot be determined.
-func getSudoUserInfo() *sudoUserInfo {
-	sudoUser := os.Getenv("SUDO_USER")
-	if sudoUser == "" {
-		return nil
-	}
-
-	// Try to get UID/GID from environment first (more reliable)
-	uidStr := os.Getenv("SUDO_UID")
-	gidStr := os.Getenv("SUDO_GID")
-
-	var uid, gid int
-	var homeDir string
-
-	// Look up the user to get their home directory
-	if u, err := user.Lookup(sudoUser); err == nil {
-		homeDir = u.HomeDir
-		// Use looked up UID/GID as fallback
-		if uidStr == "" {
-			uidStr = u.Uid
-		}
-		if gidStr == "" {
-			gidStr = u.Gid
-		}
-	}
-
-	if homeDir == "" {
-		return nil
-	}
-
-	// Parse UID
-	if uidStr != "" {
-		if parsedUID, err := strconv.Atoi(uidStr); err == nil {
-			uid = parsedUID
-		}
-	}
-
-	// Parse GID
-	if gidStr != "" {
-		if parsedGID, err := strconv.Atoi(gidStr); err == nil {
-			gid = parsedGID
-		}
-	}
-
-	return &sudoUserInfo{
-		HomeDir: homeDir,
-		UID:     uid,
-		GID:     gid,
-	}
-}
-
-// getHomeDir returns the appropriate home directory for kraftkit configuration.
-// When running under sudo, this returns the original user's home directory
-// to maintain consistent config paths between privileged and unprivileged commands.
-func getHomeDir() string {
-	if info := getSudoUserInfo(); info != nil {
-		return info.HomeDir
-	}
-	homeDir, err := os.UserHomeDir()
-	if err != nil {
-		log.Printf("warning: could not determine home directory: %v", err)
-	}
-	return homeDir
-}
-
-// ChownToUser changes ownership of a path to the original user when running under sudo.
-// This ensures that files created by sudo commands are accessible by the regular user.
-// If not running under sudo, this is a no-op.
-func ChownToUser(path string) error {
-	info := getSudoUserInfo()
-	if info == nil || info.UID == 0 {
-		// Not running under sudo or couldn't determine original user
-		return nil
-	}
-
-	return os.Chown(path, info.UID, info.GID)
-}
-
-// ChownToUserRecursive changes ownership of a path and all its contents to the original user.
-// This is useful for directories created by sudo commands.
-// Only files/dirs owned by root are chowned to avoid unnecessary syscalls.
-func ChownToUserRecursive(path string) error {
-	info := getSudoUserInfo()
-	if info == nil || info.UID == 0 {
-		return nil
-	}
-
-	return filepath.Walk(path, func(name string, fileInfo os.FileInfo, err error) error {
-		if err != nil {
-			return err
-		}
-		if stat, ok := fileInfo.Sys().(*syscall.Stat_t); ok {
-			if stat.Uid != 0 {
-				return nil
-			}
-		}
-		return os.Chown(name, info.UID, info.GID)
-	})
-}
 
 // Config path precedence
 // 1. KRAFTKIT_CONFIG_DIR

--- a/config/config_file.go
+++ b/config/config_file.go
@@ -27,9 +27,12 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log"
 	"os"
+	"os/user"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"syscall"
 )
 
@@ -41,6 +44,114 @@ const (
 	APP_DATA            = "AppData"
 	LOCAL_APP_DATA      = "LocalAppData"
 )
+
+// sudoUserInfo contains information about the original user when running under sudo.
+type sudoUserInfo struct {
+	HomeDir string
+	UID     int
+	GID     int
+}
+
+// getSudoUserInfo returns information about the original user when running under sudo.
+// Returns nil if not running under sudo or if the original user cannot be determined.
+func getSudoUserInfo() *sudoUserInfo {
+	sudoUser := os.Getenv("SUDO_USER")
+	if sudoUser == "" {
+		return nil
+	}
+
+	// Try to get UID/GID from environment first (more reliable)
+	uidStr := os.Getenv("SUDO_UID")
+	gidStr := os.Getenv("SUDO_GID")
+
+	var uid, gid int
+	var homeDir string
+
+	// Look up the user to get their home directory
+	if u, err := user.Lookup(sudoUser); err == nil {
+		homeDir = u.HomeDir
+		// Use looked up UID/GID as fallback
+		if uidStr == "" {
+			uidStr = u.Uid
+		}
+		if gidStr == "" {
+			gidStr = u.Gid
+		}
+	}
+
+	if homeDir == "" {
+		return nil
+	}
+
+	// Parse UID
+	if uidStr != "" {
+		if parsedUID, err := strconv.Atoi(uidStr); err == nil {
+			uid = parsedUID
+		}
+	}
+
+	// Parse GID
+	if gidStr != "" {
+		if parsedGID, err := strconv.Atoi(gidStr); err == nil {
+			gid = parsedGID
+		}
+	}
+
+	return &sudoUserInfo{
+		HomeDir: homeDir,
+		UID:     uid,
+		GID:     gid,
+	}
+}
+
+// getHomeDir returns the appropriate home directory for kraftkit configuration.
+// When running under sudo, this returns the original user's home directory
+// to maintain consistent config paths between privileged and unprivileged commands.
+func getHomeDir() string {
+	if info := getSudoUserInfo(); info != nil {
+		return info.HomeDir
+	}
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		log.Printf("warning: could not determine home directory: %v", err)
+	}
+	return homeDir
+}
+
+// ChownToUser changes ownership of a path to the original user when running under sudo.
+// This ensures that files created by sudo commands are accessible by the regular user.
+// If not running under sudo, this is a no-op.
+func ChownToUser(path string) error {
+	info := getSudoUserInfo()
+	if info == nil || info.UID == 0 {
+		// Not running under sudo or couldn't determine original user
+		return nil
+	}
+
+	return os.Chown(path, info.UID, info.GID)
+}
+
+// ChownToUserRecursive changes ownership of a path and all its contents to the original user.
+// This is useful for directories created by sudo commands.
+// Only files/dirs owned by root are chowned to avoid unnecessary syscalls.
+func ChownToUserRecursive(path string) error {
+	info := getSudoUserInfo()
+	if info == nil || info.UID == 0 {
+		return nil
+	}
+
+	return filepath.Walk(path, func(name string, fileInfo os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if stat, ok := fileInfo.Sys().(*syscall.Stat_t); ok {
+			if stat.Uid != 0 {
+				return nil
+			}
+		}
+		return os.Chown(name, info.UID, info.GID)
+	})
+}
 
 // Config path precedence
 // 1. KRAFTKIT_CONFIG_DIR
@@ -56,8 +167,7 @@ func ConfigDir() string {
 	} else if c := os.Getenv(APP_DATA); runtime.GOOS == "windows" && c != "" {
 		path = filepath.Join(c, "KraftKit")
 	} else {
-		d, _ := os.UserHomeDir()
-		path = filepath.Join(d, ".config", "kraftkit")
+		path = filepath.Join(getHomeDir(), ".config", "kraftkit")
 	}
 
 	// If the path does not exist and the KRAFTKIT_CONFIG_DIR flag is not set try
@@ -80,8 +190,7 @@ func StateDir() string {
 	} else if b := os.Getenv(LOCAL_APP_DATA); runtime.GOOS == "windows" && b != "" {
 		path = filepath.Join(b, "KraftKit")
 	} else {
-		c, _ := os.UserHomeDir()
-		path = filepath.Join(c, ".local", "state", "kraftkit")
+		path = filepath.Join(getHomeDir(), ".local", "state", "kraftkit")
 	}
 
 	// If the path does not exist try migrating state from default paths
@@ -103,8 +212,7 @@ func DataDir() string {
 	} else if b := os.Getenv(LOCAL_APP_DATA); runtime.GOOS == "windows" && b != "" {
 		path = filepath.Join(b, "KraftKit")
 	} else {
-		c, _ := os.UserHomeDir()
-		path = filepath.Join(c, ".local", "share", "kraftkit")
+		path = filepath.Join(getHomeDir(), ".local", "share", "kraftkit")
 	}
 
 	return path

--- a/config/config_file.go
+++ b/config/config_file.go
@@ -29,12 +29,13 @@ import (
 	"io"
 	"os"
 	"path/filepath"
-	"runtime"
 	"syscall"
 )
 
 const (
 	KRAFTKIT_CONFIG_DIR = "KRAFTKIT_CONFIG_DIR"
+	KRAFTKIT_STATE_DIR  = "KRAFTKIT_STATE_DIR"
+	KRAFTKIT_DATA_DIR   = "KRAFTKIT_DATA_DIR"
 	XDG_CONFIG_HOME     = "XDG_CONFIG_HOME"
 	XDG_STATE_HOME      = "XDG_STATE_HOME"
 	XDG_DATA_HOME       = "XDG_DATA_HOME"
@@ -53,7 +54,7 @@ func ConfigDir() string {
 		path = a
 	} else if b := os.Getenv(XDG_CONFIG_HOME); b != "" {
 		path = filepath.Join(b, "kraftkit")
-	} else if c := os.Getenv(APP_DATA); runtime.GOOS == "windows" && c != "" {
+	} else if c := os.Getenv(APP_DATA); c != "" {
 		path = filepath.Join(c, "KraftKit")
 	} else {
 		path = filepath.Join(getHomeDir(), ".config", "kraftkit")
@@ -69,21 +70,25 @@ func ConfigDir() string {
 }
 
 // State path precedence
-// 1. XDG_STATE_HOME
-// 2. LocalAppData (windows only)
-// 3. HOME
+// 1. KRAFTKIT_STATE_DIR
+// 2. XDG_STATE_HOME
+// 3. LocalAppData (windows only)
+// 4. HOME
 func StateDir() string {
 	var path string
-	if a := os.Getenv(XDG_STATE_HOME); a != "" {
-		path = filepath.Join(a, "kraftkit")
-	} else if b := os.Getenv(LOCAL_APP_DATA); runtime.GOOS == "windows" && b != "" {
-		path = filepath.Join(b, "KraftKit")
+	if a := os.Getenv(KRAFTKIT_STATE_DIR); a != "" {
+		path = a
+	} else if b := os.Getenv(XDG_STATE_HOME); b != "" {
+		path = filepath.Join(b, "kraftkit")
+	} else if c := os.Getenv(LOCAL_APP_DATA); c != "" {
+		path = filepath.Join(c, "KraftKit")
 	} else {
 		path = filepath.Join(getHomeDir(), ".local", "state", "kraftkit")
 	}
 
-	// If the path does not exist try migrating state from default paths
-	if !dirExists(path) {
+	// If the path does not exist and the KRAFTKIT_STATE_DIR flag is not set try
+	// migrating state from default paths.
+	if !dirExists(path) && os.Getenv(KRAFTKIT_STATE_DIR) == "" {
 		_ = autoMigrateStateDir(path)
 	}
 
@@ -91,15 +96,18 @@ func StateDir() string {
 }
 
 // Data path precedence
-// 1. XDG_DATA_HOME
-// 2. LocalAppData (windows only)
-// 3. HOME
+// 1. KRAFTKIT_DATA_DIR
+// 2. XDG_DATA_HOME
+// 3. LocalAppData (windows only)
+// 4. HOME
 func DataDir() string {
 	var path string
-	if a := os.Getenv(XDG_DATA_HOME); a != "" {
-		path = filepath.Join(a, "kraftkit")
-	} else if b := os.Getenv(LOCAL_APP_DATA); runtime.GOOS == "windows" && b != "" {
-		path = filepath.Join(b, "KraftKit")
+	if a := os.Getenv(KRAFTKIT_DATA_DIR); a != "" {
+		path = a
+	} else if b := os.Getenv(XDG_DATA_HOME); b != "" {
+		path = filepath.Join(b, "kraftkit")
+	} else if c := os.Getenv(LOCAL_APP_DATA); c != "" {
+		path = filepath.Join(c, "KraftKit")
 	} else {
 		path = filepath.Join(getHomeDir(), ".local", "share", "kraftkit")
 	}

--- a/config/utils_unix.go
+++ b/config/utils_unix.go
@@ -1,0 +1,152 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2019 GitHub Inc.
+//               2022 Unikraft GmbH.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+//go:build !windows
+
+package config
+
+import (
+	"log"
+	"os"
+	"os/user"
+	"path/filepath"
+	"strconv"
+	"syscall"
+)
+
+// sudoUserInfo contains information about the original user when running under sudo.
+type sudoUserInfo struct {
+	HomeDir string
+	UID     int
+	GID     int
+}
+
+// getSudoUserInfo returns information about the original user when running under sudo.
+// Returns nil if not running under sudo or if the original user cannot be determined.
+func getSudoUserInfo() *sudoUserInfo {
+	// Only use sudo detection when actually running as root
+	if os.Getuid() != 0 {
+		return nil
+	}
+
+	sudoUser := os.Getenv("SUDO_USER")
+	if sudoUser == "" {
+		return nil
+	}
+
+	// Try to get UID/GID from environment first (more reliable)
+	uidStr := os.Getenv("SUDO_UID")
+	gidStr := os.Getenv("SUDO_GID")
+
+	var uid, gid int
+	var homeDir string
+
+	// Look up the user to get their home directory
+	if u, err := user.Lookup(sudoUser); err == nil {
+		homeDir = u.HomeDir
+		// Use looked up UID/GID as fallback
+		if uidStr == "" {
+			uidStr = u.Uid
+		}
+		if gidStr == "" {
+			gidStr = u.Gid
+		}
+	}
+
+	if homeDir == "" {
+		return nil
+	}
+
+	// Parse UID
+	if uidStr != "" {
+		if parsedUID, err := strconv.Atoi(uidStr); err == nil {
+			uid = parsedUID
+		}
+	}
+
+	// Parse GID
+	if gidStr != "" {
+		if parsedGID, err := strconv.Atoi(gidStr); err == nil {
+			gid = parsedGID
+		}
+	}
+
+	return &sudoUserInfo{
+		HomeDir: homeDir,
+		UID:     uid,
+		GID:     gid,
+	}
+}
+
+// getHomeDir returns the appropriate home directory for kraftkit configuration.
+// When running under sudo, this returns the original user's home directory
+// to maintain consistent config paths between privileged and unprivileged commands.
+func getHomeDir() string {
+	if info := getSudoUserInfo(); info != nil {
+		// Verify the home directory exists and is accessible before using it
+		if _, err := os.Stat(info.HomeDir); err == nil {
+			return info.HomeDir
+		}
+		// Fall back to os.UserHomeDir() if sudo user's home is not accessible
+	}
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		log.Printf("warning: could not determine home directory: %v", err)
+	}
+	return homeDir
+}
+
+// ChownToUser changes ownership of a path to the original user when running under sudo.
+// This ensures that files created by sudo commands are accessible by the regular user.
+// If not running under sudo, this is a no-op.
+func ChownToUser(path string) error {
+	info := getSudoUserInfo()
+	if info == nil || info.UID == 0 {
+		// Not running under sudo or couldn't determine original user
+		return nil
+	}
+
+	return os.Chown(path, info.UID, info.GID)
+}
+
+// ChownToUserRecursive changes ownership of a path and all its contents to the original user.
+// This is useful for directories created by sudo commands.
+// Only files/dirs owned by root are chowned to avoid unnecessary syscalls.
+func ChownToUserRecursive(path string) error {
+	info := getSudoUserInfo()
+	if info == nil || info.UID == 0 {
+		return nil
+	}
+
+	return filepath.Walk(path, func(name string, fileInfo os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if stat, ok := fileInfo.Sys().(*syscall.Stat_t); ok {
+			if stat.Uid != 0 {
+				return nil
+			}
+		}
+		return os.Chown(name, info.UID, info.GID)
+	})
+}

--- a/config/utils_windows.go
+++ b/config/utils_windows.go
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2019 GitHub Inc.
+//               2022 Unikraft GmbH.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+//go:build windows
+
+package config
+
+import (
+	"log"
+	"os"
+)
+
+// sudoUserInfo contains information about the original user when running under sudo.
+type sudoUserInfo struct {
+	HomeDir string
+	UID     int
+	GID     int
+}
+
+// getSudoUserInfo returns information about the original user when running under sudo.
+// On Windows, sudo is not applicable so this always returns nil.
+func getSudoUserInfo() *sudoUserInfo {
+	return nil
+}
+
+// getHomeDir returns the home directory for kraftkit configuration.
+// On Windows, sudo is not applicable, so this simply returns os.UserHomeDir().
+func getHomeDir() string {
+	// Dummy call for interface consistency with Unix implementation
+	_ = getSudoUserInfo()
+
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		log.Printf("warning: could not determine home directory: %v", err)
+	}
+	return homeDir
+}
+
+// ChownToUser is a no-op on Windows as sudo/chown concepts don't apply.
+func ChownToUser(path string) error {
+	return nil
+}
+
+// ChownToUserRecursive is a no-op on Windows as sudo/chown concepts don't apply.
+func ChownToUserRecursive(path string) error {
+	return nil
+}

--- a/machine/firecracker/v1alpha1.go
+++ b/machine/firecracker/v1alpha1.go
@@ -106,6 +106,11 @@ func (service *machineV1alpha1Service) Create(ctx context.Context, machine *mach
 		return machine, err
 	}
 
+	// Ensure the directory and its contents are owned by the original user when running under sudo
+	if err := config.ChownToUserRecursive(machine.Status.StateDir); err != nil {
+		return machine, err
+	}
+
 	// Set and create the log file for this machine
 	if len(machine.Status.LogFile) == 0 {
 		machine.Status.LogFile = filepath.Join(machine.Status.StateDir, "vm.log")

--- a/machine/qemu/v1alpha1.go
+++ b/machine/qemu/v1alpha1.go
@@ -159,6 +159,11 @@ func (service *machineV1alpha1Service) Create(ctx context.Context, machine *mach
 		return machine, err
 	}
 
+	// Ensure the directory and its contents are owned by the original user when running under sudo
+	if err := config.ChownToUserRecursive(machine.Status.StateDir); err != nil {
+		return machine, err
+	}
+
 	// Set and create the log file for this machine
 	if len(machine.Status.LogFile) == 0 {
 		machine.Status.LogFile = filepath.Join(machine.Status.StateDir, "vm.log")

--- a/machine/xen/v1alpha1.go
+++ b/machine/xen/v1alpha1.go
@@ -89,6 +89,11 @@ func (service *machineV1alpha1Service) Create(ctx context.Context, machine *mach
 		return machine, err
 	}
 
+	// Ensure the directory and its contents are owned by the original user when running under sudo
+	if err := config.ChownToUserRecursive(machine.Status.StateDir); err != nil {
+		return machine, err
+	}
+
 	if len(machine.Status.LogFile) == 0 {
 		machine.Status.LogFile = filepath.Join(machine.Status.StateDir, "machine.log")
 	}

--- a/store/embedded.go
+++ b/store/embedded.go
@@ -18,6 +18,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/apiserver/pkg/storage"
+	"kraftkit.sh/config"
 	"kraftkit.sh/internal/retrytimeout"
 )
 
@@ -114,6 +115,12 @@ func (store *embedded[_, _]) open() error {
 
 	store.db = db
 
+	// When running under sudo, ensure the store directory is owned by the
+	// original user so non-sudo commands can access it
+	if err := config.ChownToUserRecursive(store.path); err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -138,7 +145,10 @@ func (store *embedded[_, _]) Create(ctx context.Context, key string, _, out runt
 		return err
 	}
 
-	defer store.close()
+	defer func() {
+		store.close()
+		config.ChownToUserRecursive(store.path)
+	}()
 
 	b := bytes.Buffer{}
 	if err := gob.NewEncoder(&b).Encode(out); err != nil {
@@ -159,7 +169,10 @@ func (store *embedded[_, _]) Delete(ctx context.Context, key string, out runtime
 		return err
 	}
 
-	defer store.close()
+	defer func() {
+		store.close()
+		config.ChownToUserRecursive(store.path)
+	}()
 
 	txn := store.db.NewTransaction(true)
 


### PR DESCRIPTION
# fix: Preserve original user's config path when running with sudo

## Description

Fixes #992

When `kraft` is invoked via `sudo`, `os.UserHomeDir()` returns `/root`, causing machine state to be stored in `/root/.local/share/kraftkit/runtime/` instead of the user's home directory. This makes machines created with `sudo kraft run` invisible to non-sudo commands like `kraft ps`.

## Changes

### `config/config_file.go`
- Added `getSudoUserInfo()` - detects sudo via `SUDO_USER` environment variable and retrieves the original user's UID, GID, and home directory
- Added `getHomeDir()` - returns the original user's home directory when running under sudo
- Added `ChownToUser()` / `ChownToUserRecursive()` - fixes file ownership for files created by sudo
- Updated `ConfigDir()`, `StateDir()`, `DataDir()` to use `getHomeDir()` instead of `os.UserHomeDir()`

### Machine Drivers
Added `config.ChownToUser(machine.Status.StateDir)` after directory creation in:
- `machine/firecracker/v1alpha1.go`
- `machine/qemu/v1alpha1.go`
- `machine/xen/v1alpha1.go`

### `store/embedded.go`
- Added `config.ChownToUserRecursive(store.path)` after BadgerDB operations
- Restructured `Create()` and `Delete()` to close DB before chowning (ensures files written during close() get correct ownership)

## Testing

**Before this fix:**
```bash
$ sudo kraft run --plat fc -d ./build/app
machine_name

$ kraft ps -a
NAME  KERNEL  ARGS  CREATED  STATUS  MEM  PORTS  PLAT
# Empty - machine not visible!
```

**After this fix:**
```bash
$ sudo kraft run --plat fc -d ./build/app
compassionate_missbaker

$ kraft ps -a   # WITHOUT sudo ✓
NAME                     KERNEL  STATUS  PLAT
compassionate_missbaker  pr...   exited  fc
```

**File ownership:**
```bash
$ ls -la ~/.local/share/kraftkit/runtime/machinev1alpha1/
drwx------ 2 jaidev jaidev 000001.sst
drwx------ 2 jaidev jaidev 000002.sst
drwx------ 2 jaidev jaidev 000003.sst  # Previously owned by root!
```

## Checklist

- [x] Code follows project conventions
- [x] Commit message follows contribution guidelines
- [x] `make fmt` passes
- [x] Manual testing completed
