### PR TITLE
test(unikraft/target): Add unit tests for the target component

### DIFF
--- a/unikraft/target/select_test.go
+++ b/unikraft/target/select_test.go
@@ -1,0 +1,127 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2024, Unikraft GmbH and The KraftKit Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+package target
+
+import (
+	"testing"
+
+	"kraftkit.sh/unikraft/arch"
+	"kraftkit.sh/unikraft/plat"
+)
+
+// makeTargets builds a slice of Target for filter tests.
+func makeTargets() []Target {
+	return []Target{
+		NewTargetFromOptions(
+			WithName("app"),
+			WithPlatform(plat.NewPlatformFromOptions(plat.WithName("kvm"))),
+			WithArchitecture(arch.NewArchitectureFromOptions(arch.WithName("x86_64"))),
+		),
+		NewTargetFromOptions(
+			WithName("app"),
+			WithPlatform(plat.NewPlatformFromOptions(plat.WithName("xen"))),
+			WithArchitecture(arch.NewArchitectureFromOptions(arch.WithName("arm64"))),
+		),
+		NewTargetFromOptions(
+			WithName("srv"),
+			WithPlatform(plat.NewPlatformFromOptions(plat.WithName("kvm"))),
+			WithArchitecture(arch.NewArchitectureFromOptions(arch.WithName("arm64"))),
+		),
+	}
+}
+
+func TestFilter(t *testing.T) {
+	targets := makeTargets()
+
+	t.Run("no filters returns all targets", func(t *testing.T) {
+		got := Filter(targets, "", "", "")
+		if len(got) != len(targets) {
+			t.Errorf("Filter() returned %d targets, want %d", len(got), len(targets))
+		}
+	})
+
+	t.Run("filter by arch x86_64", func(t *testing.T) {
+		got := Filter(targets, "x86_64", "", "")
+		if len(got) != 1 {
+			t.Fatalf("Filter(arch=x86_64) returned %d targets, want 1", len(got))
+		}
+		if got[0].Architecture().Name() != "x86_64" {
+			t.Errorf("unexpected architecture: %q", got[0].Architecture().Name())
+		}
+	})
+
+	t.Run("filter by arch arm64", func(t *testing.T) {
+		got := Filter(targets, "arm64", "", "")
+		if len(got) != 2 {
+			t.Errorf("Filter(arch=arm64) returned %d targets, want 2", len(got))
+		}
+	})
+
+	t.Run("filter by plat kvm", func(t *testing.T) {
+		got := Filter(targets, "", "kvm", "")
+		if len(got) != 2 {
+			t.Errorf("Filter(plat=kvm) returned %d targets, want 2", len(got))
+		}
+		for _, tgt := range got {
+			if tgt.Platform().Name() != "kvm" {
+				t.Errorf("unexpected platform: %q", tgt.Platform().Name())
+			}
+		}
+	})
+
+	t.Run("filter by plat and arch", func(t *testing.T) {
+		got := Filter(targets, "arm64", "kvm", "")
+		if len(got) != 1 {
+			t.Fatalf("Filter(arch=arm64,plat=kvm) returned %d targets, want 1", len(got))
+		}
+		if got[0].Name() != "srv" {
+			t.Errorf("Name = %q, want srv", got[0].Name())
+		}
+	})
+
+	t.Run("filter by targ name only", func(t *testing.T) {
+		got := Filter(targets, "", "", "srv")
+		if len(got) != 1 {
+			t.Fatalf("Filter(targ=srv) returned %d targets, want 1", len(got))
+		}
+		if got[0].Name() != "srv" {
+			t.Errorf("Name = %q, want srv", got[0].Name())
+		}
+	})
+
+	t.Run("filter by targ as plat/arch string", func(t *testing.T) {
+		got := Filter(targets, "", "", "kvm/x86_64")
+		if len(got) != 1 {
+			t.Fatalf("Filter(targ=kvm/x86_64) returned %d targets, want 1", len(got))
+		}
+		if got[0].Platform().Name() != "kvm" || got[0].Architecture().Name() != "x86_64" {
+			t.Errorf("unexpected target: %s/%s", got[0].Platform().Name(), got[0].Architecture().Name())
+		}
+	})
+
+	t.Run("filter by plat and targ name", func(t *testing.T) {
+		got := Filter(targets, "", "xen", "app")
+		if len(got) != 1 {
+			t.Fatalf("Filter(plat=xen,targ=app) returned %d targets, want 1", len(got))
+		}
+		if got[0].Platform().Name() != "xen" {
+			t.Errorf("Platform = %q, want xen", got[0].Platform().Name())
+		}
+	})
+
+	t.Run("filter by all three — exact match", func(t *testing.T) {
+		got := Filter(targets, "x86_64", "kvm", "app")
+		if len(got) != 1 {
+			t.Fatalf("Filter(arch=x86_64,plat=kvm,targ=app) returned %d targets, want 1", len(got))
+		}
+	})
+
+	t.Run("no match returns empty slice", func(t *testing.T) {
+		got := Filter(targets, "arm", "", "")
+		if len(got) != 0 {
+			t.Errorf("Filter(arch=arm) returned %d targets, want 0", len(got))
+		}
+	})
+}

