### PR TITLE
fix: Avoid overwriting fstype with empty value

### DIFF
--- a/initrd/detect.go
+++ b/initrd/detect.go
@@ -7,6 +7,8 @@ package initrd
 import (
 	"context"
 	"fmt"
+
+	"kraftkit.sh/log"
 )
 
 // New attempts to return the builder for a supplied path which
@@ -14,14 +16,32 @@ import (
 func New(ctx context.Context, path string, opts ...InitrdOption) (Initrd, error) {
 	if builder, err := NewFromDockerfile(ctx, path, opts...); err == nil {
 		return builder, nil
-	} else if builder, err := NewFromTarball(ctx, path, opts...); err == nil {
+	} else {
+		log.G(ctx).Tracef("could not build initrd from Dockerfile: %s", err)
+	}
+
+	if builder, err := NewFromTarball(ctx, path, opts...); err == nil {
 		return builder, nil
-	} else if builder, err := NewFromFile(ctx, path, opts...); err == nil {
+	} else {
+		log.G(ctx).Tracef("could not build initrd from tarball: %s", err)
+	}
+
+	if builder, err := NewFromFile(ctx, path, opts...); err == nil {
 		return builder, nil
-	} else if builder, err := NewFromDirectory(ctx, path, opts...); err == nil {
+	} else {
+		log.G(ctx).Tracef("could not build initrd from file: %s", err)
+	}
+
+	if builder, err := NewFromDirectory(ctx, path, opts...); err == nil {
 		return builder, nil
-	} else if builder, err := NewFromOCIImage(ctx, path, opts...); err == nil {
+	} else {
+		log.G(ctx).Tracef("could not build initrd from directory: %s", err)
+	}
+
+	if builder, err := NewFromOCIImage(ctx, path, opts...); err == nil {
 		return builder, nil
+	} else {
+		log.G(ctx).Tracef("could not build initrd from OCI image: %s", err)
 	}
 
 	return nil, fmt.Errorf("could not determine how to build initrd from: %s", path)

--- a/initrd/options.go
+++ b/initrd/options.go
@@ -128,8 +128,16 @@ func WithOutput(output string) InitrdOption {
 // WithOutputType sets the output type of the resulting root filesystem.
 func WithOutputType(fsType FsType) InitrdOption {
 	return func(opts *InitrdOptions) error {
-		opts.fsType = fsType
-		return nil
+		if fsType == "" {
+			return nil
+		}
+		for _, validType := range FsTypes() {
+			if fsType == validType {
+				opts.fsType = fsType
+				return nil
+			}
+		}
+		return fmt.Errorf("invalid output type '%s', valid types are: %v", fsType, FsTypeNames())
 	}
 }
 


### PR DESCRIPTION
### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes locally.

### Description of changes

This value will be set to the empty string from the CLI if it's not explicitly set with `--rootfs-type`. This essentially results in overwriting the pre-populated default cpio type with an empty fs type.
    
This then just silently skips the build in older versions of kraft, or causes a weirdly strange internal error on staging.