### PR TITLE
fix(pkg/pull): Route git/GitHub URLs to manifest provider

### DIFF
--- a/internal/cli/kraft/pkg/pull/pull.go
+++ b/internal/cli/kraft/pkg/pull/pull.go
@@ -338,13 +338,21 @@ func (opts *PullOptions) Run(ctx context.Context, args []string) error {
 		// Is this a list (space delimetered) of packages to pull?
 	} else if len(args) > 0 {
 		for _, arg := range args {
-			queries = append(queries, []packmanager.QueryOption{
+			qopts := []packmanager.QueryOption{
 				packmanager.WithRemote(opts.Update),
-				packmanager.WithName(arg),
 				packmanager.WithArchitecture(opts.Architecture),
 				packmanager.WithPlatform(opts.Platform),
 				packmanager.WithKConfig(opts.KConfig),
-			})
+			}
+			if strings.HasSuffix(arg, ".git") ||
+				strings.HasPrefix(arg, "git@") ||
+				strings.HasPrefix(arg, "github.com/") ||
+				strings.Contains(arg, "://github.com/") {
+				qopts = append(qopts, packmanager.WithSource(arg))
+			} else {
+				qopts = append(qopts, packmanager.WithName(arg))
+			}
+			queries = append(queries, qopts)
 		}
 	}
 

