### PR TITLE
fix: kraftld: allow re-running

### DIFF
--- a/scripts/kraftld
+++ b/scripts/kraftld
@@ -84,7 +84,7 @@ fi
 
 
 # Finally, build the Unikraft image
-kraft build --log-level debug --log-type basic --no-cache "${KRAFTKIT_ARG_TARG[@]}" "${KRAFTKIT_ARG_PLAT[@]}" "${KRAFTKIT_ARG_ARCH[@]}"
+kraft build --log-level debug --log-type basic --no-cache --no-prompt "${KRAFTKIT_ARG_TARG[@]}" "${KRAFTKIT_ARG_PLAT[@]}" "${KRAFTKIT_ARG_ARCH[@]}"
 
 
 # Find KraftKit output image


### PR DESCRIPTION
(re-opening, not quite sure what happened with https://github.com/unikraft/kraftkit/pull/2648)
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes locally.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->
When compiling Rust to unikraft, `rustc` calls `kraftld`, which calls `kraft build`. Any prompt that `kraft` tries to issue will result in an obscure error from the PoV of the user. For example, just building the catalog's `native/hellowrod-rs`, modifying the message and building again will result in:
```
Compiling helloworld v0.1.0
error: linking with `kraftld` failed: exit status: 1
  |
  = note:  "kraftld" "-m64" "/home/xxx/Projects/catalog/native/helloworld-rs/target/x86_64-unikraft-linux-musl/debug/deps/rustccs2eF0/symbols.o" "<9 object files omitted>" "-Wl,--as-needed" "-Wl,-Bstatic" "/home/xxx/Projects/catalog/native/helloworld-rs/target/x86_64-unikraft-linux-musl/debug/deps/{libpanic_abort-3a3fc17b99e43b0d,libstd-b8b88691ef5b60e2,libobject-1a10e4a903c4ee27,libmemchr-60e95ba718f88f2c,libaddr2line-7b899af8a3dfbe8e,libgimli-a21dd6c001728f93,libcfg_if-b1bd73045de1160b,librustc_demangle-91fa3306e29ed1a7,libstd_detect-5dc1fb615818ddc7,libhashbrown-1f95d6c1d6a4f2bc,librustc_std_workspace_alloc-0aa5dc9f1fba2fcf,libminiz_oxide-3a4a4ad574bef930,libadler2-d9d1a642de152172,libunwind-6ad495f04d160482,liblibc-6867aab44b906e4e,librustc_std_workspace_core-1681bbf926c96e5d,liballoc-9af9bea6009e9e69,libcore-291420ac24b41699,libcompiler_builtins-c4095feda71caeb8}.rlib" "-Wl,-Bdynamic" "-lgcc_s" "-lc" "-L" "/home/xxx/Projects/catalog/native/helloworld-rs/target/x86_64-unikraft-linux-musl/debug/deps/rustccs2eF0/raw-dylibs" "-Wl,--eh-frame-hdr" "-Wl,-z,noexecstack" "-L" "<sysroot>/lib/rustlib/x86_64-unikraft-linux-musl/lib" "-o" "/home/xxx/Projects/catalog/native/helloworld-rs/target/x86_64-unikraft-linux-musl/debug/deps/helloworld-4b513cef4b363c83" "-Wl,--gc-sections" "-no-pie" "-nodefaultlibs"
  = note: some arguments are omitted. use `--verbose` to show all linker arguments
  = note: level=debug msg=kraftkit version=0.12.5
          level=debug msg=using builder=kraftfile-unikraft
          level=info msg="updating index"
          level=debug msg="saving unikraft.org/lua:5.4 (fc/x86_64)"
         [...]
          level=debug msg="saving lib/zydis" path="/home/xxx/.local/share/kraftkit/manifests/libs/zydis.yaml"
          level=error msg="could not complete build: running prompt: error creating cancelreader: bubbletea: error creating cancel reader: add reader to epoll interest list"


error: could not compile `helloworld` (bin "helloworld") due to 1 previous error
```

This is fixed by passing `--no-prompt` to `kraft`, building on https://github.com/unikraft/kraftkit/pull/2647 to ensure that this actually makes `kraft` not prompt.