### PR TITLE
test(make): Add tests for make/options.go

### DIFF
--- a/make/options_test.go
+++ b/make/options_test.go
@@ -1,0 +1,378 @@
+package make
+
+import (
+	"errors"
+	"os"
+	"reflect"
+	"runtime"
+	"sort"
+	"testing"
+
+	"kraftkit.sh/exec"
+)
+
+func TestNewMakeOptions(t *testing.T) {
+	tests := []struct {
+		name     string
+		mopt     []MakeOption
+		expected *MakeOptions
+	}{
+		{
+			name:     "Default MakeOptions",
+			mopt:     []MakeOption{},
+			expected: &MakeOptions{},
+		},
+		{
+			name: "string setters",
+			mopt: []MakeOption{
+				WithDirectory("/path/to/dir"),
+				WithEvaluates("evaluate"),
+				WithFile("/path/to/file1"),
+				WithIncludeDir("/path/to/include"),
+				WithOldFile("/path/to/old_file1"),
+				WithAssumeNew("/path/to/new_file"),
+				WithBinPath("/path/to/bin"),
+				WithFile("/path/to/file2"),
+				WithOldFile("/path/to/old_file2"),
+			},
+			expected: &MakeOptions{
+				directory:   "/path/to/dir",
+				evaluates:   []string{"evaluate"},
+				files:       []string{"/path/to/file1", "/path/to/file2"},
+				includeDirs: []string{"/path/to/include"},
+				oldFiles:    []string{"/path/to/old_file1", "/path/to/old_file2"},
+				newFiles:    []string{"/path/to/new_file"},
+				bin:         "/path/to/bin",
+			},
+		},
+		{
+			name: "bool setters",
+			mopt: []MakeOption{
+				WithAlwaysMake(true),
+				WithDebug(true),
+				WithEnvOverrides(true),
+				WithIgnoreErrors(true),
+				WithKeepGoing(false),
+				WithCheckSymlinkTimes(false),
+				WithJustPrint(true),
+				WithPrintDataBase(true),
+				WithQuestion(false),
+				WithNoBuiltinRules(false),
+				WithNoBuiltinVariables(true),
+				WithNoPrintDirectory(true),
+				WithSilent(true),
+				WithSyncOutput(true),
+				WithTouch(false),
+				WithTrace(false),
+				WithVersion(false),
+				WithPrintDirectory(true),
+				WithWarnUndefinedVariables(true),
+			},
+			expected: &MakeOptions{
+				alwaysMake:             true,
+				debug:                  true,
+				envOverrides:           true,
+				ignoreErrors:           true,
+				keepGoing:              false,
+				checkSymlinkTimes:      false,
+				justPrint:              true,
+				printDataBase:          true,
+				question:               false,
+				noBuiltinRules:         false,
+				noPrintDirectory:       true,
+				noBuiltinVariables:     true,
+				silent:                 true,
+				syncOutput:             true,
+				touch:                  false,
+				trace:                  false,
+				version:                false,
+				printDirectory:         true,
+				warnUndefinedVariables: true,
+			},
+		},
+		{
+			name: "int setters",
+			mopt: []MakeOption{
+				WithJobs(1),
+				WithLoadAverage(4),
+			},
+			expected: &MakeOptions{
+				jobs:        func(jobs int) *int { return &jobs }(1),
+				loadAverage: func(loadAverage int) *int { return &loadAverage }(4),
+			},
+		},
+		{
+			name: "Var setters",
+			mopt: []MakeOption{
+				WithVar("CC", "gcc-14"),
+				WithVar("CXX", "g++"),
+				WithVar("GOPATH", "/usr/bin/go"),
+				WithVar("😀", "😃"),
+				WithVars(map[string]string{"CURL": "curl", "MKDIR": "mkdir", "CMAKE": "cmake", "GOOS": "linux", "GOARCH": "amd64"}),
+			},
+			expected: &MakeOptions{
+				vars: map[string]string{
+					"CC":     "gcc-14",
+					"CXX":    "g++",
+					"GOPATH": "/usr/bin/go",
+					"😀":      "😃",
+					"CURL":   "curl",
+					"MKDIR":  "mkdir",
+					"CMAKE":  "cmake",
+					"GOOS":   "linux",
+					"GOARCH": "amd64",
+				},
+			},
+		},
+		{
+			name:     "Nil Vars setter",
+			mopt:     []MakeOption{WithVars(nil)},
+			expected: &MakeOptions{vars: map[string]string{}},
+		},
+		{
+			name: "No Max Jobs",
+			mopt: []MakeOption{
+				WithMaxJobs(false),
+			},
+			expected: &MakeOptions{
+				jobs: nil,
+			},
+		},
+		{
+			name: "With Max Jobs",
+			mopt: []MakeOption{
+				WithMaxJobs(true),
+			},
+			expected: &MakeOptions{
+				jobs: func(jobs int) *int { return &jobs }(runtime.NumCPU()),
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			actual, err := NewMakeOptions(test.mopt...)
+			if err != nil {
+				t.Fatalf("NewMakeOptions failed: %v", err)
+			}
+
+			if !reflect.DeepEqual(actual, test.expected) {
+				t.Fatalf("%s: NewMakeOptions failed: got %#v, want %#v", test.name, actual, test.expected)
+			}
+		})
+	}
+}
+
+func TestNewMakeOptionsReturnsError(t *testing.T) {
+	mopts, err := NewMakeOptions(
+		func(mo *MakeOptions) error {
+			return errors.New("intentional Error")
+		},
+	)
+	if mopts != nil {
+		t.Fatalf("NewMakeOptions failed: got %#v, want nil on error", mopts)
+	}
+
+	if err == nil {
+		t.Fatalf("NewMakeOptions failed: got nil, want error")
+	}
+
+	expectedError := errors.New("could not apply option: intentional Error")
+	if err.Error() != expectedError.Error() {
+		t.Fatalf("NewMakeOptions failed: got error %#v, want %#v", err, expectedError)
+	}
+}
+
+func TestNewMakeOptionsWithOnProgress(t *testing.T) {
+	tests := []struct {
+		name          string
+		args          []float64
+		hasOnProgress bool
+	}{
+		{name: "Nil onProgress", args: nil, hasOnProgress: false},
+		{name: "zero progress", args: []float64{0.0}, hasOnProgress: true},
+		{name: "mid progress", args: []float64{0.5}, hasOnProgress: true},
+		{name: "complete", args: []float64{1.0}, hasOnProgress: true},
+		{name: "negative value", args: []float64{-1.0}, hasOnProgress: true},
+		{name: "over complete", args: []float64{1.5}, hasOnProgress: true},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var captured float64
+
+			var fn func(float64)
+
+			if test.hasOnProgress {
+				fn = func(val float64) { captured = val }
+			}
+
+			mopts, err := NewMakeOptions(WithProgressFunc(fn))
+			if err != nil {
+				t.Fatalf("NewMakeOptions failed: %v", err)
+			}
+
+			if test.hasOnProgress && mopts.onProgress == nil {
+				t.Fatalf("NewMakeOptions failed: got nil, want non-nil")
+			}
+
+			if !test.hasOnProgress && mopts.onProgress != nil {
+				t.Fatalf("NewMakeOptions failed: got non-nil, want nil")
+			}
+
+			for _, arg := range test.args {
+				mopts.onProgress(arg)
+				if captured != arg {
+					t.Fatalf("NewMakeOptions failed: got %v, want %v", captured, arg)
+				}
+			}
+		})
+	}
+}
+
+func TestNewMakeOptionsWithExecOptions(t *testing.T) {
+	tests := []struct {
+		name    string
+		eopts   []exec.ExecOption
+		wantLen int
+	}{
+		{
+			name:    "Nil ExecOptions",
+			eopts:   nil,
+			wantLen: 0,
+		},
+		{
+			name:    "Single ExecOptions",
+			eopts:   []exec.ExecOption{exec.WithDetach(false)},
+			wantLen: 1,
+		},
+		{
+			name:    "Multi ExecOptions",
+			eopts:   []exec.ExecOption{exec.WithEnvKey("CC", "gcc-14"), exec.WithDetach(true), exec.WithStdin(os.Stdin)},
+			wantLen: 3,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			mopts, err := NewMakeOptions(WithExecOptions(test.eopts...))
+			if err != nil {
+				t.Fatalf("NewMakeOptions failed: %v", err)
+			}
+
+			if test.wantLen != len(mopts.eopts) {
+				t.Fatalf("NewMakeOptions failed: got length %v, want length %v", len(mopts.eopts), test.wantLen)
+			}
+		})
+	}
+	t.Run("Multiple WithExecOptions Call", func(t *testing.T) {
+		wantLen := 3
+		mopts, err := NewMakeOptions(
+			WithExecOptions(exec.WithStdout(os.Stdout)),
+			WithExecOptions(exec.WithStderr(os.Stderr)),
+			WithExecOptions(exec.WithStdin(os.Stdin)),
+		)
+		if err != nil {
+			t.Fatalf("NewMakeOptions failed: %v", err)
+		}
+
+		if wantLen != len(mopts.eopts) {
+			t.Fatalf("NewMakeOptions failed: got length %v, want length %v", len(mopts.eopts), wantLen)
+		}
+	})
+}
+
+func TestMakeOptions_Vars(t *testing.T) {
+	mopts := &MakeOptions{
+		vars: map[string]string{
+			"CC":     "gcc-14",
+			"CXX":    "g++",
+			"GOPATH": "/usr/bin/go",
+			"😀":      "😃",
+			"CURL":   "curl",
+			"MKDIR":  "mkdir",
+			"CMAKE":  "cmake",
+			"GOOS":   "linux",
+			"GOARCH": "amd64",
+		},
+		targets: []string{"build", "run", "dev", "clean"},
+	}
+	want := []string{
+		"CC=gcc-14",
+		"CXX=g++",
+		"GOPATH=/usr/bin/go",
+		"MKDIR=mkdir", "GOOS=linux",
+		"GOARCH=amd64",
+		"CURL=curl",
+		"CMAKE=cmake",
+		"😀=😃",
+		"build",
+		"clean",
+		"run",
+		"dev",
+	}
+	t.Run("Testing MakeOptions Vars", func(t *testing.T) {
+		actual := mopts.Vars()
+		sort.Strings(actual)
+		sort.Strings(want)
+		if !reflect.DeepEqual(actual, want) {
+			t.Fatalf("MakeOptions Vars failed: got %v, want %v", actual, want)
+		}
+	})
+}
+
+func TestMakeOptions_WithTarget(t *testing.T) {
+	tests := []struct {
+		name    string
+		targets []string
+		wantLen int
+	}{
+		{
+			name:    "Empty Targets",
+			targets: nil,
+			wantLen: 0,
+		},
+		{
+			name:    "Single Target",
+			targets: []string{"build"},
+			wantLen: 1,
+		},
+		{
+			name:    "Multi Target",
+			targets: []string{"build", "run", "dev", "clean"},
+			wantLen: 4,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			mopts, err := NewMakeOptions(WithTarget(test.targets...))
+			if err != nil {
+				t.Fatalf("NewMakeOptions failed: %v", err)
+			}
+
+			if test.wantLen != len(mopts.targets) {
+				t.Fatalf("NewMakeOptions failed: got length %v, want length %v", len(mopts.targets), test.wantLen)
+			}
+
+			if !reflect.DeepEqual(mopts.targets, test.targets) {
+				t.Fatalf("NewMakeOptions failed: got %v, want %v", mopts.targets, test.targets)
+			}
+		})
+	}
+	t.Run("Multiple WithTarget Args", func(t *testing.T) {
+		targets := []string{"build", "run", "dev", "clean"}
+		mopts, err := NewMakeOptions(WithTarget("build", "run"), WithTarget("dev"), WithTarget("clean"))
+		if err != nil {
+			t.Fatalf("NewMakeOptions failed: %v", err)
+		}
+
+		if len(targets) != len(mopts.targets) {
+			t.Fatalf("NewMakeOptions failed: got %v, want %v", len(mopts.targets), len(targets))
+		}
+
+		if !reflect.DeepEqual(mopts.targets, targets) {
+			t.Fatalf("NewMakeOptions failed: got %v, want %v", mopts.targets, targets)
+		}
+	})
+}


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes locally.

