### PR TITLE
fix(config): Support unsetting values in map structure

### DIFF
--- a/config/manager.go
+++ b/config/manager.go
@@ -259,6 +259,60 @@ func (cm *ConfigManager[C]) Set(key string, val any) error {
 	return nil
 }
 
+// Unset removes a key from the config. For map fields (e.g. toolchain.CC) it
+// deletes the map entry. For scalar fields it resets them to the zero value.
+func (cm *ConfigManager[C]) Unset(key string) error {
+	v := reflect.ValueOf(cm.Config)
+	if v.Kind() != reflect.Ptr || v.Elem().Kind() != reflect.Struct {
+		return errors.New("cfg must be a pointer to a struct")
+	}
+
+	v = v.Elem()
+	keys := strings.Split(key, ".")
+
+	for i, k := range keys {
+		field := v.FieldByNameFunc(func(f string) bool {
+			return getYAMLTag(v.Type().FieldByName(f)) == k
+		})
+
+		if !field.IsValid() {
+			return errors.New("invalid key: " + k)
+		}
+
+		if field.Kind() == reflect.Map &&
+			field.Type().Key().Kind() == reflect.String &&
+			field.Type().Elem().Kind() == reflect.String {
+
+			if i+1 != len(keys)-1 {
+				return errors.New("cannot traverse further into map: " + k)
+			}
+			if !field.IsNil() {
+				field.SetMapIndex(reflect.ValueOf(keys[i+1]), reflect.Value{})
+			}
+			return nil
+		}
+
+		if i == len(keys)-1 {
+			if !field.CanSet() {
+				return errors.New("cannot unset field: " + k)
+			}
+			field.Set(reflect.Zero(field.Type()))
+			return nil
+		}
+
+		if field.Kind() == reflect.Ptr {
+			if field.IsNil() {
+				return nil
+			}
+			v = field.Elem()
+		} else {
+			v = field
+		}
+	}
+
+	return nil
+}
+
 // SetupListener adds an OS signal listener to the Config instance. The listener
 // listens to the `SIGHUP` signal and refreshes the Config instance. It would
 // call the provided fallback if the refresh process failed.

--- a/config/manager_test.go
+++ b/config/manager_test.go
@@ -7,6 +7,68 @@ package config
 
 import "testing"
 
