### PR TITLE
feat(system): Introduce system list subcommand

### DIFF
--- a/internal/cli/kraft/system/list/list.go
+++ b/internal/cli/kraft/system/list/list.go
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2025, Unikraft GmbH and The KraftKit Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+
+package list
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"strings"
+
+	"github.com/MakeNowJust/heredoc"
+	"github.com/spf13/cobra"
+
+	"kraftkit.sh/cmdfactory"
+	"kraftkit.sh/config"
+	"kraftkit.sh/iostreams"
+)
+
+type List struct{}
+
+func NewCmd() *cobra.Command {
+	cmd, err := cmdfactory.New(&List{}, cobra.Command{
+		Short:   "List KraftKit configuration options",
+		Use:     "list [FLAGS]",
+		Aliases: []string{"ls"},
+		Args:    cobra.NoArgs,
+		Long: heredoc.Doc(`
+			List all KraftKit configuration options and their current values.
+		`),
+		Example: heredoc.Doc(`
+			# List all configuration options
+			$ kraft system list
+		`),
+		Annotations: map[string]string{
+			cmdfactory.AnnotationHelpGroup: "misc",
+		},
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	return cmd
+}
+
+func (opts *List) Run(ctx context.Context, _ []string) error {
+	cfg := config.G[config.KraftKit](ctx)
+
+	pairs := flattenConfig(reflect.ValueOf(cfg).Elem(), "")
+
+	out := iostreams.G(ctx).Out
+	for _, pair := range pairs {
+		fmt.Fprintln(out, pair)
+	}
+
+	return nil
+}
+
+func flattenConfig(v reflect.Value, prefix string) []string {
+	var pairs []string
+
+	t := v.Type()
+
+	for i := 0; i < t.NumField(); i++ {
+		field := t.Field(i)
+		fieldVal := v.Field(i)
+
+		// Using yaml tag as key name, consistent with kraft system set
+		tag := field.Tag.Get("yaml")
+		if tag == "" || tag == "-" {
+			continue
+		}
+		tagName := strings.Split(tag, ",")[0]
+		if tagName == "-" {
+			continue
+		}
+
+		key := tagName
+		if prefix != "" {
+			key = prefix + "." + tagName
+		}
+
+		switch fieldVal.Kind() {
+		case reflect.Struct:
+			pairs = append(pairs, flattenConfig(fieldVal, key)...)
+
+		case reflect.Map:
+			for _, mapKey := range fieldVal.MapKeys() {
+				mapVal := fieldVal.MapIndex(mapKey)
+				pairs = append(pairs, fmt.Sprintf("%s.%s=%v", key, mapKey, mapVal))
+			}
+
+		default:
+			pairs = append(pairs, fmt.Sprintf("%s=%v", key, fieldVal))
+		}
+	}
+
+	return pairs
+}

--- a/internal/cli/kraft/system/system.go
+++ b/internal/cli/kraft/system/system.go
@@ -13,6 +13,7 @@ import (
 
 	"kraftkit.sh/cmdfactory"
 
+	"kraftkit.sh/internal/cli/kraft/system/list"
 	"kraftkit.sh/internal/cli/kraft/system/set"
 )
 
@@ -33,6 +34,7 @@ func NewCmd() *cobra.Command {
 	}
 
 	cmd.AddCommand(set.NewCmd())
+	cmd.AddCommand(list.NewCmd())
 
 	return cmd
 }


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist
<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes locally.

### Description of changes
Adresses the final item on the checklist in #673.
- [x] Introduce cli options/commands to set/list toolchain variables

Follows up on #2685 (`kraft system set`).

Introduces `kraft system list` which prints all KraftKit configuration
options and their current values by walking the KraftKit config struct

**Example:**   ` $ kraft system list`

```
  no_prompt=false
  log.level=info
  toolchain.CC=clang
  ...
```