### Description of changes
- Add unit tests for `make/options.go` covering `NewMakeOptions`, `MakeOptions` setters for all field types(bool, string, int, map, slice, func, exec options), error handling and `Vars()` method

```
$ go tool cover -func=coverage.out | grep options.go
kraftkit.sh/make/options.go:55:		NewMakeOptions			100.0%
kraftkit.sh/make/options.go:69:		Vars				100.0%
kraftkit.sh/make/options.go:83:		WithAlwaysMake			100.0%
kraftkit.sh/make/options.go:92:		WithDirectory			100.0%
kraftkit.sh/make/options.go:101:	WithDebug			100.0%
kraftkit.sh/make/options.go:110:	WithEnvOverrides		100.0%
kraftkit.sh/make/options.go:118:	WithVar				100.0%
kraftkit.sh/make/options.go:131:	WithVars			100.0%
kraftkit.sh/make/options.go:147:	WithEvaluates			100.0%
kraftkit.sh/make/options.go:161:	WithFile			100.0%
kraftkit.sh/make/options.go:175:	WithIgnoreErrors		100.0%
kraftkit.sh/make/options.go:184:	WithIncludeDir			100.0%
kraftkit.sh/make/options.go:198:	WithJobs			100.0%
kraftkit.sh/make/options.go:207:	WithMaxJobs			100.0%
kraftkit.sh/make/options.go:223:	WithKeepGoing			100.0%
kraftkit.sh/make/options.go:232:	WithLoadAverage			100.0%
kraftkit.sh/make/options.go:241:	WithCheckSymlinkTimes		100.0%
kraftkit.sh/make/options.go:250:	WithJustPrint			100.0%
kraftkit.sh/make/options.go:259:	WithOldFile			100.0%
kraftkit.sh/make/options.go:273:	WithPrintDataBase		100.0%
kraftkit.sh/make/options.go:282:	WithQuestion			100.0%
kraftkit.sh/make/options.go:291:	WithNoBuiltinRules		100.0%
kraftkit.sh/make/options.go:300:	WithNoBuiltinVariables		100.0%
kraftkit.sh/make/options.go:309:	WithNoPrintDirectory		100.0%
kraftkit.sh/make/options.go:317:	WithSilent			100.0%
kraftkit.sh/make/options.go:325:	WithSyncOutput			100.0%
kraftkit.sh/make/options.go:334:	WithTouch			100.0%
kraftkit.sh/make/options.go:342:	WithTrace			100.0%
kraftkit.sh/make/options.go:351:	WithVersion			100.0%
kraftkit.sh/make/options.go:360:	WithPrintDirectory		100.0%
kraftkit.sh/make/options.go:369:	WithAssumeNew			100.0%
kraftkit.sh/make/options.go:383:	WithWarnUndefinedVariables	100.0%
kraftkit.sh/make/options.go:392:	WithTarget			100.0%
kraftkit.sh/make/options.go:411:	WithProgressFunc		100.0%
kraftkit.sh/make/options.go:420:	WithExecOptions			100.0%
kraftkit.sh/make/options.go:433:	WithBinPath			100.0%
```
<!--
Please provide a detailed description of the changes made in this new PR.
-->
