### PR TITLE
test(volume): Add unit tests for volume/transform.go

### DIFF
--- a/unikraft/app/volume/transform_test.go
+++ b/unikraft/app/volume/transform_test.go
@@ -13,13 +13,13 @@ func Test_TransformFromSchema(t *testing.T) {
 	ctx := context.Background()
 
 	tests := []struct {
-		name        string
-		input       interface{}
-		wantSource  string
-		wantDest    string
-		wantDriver  string
+		name         string
+		input        interface{}
+		wantSource   string
+		wantDest     string
+		wantDriver   string
 		wantReadOnly bool
-		wantErr     bool
+		wantErr      bool
 	}{
 		{
 			name:       "string with colon sets source and destination",
@@ -39,7 +39,7 @@ func Test_TransformFromSchema(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name:       "map with all fields",
+			name: "map with all fields",
 			input: map[string]interface{}{
 				"driver":      "9pfs",
 				"source":      "/host/path",
@@ -52,14 +52,14 @@ func Test_TransformFromSchema(t *testing.T) {
 			wantReadOnly: true,
 		},
 		{
-			name:  "map with only source",
+			name: "map with only source",
 			input: map[string]interface{}{
 				"source": "/host/path",
 			},
 			wantSource: "/host/path",
 		},
 		{
-			name:  "map with readonly false",
+			name: "map with readonly false",
 			input: map[string]interface{}{
 				"source":   "/host/path",
 				"readonly": false,

--- a/unikraft/app/volume/transform_test.go
+++ b/unikraft/app/volume/transform_test.go
@@ -1,0 +1,134 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2022, Unikraft GmbH and The KraftKit Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+package volume
+
+import (
+	"context"
+	"testing"
+)
+
+func Test_TransformFromSchema(t *testing.T) {
+	ctx := context.Background()
+
+	tests := []struct {
+		name        string
+		input       interface{}
+		wantSource  string
+		wantDest    string
+		wantDriver  string
+		wantReadOnly bool
+		wantErr     bool
+	}{
+		{
+			name:       "string with colon sets source and destination",
+			input:      "src:/mnt",
+			wantSource: "src",
+			wantDest:   "/mnt",
+		},
+		{
+			name:       "string without colon defaults destination to slash",
+			input:      "src",
+			wantSource: "src",
+			wantDest:   "/",
+		},
+		{
+			name:    "string with more than one colon returns error",
+			input:   "src:/mnt:/extra",
+			wantErr: true,
+		},
+		{
+			name:       "map with all fields",
+			input: map[string]interface{}{
+				"driver":      "9pfs",
+				"source":      "/host/path",
+				"destination": "/guest/path",
+				"readonly":    true,
+			},
+			wantDriver:   "9pfs",
+			wantSource:   "/host/path",
+			wantDest:     "/guest/path",
+			wantReadOnly: true,
+		},
+		{
+			name:  "map with only source",
+			input: map[string]interface{}{
+				"source": "/host/path",
+			},
+			wantSource: "/host/path",
+		},
+		{
+			name:  "map with readonly false",
+			input: map[string]interface{}{
+				"source":   "/host/path",
+				"readonly": false,
+			},
+			wantSource:   "/host/path",
+			wantReadOnly: false,
+		},
+		{
+			name:    "map with invalid driver type errors",
+			input:   map[string]interface{}{"driver": 123},
+			wantErr: true,
+		},
+		{
+			name:    "map with invalid source type errors",
+			input:   map[string]interface{}{"source": 123},
+			wantErr: true,
+		},
+		{
+			name:    "map with invalid destination type errors",
+			input:   map[string]interface{}{"destination": 123},
+			wantErr: true,
+		},
+		{
+			name:    "map with invalid readonly type errors",
+			input:   map[string]interface{}{"readonly": "yes"},
+			wantErr: true,
+		},
+		{
+			name:       "empty map returns empty volume",
+			input:      map[string]interface{}{},
+			wantSource: "",
+			wantDest:   "",
+		},
+		{
+			name:       "empty string sets empty source and slash destination",
+			input:      "",
+			wantSource: "",
+			wantDest:   "/",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := TransformFromSchema(ctx, tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("TransformFromSchema() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if tt.wantErr {
+				return
+			}
+
+			vol, ok := got.(VolumeConfig)
+			if !ok {
+				t.Fatalf("TransformFromSchema() result type = %T, want VolumeConfig", got)
+			}
+
+			if vol.Source() != tt.wantSource {
+				t.Errorf("Source() = %q, want %q", vol.Source(), tt.wantSource)
+			}
+			if vol.Destination() != tt.wantDest {
+				t.Errorf("Destination() = %q, want %q", vol.Destination(), tt.wantDest)
+			}
+			if vol.Driver() != tt.wantDriver {
+				t.Errorf("Driver() = %q, want %q", vol.Driver(), tt.wantDriver)
+			}
+			if vol.ReadOnly() != tt.wantReadOnly {
+				t.Errorf("ReadOnly() = %v, want %v", vol.ReadOnly(), tt.wantReadOnly)
+			}
+		})
+	}
+}


### PR DESCRIPTION
…ansform.go

<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [ ] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [ ] Tested your changes locally.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->
## Summary

- Adds table-driven unit tests for `TransformFromSchema` in `unikraft/app/volume/transform.go`
- Covers both string and map input formats for volume definitions

## Cases tested
- String with `:` sets source and destination
- String without `:` defaults destination to `/`
- String with more than one `:` returns error
- Map with all fields (driver, source, destination, readonly)
- Map with invalid field types (non-string driver/source/destination, non-bool readonly)
- Empty map and empty string edge cases

## Related Issue
Closes #2698 

## Test plan
- [ ] Run `go test ./unikraft/app/volume/...` — all 12 tests pass
