### PR TITLE
fix: --no-prompt suppresses reconfigure prompt

### DIFF
--- a/internal/cli/kraft/build/builder_kraftfile_unikraft.go
+++ b/internal/cli/kraft/build/builder_kraftfile_unikraft.go
@@ -481,7 +481,7 @@ func (build *builderKraftfileUnikraft) Build(ctx context.Context, opts *BuildOpt
 		var err error
 		configure := true
 
-		if opts.Project.IsConfigured(*opts.Target) {
+		if opts.Project.IsConfigured(*opts.Target) && !config.G[config.KraftKit](ctx).NoPrompt {
 			configure, err = confirm.NewConfirm("project already configured, are you sure you want to rerun the configure step:")
 			if err != nil {
 				return err

--- a/internal/cli/kraft/fetch/fetch.go
+++ b/internal/cli/kraft/fetch/fetch.go
@@ -423,7 +423,7 @@ func (opts *FetchOptions) Run(ctx context.Context, _ []string) error {
 			var err error
 			configure := true
 
-			if opts.project.IsConfigured(targ) {
+			if opts.project.IsConfigured(targ) && !config.G[config.KraftKit](ctx).NoPrompt {
 				configure, err = confirm.NewConfirm("project already configured, are you sure you want to rerun the configure step:")
 				if err != nil {
 					return err

--- a/internal/cli/kraft/menu/menu.go
+++ b/internal/cli/kraft/menu/menu.go
@@ -425,7 +425,7 @@ func (opts *MenuOptions) Run(ctx context.Context, _ []string) error {
 			var err error
 			configure := true
 
-			if opts.project.IsConfigured(targ) {
+			if opts.project.IsConfigured(targ) && !config.G[config.KraftKit](ctx).NoPrompt {
 				configure, err = confirm.NewConfirm("project already configured, are you sure you want to rerun the configure step:")
 				if err != nil {
 					return err


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes locally.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->
Makes it so that `--no-prompt`, which is documented as "Do not prompt for user interaction", actually prevents prompting if the project is already configured.

It defaults to going through with the reconfiguration, which should be expected since "Yes" is presented as the default choice (as opposed to `--no-configure`).