### PR TITLE
test(internal/set): Add unit tests for ContainsAnyOf

### DIFF
--- a/internal/set/string_set_test.go
+++ b/internal/set/string_set_test.go
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2026, Unikraft GmbH and The KraftKit Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+
+package set
+
+import (
+	"testing"
+)
+
+func TestContainsAnyOf(t *testing.T) {
+	tests := []struct {
+		name   string
+		args   []string
+		fields []string
+		want   bool
+	}{
+		{
+			name:   "nil values",
+			args:   nil,
+			fields: []string{"one", "two"},
+		},
+		{
+			name:   "empty args",
+			args:   []string{},
+			fields: []string{"one", "two"},
+		},
+		{
+			name:   "empty stringSet",
+			args:   []string{"one", "two"},
+			fields: []string{},
+		},
+		{
+			name:   "partial match",
+			args:   []string{"thr"},
+			fields: []string{"one", "two", "three"},
+			want:   true,
+		},
+		{
+			name:   "single match",
+			args:   []string{"zero", "two"},
+			fields: []string{"one", "two", "three"},
+			want:   true,
+		},
+		{
+			name:   "case sensitivity",
+			args:   []string{"ONE"},
+			fields: []string{"one", "two", "three"},
+		},
+		{
+			name:   "multiple match",
+			args:   []string{"zero", "on", "two", "three"},
+			fields: []string{"one", "two", "three"},
+			want:   true,
+		},
+		{
+			name:   "emogi",
+			args:   []string{"🫩", "💀"},
+			fields: []string{"😀", "💀🐹", "🐹", "😇", "😑"},
+			want:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := NewStringSet(tt.fields...)
+			if got := s.ContainsAnyOf(tt.args...); got != tt.want {
+				t.Errorf("ContainsAnyOf() = %t, want %t", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Implement table-driven tests for the ContainsAnyOf method, covering:
- Nil and empty slice inputs
- Partial substring matching
- Unicode/Emoji support
- Case sensitivity

Note: This is the start of a bottom-up testing approach for this package. Once these core methods are verified, I will proceed with testing the remainder of the file.

<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes locally.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->
