### PR TITLE
fix: Add rootfs to initramfs filename

### DIFF
--- a/internal/cli/kraft/build/build.go
+++ b/internal/cli/kraft/build/build.go
@@ -128,7 +128,7 @@ func Build(ctx context.Context, opts *BuildOptions, args ...string) error {
 			initrd.WithOutput(filepath.Join(
 				opts.Workdir,
 				unikraft.BuildDir,
-				fmt.Sprintf(initrd.DefaultInitramfsArchFileName, (*opts.Target).Architecture().String()),
+				fmt.Sprintf(initrd.DefaultInitramfsArchFileName, (*opts.Target).Architecture(), opts.RootfsType),
 			)),
 			initrd.WithOutputType(opts.RootfsType),
 			initrd.WithCacheDir(filepath.Join(

--- a/internal/cli/kraft/pkg/packager_cli_kernel.go
+++ b/internal/cli/kraft/pkg/packager_cli_kernel.go
@@ -76,7 +76,7 @@ func (p *packagerCliKernel) Pack(ctx context.Context, opts *PkgOptions, args ...
 			initrd.WithOutput(filepath.Join(
 				opts.Workdir,
 				unikraft.BuildDir,
-				fmt.Sprintf(initrd.DefaultInitramfsArchFileName, targ.Architecture().String()),
+				fmt.Sprintf(initrd.DefaultInitramfsArchFileName, targ.Architecture(), opts.RootfsType),
 			)),
 			initrd.WithOutputType(opts.RootfsType),
 			initrd.WithCacheDir(filepath.Join(

--- a/internal/cli/kraft/pkg/packager_kraftfile_runtime.go
+++ b/internal/cli/kraft/pkg/packager_kraftfile_runtime.go
@@ -407,7 +407,7 @@ func (p *packagerKraftfileRuntime) Pack(ctx context.Context, opts *PkgOptions, a
 			initrd.WithOutput(filepath.Join(
 				opts.Workdir,
 				unikraft.BuildDir,
-				fmt.Sprintf(initrd.DefaultInitramfsArchFileName, p.architecture.String()),
+				fmt.Sprintf(initrd.DefaultInitramfsArchFileName, p.architecture, opts.RootfsType),
 			)),
 			initrd.WithOutputType(opts.RootfsType),
 			initrd.WithCacheDir(filepath.Join(

--- a/internal/cli/kraft/pkg/packager_kraftfile_unikraft.go
+++ b/internal/cli/kraft/pkg/packager_kraftfile_unikraft.go
@@ -127,7 +127,7 @@ func (p *packagerKraftfileUnikraft) Pack(ctx context.Context, opts *PkgOptions, 
 					initrd.WithOutput(filepath.Join(
 						opts.Workdir,
 						unikraft.BuildDir,
-						fmt.Sprintf(initrd.DefaultInitramfsArchFileName, targ.Architecture().String()),
+						fmt.Sprintf(initrd.DefaultInitramfsArchFileName, targ.Architecture(), opts.RootfsType),
 					)),
 					initrd.WithOutputType(opts.RootfsType),
 					initrd.WithCacheDir(filepath.Join(


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes locally.

### Description of changes

Follow-up to https://github.com/unikraft/kraftkit/pull/2497.

Fixes the `MISSING` element in filenames as reported by @craciunoiuc:

```
 D  including initrd dest=/unikraft/bin/initrd src=/home/cez/unikraft-io/kraftcloud-examples/nginx/.unikraft/build/initramfs-x86_64.%!s(MISSING)
 T  archive: tarring dst=unikraft/bin/initrd src=/home/cez/unikraft-io/kraftcloud-examples/nginx/.unikraft/build/initramfs-x86_64.%!s(MISSING)
```

<!--
Please provide a detailed description of the changes made in this new PR.
-->