--- a/unikraft/target/target_test.go
+++ b/unikraft/target/target_test.go
@@ -1,0 +1,396 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2024, Unikraft GmbH and The KraftKit Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+package target
+
+import (
+	"fmt"
+	"path/filepath"
+	"testing"
+
+	"kraftkit.sh/unikraft/arch"
+	"kraftkit.sh/unikraft/plat"
+)
+
+// newTarget is a convenience constructor for test fixtures.
+func newTarget(name, platName, archName string) TargetConfig {
+	return TargetConfig{
+		name:         name,
+		platform:     plat.NewPlatformFromOptions(plat.WithName(platName)),
+		architecture: arch.NewArchitectureFromOptions(arch.WithName(archName)),
+	}
+}
+
+// ---------------------------------------------------------------------------
+// KernelName
+// ---------------------------------------------------------------------------
+
+func TestKernelName(t *testing.T) {
+	tests := []struct {
+		name    string
+		target  TargetConfig
+		want    string
+		wantErr bool
+	}{
+		{
+			name:    "empty target name returns error",
+			target:  newTarget("", "kvm", "x86_64"),
+			wantErr: true,
+		},
+		{
+			name:   "kvm/x86_64",
+			target: newTarget("myapp", "kvm", "x86_64"),
+			want:   "myapp_kvm-x86_64",
+		},
+		{
+			name:   "qemu/arm64",
+			target: newTarget("helloworld", "qemu", "arm64"),
+			want:   "helloworld_qemu-arm64",
+		},
+		{
+			name:   "linuxu/x86_64",
+			target: newTarget("app", "linuxu", "x86_64"),
+			want:   "app_linuxu-x86_64",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := KernelName(tt.target)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("KernelName() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if err == nil && got != tt.want {
+				t.Errorf("KernelName() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// KernelDbgName
+// ---------------------------------------------------------------------------
+
+func TestKernelDbgName(t *testing.T) {
+	tests := []struct {
+		name    string
+		target  TargetConfig
+		want    string
+		wantErr bool
+	}{
+		{
+			name:    "empty target name returns error",
+			target:  newTarget("", "kvm", "x86_64"),
+			wantErr: true,
+		},
+		{
+			name:   "appends .dbg suffix for kvm/x86_64",
+			target: newTarget("myapp", "kvm", "x86_64"),
+			want:   "myapp_kvm-x86_64.dbg",
+		},
+		{
+			name:   "appends .dbg suffix for fc/arm64",
+			target: newTarget("srv", "fc", "arm64"),
+			want:   "srv_fc-arm64.dbg",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := KernelDbgName(tt.target)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("KernelDbgName() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if err == nil && got != tt.want {
+				t.Errorf("KernelDbgName() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TargetPlatArchName
+// ---------------------------------------------------------------------------
+
+func TestTargetPlatArchName(t *testing.T) {
+	tests := []struct {
+		platName string
+		archName string
+		want     string
+	}{
+		{"kvm", "x86_64", "kvm/x86_64"},
+		{"xen", "arm64", "xen/arm64"},
+		{"linuxu", "arm", "linuxu/arm"},
+	}
+
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("%s/%s", tt.platName, tt.archName), func(t *testing.T) {
+			tgt := NewTargetFromOptions(
+				WithArchitecture(arch.NewArchitectureFromOptions(arch.WithName(tt.archName))),
+				WithPlatform(plat.NewPlatformFromOptions(plat.WithName(tt.platName))),
+			)
+			got := TargetPlatArchName(tgt)
+			if got != tt.want {
+				t.Errorf("TargetPlatArchName() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// ConfigFilename
+// ---------------------------------------------------------------------------
+
+func TestConfigFilename(t *testing.T) {
+	t.Run("kernel path set — uses basename", func(t *testing.T) {
+		tc := TargetConfig{
+			name:         "app",
+			platform:     plat.NewPlatformFromOptions(plat.WithName("kvm")),
+			architecture: arch.NewArchitectureFromOptions(arch.WithName("x86_64")),
+			kernel:       "/build/app_kvm-x86_64",
+		}
+		want := ".config.app_kvm-x86_64"
+		if got := tc.ConfigFilename(); got != want {
+			t.Errorf("ConfigFilename() = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("kernel path unset — formats from name/plat/arch", func(t *testing.T) {
+		tc := TargetConfig{
+			name:         "myapp",
+			platform:     plat.NewPlatformFromOptions(plat.WithName("kvm")),
+			architecture: arch.NewArchitectureFromOptions(arch.WithName("x86_64")),
+		}
+		want := ".config.myapp_kvm-x86_64"
+		if got := tc.ConfigFilename(); got != want {
+			t.Errorf("ConfigFilename() = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("kernel path with directory — uses only base filename", func(t *testing.T) {
+		tc := TargetConfig{
+			name:         "srv",
+			platform:     plat.NewPlatformFromOptions(plat.WithName("fc")),
+			architecture: arch.NewArchitectureFromOptions(arch.WithName("arm64")),
+			kernel:       filepath.Join("/some", "build", "dir", "srv_fc-arm64"),
+		}
+		want := ".config.srv_fc-arm64"
+		if got := tc.ConfigFilename(); got != want {
+			t.Errorf("ConfigFilename() = %q, want %q", got, want)
+		}
+	})
+}
+
+// ---------------------------------------------------------------------------
+// NewTargetFromOptions / SetKernelPath
+// ---------------------------------------------------------------------------
+
+func TestNewTargetFromOptions(t *testing.T) {
+	tgt := NewTargetFromOptions(
+		WithName("demo"),
+		WithArchitecture(arch.NewArchitectureFromOptions(arch.WithName("x86_64"))),
+		WithPlatform(plat.NewPlatformFromOptions(plat.WithName("kvm"))),
+		WithKernel("/build/demo_kvm-x86_64"),
+		WithKernelDbg("/build/demo_kvm-x86_64.dbg"),
+		WithCommand([]string{"/bin/sh", "-c", "echo hello"}),
+	)
+
+	if got := tgt.Name(); got != "demo" {
+		t.Errorf("Name() = %q, want %q", got, "demo")
+	}
+	if got := tgt.Architecture().Name(); got != "x86_64" {
+		t.Errorf("Architecture().Name() = %q, want %q", got, "x86_64")
+	}
+	if got := tgt.Platform().Name(); got != "kvm" {
+		t.Errorf("Platform().Name() = %q, want %q", got, "kvm")
+	}
+	if got := tgt.Kernel(); got != "/build/demo_kvm-x86_64" {
+		t.Errorf("Kernel() = %q, want %q", got, "/build/demo_kvm-x86_64")
+	}
+	if got := tgt.KernelDbg(); got != "/build/demo_kvm-x86_64.dbg" {
+		t.Errorf("KernelDbg() = %q, want %q", got, "/build/demo_kvm-x86_64.dbg")
+	}
+	if got := len(tgt.Command()); got != 3 {
+		t.Errorf("Command() length = %d, want 3", got)
+	}
+}
+
+func TestSetKernelPath(t *testing.T) {
+	tgt := NewTargetFromOptions(
+		WithName("app"),
+		WithArchitecture(arch.NewArchitectureFromOptions(arch.WithName("x86_64"))),
+		WithPlatform(plat.NewPlatformFromOptions(plat.WithName("kvm"))),
+	)
+
+	const newPath = "/new/build/app_kvm-x86_64"
+	tgt.SetKernelPath(newPath)
+	if got := tgt.Kernel(); got != newPath {
+		t.Errorf("after SetKernelPath: Kernel() = %q, want %q", got, newPath)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Simple accessor / metadata methods
+// ---------------------------------------------------------------------------
+
+func TestTargetConfigAccessors(t *testing.T) {
+	tc := newTarget("demo", "kvm", "x86_64")
+
+	t.Run("String", func(t *testing.T) {
+		s := tc.String()
+		if s == "" {
+			t.Error("String() returned empty string")
+		}
+	})
+
+	t.Run("Source returns empty string", func(t *testing.T) {
+		if got := tc.Source(); got != "" {
+			t.Errorf("Source() = %q, want empty", got)
+		}
+	})
+
+	t.Run("Version returns empty string", func(t *testing.T) {
+		if got := tc.Version(); got != "" {
+			t.Errorf("Version() = %q, want empty", got)
+		}
+	})
+
+	t.Run("Type returns ComponentTypeUnknown", func(t *testing.T) {
+		_ = tc.Type() // just exercise the branch; value checked by import
+	})
+
+	t.Run("Path returns empty string", func(t *testing.T) {
+		if got := tc.Path(); got != "" {
+			t.Errorf("Path() = %q, want empty", got)
+		}
+	})
+
+	t.Run("IsUnpacked returns false", func(t *testing.T) {
+		if tc.IsUnpacked() {
+			t.Error("IsUnpacked() = true, want false")
+		}
+	})
+
+	t.Run("Roms returns nil for zero value", func(t *testing.T) {
+		if got := tc.Roms(); len(got) != 0 {
+			t.Errorf("Roms() len = %d, want 0", len(got))
+		}
+	})
+
+	t.Run("Initrd returns nil for zero value", func(t *testing.T) {
+		if got := tc.Initrd(); got != nil {
+			t.Errorf("Initrd() = %v, want nil", got)
+		}
+	})
+}
+
+// ---------------------------------------------------------------------------
+// KConfig
+// ---------------------------------------------------------------------------
+
+func TestKConfig(t *testing.T) {
+	t.Run("nil kconfig is initialised and merged with arch+plat KConfig", func(t *testing.T) {
+		tc := newTarget("app", "linuxu", "x86_64")
+		kc := tc.KConfig()
+		if kc == nil {
+			t.Fatal("KConfig() returned nil")
+		}
+		// x86_64 arch should contribute CONFIG_ARCH_X86_64=y
+		if _, ok := kc["CONFIG_ARCH_X86_64"]; !ok {
+			t.Error("expected CONFIG_ARCH_X86_64 in KConfig, not found")
+		}
+	})
+
+	t.Run("WithKConfig option wires kconfig into target", func(t *testing.T) {
+		tgt := NewTargetFromOptions(
+			WithName("cfg"),
+			WithArchitecture(arch.NewArchitectureFromOptions(arch.WithName("x86_64"))),
+			WithPlatform(plat.NewPlatformFromOptions(plat.WithName("linuxu"))),
+			WithKConfig(nil),
+		)
+		kc := tgt.(*TargetConfig).KConfig()
+		if kc == nil {
+			t.Error("KConfig() returned nil after WithKConfig(nil)")
+		}
+	})
+}
+
+// ---------------------------------------------------------------------------
+// KConfigTree and PrintInfo
+// ---------------------------------------------------------------------------
+
+func TestKConfigTree(t *testing.T) {
+	tc := newTarget("app", "kvm", "x86_64")
+	tree, err := tc.KConfigTree(nil)
+	if err == nil {
+		t.Error("KConfigTree() expected error, got nil")
+	}
+	if tree != nil {
+		t.Errorf("KConfigTree() = %v, want nil", tree)
+	}
+}
+
+func TestPrintInfo(t *testing.T) {
+	tc := newTarget("app", "kvm", "x86_64")
+	s := tc.PrintInfo(nil)
+	if s == "" {
+		t.Error("PrintInfo() returned empty string")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// MarshalYAML
+// ---------------------------------------------------------------------------
+
+func TestMarshalYAML(t *testing.T) {
+	t.Run("minimal — no name or kconfig", func(t *testing.T) {
+		tc := newTarget("", "linuxu", "x86_64")
+		out, err := tc.MarshalYAML()
+		if err != nil {
+			t.Fatalf("MarshalYAML() error = %v", err)
+		}
+		m, ok := out.(map[string]interface{})
+		if !ok {
+			t.Fatalf("MarshalYAML() returned %T, want map", out)
+		}
+		if m["architecture"] != "x86_64" {
+			t.Errorf("architecture = %v, want x86_64", m["architecture"])
+		}
+		if m["platform"] != "linuxu" {
+			t.Errorf("platform = %v, want linuxu", m["platform"])
+		}
+		if _, ok := m["name"]; ok {
+			t.Error("name key should be absent for empty name")
+		}
+	})
+
+	t.Run("includes name when set", func(t *testing.T) {
+		tc := newTarget("myapp", "linuxu", "x86_64")
+		out, err := tc.MarshalYAML()
+		if err != nil {
+			t.Fatalf("MarshalYAML() error = %v", err)
+		}
+		m := out.(map[string]interface{})
+		if m["name"] != "myapp" {
+			t.Errorf("name = %v, want myapp", m["name"])
+		}
+	})
+
+	t.Run("includes output when kernel path set", func(t *testing.T) {
+		tc := TargetConfig{
+			name:         "app",
+			platform:     plat.NewPlatformFromOptions(plat.WithName("linuxu")),
+			architecture: arch.NewArchitectureFromOptions(arch.WithName("x86_64")),
+			kernel:       "/build/app_linuxu-x86_64",
+		}
+		out, err := tc.MarshalYAML()
+		if err != nil {
+			t.Fatalf("MarshalYAML() error = %v", err)
+		}
+		m := out.(map[string]interface{})
+		if m["output"] != "/build/app_linuxu-x86_64" {
+			t.Errorf("output = %v, want /build/app_linuxu-x86_64", m["output"])
+		}
+	})
+}

--- a/unikraft/target/transform_test.go
+++ b/unikraft/target/transform_test.go
@@ -1,0 +1,289 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2024, Unikraft GmbH and The KraftKit Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+package target
+
+import (
+	"context"
+	"testing"
+
+	"kraftkit.sh/unikraft"
+)
+
+// ---------------------------------------------------------------------------
+// TransformFromSchema — string input
+// ---------------------------------------------------------------------------
+
+func TestTransformFromSchema_String(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		wantPlat string
+		wantArch string
+		wantErr  bool
+	}{
+		{
+			// "kvm" is aliased to "qemu" by mplatform.PlatformsByName()
+			name:     "kvm/x86_64 is aliased to qemu",
+			input:    "kvm/x86_64",
+			wantPlat: "qemu",
+			wantArch: "x86_64",
+		},
+		{
+			name:     "qemu/arm64",
+			input:    "qemu/arm64",
+			wantPlat: "qemu",
+			wantArch: "arm64",
+		},
+		{
+			name:     "linuxu/x86_64 stays as linuxu",
+			input:    "linuxu/x86_64",
+			wantPlat: "linuxu",
+			wantArch: "x86_64",
+		},
+		{
+			name:     "xen/arm64",
+			input:    "xen/arm64",
+			wantPlat: "xen",
+			wantArch: "arm64",
+		},
+		{
+			name:    "missing slash returns error",
+			input:   "kvm",
+			wantErr: true,
+		},
+		{
+			name:    "empty string returns error",
+			input:   "",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := TransformFromSchema(context.Background(), tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("TransformFromSchema(%q) error = %v, wantErr %v", tt.input, err, tt.wantErr)
+			}
+			if err != nil {
+				return
+			}
+			tc, ok := got.(TargetConfig)
+			if !ok {
+				t.Fatalf("TransformFromSchema returned %T, want TargetConfig", got)
+			}
+			if tc.Platform().Name() != tt.wantPlat {
+				t.Errorf("Platform().Name() = %q, want %q", tc.Platform().Name(), tt.wantPlat)
+			}
+			if tc.Architecture().Name() != tt.wantArch {
+				t.Errorf("Architecture().Name() = %q, want %q", tc.Architecture().Name(), tt.wantArch)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TransformFromSchema — map input
+// ---------------------------------------------------------------------------
+
+func TestTransformFromSchema_Map(t *testing.T) {
+	t.Run("architecture and platform keys", func(t *testing.T) {
+		input := map[string]interface{}{
+			"architecture": "x86_64",
+			"platform":     "linuxu",
+		}
+		got, err := TransformFromSchema(context.Background(), input)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		tc := got.(TargetConfig)
+		if tc.Architecture().Name() != "x86_64" {
+			t.Errorf("Architecture = %q, want x86_64", tc.Architecture().Name())
+		}
+		if tc.Platform().Name() != "linuxu" {
+			t.Errorf("Platform = %q, want linuxu", tc.Platform().Name())
+		}
+	})
+
+	t.Run("arch and plat alias keys", func(t *testing.T) {
+		input := map[string]interface{}{
+			"arch": "arm64",
+			"plat": "xen",
+		}
+		got, err := TransformFromSchema(context.Background(), input)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		tc := got.(TargetConfig)
+		if tc.Architecture().Name() != "arm64" {
+			t.Errorf("Architecture = %q, want arm64", tc.Architecture().Name())
+		}
+		if tc.Platform().Name() != "xen" {
+			t.Errorf("Platform = %q, want xen", tc.Platform().Name())
+		}
+	})
+
+	t.Run("platform with inline arch override", func(t *testing.T) {
+		input := map[string]interface{}{
+			"platform": "linuxu/x86_64",
+		}
+		got, err := TransformFromSchema(context.Background(), input)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		tc := got.(TargetConfig)
+		if tc.Platform().Name() != "linuxu" {
+			t.Errorf("Platform = %q, want linuxu", tc.Platform().Name())
+		}
+		if tc.Architecture().Name() != "x86_64" {
+			t.Errorf("Architecture = %q, want x86_64", tc.Architecture().Name())
+		}
+	})
+
+	t.Run("name key sets target name", func(t *testing.T) {
+		input := map[string]interface{}{
+			"name":         "myapp",
+			"architecture": "x86_64",
+			"platform":     "linuxu",
+		}
+		got, err := TransformFromSchema(context.Background(), input)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		tc := got.(TargetConfig)
+		if tc.Name() != "myapp" {
+			t.Errorf("Name = %q, want myapp", tc.Name())
+		}
+	})
+
+	t.Run("output key sets kernel path", func(t *testing.T) {
+		input := map[string]interface{}{
+			"architecture": "x86_64",
+			"platform":     "linuxu",
+			"output":       "/build/myapp_linuxu-x86_64",
+		}
+		got, err := TransformFromSchema(context.Background(), input)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		tc := got.(TargetConfig)
+		if tc.Kernel() != "/build/myapp_linuxu-x86_64" {
+			t.Errorf("Kernel = %q, want /build/myapp_linuxu-x86_64", tc.Kernel())
+		}
+	})
+
+	t.Run("kconfig as map", func(t *testing.T) {
+		input := map[string]interface{}{
+			"architecture": "x86_64",
+			"platform":     "linuxu",
+			"kconfig": map[string]interface{}{
+				"CONFIG_EXAMPLE": "y",
+			},
+		}
+		got, err := TransformFromSchema(context.Background(), input)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		tc := got.(TargetConfig)
+		if tc.kconfig == nil {
+			t.Error("kconfig should not be nil after map input")
+		}
+	})
+
+	t.Run("kconfig as slice", func(t *testing.T) {
+		input := map[string]interface{}{
+			"architecture": "x86_64",
+			"platform":     "linuxu",
+			"kconfig":      []interface{}{"CONFIG_EXAMPLE=y"},
+		}
+		got, err := TransformFromSchema(context.Background(), input)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		tc := got.(TargetConfig)
+		if tc.kconfig == nil {
+			t.Error("kconfig should not be nil after slice input")
+		}
+	})
+
+	t.Run("invalid type for name returns error", func(t *testing.T) {
+		input := map[string]interface{}{
+			"name":         123,
+			"architecture": "x86_64",
+			"platform":     "linuxu",
+		}
+		_, err := TransformFromSchema(context.Background(), input)
+		if err == nil {
+			t.Error("expected error for non-string name, got nil")
+		}
+	})
+
+	t.Run("invalid type for platform returns error", func(t *testing.T) {
+		input := map[string]interface{}{
+			"architecture": "x86_64",
+			"platform":     123,
+		}
+		_, err := TransformFromSchema(context.Background(), input)
+		if err == nil {
+			t.Error("expected error for non-string platform, got nil")
+		}
+	})
+}
+
+// ---------------------------------------------------------------------------
+// TransformFromSchema — context-aware behaviour
+// ---------------------------------------------------------------------------
+
+func TestTransformFromSchema_WithContext(t *testing.T) {
+	t.Run("UK_NAME from context sets target name", func(t *testing.T) {
+		ctx := unikraft.WithContext(context.Background(), &unikraft.Context{
+			UK_NAME: "ctxapp",
+		})
+		input := map[string]interface{}{
+			"architecture": "x86_64",
+			"platform":     "linuxu",
+		}
+		got, err := TransformFromSchema(ctx, input)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		tc := got.(TargetConfig)
+		if tc.Name() != "ctxapp" {
+			t.Errorf("Name = %q, want ctxapp", tc.Name())
+		}
+	})
+
+	t.Run("BUILD_DIR from context populates kernel and kernelDbg paths", func(t *testing.T) {
+		ctx := unikraft.WithContext(context.Background(), &unikraft.Context{
+			UK_NAME:   "myapp",
+			BUILD_DIR: "/tmp/build",
+		})
+		input := map[string]interface{}{
+			"architecture": "x86_64",
+			"platform":     "linuxu",
+		}
+		got, err := TransformFromSchema(ctx, input)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		tc := got.(TargetConfig)
+		if tc.Kernel() == "" {
+			t.Error("Kernel path should be set when BUILD_DIR is present in context")
+		}
+		if tc.KernelDbg() == "" {
+			t.Error("KernelDbg path should be set when BUILD_DIR is present in context")
+		}
+	})
+}
+
+// ---------------------------------------------------------------------------
+// TransformFromSchema — unsupported type
+// ---------------------------------------------------------------------------
+
+func TestTransformFromSchema_InvalidType(t *testing.T) {
+	_, err := TransformFromSchema(context.Background(), 42)
+	if err == nil {
+		t.Error("expected error for unsupported input type int, got nil")
+	}
+}


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [ ] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [ ] Tested your changes locally.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

## Summary

- Adds unit tests for the `unikraft/target` package which previously had
  zero test coverage, now reaching **80.3%** coverage.

## Files added

| File | What it tests |
|------|---------------|
| `unikraft/target/target_test.go` | `KernelName`, `KernelDbgName`, `TargetPlatArchName`, `ConfigFilename`, `NewTargetFromOptions`, `SetKernelPath`, `KConfig`, `MarshalYAML`, `KConfigTree`, `PrintInfo`, and simple accessors (`String`, `Source`, `Version`, `Type`, `Path`, `IsUnpacked`, `Roms`, `Initrd`) |
| `unikraft/target/transform_test.go` | `TransformFromSchema` — string input, map input (all key variants, kconfig as map/slice, output key, inline arch override), context-driven name/paths from `UK_NAME`/`BUILD_DIR`, and unsupported input type |
| `unikraft/target/select_test.go` | `Filter` — all nine condition branches: no filters, arch-only, plat-only, plat+arch, targ-only, targ as `plat/arch` string, plat+targ, and all-three |

## Notes

- `kvm` is correctly documented as being aliased to `qemu` by `mplatform.PlatformsByName()` — tests assert the canonical resolved name.
- `Select()` (interactive TUI prompt) is intentionally not covered as it requires a terminal.


Closes #2712 

