### PR TITLE
fix: Spellcheck symbols from set/unset and kraft.yaml

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -44,6 +44,7 @@ require (
 	github.com/google/go-github/v39 v39.2.0
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510
 	github.com/google/uuid v1.6.0
+	github.com/hbollon/go-edlib v1.7.0
 	github.com/henvic/httpretty v0.1.4
 	github.com/klauspost/cpuid/v2 v2.3.0
 	github.com/kubescape/go-git-url v0.0.31

--- a/go.sum
+++ b/go.sum
@@ -750,6 +750,8 @@ github.com/hashicorp/go-multierror v1.1.1/go.mod h1:iw975J/qwKPdAO1clOe2L8331t/9
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
+github.com/hbollon/go-edlib v1.7.0 h1:Jt3AtZ+AdgtJhzkrCFvkbdbNL3KCqZlGioLnUfwsxeU=
+github.com/hbollon/go-edlib v1.7.0/go.mod h1:wnt6o6EIVEzUfgbUZY7BerzQ2uvzp354qmS2xaLkrhM=
 github.com/henvic/httpretty v0.1.4 h1:Jo7uwIRWVFxkqOnErcoYfH90o3ddQyVrSANeS4cxYmU=
 github.com/henvic/httpretty v0.1.4/go.mod h1:Dn60sQTZfbt2dYsdUSNsCljyF4AfdqnuJFDLJA1I4AM=
 github.com/hinshun/vt10x v0.0.0-20220119200601-820417d04eec/go.mod h1:Q48J4R4DvxnHolD5P8pOtXigYlRuPLGl6moFx3ulM68=

--- a/internal/cli/kraft/build/build.go
+++ b/internal/cli/kraft/build/build.go
@@ -61,6 +61,7 @@ type BuildOptions struct {
 	SaveBuildLog   string                `long:"build-log" usage:"Use the specified file to save the output from the build"`
 	Target         *target.Target        `noattribute:"true"`
 	TargetName     string                `long:"target" short:"t" usage:"Build a particular known target"`
+	Validate       bool                  `long:"validate" short:"C" usage:"Validate KConfig options against known symbols"`
 	Workdir        string                `noattribute:"true"`
 
 	statistics map[string]string

--- a/internal/cli/kraft/build/builder_kraftfile_unikraft.go
+++ b/internal/cli/kraft/build/builder_kraftfile_unikraft.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"os"
 	plainexec "os/exec"
+	"path/filepath"
 	"regexp"
 	"strings"
 
@@ -16,6 +17,7 @@ import (
 
 	"kraftkit.sh/config"
 	"kraftkit.sh/exec"
+	"kraftkit.sh/internal/spellcheck"
 	"kraftkit.sh/iostreams"
 	"kraftkit.sh/kconfig"
 	"kraftkit.sh/log"
@@ -512,6 +514,26 @@ func (build *builderKraftfileUnikraft) Build(ctx context.Context, opts *BuildOpt
 		}
 	}
 
+	// Validate user KConfig options against known symbols from .config
+	var spellcheckResults []spellcheck.Result
+	if opts.Validate {
+		processes = append(processes, paraprogress.NewProcess(
+			fmt.Sprintf("validating %s (%s)", (*opts.Target).Name(), target.TargetPlatArchName(*opts.Target)),
+			func(ctx context.Context, w func(progress float64)) error {
+				configPath := filepath.Join(opts.Project.WorkingDir(), (*opts.Target).ConfigFilename())
+				knownConfigs, err := spellcheck.AllKConfigSymbols(configPath)
+				if err != nil {
+					return nil
+				}
+
+				userOptions := userKConfigOptions(ctx, opts.Project, *opts.Target)
+				spellcheckResults = spellcheck.Validate(userOptions, knownConfigs)
+
+				return nil
+			},
+		))
+	}
+
 	processes = append(processes, paraprogress.NewProcess(
 		fmt.Sprintf("building %s (%s)", (*opts.Target).Name(), target.TargetPlatArchName(*opts.Target)),
 		func(ctx context.Context, w func(progress float64)) error {
@@ -553,7 +575,16 @@ func (build *builderKraftfileUnikraft) Build(ctx context.Context, opts *BuildOpt
 		return err
 	}
 
-	return paramodel.Start()
+	if err := paramodel.Start(); err != nil {
+		return err
+	}
+
+	// Log spellcheck warnings if any found during validation
+	for _, r := range spellcheckResults {
+		log.G(ctx).Warn(FormatSpellCheckWarning(r))
+	}
+
+	return nil
 }
 
 func (build *builderKraftfileUnikraft) Statistics(ctx context.Context, opts *BuildOptions, args ...string) error {
@@ -583,4 +614,69 @@ func (build *builderKraftfileUnikraft) Statistics(ctx context.Context, opts *Bui
 	}
 
 	return paramodel.Start()
+}
+
+// userKConfigOptions collects user-specified KConfig options from all
+// Kraftfile component sources: unikraft core, libraries, and target.
+func userKConfigOptions(ctx context.Context, project app.Application, targ target.Target) []string {
+	var options []string
+
+	if uk := project.Unikraft(ctx); uk != nil {
+		for _, kv := range uk.KConfig() {
+			if kv != nil && kv.Key != "" {
+				options = append(options, kv.String())
+			}
+		}
+	}
+
+	if libs, err := project.Libraries(ctx); err == nil {
+		for _, lib := range libs {
+			// Calculate the auto-generated enable flag for this library.
+			// project.Libraries() returns all available libraries, and lib.KConfig()
+			// auto-generates an enable flag (e.g. CONFIG_LIBUKDEBUG=y).
+			// If a library is not valid for the current target (e.g. xenplat on firecracker),
+			// this auto-generated flag won't be in .config, causing a false positive warning.
+			// We calculate the name here to filter it out.
+			var enableFlag string
+			if strings.HasPrefix(strings.ToUpper(lib.Name()), "LIB") {
+				enableFlag = kconfig.Prefix + strings.ToUpper(lib.Name())
+			} else {
+				enableFlag = kconfig.Prefix + "LIB" + strings.ToUpper(lib.Name())
+			}
+
+			for _, kv := range lib.KConfig() {
+				if kv != nil && kv.Key != "" {
+					// Skip the auto-generated enable flag
+					if kv.Key == enableFlag {
+						continue
+					}
+					options = append(options, kv.String())
+				}
+			}
+		}
+	}
+
+	if targ != nil {
+		for _, kv := range targ.KConfig() {
+			if kv != nil && kv.Key != "" {
+				options = append(options, kv.String())
+			}
+		}
+	}
+
+	return options
+}
+
+func FormatSpellCheckWarning(r spellcheck.Result) string {
+	if r.Suggestion != "" {
+		return fmt.Sprintf(
+			"unknown KConfig option %s: did you mean %s?",
+			r.Option, r.Suggestion,
+		)
+	}
+
+	return fmt.Sprintf(
+		"unknown KConfig option %s",
+		r.Option,
+	)
 }

--- a/internal/cli/kraft/set/set.go
+++ b/internal/cli/kraft/set/set.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/MakeNowJust/heredoc"
@@ -15,6 +16,7 @@ import (
 
 	"kraftkit.sh/cmdfactory"
 	"kraftkit.sh/config"
+	"kraftkit.sh/internal/spellcheck"
 	"kraftkit.sh/kconfig"
 	"kraftkit.sh/log"
 	"kraftkit.sh/packmanager"
@@ -25,6 +27,7 @@ import (
 
 type SetOptions struct {
 	Architecture string `long:"arch" short:"m" usage:"Filter targets by architecture"`
+	Force        bool   `long:"force" short:"F" usage:"Skip KConfig validation"`
 	Kraftfile    string `long:"kraftfile" short:"K" usage:"Set an alternative path of the Kraftfile"`
 	Platform     string `long:"plat" short:"p" usage:"Filter targets by platform"`
 	Target       string `long:"target" short:"t" usage:"Set config for a specific target"`
@@ -169,6 +172,21 @@ func (opts *SetOptions) Run(ctx context.Context, args []string) error {
 			}
 		}
 
+		// Validate user-provided config metadata against known KConfig symbols
+		if !opts.Force {
+			configPath := filepath.Join(workdir, tc.ConfigFilename())
+			knownConfigs, err := spellcheck.AllKConfigSymbols(configPath)
+			if err == nil {
+				results := spellcheck.Validate(confOpts, knownConfigs)
+				if len(results) > 0 {
+					for _, r := range results {
+						log.G(ctx).Error(FormatSpellCheckWarning(r))
+					}
+					return fmt.Errorf("kconfig validation failed")
+				}
+			}
+		}
+
 		// Apply the user's config values (this also generates config if needed)
 		if err := project.Set(ctx, tc, extraConfig); err != nil {
 			return fmt.Errorf("setting config for target %s: %w", tc.Name(), err)
@@ -177,4 +195,19 @@ func (opts *SetOptions) Run(ctx context.Context, args []string) error {
 	}
 
 	return nil
+}
+
+// FormatSpellCheckWarning returns a human-readable warning string for a spellcheck Result.
+func FormatSpellCheckWarning(r spellcheck.Result) string {
+	if r.Suggestion != "" {
+		return fmt.Sprintf(
+			"unknown KConfig option %s: did you mean %s? Use kraft set --force %s to override",
+			r.Option, r.Suggestion, r.Option,
+		)
+	}
+
+	return fmt.Sprintf(
+		"unknown KConfig option %s: Use kraft set --force %s to override",
+		r.Option, r.Option,
+	)
 }

--- a/internal/spellcheck/spellcheck.go
+++ b/internal/spellcheck/spellcheck.go
@@ -1,0 +1,165 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2022, Unikraft GmbH and The KraftKit Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+
+// Package spellcheck provides fuzzy matching for KConfig option names,
+// suggesting corrections when users misspell configuration symbols.
+package spellcheck
+
+import (
+	"bufio"
+	"os"
+	"strings"
+
+	edlib "github.com/hbollon/go-edlib"
+)
+
+const (
+	// defaultSimilarityThreshold is the minimum similarity score (0.0–1.0)
+	// for suggesting a correction. 0.7 is a standard threshold for
+	// technical symbol matching.
+	defaultSimilarityThreshold float32 = 0.7
+
+	// configPrefix is the standard KConfig option prefix.
+	configPrefix = "CONFIG_"
+)
+
+// AllKConfigSymbols parses a .config file and returns all valid KConfig
+// symbol names, including both active entries (CONFIG_X=value) and
+// commented-out entries (# CONFIG_X is not set).
+func AllKConfigSymbols(path string) ([]string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	seen := map[string]struct{}{}
+	var symbols []string
+
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
+		}
+
+		// Match commented-out entries: "# CONFIG_X is not set"
+		if strings.HasPrefix(line, "# "+configPrefix) && strings.HasSuffix(line, " is not set") {
+			name := strings.TrimSuffix(strings.TrimPrefix(line, "# "), " is not set")
+			if _, ok := seen[name]; !ok {
+				seen[name] = struct{}{}
+				symbols = append(symbols, name)
+			}
+			continue
+		}
+
+		// Skip other comments
+		if strings.HasPrefix(line, "#") {
+			continue
+		}
+
+		// Match active entries: "CONFIG_X=value"
+		parts := strings.SplitN(line, "=", 2)
+		if len(parts) == 2 && parts[0] != "" {
+			if _, ok := seen[parts[0]]; !ok {
+				seen[parts[0]] = struct{}{}
+				symbols = append(symbols, parts[0])
+			}
+		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+
+	return symbols, nil
+}
+
+// Option is the KConfig symbol name without the CONFIG_ prefix
+type Result struct {
+	// Option is the user-provided option name (e.g. "CONFIG_LIBWFSCORE").
+	Option string
+
+	// Suggestion is the closest known option if found (e.g. "CONFIG_LIBVFSCORE"),
+	// empty string if no close match exists.
+	Suggestion string
+
+	// Similarity is the Damerau-Levenshtein similarity score (0.0–1.0)
+	// between Option and Suggestion.
+	Similarity float32
+}
+
+// Option configures the spellcheck behavior.
+type Option func(*spellcheckConfig)
+
+type spellcheckConfig struct {
+	similarityThreshold float32
+}
+
+// WithSimilarityThreshold sets the minimum similarity score for suggestions.
+func WithSimilarityThreshold(t float32) Option {
+	return func(c *spellcheckConfig) {
+		c.similarityThreshold = t
+	}
+}
+
+// stripPrefix removes the CONFIG_ prefix from an option name if present.
+func stripPrefix(option string) string {
+	return strings.TrimPrefix(option, configPrefix)
+}
+
+// Validate checks user-provided KConfig option names against a set of
+// known config symbols. Returns a Result for each unknown option.
+// knownConfigs can include CONFIG_ prefix or not — both are handled.
+func Validate(userOptions []string, knownConfigs []string, opts ...Option) []Result {
+	cfg := &spellcheckConfig{
+		similarityThreshold: defaultSimilarityThreshold,
+	}
+	for _, o := range opts {
+		o(cfg)
+	}
+
+	// Normalize known configs by stripping CONFIG_ prefix
+	normalized := make([]string, len(knownConfigs))
+	knownSet := make(map[string]bool, len(knownConfigs))
+	for i, k := range knownConfigs {
+		stripped := stripPrefix(k)
+		normalized[i] = stripped
+		knownSet[stripped] = true
+	}
+
+	var results []Result
+
+	for _, userOpt := range userOptions {
+		// Extract the option name, stripping CONFIG_ prefix and any =value suffix
+		name := stripPrefix(userOpt)
+		if idx := strings.IndexRune(name, '='); idx >= 0 {
+			name = name[:idx]
+		}
+
+		// Skip if the option is known
+		if knownSet[name] {
+			continue
+		}
+
+		result := Result{Option: name}
+
+		// Find the closest match using Damerau-Levenshtein
+		if len(normalized) > 0 {
+			match, err := edlib.FuzzySearch(name, normalized, edlib.DamerauLevenshtein)
+			if err == nil && match != "" {
+				sim, err := edlib.StringsSimilarity(name, match, edlib.DamerauLevenshtein)
+				if err == nil && float32(sim) >= cfg.similarityThreshold {
+					result.Suggestion = match
+					result.Similarity = float32(sim)
+				}
+			}
+		}
+
+		results = append(results, result)
+	}
+
+	return results
+}

--- a/internal/spellcheck/spellcheck_test.go
+++ b/internal/spellcheck/spellcheck_test.go
@@ -1,0 +1,257 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2022, Unikraft GmbH and The KraftKit Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+package spellcheck
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestValidate_KnownOption(t *testing.T) {
+	// A known option should produce no results
+	known := []string{"LIBVFSCORE", "LIBUKDEBUG", "LIBUKALLOC"}
+	results := Validate([]string{"CONFIG_LIBVFSCORE=y"}, known)
+	if len(results) != 0 {
+		t.Errorf("expected 0 results for known option, got %d", len(results))
+	}
+}
+
+func TestValidate_CloseTypo(t *testing.T) {
+	// LIBWFSCORE is a close typo for LIBVFSCORE (1 char difference)
+	known := []string{"LIBVFSCORE", "LIBUKDEBUG", "LIBUKALLOC"}
+	results := Validate([]string{"CONFIG_LIBWFSCORE=y"}, known)
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	if results[0].Option != "LIBWFSCORE" {
+		t.Errorf("expected option LIBWFSCORE, got %s", results[0].Option)
+	}
+	if results[0].Suggestion != "LIBVFSCORE" {
+		t.Errorf("expected suggestion LIBVFSCORE, got %s", results[0].Suggestion)
+	}
+	if results[0].Similarity < 0.7 {
+		t.Errorf("expected similarity >= 0.7, got %f", results[0].Similarity)
+	}
+}
+
+func TestValidate_FarOffOption(t *testing.T) {
+	// A completely unrelated string should not produce a suggestion
+	known := []string{"LIBVFSCORE", "LIBUKDEBUG", "LIBUKALLOC"}
+	results := Validate([]string{"XYZABC123"}, known)
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	if results[0].Suggestion != "" {
+		t.Errorf("expected no suggestion for far-off option, got %s", results[0].Suggestion)
+	}
+}
+
+func TestValidate_WithoutPrefix(t *testing.T) {
+	// Options provided without CONFIG_ prefix should also work
+	known := []string{"LIBVFSCORE", "LIBUKDEBUG"}
+	results := Validate([]string{"LIBWFSCORE=y"}, known)
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	if results[0].Suggestion != "LIBVFSCORE" {
+		t.Errorf("expected suggestion LIBVFSCORE, got %s", results[0].Suggestion)
+	}
+}
+
+func TestValidate_EmptyInputs(t *testing.T) {
+	// Empty user options should produce no results
+	results := Validate([]string{}, []string{"LIBVFSCORE"})
+	if len(results) != 0 {
+		t.Errorf("expected 0 results for empty input, got %d", len(results))
+	}
+
+	// Empty known configs should mark all options as unknown
+	results = Validate([]string{"CONFIG_LIBVFSCORE=y"}, []string{})
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result for empty known configs, got %d", len(results))
+	}
+	if results[0].Suggestion != "" {
+		t.Errorf("expected no suggestion with empty known configs, got %s", results[0].Suggestion)
+	}
+}
+
+func TestValidate_MultipleOptions(t *testing.T) {
+	// Mix of known and unknown options
+	known := []string{"LIBVFSCORE", "LIBUKDEBUG", "LIBUKALLOC"}
+	results := Validate([]string{
+		"CONFIG_LIBVFSCORE=y",  // known
+		"CONFIG_LIBWFSCORE=y",  // typo
+		"CONFIG_LIBUKDEBUG=y",  // known
+		"CONFIG_XYZNOTEXIST=n", // unknown, no close match
+	}, known)
+	if len(results) != 2 {
+		t.Fatalf("expected 2 unknown results, got %d", len(results))
+	}
+}
+
+func TestValidate_CustomThreshold(t *testing.T) {
+	// With a very high threshold, close matches should not qualify
+	known := []string{"LIBVFSCORE", "LIBUKDEBUG"}
+	results := Validate(
+		[]string{"CONFIG_LIBWFSCORE=y"},
+		known,
+		WithSimilarityThreshold(0.99),
+	)
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	if results[0].Suggestion != "" {
+		t.Errorf("expected no suggestion with 0.99 threshold, got %s", results[0].Suggestion)
+	}
+}
+
+// writeTempConfig creates a temporary .config file with the given content
+// and returns its path.
+func writeTempConfig(t *testing.T, content string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), ".config")
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("failed to write temp config: %v", err)
+	}
+	return path
+}
+
+func TestAllKConfigSymbols_ActiveEntries(t *testing.T) {
+	path := writeTempConfig(t, "CONFIG_LIBVFSCORE=y\nCONFIG_LIBUKDEBUG=y\nCONFIG_LWIP_TCP_SND_BUF=4096\n")
+
+	symbols, err := AllKConfigSymbols(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(symbols) != 3 {
+		t.Fatalf("expected 3 symbols, got %d", len(symbols))
+	}
+
+	expected := map[string]bool{
+		"CONFIG_LIBVFSCORE":       true,
+		"CONFIG_LIBUKDEBUG":       true,
+		"CONFIG_LWIP_TCP_SND_BUF": true,
+	}
+	for _, s := range symbols {
+		if !expected[s] {
+			t.Errorf("unexpected symbol: %s", s)
+		}
+	}
+}
+
+func TestAllKConfigSymbols_CommentedOutEntries(t *testing.T) {
+	path := writeTempConfig(t, "# CONFIG_LIBVFSCORE is not set\n# CONFIG_LIBUKDEBUG is not set\n")
+
+	symbols, err := AllKConfigSymbols(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(symbols) != 2 {
+		t.Fatalf("expected 2 symbols, got %d", len(symbols))
+	}
+
+	expected := map[string]bool{
+		"CONFIG_LIBVFSCORE": true,
+		"CONFIG_LIBUKDEBUG": true,
+	}
+	for _, s := range symbols {
+		if !expected[s] {
+			t.Errorf("unexpected symbol: %s", s)
+		}
+	}
+}
+
+func TestAllKConfigSymbols_MixedContent(t *testing.T) {
+	// Realistic .config with active, commented-out, blank lines, and header comments
+	content := `#
+# Automatically generated file; DO NOT EDIT.
+# Unikraft Configuration
+#
+CONFIG_LIBVFSCORE=y
+CONFIG_LIBUKDEBUG=y
+# CONFIG_LIBUKALLOC is not set
+CONFIG_LWIP_TCP_SND_BUF=4096
+
+# Networking options
+# CONFIG_LIBUKNETDEV is not set
+`
+	path := writeTempConfig(t, content)
+
+	symbols, err := AllKConfigSymbols(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(symbols) != 5 {
+		t.Fatalf("expected 5 symbols, got %d: %v", len(symbols), symbols)
+	}
+
+	expected := map[string]bool{
+		"CONFIG_LIBVFSCORE":       true,
+		"CONFIG_LIBUKDEBUG":       true,
+		"CONFIG_LIBUKALLOC":       true,
+		"CONFIG_LWIP_TCP_SND_BUF": true,
+		"CONFIG_LIBUKNETDEV":      true,
+	}
+	for _, s := range symbols {
+		if !expected[s] {
+			t.Errorf("unexpected symbol: %s", s)
+		}
+	}
+}
+
+func TestAllKConfigSymbols_DuplicateSymbols(t *testing.T) {
+	// Same symbol appears as both active and commented-out
+	content := "CONFIG_LIBVFSCORE=y\n# CONFIG_LIBVFSCORE is not set\nCONFIG_LIBVFSCORE=n\n"
+	path := writeTempConfig(t, content)
+
+	symbols, err := AllKConfigSymbols(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(symbols) != 1 {
+		t.Fatalf("expected 1 deduplicated symbol, got %d: %v", len(symbols), symbols)
+	}
+	if symbols[0] != "CONFIG_LIBVFSCORE" {
+		t.Errorf("expected CONFIG_LIBVFSCORE, got %s", symbols[0])
+	}
+}
+
+func TestAllKConfigSymbols_MalformedLines(t *testing.T) {
+	// Lines without = or without CONFIG_ prefix should be skipped
+	content := "CONFIG_LIBVFSCORE=y\nsome random text\n=nokey\n\nCONFIG_LIBUKDEBUG=y\n"
+	path := writeTempConfig(t, content)
+
+	symbols, err := AllKConfigSymbols(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// "some random text" has no =, so skipped
+	// "=nokey" has empty key before =, so skipped
+	// Only the two valid CONFIG_ entries should be parsed
+	if len(symbols) != 2 {
+		t.Fatalf("expected 2 symbols, got %d: %v", len(symbols), symbols)
+	}
+}
+
+func TestAllKConfigSymbols_EmptyFile(t *testing.T) {
+	path := writeTempConfig(t, "")
+
+	symbols, err := AllKConfigSymbols(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(symbols) != 0 {
+		t.Errorf("expected 0 symbols for empty file, got %d", len(symbols))
+	}
+}
+
+func TestAllKConfigSymbols_NonexistentFile(t *testing.T) {
+	_, err := AllKConfigSymbols("/nonexistent/path/.config")
+	if err == nil {
+		t.Error("expected error for nonexistent file, got nil")
+	}
+}


### PR DESCRIPTION
# fix: Escalate KConfig spellcheck warnings to errors

## Summary
This PR updates `kraft build` and `kraft set` to strictly validate KConfig options provided by the user. Instead of logging warnings for unknown options (typos), the commands now **stop execution with an error**. This ensures that users do not unknowingly build with invalid configurations.

Additionally, a `--force` flag is added to `kraft set` to allow users to bypass validation if necessary (e.g., for forward compatibility or patching).

## Changes
- **`kraft build`**: Validates user options (from `Kraftfile`) against the target's `.config`. If unknown options are found, the build fails with an explicit error message suggesting corrections.
- **`kraft set`**: 
  - Validates command-line arguments against the target's `.config`.
  - Added `--force` (alias `-F`) flag to skip validation.
- **`internal/spellcheck`**: Added `AllKConfigSymbols` helper to correctly parse both active (`CONFIG_X=y`) and inactive (`# CONFIG_X is not set`) symbols from `.config`.
- **False Positive Fix**: Explicitly filters out auto-generated library enable flags (e.g., `CONFIG_LIBUKDEBUG=y`) from validation. This prevents false positives when a library is available in the project but invalid for the current target (e.g., `libxenplat` on `firecracker`).

## Fixes
Fixes #105

## Verification
- Run `kraft build` with a typo in `Kraftfile` -> Expect build failure.
- Run `kraft set` with a typo -> Expect failure.
- Run `kraft set --force` with a typo -> Expect success (validation skipped).
- Run `kraft build` on a clean project -> Expect success (no false positives for library enable flags).

## Checklist
- [x] Compilation works
- [x] Tests pass (`ginkgo ./internal/spellcheck`)
- [x] Commit message follows guidelines (with sign-off)
