### PR TITLE
fix(internal/set): Use ContainsExactly instead

### DIFF
--- a/internal/set/string_set.go
+++ b/internal/set/string_set.go
@@ -47,7 +47,7 @@ func NewStringSet(values ...string) *stringSet {
 
 func (s *stringSet) Add(values ...string) *stringSet {
 	for _, value := range values {
-		if s.Contains(value) {
+		if s.ContainsExactly(value) {
 			continue
 		}
 		s.m[value] = exists
@@ -59,7 +59,7 @@ func (s *stringSet) Add(values ...string) *stringSet {
 
 func (s *stringSet) Remove(values ...string) *stringSet {
 	for _, value := range values {
-		if !s.Contains(value) {
+		if !s.ContainsExactly(value) {
 			continue
 		}
 		delete(s.m, value)
@@ -125,7 +125,7 @@ func (s1 *stringSet) Equal(s2 *stringSet) bool {
 	}
 	isEqual := true
 	for _, v := range s1.v {
-		if !s2.Contains(v) {
+		if !s2.ContainsExactly(v) {
 			isEqual = false
 			break
 		}


### PR DESCRIPTION
Use ContinsExactly for Add, Remove and Equal methods instead of using Contains which does a substring match

<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes locally.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->
