### PR TITLE
fix(cloud/quota): Prevent panic when usage exceeds quota limits

### DIFF
--- a/internal/cli/kraft/cloud/utils/print.go
+++ b/internal/cli/kraft/cloud/utils/print.go
@@ -869,6 +869,10 @@ func printBar(cs *iostreams.ColorScheme, progress, max int) string {
 	var ret strings.Builder
 
 	percent := math.Floor(float64(progress) / float64(max) * float64(width))
+	// Clamp percent to width to avoid negative repeat count
+	if percent > float64(width) {
+		percent = float64(width)
+	}
 
 	color := "green"
 	if percent > 30 { // ~83%


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes locally.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->
Fixes a case where the `kraft cloud quota` subcommand crashes upon trying to print the progress bar on a quota item that exceeds 100%.
The fix clamps the percentage to 100.