--- a/internal/cli/kraft/pkg/pull/pull.go
+++ b/internal/cli/kraft/pkg/pull/pull.go
@@ -15,6 +15,7 @@ import (
 
 	"kraftkit.sh/cmdfactory"
 	"kraftkit.sh/config"
+	"kraftkit.sh/internal/gitutil"
 	"kraftkit.sh/iostreams"
 	"kraftkit.sh/log"
 	"kraftkit.sh/machine/platform"
@@ -344,10 +345,7 @@ func (opts *PullOptions) Run(ctx context.Context, args []string) error {
 				packmanager.WithPlatform(opts.Platform),
 				packmanager.WithKConfig(opts.KConfig),
 			}
-			if strings.HasSuffix(arg, ".git") ||
-				strings.HasPrefix(arg, "git@") ||
-				strings.HasPrefix(arg, "github.com/") ||
-				strings.Contains(arg, "://github.com/") {
+			if gitutil.IsGitSource(arg) {
 				qopts = append(qopts, packmanager.WithSource(arg))
 			} else {
 				qopts = append(qopts, packmanager.WithName(arg))

--- a/internal/ghrepo/repo.go
+++ b/internal/ghrepo/repo.go
@@ -49,6 +49,16 @@ func New(owner, repo string) Interface {
 
 // NewFromURL parses a given GitHub url and returns the populated Interface
 func NewFromURL(path string) (Interface, error) {
+	// Normalize SCP-style SSH URLs (git@github.com:owner/repo.git) to
+	// https:// so url.Parse handles them correctly.
+	if strings.HasPrefix(path, "git@") {
+		path = strings.Replace(path, ":", "/", 1)
+		path = strings.TrimPrefix(path, "git@")
+		path = "https://" + path
+	} else if strings.HasPrefix(path, "github.com/") {
+		path = "https://" + path
+	}
+
 	u, err := url.Parse(path)
 	if err != nil {
 		return nil, fmt.Errorf("could not parse url: %s", err)

--- a/internal/ghrepo/repo.go
+++ b/internal/ghrepo/repo.go
@@ -55,6 +55,14 @@ func NewFromURL(path string) (Interface, error) {
 		path = strings.Replace(path, ":", "/", 1)
 		path = strings.TrimPrefix(path, "git@")
 		path = "https://" + path
+	} else if strings.HasPrefix(path, "ssh+git@") {
+		path = strings.Replace(path, ":", "/", 1)
+		path = strings.TrimPrefix(path, "ssh+git@")
+		path = "https://" + path
+	} else if strings.HasPrefix(path, "ssh://git@") {
+		path = strings.TrimPrefix(path, "ssh://git@")
+		path = strings.Replace(path, ":", "/", 1)
+		path = "https://" + path
 	} else if strings.HasPrefix(path, "github.com/") {
 		path = "https://" + path
 	}

--- a/internal/ghrepo/repo_test.go
+++ b/internal/ghrepo/repo_test.go
@@ -41,6 +41,24 @@ func TestNewFromURL(t *testing.T) {
 			wantRepo:  "lib-nginx",
 		},
 		{
+			name:      "ssh+git@ URL with .git",
+			input:     "ssh+git@github.com:unikraft/lib-nginx.git",
+			wantOwner: "unikraft",
+			wantRepo:  "lib-nginx",
+		},
+		{
+			name:      "ssh://git@ URL with slash path",
+			input:     "ssh://git@github.com/unikraft/lib-nginx.git",
+			wantOwner: "unikraft",
+			wantRepo:  "lib-nginx",
+		},
+		{
+			name:      "ssh://git@ URL with colon path",
+			input:     "ssh://git@github.com:unikraft/lib-nginx.git",
+			wantOwner: "unikraft",
+			wantRepo:  "lib-nginx",
+		},
+		{
 			name:    "non-github host",
 			input:   "https://gitlab.com/unikraft/lib-nginx",
 			wantErr: true,

--- a/internal/ghrepo/repo_test.go
+++ b/internal/ghrepo/repo_test.go
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2022, Unikraft GmbH and The KraftKit Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+package ghrepo
+
+import (
+	"testing"
+)
+
+func TestNewFromURL(t *testing.T) {
+	tests := []struct {
+		name      string
+		input     string
+		wantOwner string
+		wantRepo  string
+		wantErr   bool
+	}{
+		{
+			name:      "https without .git",
+			input:     "https://github.com/unikraft/lib-nginx",
+			wantOwner: "unikraft",
+			wantRepo:  "lib-nginx",
+		},
+		{
+			name:      "https with .git suffix",
+			input:     "https://github.com/unikraft/lib-nginx.git",
+			wantOwner: "unikraft",
+			wantRepo:  "lib-nginx",
+		},
+		{
+			name:      "ssh git@ URL",
+			input:     "git@github.com:unikraft/lib-nginx.git",
+			wantOwner: "unikraft",
+			wantRepo:  "lib-nginx",
+		},
+		{
+			name:      "ssh git@ URL without .git",
+			input:     "git@github.com:unikraft/lib-nginx",
+			wantOwner: "unikraft",
+			wantRepo:  "lib-nginx",
+		},
+		{
+			name:    "non-github host",
+			input:   "https://gitlab.com/unikraft/lib-nginx",
+			wantErr: true,
+		},
+		{
+			name:      "bare github.com with .git",
+			input:     "github.com/unikraft/lib-nginx.git",
+			wantOwner: "unikraft",
+			wantRepo:  "lib-nginx",
+		},
+		{
+			name:      "bare github.com without .git",
+			input:     "github.com/unikraft/lib-nginx",
+			wantOwner: "unikraft",
+			wantRepo:  "lib-nginx",
+		},
+		{
+			name:    "missing repo segment",
+			input:   "https://github.com/unikraft",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := NewFromURL(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("NewFromURL(%q) error = %v, wantErr %v", tt.input, err, tt.wantErr)
+			}
+			if tt.wantErr {
+				return
+			}
+			if got.RepoOwner() != tt.wantOwner {
+				t.Errorf("RepoOwner() = %q, want %q", got.RepoOwner(), tt.wantOwner)
+			}
+			if got.RepoName() != tt.wantRepo {
+				t.Errorf("RepoName() = %q, want %q", got.RepoName(), tt.wantRepo)
+			}
+		})
+	}
+}

--- a/internal/gitutil/detector.go
+++ b/internal/gitutil/detector.go
@@ -26,6 +26,10 @@ func IsGitSource(source string) bool {
 		}
 	}
 
+	if strings.HasPrefix(source, "ssh+git@") {
+		return true
+	}
+
 	// Check for SCP-style SSH: git@host:path
 	if strings.HasPrefix(source, "git@") {
 		return true

--- a/internal/gitutil/detector.go
+++ b/internal/gitutil/detector.go
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2026, Unikraft GmbH and The KraftKit Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+package gitutil
+
+import (
+	"net/url"
+	"strings"
+)
+
+// IsGitSource returns true if the source string appears to be a git repository
+// URL rather than an OCI image reference. It handles:
+// - SSH URLs: ssh://git@host/path, git@host:path, git+ssh://, ssh+git://
+// - HTTPS URLs: https://host/path.git, https://github.com/owner/repo
+// - Bare paths: github.com/owner/repo, gitlab.com/owner/repo
+func IsGitSource(source string) bool {
+	if source == "" {
+		return false
+	}
+
+	// Check for explicit SSH URL schemes
+	for _, prefix := range []string{"ssh://", "ssh+git://", "git+ssh://", "git://"} {
+		if strings.HasPrefix(source, prefix) {
+			return true
+		}
+	}
+
+	// Check for SCP-style SSH: git@host:path
+	if strings.HasPrefix(source, "git@") {
+		return true
+	}
+
+	// Try to parse as URL to distinguish from OCI refs
+	// Normalize common patterns first
+	normalized := source
+	if strings.HasPrefix(source, "github.com/") ||
+		strings.HasPrefix(source, "gitlab.com/") ||
+		strings.HasPrefix(source, "bitbucket.org/") {
+		normalized = "https://" + source
+	}
+
+	// Parse the URL
+	u, err := url.Parse(normalized)
+	if err != nil {
+		// If it ends with .git but can't be parsed, it's likely a git source
+		return strings.HasSuffix(source, ".git")
+	}
+
+	// Check for known git hosting platforms
+	if isKnownGitHost(u.Host) {
+		return true
+	}
+
+	// Check for .git suffix
+	// Git URLs have .git at the end of the repository name
+	if strings.HasSuffix(source, ".git") {
+		if u.Scheme == "http" || u.Scheme == "https" {
+			return true
+		}
+		// If no scheme and it contains a known git host, it's likely git
+		if isKnownGitHost(u.Host) {
+			return true
+		}
+		if strings.Contains(source, ":") || strings.Contains(source, "@") {
+			// Check if .git comes before : or @
+			gitIdx := strings.LastIndex(source, ".git")
+			colonIdx := strings.Index(source, ":")
+			atIdx := strings.Index(source, "@")
+
+			// If there's a : or @ after .git, it's an OCI ref with tag/digest
+			if (colonIdx > gitIdx && colonIdx != -1) || (atIdx > gitIdx && atIdx != -1) {
+				return false
+			}
+		}
+		// Otherwise, .git suffix suggests git source
+		return true
+	}
+
+	return false
+}
+
+// isKnownGitHost checks if the hostname is a known git hosting service
+func isKnownGitHost(host string) bool {
+	// Remove port if present
+	if idx := strings.Index(host, ":"); idx != -1 {
+		host = host[:idx]
+	}
+
+	knownHosts := []string{
+		"github.com",
+		"gitlab.com",
+		"bitbucket.org",
+	}
+
+	for _, known := range knownHosts {
+		if strings.EqualFold(host, known) || strings.HasSuffix(host, "."+known) {
+			return true
+		}
+	}
+
+	return false
+}

--- a/internal/gitutil/detector_test.go
+++ b/internal/gitutil/detector_test.go
@@ -1,0 +1,242 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2026, Unikraft GmbH and The KraftKit Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+package gitutil
+
+import "testing"
+
+func TestIsGitSource(t *testing.T) {
+	tests := []struct {
+		name   string
+		source string
+		want   bool
+	}{
+		// SSH URL variants (should be git sources)
+		{
+			name:   "ssh:// URL without .git",
+			source: "ssh://git@github.com/owner/repo",
+			want:   true,
+		},
+		{
+			name:   "ssh:// URL with .git",
+			source: "ssh://git@github.com/owner/repo.git",
+			want:   true,
+		},
+		{
+			name:   "ssh+git:// URL",
+			source: "ssh+git://github.com/owner/repo",
+			want:   true,
+		},
+		{
+			name:   "git+ssh:// URL",
+			source: "git+ssh://github.com/owner/repo",
+			want:   true,
+		},
+		{
+			name:   "git:// URL",
+			source: "git://github.com/owner/repo",
+			want:   true,
+		},
+		{
+			name:   "SCP-style git@host:path",
+			source: "git@github.com:owner/repo",
+			want:   true,
+		},
+		{
+			name:   "SCP-style git@host:path with .git",
+			source: "git@github.com:owner/repo.git",
+			want:   true,
+		},
+		{
+			name:   "SCP-style with GitLab",
+			source: "git@gitlab.com:owner/repo.git",
+			want:   true,
+		},
+
+		// HTTPS/HTTP git URLs (should be git sources)
+		{
+			name:   "HTTPS GitHub URL without .git",
+			source: "https://github.com/owner/repo",
+			want:   true,
+		},
+		{
+			name:   "HTTPS GitHub URL with .git",
+			source: "https://github.com/owner/repo.git",
+			want:   true,
+		},
+		{
+			name:   "HTTPS GitLab URL with .git",
+			source: "https://gitlab.com/owner/repo.git",
+			want:   true,
+		},
+		{
+			name:   "HTTPS Bitbucket URL",
+			source: "https://bitbucket.org/owner/repo.git",
+			want:   true,
+		},
+
+		// Bare host/path patterns (should be git sources)
+		{
+			name:   "Bare github.com path without .git",
+			source: "github.com/owner/repo",
+			want:   true,
+		},
+		{
+			name:   "Bare github.com path with .git",
+			source: "github.com/owner/repo.git",
+			want:   true,
+		},
+		{
+			name:   "Bare gitlab.com path",
+			source: "gitlab.com/owner/repo",
+			want:   true,
+		},
+		{
+			name:   "Bare bitbucket.org path",
+			source: "bitbucket.org/owner/repo.git",
+			want:   true,
+		},
+
+		// .git suffix on non-known hosts (should be git sources)
+		{
+			name:   ".git suffix on custom domain",
+			source: "git.example.com/owner/repo.git",
+			want:   true,
+		},
+		{
+			name:   "HTTPS with .git on custom domain",
+			source: "https://git.example.com/owner/repo.git",
+			want:   true,
+		},
+
+		// OCI image references (should NOT be git sources)
+		{
+			name:   "OCI image with .git in name and tag",
+			source: "ghcr.io/org/repo.git:latest",
+			want:   false,
+		},
+		{
+			name:   "OCI image with .git in name and digest",
+			source: "ghcr.io/org/repo.git@sha256:abc123",
+			want:   false,
+		},
+		{
+			name:   "Docker Hub image",
+			source: "docker.io/library/nginx:latest",
+			want:   false,
+		},
+		{
+			name:   "Plain OCI image with tag",
+			source: "unikraft.org/helloworld:latest",
+			want:   false,
+		},
+		{
+			name:   "Plain OCI image with digest",
+			source: "unikraft.org/helloworld@sha256:abc123def",
+			want:   false,
+		},
+		{
+			name:   "Registry hostname only",
+			source: "index.unikraft.io",
+			want:   false,
+		},
+		{
+			name:   "Localhost registry with port",
+			source: "localhost:5000/myimage:v1",
+			want:   false,
+		},
+		{
+			name:   "OCI ref with registry and tag",
+			source: "registry.example.com/org/app:v1.0.0",
+			want:   false,
+		},
+
+		// Edge cases
+		{
+			name:   "Empty string",
+			source: "",
+			want:   false,
+		},
+		{
+			name:   "Just .git",
+			source: ".git",
+			want:   true,
+		},
+		{
+			name:   "Path with .git in middle",
+			source: "example.com/.git/repo",
+			want:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsGitSource(tt.source); got != tt.want {
+				t.Errorf("IsGitSource(%q) = %v, want %v", tt.source, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsKnownGitHost(t *testing.T) {
+	tests := []struct {
+		name string
+		host string
+		want bool
+	}{
+		{
+			name: "github.com",
+			host: "github.com",
+			want: true,
+		},
+		{
+			name: "GitHub.com (case insensitive)",
+			host: "GitHub.com",
+			want: true,
+		},
+		{
+			name: "gitlab.com",
+			host: "gitlab.com",
+			want: true,
+		},
+		{
+			name: "bitbucket.org",
+			host: "bitbucket.org",
+			want: true,
+		},
+		{
+			name: "github.com with port",
+			host: "github.com:443",
+			want: true,
+		},
+		{
+			name: "subdomain of github.com",
+			host: "api.github.com",
+			want: true,
+		},
+		{
+			name: "custom domain",
+			host: "git.example.com",
+			want: false,
+		},
+		{
+			name: "docker.io",
+			host: "docker.io",
+			want: false,
+		},
+		{
+			name: "empty host",
+			host: "",
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isKnownGitHost(tt.host); got != tt.want {
+				t.Errorf("isKnownGitHost(%q) = %v, want %v", tt.host, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/gitutil/detector_test.go
+++ b/internal/gitutil/detector_test.go
@@ -19,6 +19,11 @@ func TestIsGitSource(t *testing.T) {
 			want:   true,
 		},
 		{
+			name:   "ssh:// URL with colon path",
+			source: "ssh://git@github.com:owner/repo.git",
+			want:   true,
+		},
+		{
 			name:   "ssh:// URL with .git",
 			source: "ssh://git@github.com/owner/repo.git",
 			want:   true,
@@ -26,6 +31,11 @@ func TestIsGitSource(t *testing.T) {
 		{
 			name:   "ssh+git:// URL",
 			source: "ssh+git://github.com/owner/repo",
+			want:   true,
+		},
+		{
+			name:   "ssh+git@ SCP-like URL",
+			source: "ssh+git@github.com:unikraft/app-nginx.git",
 			want:   true,
 		},
 		{

--- a/manifest/manager.go
+++ b/manifest/manager.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strings"
 	"time"
 	"unicode"
 
@@ -514,6 +515,13 @@ func (m *ManifestManager) IsCompatible(ctx context.Context, source string, qopts
 	}
 
 	if t, _, _, err := unikraft.GuessTypeNameVersion(source); err == nil && t != unikraft.ComponentTypeUnknown {
+		return m, true, nil
+	}
+
+	if strings.HasSuffix(source, ".git") ||
+		strings.HasPrefix(source, "git@") ||
+		strings.HasPrefix(source, "github.com/") ||
+		strings.Contains(source, "://github.com/") {
 		return m, true, nil
 	}
 

--- a/manifest/manager.go
+++ b/manifest/manager.go
@@ -11,7 +11,6 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
-	"strings"
 	"time"
 	"unicode"
 
@@ -20,6 +19,7 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"kraftkit.sh/config"
+	"kraftkit.sh/internal/gitutil"
 	"kraftkit.sh/log"
 	"kraftkit.sh/pack"
 	"kraftkit.sh/packmanager"
@@ -518,10 +518,7 @@ func (m *ManifestManager) IsCompatible(ctx context.Context, source string, qopts
 		return m, true, nil
 	}
 
-	if strings.HasSuffix(source, ".git") ||
-		strings.HasPrefix(source, "git@") ||
-		strings.HasPrefix(source, "github.com/") ||
-		strings.Contains(source, "://github.com/") {
+	if gitutil.IsGitSource(source) {
 		return m, true, nil
 	}
 

--- a/manifest/manager_test.go
+++ b/manifest/manager_test.go
@@ -36,6 +36,16 @@ func TestManifestManager_IsCompatible_gitSources(t *testing.T) {
 			wantCompat: true,
 		},
 		{
+			name:       "ssh:// URL without .git",
+			source:     "ssh://git@github.com/owner/repo",
+			wantCompat: true,
+		},
+		{
+			name:       "git+ssh:// URL",
+			source:     "git+ssh://github.com/owner/repo.git",
+			wantCompat: true,
+		},
+		{
 			name:       "empty source",
 			source:     "",
 			wantCompat: false,

--- a/manifest/manager_test.go
+++ b/manifest/manager_test.go
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2026, Unikraft GmbH and The KraftKit Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+package manifest
+
+import (
+	"context"
+	"testing"
+)
+
+func TestManifestManager_IsCompatible_gitSources(t *testing.T) {
+	tests := []struct {
+		name       string
+		source     string
+		wantCompat bool
+	}{
+		{
+			name:       "github.com path",
+			source:     "github.com/unikraft/lib-nginx.git",
+			wantCompat: true,
+		},
+		{
+			name:       "https github URL",
+			source:     "https://github.com/unikraft/lib-nginx",
+			wantCompat: true,
+		},
+		{
+			name:       "git@ SSH URL",
+			source:     "git@github.com:unikraft/lib-nginx.git",
+			wantCompat: true,
+		},
+		{
+			name:       "non-github .git suffix",
+			source:     "https://gitlab.com/foo/bar.git",
+			wantCompat: true,
+		},
+		{
+			name:       "empty source",
+			source:     "",
+			wantCompat: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := &ManifestManager{}
+			ctx := context.Background()
+			_, compat, err := m.IsCompatible(ctx, tt.source)
+			if tt.wantCompat {
+				if err != nil {
+					t.Fatalf("IsCompatible(%q) unexpected error: %v", tt.source, err)
+				}
+				if !compat {
+					t.Errorf("IsCompatible(%q) = false, want true", tt.source)
+				}
+			} else {
+				if compat {
+					t.Errorf("IsCompatible(%q) = true, want false", tt.source)
+				}
+			}
+		})
+	}
+}

--- a/manifest/provider.go
+++ b/manifest/provider.go
@@ -104,10 +104,12 @@ func NewProvider(ctx context.Context, path string, mopts ...ManifestOption) (Pro
 			return ghProvider, nil
 		}
 
-		log.G(ctx).WithFields(logrus.Fields{
-			"path": path,
-		}).Trace("using git provider")
-		return provider, nil
+		if provider != nil {
+			log.G(ctx).WithFields(logrus.Fields{
+				"path": path,
+			}).Trace("using git provider")
+			return provider, nil
+		}
 	}
 
 	return nil, fmt.Errorf("could not determine provider for: %s", path)

--- a/manifest/provider_git.go
+++ b/manifest/provider_git.go
@@ -35,14 +35,21 @@ type GitProvider struct {
 func NewGitProvider(ctx context.Context, path string, opts ...ManifestOption) (Provider, error) {
 	isSSH := false
 	fullpath := path
-	if isSSHURL(path) {
+
+	if strings.HasPrefix(path, "github.com/") {
+		fullpath = "https://" + path
+	} else if isSSHURL(path) {
 		isSSH = true
 
 		// This is a quirk of go-git, if we have determined it was an SSH path and
 		// it does not contain the prefix, we should include it so it can be
 		// recognised internally by the module.
 		if strings.HasPrefix(path, "git@") {
-			fullpath = "ssh://" + path
+			// Convert SCP-style git@HOST:path to ssh://git@HOST/path so that
+			// URL parsers (giturl, go-git) handle it correctly.
+			scp := strings.TrimPrefix(path, "git@")
+			scp = strings.Replace(scp, ":", "/", 1)
+			fullpath = "ssh://git@" + scp
 		}
 	}
 

--- a/manifest/provider_git.go
+++ b/manifest/provider_git.go
@@ -44,10 +44,11 @@ func NewGitProvider(ctx context.Context, path string, opts ...ManifestOption) (P
 		// This is a quirk of go-git, if we have determined it was an SSH path and
 		// it does not contain the prefix, we should include it so it can be
 		// recognised internally by the module.
-		if strings.HasPrefix(path, "git@") {
+		if strings.HasPrefix(path, "git@") || strings.HasPrefix(path, "ssh+git@") {
 			// Convert SCP-style git@HOST:path to ssh://git@HOST/path so that
 			// URL parsers (giturl, go-git) handle it correctly.
-			scp := strings.TrimPrefix(path, "git@")
+			scp := strings.TrimPrefix(path, "ssh+git@")
+			scp = strings.TrimPrefix(scp, "git@")
 			scp = strings.Replace(scp, ":", "/", 1)
 			fullpath = "ssh://git@" + scp
 		}
@@ -240,6 +241,7 @@ func isSSHURL(path string) bool {
 	for _, prefix := range []string{
 		"ssh://",
 		"ssh+git://",
+		"ssh+git@",
 		"git+ssh://",
 		"git@",
 	} {

--- a/manifest/provider_github.go
+++ b/manifest/provider_github.go
@@ -109,9 +109,13 @@ func (ghp GitHubProvider) Manifests() ([]*Manifest, error) {
 		return ghp.manifestsFromWildcard()
 	}
 
-	// Ultimately, since this is Git, we can use the GitProvider, and update the
-	// path to the resource with a known location
-	repo := ghp.path
+	// Probe the repository via HTTPS so public GitHub repositories work even when
+	// the input was an SSH-style URL and no SSH agent is available.
+	repo := fmt.Sprintf("https://%s/%s/%s.git",
+		ghp.repo.RepoHost(),
+		ghp.repo.RepoOwner(),
+		ghp.repo.RepoName(),
+	)
 	if len(ghp.branch) > 0 {
 		repo += "@" + ghp.branch
 	}
@@ -125,6 +129,7 @@ func (ghp GitHubProvider) Manifests() ([]*Manifest, error) {
 	}
 
 	manifest.Provider = ghp
+	manifest.Origin = ghp.path
 
 	return []*Manifest{manifest}, nil
 }

--- a/oci/manager.go
+++ b/oci/manager.go
@@ -411,6 +411,10 @@ func (manager *OCIManager) Catalog(ctx context.Context, qopts ...packmanager.Que
 		return nil, nil
 	}
 
+	if isGitSource(query.Source()) {
+		return nil, nil
+	}
+
 	var qglob glob.Glob
 	var err error
 	packs := make(map[string]pack.Package)
@@ -909,6 +913,13 @@ func (manager *OCIManager) RemoveSource(ctx context.Context, source string) erro
 	return nil
 }
 
+func isGitSource(source string) bool {
+	return strings.HasSuffix(source, ".git") ||
+		strings.HasPrefix(source, "git@") ||
+		strings.HasPrefix(source, "github.com/") ||
+		strings.Contains(source, "://github.com/")
+}
+
 // IsCompatible implements packmanager.PackageManager
 func (manager *OCIManager) IsCompatible(ctx context.Context, source string, qopts ...packmanager.QueryOption) (packmanager.PackageManager, bool, error) {
 	ctx, handle, err := manager.handle(ctx)
@@ -958,6 +969,10 @@ func (manager *OCIManager) IsCompatible(ctx context.Context, source string, qopt
 			WithField("source", source).
 			Tracef("checking if source is registry")
 
+		if isGitSource(source) {
+			return false
+		}
+
 		regName, err := name.NewRegistry(source)
 		if err != nil {
 			return false
@@ -975,6 +990,10 @@ func (manager *OCIManager) IsCompatible(ctx context.Context, source string, qopt
 		log.G(ctx).
 			WithField("source", source).
 			Tracef("checking if source is remote image")
+
+		if isGitSource(source) {
+			return false
+		}
 
 		ref, err := name.ParseReference(source,
 			name.WithDefaultRegistry(DefaultRegistry),

--- a/oci/manager.go
+++ b/oci/manager.go
@@ -28,6 +28,7 @@ import (
 	"oras.land/oras-go/v2/content"
 
 	"kraftkit.sh/config"
+	"kraftkit.sh/internal/gitutil"
 	"kraftkit.sh/internal/set"
 	"kraftkit.sh/internal/version"
 	"kraftkit.sh/log"
@@ -914,10 +915,7 @@ func (manager *OCIManager) RemoveSource(ctx context.Context, source string) erro
 }
 
 func isGitSource(source string) bool {
-	return strings.HasSuffix(source, ".git") ||
-		strings.HasPrefix(source, "git@") ||
-		strings.HasPrefix(source, "github.com/") ||
-		strings.Contains(source, "://github.com/")
+	return gitutil.IsGitSource(source)
 }
 
 // IsCompatible implements packmanager.PackageManager

--- a/oci/manager_test.go
+++ b/oci/manager_test.go
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2026, Unikraft GmbH and The KraftKit Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+package oci
+
+import "testing"
+
+func Test_isGitSource(t *testing.T) {
+	tests := []struct {
+		name   string
+		source string
+		want   bool
+	}{
+		{
+			name:   "github.com path prefix",
+			source: "github.com/unikraft/lib-nginx.git",
+			want:   true,
+		},
+		{
+			name:   "https github URL",
+			source: "https://github.com/unikraft/lib-nginx.git",
+			want:   true,
+		},
+		{
+			name:   "git@ SSH URL",
+			source: "git@github.com:unikraft/lib-nginx.git",
+			want:   true,
+		},
+		{
+			name:   ".git suffix without github host",
+			source: "gitlab.com/foo/bar.git",
+			want:   true,
+		},
+		{
+			name:   "plain OCI image ref",
+			source: "unikraft.org/helloworld:latest",
+			want:   false,
+		},
+		{
+			name:   "docker.io image",
+			source: "docker.io/library/nginx:latest",
+			want:   false,
+		},
+		{
+			name:   "registry hostname only",
+			source: "index.unikraft.io",
+			want:   false,
+		},
+		{
+			name:   "image with digest",
+			source: "unikraft.org/helloworld@sha256:abc123",
+			want:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isGitSource(tt.source); got != tt.want {
+				t.Errorf("isGitSource(%q) = %v, want %v", tt.source, got, tt.want)
+			}
+		})
+	}
+}

--- a/oci/manager_test.go
+++ b/oci/manager_test.go
@@ -6,50 +6,30 @@ package oci
 
 import "testing"
 
-func Test_isGitSource(t *testing.T) {
+func Test_isGitSource_Wrapper(t *testing.T) {
 	tests := []struct {
 		name   string
 		source string
 		want   bool
 	}{
 		{
-			name:   "github.com path prefix",
+			name:   "github.com path",
 			source: "github.com/unikraft/lib-nginx.git",
 			want:   true,
 		},
 		{
-			name:   "https github URL",
-			source: "https://github.com/unikraft/lib-nginx.git",
+			name:   "ssh URL without .git",
+			source: "ssh://git@github.com/owner/repo",
 			want:   true,
 		},
 		{
-			name:   "git@ SSH URL",
-			source: "git@github.com:unikraft/lib-nginx.git",
-			want:   true,
-		},
-		{
-			name:   ".git suffix without github host",
-			source: "gitlab.com/foo/bar.git",
-			want:   true,
-		},
-		{
-			name:   "plain OCI image ref",
+			name:   "OCI image",
 			source: "unikraft.org/helloworld:latest",
 			want:   false,
 		},
 		{
-			name:   "docker.io image",
-			source: "docker.io/library/nginx:latest",
-			want:   false,
-		},
-		{
-			name:   "registry hostname only",
-			source: "index.unikraft.io",
-			want:   false,
-		},
-		{
-			name:   "image with digest",
-			source: "unikraft.org/helloworld@sha256:abc123",
+			name:   "OCI with .git in name",
+			source: "ghcr.io/org/repo.git:latest",
 			want:   false,
 		},
 	}

--- a/packmanager/query.go
+++ b/packmanager/query.go
@@ -245,6 +245,8 @@ func (cq Query) String() string {
 
 	if len(cq.name) > 0 {
 		s += cq.name
+	} else if len(cq.source) > 0 {
+		s += cq.source
 	} else {
 		s += "*"
 	}


### PR DESCRIPTION
### Prerequisite checklist

- [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
- [x] Tested your changes locally.

### Description of changes


Closes #1114 `kraft pkg pull` failed to handle git/GitHub URLs such as:

- `github.com/unikraft/lib-nginx.git`
- `https://github.com/unikraft/lib-nginx`
- `git@github.com:unikraft/lib-nginx.git`

Instead of routing them to the manifest provider, they were either claimed by the OCI manager or crashed with a nil pointer dereference.

| # | Root Cause | Fix |
|---|-----------|-----|
| 1 | `name.ParseReference` treats `github.com` as a valid registry host, so `OCIManager.IsCompatible` claimed git/GitHub URLs before the manifest manager could | Added `isGitSource()` to reject these URLs early in `IsCompatible` and `Catalog()` |
| 2 | git/GitHub args in `pull.go` were passed as `WithName`, but the manifest manager's `Catalog()` only resolves a provider when `WithSource` is set | Changed to use `WithSource` for all git/GitHub args |
| 3 | `ManifestManager.IsCompatible` had no recognition of git/GitHub URL patterns, so it never short-circuited to claim them | Added an early-return guard matching `.git`, `git@`, `github.com/`, and `://github.com/` |
| 4 | When both `NewGitProvider` and `NewGitHubProvider` failed, a nil provider was returned without error, causing a nil pointer dereference in `Manifests()` | Added a nil guard before the fallback return in `NewProvider` |
| 5 | `NewGitProvider` converted `git@HOST:path` to `ssh://git@HOST:path` (colon kept), which URL parsers reject | Fixed to produce `ssh://git@HOST/path` (colon replaced with slash) |
| 6 | `ghrepo.NewFromURL` used `url.Parse` directly, which cannot handle SCP-style SSH or bare `github.com/` URLs, resulting in an empty host | Normalize both forms to `https://` before parsing |

