### PR TITLE
feat: Introduce global Toolchain config map

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -54,6 +54,8 @@ type KraftKit struct {
 	Auth map[string]AuthConfig `yaml:"auth,omitempty" noattribute:"true"`
 
 	Aliases map[string]map[string]string `yaml:"aliases" noattribute:"true"`
+
+	Toolchain map[string]string `yaml:"toolchain,omitempty" noattribute:"true"`
 }
 
 type ConfigDetail struct {

--- a/internal/cli/kraft/build/builder_kraftfile_unikraft.go
+++ b/internal/cli/kraft/build/builder_kraftfile_unikraft.go
@@ -439,6 +439,11 @@ func (build *builderKraftfileUnikraft) Build(ctx context.Context, opts *BuildOpt
 		mopts = append(mopts, make.WithMaxJobs(!opts.NoFast && !config.G[config.KraftKit](ctx).NoParallel))
 	}
 
+	// Inject global toolchain variables into the make invocation
+	if toolchain := config.G[config.KraftKit](ctx).Toolchain; len(toolchain) > 0 {
+		mopts = append(mopts, make.WithVars(toolchain))
+	}
+
 	allEnvs := map[string]string{}
 	for k, v := range opts.Project.Env() {
 		allEnvs[k] = v


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes locally.

### Description of changes
Adds a `Toolchain map[string]string` field to the `KraftKit` config
struct in `config/config.go` as the first step towards #673.

The field follows the existing pattern of `Auth` and `Aliases` which
are both maps using `noattribute:"true"`.

The toolchain variables are injected into any `make` invocation via
`make.WithVars()` in `builder_kraftfile_unikraft.go`, accessible via
`config.G[config.KraftKit](ctx).Toolchain`.

Allowing users to set global toolchain variables in their KraftKit
config file which will be passed directly to Unikraft's build system.
For example:

```
toolchain:
  CC: /path/to/alternative/gcc
  UK_CFLAGS: -fdiagnostics-color=always
```

Remaining work tracked in #673:
- Initialize CC: gcc default in config/defaults.go
- Add toolchain directive to Kraftfile schema and loader
- Add per-target override support in Kraftfile targets
- Add kraft toolchain set/list/unset CLI commands
<!--
Please provide a detailed description of the changes made in this new PR.
-->