+func TestConfigManagerUnset_MapField(t *testing.T) {
+	unset := func(t *testing.T, cfg *KraftKit, key string) {
+		t.Helper()
+		cm := &ConfigManager[KraftKit]{Config: cfg}
+		if err := cm.Unset(key); err != nil {
+			t.Fatalf("Unset(%q) returned unexpected error: %v", key, err)
+		}
+	}
+
+	t.Run("Remove existing map key", func(t *testing.T) {
+		cfg := &KraftKit{Toolchain: map[string]string{"CC": "clang", "UK_CFLAGS": "-O2"}}
+		unset(t, cfg, "toolchain.CC")
+		if _, ok := cfg.Toolchain["CC"]; ok {
+			t.Error("expected toolchain.CC to be removed, but it still exists")
+		}
+		if expect, got := "-O2", cfg.Toolchain["UK_CFLAGS"]; expect != got {
+			t.Errorf("Toolchain[UK_CFLAGS]: expected %q, got %q", expect, got)
+		}
+	})
+
+	t.Run("Unset on nil map is a no-op", func(t *testing.T) {
+		cfg := &KraftKit{}
+		unset(t, cfg, "toolchain.CC")
+		if cfg.Toolchain != nil {
+			t.Error("expected Toolchain to remain nil")
+		}
+	})
+
+	t.Run("Unset string field resets to zero value", func(t *testing.T) {
+		cfg := &KraftKit{Editor: "vim"}
+		unset(t, cfg, "editor")
+		if cfg.Editor != "" {
+			t.Errorf("Editor: expected empty string, got %q", cfg.Editor)
+		}
+	})
+
+	t.Run("Unset nested struct field resets to zero value", func(t *testing.T) {
+		cfg := &KraftKit{}
+		cfg.Log.Level = "debug"
+		unset(t, cfg, "log.level")
+		if cfg.Log.Level != "" {
+			t.Errorf("Log.Level: expected empty string, got %q", cfg.Log.Level)
+		}
+	})
+
+	t.Run("Error on unknown key", func(t *testing.T) {
+		cfg := &KraftKit{}
+		cm := &ConfigManager[KraftKit]{Config: cfg}
+		if err := cm.Unset("nonexistent"); err == nil {
+			t.Error("expected error for unknown key, got nil")
+		}
+	})
+
+	t.Run("Error on too deep map traversal", func(t *testing.T) {
+		cfg := &KraftKit{}
+		cm := &ConfigManager[KraftKit]{Config: cfg}
+		if err := cm.Unset("toolchain.CC.extra"); err == nil {
+			t.Error("expected error for toolchain.CC.extra, got nil")
+		}
+	})
+}
+
 func TestConfigManagerSet_MapField(t *testing.T) {
 	// set is a helper that creates a ConfigManager and calls Set(key, val)
 	set := func(t *testing.T, cfg *KraftKit, key, val string) {

--- a/internal/cli/kraft/system/system.go
+++ b/internal/cli/kraft/system/system.go
@@ -15,6 +15,7 @@ import (
 
 	"kraftkit.sh/internal/cli/kraft/system/list"
 	"kraftkit.sh/internal/cli/kraft/system/set"
+	"kraftkit.sh/internal/cli/kraft/system/unset"
 )
 
 type System struct{}
@@ -35,6 +36,7 @@ func NewCmd() *cobra.Command {
 
 	cmd.AddCommand(set.NewCmd())
 	cmd.AddCommand(list.NewCmd())
+	cmd.AddCommand(unset.NewCmd())
 
 	return cmd
 }

--- a/internal/cli/kraft/system/unset/unset.go
+++ b/internal/cli/kraft/system/unset/unset.go
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2026, Unikraft GmbH and The KraftKit Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+
+package unset
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/MakeNowJust/heredoc"
+	"github.com/spf13/cobra"
+
+	"kraftkit.sh/cmdfactory"
+	"kraftkit.sh/config"
+	"kraftkit.sh/log"
+)
+
+type Unset struct{}
+
+func NewCmd() *cobra.Command {
+	cmd, err := cmdfactory.New(&Unset{}, cobra.Command{
+		Short: "Unset a KraftKit configuration option",
+		Use:   "unset KEY [KEY ...]",
+		Args:  cobra.MinimumNArgs(1),
+		Example: heredoc.Doc(`
+			# Remove a previously set toolchain variable
+			$ kraft system unset toolchain.CC
+
+			# Remove multiple keys at once
+			$ kraft system unset toolchain.CC toolchain.UK_CFLAGS
+		`),
+		Annotations: map[string]string{
+			cmdfactory.AnnotationHelpGroup: "misc",
+		},
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	return cmd
+}
+
+func (opts *Unset) Run(ctx context.Context, args []string) error {
+	for _, key := range args {
+		log.G(ctx).
+			WithField("key", key).
+			Info("unsetting")
+
+		if err := config.M[config.KraftKit](ctx).Unset(key); err != nil {
+			return fmt.Errorf("could not unset configuration option: %w", err)
+		}
+	}
+
+	return config.M[config.KraftKit](ctx).Write(true)
+}


### PR DESCRIPTION
### Prerequisite checklist

- [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
- [x] Tested your changes locally.

### Description of changes

Addresses #673.

Extends `ConfigManager` with an `Unset` method and wires it to a new `kraft system unset` subcommand.

The `Unset` method uses the same dot-separated key addressing as `Set`.
For `map[string]string` fields it deletes the map entry. For scalar and
nested struct fields it resets them to their zero value. A nil map is
treated as a no-op.

**Example**
```
$ kraft system unset toolchain.CC
$ kraft system unset toolchain.CC toolchain.UK_CFLAGS
```
