### PR TITLE
feat(build): Add --toolchain flag for per-invocation toolchain overrides

### DIFF
--- a/internal/cli/kraft/build/build.go
+++ b/internal/cli/kraft/build/build.go
@@ -39,6 +39,7 @@ type BuildOptions struct {
 	Architecture   string                `long:"arch" short:"m" usage:"Filter the creation of the build by architecture of known targets (x86_64/arm64/arm)"`
 	DotConfig      string                `long:"config" short:"c" usage:"Override the path to the KConfig .config file"`
 	Env            []string              `long:"env" short:"e" usage:"Set environment variables to be built in the unikernel" split:"false"`
+	Toolchain      []string              `long:"toolchain" short:"T" usage:"Override toolchain variables for this build (e.g. CC=clang LD=ld.lld)" split:"false"`
 	ForcePull      bool                  `long:"force-pull" usage:"Force pulling packages before building"`
 	InitrdOptions  []initrd.InitrdOption `noattribute:"true"`
 	Jobs           int                   `long:"jobs" short:"j" usage:"Allow N jobs at once"`
@@ -398,4 +399,18 @@ func moveFile(src, dst string) error {
 	}
 
 	return nil
+}
+
+func mergeToolchain(global map[string]string, flags []string) map[string]string {
+	result := map[string]string{}
+	for k, v := range global {
+		result[k] = v
+	}
+	for _, f := range flags {
+		parts := strings.SplitN(f, "=", 2)
+		if len(parts) == 2 {
+			result[parts[0]] = parts[1]
+		}
+	}
+	return result
 }

--- a/internal/cli/kraft/build/build_toolchain_test.go
+++ b/internal/cli/kraft/build/build_toolchain_test.go
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2026, Unikraft GmbH and The KraftKit Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+package build
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestMergeToolchain(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		global map[string]string
+		flags  []string
+		expect map[string]string
+	}{
+		{
+			name:   "flags only",
+			global: nil,
+			flags:  []string{"CC=clang", "LD=ld.lld"},
+			expect: map[string]string{"CC": "clang", "LD": "ld.lld"},
+		},
+		{
+			name:   "global only",
+			global: map[string]string{"CC": "gcc", "UK_CFLAGS": "-O2"},
+			flags:  nil,
+			expect: map[string]string{"CC": "gcc", "UK_CFLAGS": "-O2"},
+		},
+		{
+			name:   "flags and global disjoint keys",
+			global: map[string]string{"UK_CFLAGS": "-O2"},
+			flags:  []string{"CC=clang"},
+			expect: map[string]string{"CC": "clang", "UK_CFLAGS": "-O2"},
+		},
+		{
+			name:   "flag overrides global on same key",
+			global: map[string]string{"CC": "gcc"},
+			flags:  []string{"CC=clang"},
+			expect: map[string]string{"CC": "clang"},
+		},
+		{
+			name:   "malformed flag without equals is ignored",
+			global: nil,
+			flags:  []string{"BADENTRY", "CC=clang"},
+			expect: map[string]string{"CC": "clang"},
+		},
+		{
+			name:   "both empty returns empty map",
+			global: nil,
+			flags:  nil,
+			expect: map[string]string{},
+		},
+		{
+			name:   "value containing equals sign is preserved",
+			global: nil,
+			flags:  []string{"UK_CFLAGS=-O2 -DFOO=1"},
+			expect: map[string]string{"UK_CFLAGS": "-O2 -DFOO=1"},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := mergeToolchain(tc.global, tc.flags)
+			if !reflect.DeepEqual(got, tc.expect) {
+				t.Errorf("mergeToolchain() = %v, want %v", got, tc.expect)
+			}
+		})
+	}
+}

--- a/internal/cli/kraft/build/builder_kraftfile_unikraft.go
+++ b/internal/cli/kraft/build/builder_kraftfile_unikraft.go
@@ -439,8 +439,7 @@ func (build *builderKraftfileUnikraft) Build(ctx context.Context, opts *BuildOpt
 		mopts = append(mopts, make.WithMaxJobs(!opts.NoFast && !config.G[config.KraftKit](ctx).NoParallel))
 	}
 
-	// Inject global toolchain variables into the make invocation
-	if toolchain := config.G[config.KraftKit](ctx).Toolchain; len(toolchain) > 0 {
+	if toolchain := mergeToolchain(config.G[config.KraftKit](ctx).Toolchain, opts.Toolchain); len(toolchain) > 0 {
 		mopts = append(mopts, make.WithVars(toolchain))
 	}
 


### PR DESCRIPTION
### Prerequisite checklist
- [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
- [x] Tested your changes locally.

### Description of changes

Add a `-T`/`--toolchain` flag to `kraft build` that allows overriding toolchain variables (e.g. `CC`, `LD`, `UK_CFLAGS`) for a single build invocation without modifying the user's persistent KraftKit config.

The flag accepts one or more `KEY=VALUE` pairs:

```sh
kraft build --toolchain CC=clang --toolchain LD=ld.lld
# or shorthand
kraft build -T CC=clang -T LD=ld.lld
```

Per-invocation values are merged with any toolchain variables already stored in the global KraftKit config (`kraft system set toolchain.*`), with the flag values taking precedence on key conflicts. The merged map is passed to the underlying make invocation via `make.WithVars`.

Unit tests added for the `mergeToolchain` helper (7 cases).

Relates to #673