### PR TITLE
feat(app): Introduce v0.7 Kraftfile support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -90,6 +90,7 @@ require (
 	oras.land/oras-go/v2 v2.6.0
 	sdk.kraft.cloud v0.5.10-0.20251010085803-9d579e3ec270
 	sigs.k8s.io/kustomize/kyaml v0.21.1
+	unikraft.com/x/kraftfile v0.0.0-20260312090406-2288b116dfa1
 	xenbits.xenproject.org/git-http/xen.git/tools/golang/xenlight v0.0.0-20240729172045-026c9fa29716
 )
 
@@ -106,10 +107,12 @@ require (
 	github.com/anchore/go-logger v0.0.0-20220728155337-03b66a5207d8 // indirect
 	github.com/atotto/clipboard v0.1.4 // indirect
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
+	github.com/bahlo/generic-list-go v0.2.0 // indirect
 	github.com/becheran/wildmatch-go v1.0.0 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/blang/semver/v4 v4.0.0 // indirect
 	github.com/bmatcuk/doublestar/v4 v4.10.0 // indirect
+	github.com/buger/jsonparser v1.1.1 // indirect
 	github.com/cenkalti/backoff/v4 v4.3.0 // indirect
 	github.com/cespare/xxhash v1.1.0 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
@@ -199,6 +202,7 @@ require (
 	github.com/in-toto/attestation v1.1.2 // indirect
 	github.com/in-toto/in-toto-golang v0.10.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
+	github.com/invopop/jsonschema v0.13.0 // indirect
 	github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/kevinburke/ssh_config v1.2.0 // indirect
@@ -206,6 +210,7 @@ require (
 	github.com/lucasb-eyer/go-colorful v1.3.0 // indirect
 	github.com/lufia/plan9stats v0.0.0-20230110061619-bbe2e5e100de // indirect
 	github.com/magiconair/properties v1.8.10 // indirect
+	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/mattn/go-localereader v0.0.1 // indirect
 	github.com/mattn/go-runewidth v0.0.19 // indirect
 	github.com/moby/docker-image-spec v1.3.1 // indirect
@@ -241,6 +246,7 @@ require (
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/rootless-containers/rootlesskit/v2 v2.3.6 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
+	github.com/santhosh-tekuri/jsonschema/v5 v5.3.1 // indirect
 	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 // indirect
 	github.com/sasha-s/go-deadlock v0.3.5 // indirect
 	github.com/scylladb/go-set v1.0.3-0.20200225121959-cc7b2070d91e // indirect
@@ -265,6 +271,7 @@ require (
 	github.com/vishvananda/netns v0.0.5 // indirect
 	github.com/wagoodman/go-partybus v0.0.0-20200526224238-eb215533f07d // indirect
 	github.com/wagoodman/go-progress v0.0.0-20230925121702-07e42b3cdba0 // indirect
+	github.com/wk8/go-ordered-map/v2 v2.1.8 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
 	github.com/xanzy/ssh-agent v0.3.3 // indirect
 	github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb // indirect
@@ -302,6 +309,7 @@ require (
 	k8s.io/klog/v2 v2.130.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20250910181357-589584f1c912 // indirect
 	k8s.io/utils v0.0.0-20251002143259-bc988d571ff4 // indirect
+	mvdan.cc/sh/v3 v3.12.0 // indirect
 	sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 // indirect
 	sigs.k8s.io/randfill v1.0.0 // indirect
 	sigs.k8s.io/structured-merge-diff/v6 v6.3.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -125,6 +125,8 @@ github.com/atotto/clipboard v0.1.4/go.mod h1:ZY9tmq7sm5xIbd9bOK4onWV4S6X0u6GY7Vn
 github.com/aws/aws-sdk-go v1.15.11/go.mod h1:mFuSZ37Z9YOHbQEwBWztmVzqXrEkub65tZoCYDt7FT0=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1 h1:HwpRHbFMcZLEVr42D4p7XBqjyuxQH5SMiErDT4WkJ2k=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1/go.mod h1:uYgXzlJ7ZpABp8OJ+exZzJJhRNQ2ASbcXHWsFqH8hp8=
+github.com/bahlo/generic-list-go v0.2.0 h1:5sz/EEAK+ls5wF+NeqDpk5+iNdMDXrh3z3nPnH1Wvgk=
+github.com/bahlo/generic-list-go v0.2.0/go.mod h1:2KvAjgMlE5NNynlg/5iLrrCCZ2+5xWbdbCW3pNTGyYg=
 github.com/becheran/wildmatch-go v1.0.0 h1:mE3dGGkTmpKtT4Z+88t8RStG40yN9T+kFEGj2PZFSzA=
 github.com/becheran/wildmatch-go v1.0.0/go.mod h1:gbMvj0NtVdJ15Mg/mH9uxk2R1QCistMyU7d9KFzroX4=
 github.com/beorn7/perks v0.0.0-20160804104726-4c0e84591b9a/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
@@ -145,6 +147,7 @@ github.com/briandowns/spinner v1.23.2 h1:Zc6ecUnI+YzLmJniCfDNaMbW0Wid1d5+qcTq4L2
 github.com/briandowns/spinner v1.23.2/go.mod h1:LaZeM4wm2Ywy6vO571mvhQNRcWfRUnXOs0RcKV0wYKM=
 github.com/bshuster-repo/logrus-logstash-hook v0.4.1/go.mod h1:zsTqEiSzDgAa/8GZR7E1qaXrhYNDKBYy5/dWPTIflbk=
 github.com/buger/jsonparser v0.0.0-20180808090653-f4dd9f5a6b44/go.mod h1:bbYlZJ7hK1yFx9hf58LP0zeX7UjIGs20ufpu3evjr+s=
+github.com/buger/jsonparser v1.1.1 h1:2PnMjfWD7wBILjqQbt530v576A/cAbQvEW9gGIpYMUs=
 github.com/buger/jsonparser v1.1.1/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx27UK13J/0=
 github.com/bugsnag/bugsnag-go v0.0.0-20141110184014-b1d153021fcd/go.mod h1:2oa8nejYd4cQ/b0hMIopN0lCRxU0bueqREvZLWFrtK8=
 github.com/bugsnag/osext v0.0.0-20130617224835-0dd3f918b21b/go.mod h1:obH5gd0BsqsP2LwDJ9aOkm/6J86V6lyAXCoQWGw3K50=
@@ -572,6 +575,8 @@ github.com/go-openapi/validate v0.25.1 h1:sSACUI6Jcnbo5IWqbYHgjibrhhmt3vR6lCzKZn
 github.com/go-openapi/validate v0.25.1/go.mod h1:RMVyVFYte0gbSTaZ0N4KmTn6u/kClvAFp+mAVfS/DQc=
 github.com/go-ping/ping v0.0.0-20211130115550-779d1e919534 h1:dhy9OQKGBh4zVXbjwbxxHjRxMJtLXj3zfgpBYQaR4Q4=
 github.com/go-ping/ping v0.0.0-20211130115550-779d1e919534/go.mod h1:xIFjORFzTxqIV/tDVGO4eDy/bLuSyawEeojSm3GfRGk=
+github.com/go-quicktest/qt v1.101.0 h1:O1K29Txy5P2OK0dGo59b7b0LR6wKfIhttaAhHUyn7eI=
+github.com/go-quicktest/qt v1.101.0/go.mod h1:14Bz/f7NwaXPtdYEgzsx46kqSxVwTbzVZsDC26tQJow=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/go-stack/stack v1.8.1/go.mod h1:dcoOX6HbPZSZptuspn9bctJ+N/CnF5gGygcUP3XYfe4=
 github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0/go.mod h1:fyg7847qk6SyHyPtNmDHnmrv/HOrqktSC+C9fM+CJOE=
@@ -768,6 +773,8 @@ github.com/in-toto/in-toto-golang v0.10.0/go.mod h1:wjT4RiyFlLWCmLUJjwB8oZcjaq7H
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/invopop/jsonschema v0.13.0 h1:KvpoAJWEjR3uD9Kbm2HWJmqsEaHt8lBUpd0qHcIi21E=
+github.com/invopop/jsonschema v0.13.0/go.mod h1:ffZ5Km5SWWRAIN6wbDXItl95euhFz2uON45H2qjYt+0=
 github.com/j-keck/arping v0.0.0-20160618110441-2cf9dc699c56/go.mod h1:ymszkNOg6tORTn+6F6j+Jc8TOr5osrynvN6ivFWZ2GA=
 github.com/j-keck/arping v1.0.2/go.mod h1:aJbELhR92bSk7tp79AWM/ftfc90EfEi2bQJrbBFOsPw=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 h1:BQSFePA1RWJOlocH6Fxy8MmwDt+yVQYULKfN0RoTN8A=
@@ -836,6 +843,7 @@ github.com/mailru/easyjson v0.0.0-20190614124828-94de47d64c63/go.mod h1:C1wdFJiN
 github.com/mailru/easyjson v0.0.0-20190626092158-b2ccc519800e/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
 github.com/mailru/easyjson v0.7.0/go.mod h1:KAzv3t3aY1NaHWoQz1+4F1ccyAH66Jk7yos7ldAVICs=
 github.com/mailru/easyjson v0.7.6/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
+github.com/mailru/easyjson v0.7.7 h1:UGYAvKxe3sBsEDzO8ZeWOSlIQfWFlxbzLZe7hwFURr0=
 github.com/mailru/easyjson v0.7.7/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
 github.com/markbates/oncer v0.0.0-20181203154359-bf2de49a0be2/go.mod h1:Ld9puTsIW75CHf65OeIOkyKbteujpZVXDpWK6YGZbxE=
 github.com/markbates/safe v1.0.1/go.mod h1:nAqgmRi7cY2nqMc92/bSEeQA+R4OheNU2T1kNSCBdG0=
@@ -1087,6 +1095,8 @@ github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/safchain/ethtool v0.0.0-20190326074333-42ed695e3de8/go.mod h1:Z0q5wiBQGYcxhMZ6gUqHn6pYNLypFAvaL3UvgZLR0U4=
 github.com/safchain/ethtool v0.0.0-20210803160452-9aa261dae9b1/go.mod h1:Z0q5wiBQGYcxhMZ6gUqHn6pYNLypFAvaL3UvgZLR0U4=
+github.com/santhosh-tekuri/jsonschema/v5 v5.3.1 h1:lZUw3E0/J3roVtGQ+SCrUrg3ON6NgVqpn3+iol9aGu4=
+github.com/santhosh-tekuri/jsonschema/v5 v5.3.1/go.mod h1:uToXkOrWAZ6/Oc07xWQrPOhJotwFIyu2bBVN41fcDUY=
 github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 h1:KRzFb2m7YtdldCEkzs6KqmJw4nqEVZGK7IN2kJkjTuQ=
 github.com/santhosh-tekuri/jsonschema/v6 v6.0.2/go.mod h1:JXeL+ps8p7/KNMjDQk3TCwPpBy0wYklyWTfbkIzdIFU=
 github.com/sasha-s/go-deadlock v0.3.5 h1:tNCOEEDG6tBqrNDOX35j/7hL5FcFViG6awUGROb2NsU=
@@ -1251,6 +1261,8 @@ github.com/wagoodman/go-progress v0.0.0-20230925121702-07e42b3cdba0 h1:0KGbf+0SM
 github.com/wagoodman/go-progress v0.0.0-20230925121702-07e42b3cdba0/go.mod h1:jLXFoL31zFaHKAAyZUh+sxiTDFe1L1ZHrcK2T1itVKA=
 github.com/willf/bitset v1.1.11-0.20200630133818-d5bec3311243/go.mod h1:RjeCKbqT1RxIR/KWY6phxZiaY1IyutSBfGjNPySAYV4=
 github.com/willf/bitset v1.1.11/go.mod h1:83CECat5yLh5zVOf4P1ErAgKA5UDvKtgyUABdr3+MjI=
+github.com/wk8/go-ordered-map/v2 v2.1.8 h1:5h/BUHu93oj4gIdvHHHGsScSTMijfx5PeYkE/fJgbpc=
+github.com/wk8/go-ordered-map/v2 v2.1.8/go.mod h1:5nJHM5DyteebpVlHnWMV0rPz6Zp7+xBAnxjb1X5vnTw=
 github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=
 github.com/x448/float16 v0.8.4/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcYsOfg=
 github.com/xanzy/ssh-agent v0.3.3 h1:+/15pJfg/RsTxqYcX6fHqOXZwwMP+2VyYWJeWM2qQFM=
@@ -1783,6 +1795,8 @@ k8s.io/kubernetes v1.13.0/go.mod h1:ocZa8+6APFNC2tX1DZASIbocyYT5jHzqFVsY5aoB7Jk=
 k8s.io/utils v0.0.0-20201110183641-67b214c5f920/go.mod h1:jPW/WVKK9YHAvNhRxK0md/EJ228hCsBRufyofKtW8HA=
 k8s.io/utils v0.0.0-20251002143259-bc988d571ff4 h1:SjGebBtkBqHFOli+05xYbK8YF1Dzkbzn+gDM4X9T4Ck=
 k8s.io/utils v0.0.0-20251002143259-bc988d571ff4/go.mod h1:OLgZIPagt7ERELqWJFomSt595RzquPNLL48iOWgYOg0=
+mvdan.cc/sh/v3 v3.12.0 h1:ejKUR7ONP5bb+UGHGEG/k9V5+pRVIyD+LsZz7o8KHrI=
+mvdan.cc/sh/v3 v3.12.0/go.mod h1:Se6Cj17eYSn+sNooLZiEUnNNmNxg0imoYlTu4CyaGyg=
 oras.land/oras-go/v2 v2.6.0 h1:X4ELRsiGkrbeox69+9tzTu492FMUu7zJQW6eJU+I2oc=
 oras.land/oras-go/v2 v2.6.0/go.mod h1:magiQDfG6H1O9APp+rOsvCPcW1GD2MM7vgnKY0Y+u1o=
 pgregory.net/rapid v1.2.0 h1:keKAYRcjm+e1F0oAuU5F5+YPAWcyxNNRK2wud503Gnk=
@@ -1808,5 +1822,7 @@ sigs.k8s.io/yaml v1.1.0/go.mod h1:UJmg0vDUVViEyp3mgSv9WPwZCDxu4rQW1olrI1uml+o=
 sigs.k8s.io/yaml v1.2.0/go.mod h1:yfXDCHCao9+ENCvLSE62v9VSji2MKu5jeNfTrofGhJc=
 sigs.k8s.io/yaml v1.6.0 h1:G8fkbMSAFqgEFgh4b1wmtzDnioxFCUgTZhlbj5P9QYs=
 sigs.k8s.io/yaml v1.6.0/go.mod h1:796bPqUfzR/0jLAl6XjHl3Ck7MiyVv8dbTdyT3/pMf4=
+unikraft.com/x/kraftfile v0.0.0-20260312090406-2288b116dfa1 h1:p2ShbnyCbyi9oK0DOcXrHkH1RXq0CeU1qgH2TJuwXYA=
+unikraft.com/x/kraftfile v0.0.0-20260312090406-2288b116dfa1/go.mod h1:OYaIMOzV1IpbZCe2J3SuC5jvT4tAfR0XG9uOPPD+p50=
 xenbits.xenproject.org/git-http/xen.git/tools/golang/xenlight v0.0.0-20240729172045-026c9fa29716 h1:y52AcO4BZop/FrR523z47VCLFViGmMJqY21uL+FxXXI=
 xenbits.xenproject.org/git-http/xen.git/tools/golang/xenlight v0.0.0-20240729172045-026c9fa29716/go.mod h1:tbZ4iMnk8RWkXPxTiCGdAw3hCOa3feShlf3sBh50uIc=

--- a/unikraft/app/application_v07.go
+++ b/unikraft/app/application_v07.go
@@ -1,0 +1,294 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2026, Unikraft GmbH and The KraftKit Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+
+package app
+
+import (
+	"context"
+	"fmt"
+
+	"unikraft.com/x/kraftfile"
+
+	"kraftkit.sh/initrd"
+	"kraftkit.sh/kconfig"
+	umake "kraftkit.sh/make" // make package to ukmake so it doesn't collide with Go's built in make()
+	"kraftkit.sh/unikraft"
+	"kraftkit.sh/unikraft/app/volume"
+	"kraftkit.sh/unikraft/component"
+	"kraftkit.sh/unikraft/core"
+	"kraftkit.sh/unikraft/lib"
+	"kraftkit.sh/unikraft/runtime"
+	"kraftkit.sh/unikraft/target"
+	"kraftkit.sh/unikraft/template"
+)
+
+// When a kraft.yaml file has "spec: v0.7", we skip the old parser and use
+// unikraft.com/x/kraftfile to read it instead. applicationV07 holds the
+// result and makes it work with the rest of KraftKit.
+
+// Type layout from unikraft.com/x/kraftfile (spec.go):
+//
+//	Kraftfile { Name, Targets []Target, Cmd Command, Env Map,
+//	            Labels, Runtime *Runtime, Unikraft *Unikraft,
+//	            Libraries map[string]Library, Rootfs *FS, Roms []FS,
+//	            Volumes Volumes, Template *Template }
+
+type applicationV07 struct {
+	kf         *kraftfile.Kraftfile // parsed by unikraft.com/x/kraftfile
+	workingDir string
+	outDir     string
+	kraftfile  *Kraftfile // kraftkit's own file metadata struct
+}
+
+/*
+newApplicationV07 is the constructor called from project.go when
+spec: v0.7 is detected in the raw file bytes.
+*/
+func newApplicationV07(_ context.Context, popts *ProjectOptions) (Application, error) {
+	// ParseBytes is the entry point from unikraft.com/x/kraftfile/parse.go
+	// It validates the spec version and unmarshals every field.
+	kf, err := kraftfile.ParseBytes(popts.kraftfile.content)
+	if err != nil {
+		return nil, fmt.Errorf("parsing v0.7 Kraftfile: %w", err)
+	}
+
+	outDir := popts.outDir
+	if outDir == "" {
+		outDir = popts.RelativePath(unikraft.BuildDir)
+	}
+
+	return &applicationV07{
+		kf:         kf,
+		workingDir: popts.workdir,
+		outDir:     outDir,
+		kraftfile:  popts.kraftfile,
+	}, nil
+}
+
+//─── unikraft.Nameable
+
+func (a *applicationV07) Type() unikraft.ComponentType {
+	return unikraft.ComponentTypeApp
+}
+
+func (a *applicationV07) Name() string {
+	return a.kf.Name
+}
+
+func (a *applicationV07) Version() string {
+	return ""
+}
+
+func (a *applicationV07) String() string {
+	return a.kf.Name
+}
+
+//─── component.Component
+
+func (a *applicationV07) Source() string {
+	return ""
+}
+
+func (a *applicationV07) Path() string {
+	return a.workingDir
+}
+
+func (a *applicationV07) KConfigTree(_ context.Context, _ ...*kconfig.KeyValue) (*kconfig.KConfigFile, error) {
+	return nil, fmt.Errorf("not yet implemented for v0.7 schema")
+}
+
+func (a *applicationV07) KConfig() kconfig.KeyValueMap {
+	return kconfig.KeyValueMap{}
+}
+
+func (a *applicationV07) PrintInfo(_ context.Context) string {
+	return fmt.Sprintf("%s (spec: v0.7)", a.kf.Name)
+}
+
+func (a *applicationV07) MarshalYAML() (interface{}, error) {
+	return nil, fmt.Errorf("not yet implemented for v0.7 schema")
+}
+
+//─── Implementing Application: simple field reads
+
+func (a *applicationV07) WorkingDir() string {
+	return a.workingDir
+}
+
+func (a *applicationV07) OutDir() string {
+	return a.outDir
+}
+
+func (a *applicationV07) Kraftfile() *Kraftfile {
+	return a.kraftfile
+}
+
+func (a *applicationV07) Labels() map[string]string {
+	return a.kf.Labels
+}
+
+func (a *applicationV07) Command() []string {
+	return []string(a.kf.Cmd)
+}
+
+// Env reads from kraftfile.Map (kraftfile/spec.go)
+// converts []MapPair{Key, Value any} → map[string]string.
+func (a *applicationV07) Env() map[string]string {
+	return a.kf.Env.AsStringMap()
+}
+
+// Rootfs reads from kraftfile.FS.Source
+func (a *applicationV07) Rootfs() string {
+	if a.kf.Rootfs != nil {
+		return a.kf.Rootfs.Source
+	}
+	return ""
+}
+
+func (a *applicationV07) Roms() []string {
+	roms := make([]string, 0, len(a.kf.Roms))
+	for _, r := range a.kf.Roms {
+		roms = append(roms, r.Source)
+	}
+	return roms
+}
+
+// InitrdFsType reads from kraftfile.FS.Format which is FsType
+// FsType.String() returns the string value
+func (a *applicationV07) InitrdFsType() initrd.FsType {
+	if a.kf.Rootfs != nil {
+		return initrd.FsType(a.kf.Rootfs.Format.String())
+	}
+	return initrd.FsTypeCpio
+}
+
+func (a *applicationV07) SetInitrdFsType(_ initrd.FsType) {}
+
+func (a *applicationV07) SetRootfs(rootfs string) {
+	if a.kf.Rootfs == nil {
+		a.kf.Rootfs = &kraftfile.FS{}
+	}
+	a.kf.Rootfs.Source = rootfs
+}
+
+// LibraryNames iterates the libraries map
+func (a *applicationV07) LibraryNames() []string {
+	names := make([]string, 0, len(a.kf.Libraries))
+	for name := range a.kf.Libraries {
+		names = append(names, name)
+	}
+	return names
+}
+
+// TargetNames iterates []Target
+func (a *applicationV07) TargetNames() []string {
+	names := make([]string, 0, len(a.kf.Targets))
+	for _, t := range a.kf.Targets {
+		names = append(names, fmt.Sprintf("%s/%s", t.Plat, t.Arch))
+	}
+	return names
+}
+
+func (a *applicationV07) Extensions() component.Extensions {
+	return nil
+}
+
+// ─── Application: stubs (require kraftkit type conversion, TODO in separate PR)
+
+func (a *applicationV07) Unikraft(_ context.Context) *core.UnikraftConfig {
+	return nil
+}
+
+func (a *applicationV07) Template() *template.TemplateConfig {
+	return nil
+}
+
+func (a *applicationV07) Runtime() *runtime.Runtime {
+	return nil
+}
+
+func (a *applicationV07) Libraries(_ context.Context) (map[string]*lib.LibraryConfig, error) {
+	return nil, fmt.Errorf("not yet implemented for v0.7 schema")
+}
+
+func (a *applicationV07) Targets() []target.Target {
+	return nil
+}
+
+func (a *applicationV07) Volumes() []*volume.VolumeConfig {
+	return nil
+}
+
+func (a *applicationV07) IsConfigured(_ target.Target) bool {
+	return false
+}
+
+func (a *applicationV07) MakeArgs(_ context.Context, _ target.Target) (*core.MakeArgs, error) {
+	return nil, fmt.Errorf("not yet implemented for v0.7 schema")
+}
+
+func (a *applicationV07) Make(_ context.Context, _ target.Target, _ ...umake.MakeOption) error {
+	return fmt.Errorf("not yet implemented for v0.7 schema")
+}
+
+func (a *applicationV07) SyncConfig(_ context.Context, _ target.Target, _ ...umake.MakeOption) error {
+	return fmt.Errorf("not yet implemented for v0.7 schema")
+}
+
+func (a *applicationV07) Configure(_ context.Context, _ target.Target, _ kconfig.KeyValueMap, _ ...umake.MakeOption) error {
+	return fmt.Errorf("not yet implemented for v0.7 schema")
+}
+
+func (a *applicationV07) Prepare(_ context.Context, _ target.Target, _ ...umake.MakeOption) error {
+	return fmt.Errorf("not yet implemented for v0.7 schema")
+}
+
+func (a *applicationV07) Clean(_ context.Context, _ target.Target, _ ...umake.MakeOption) error {
+	return fmt.Errorf("not yet implemented for v0.7 schema")
+}
+
+func (a *applicationV07) Properclean(_ context.Context, _ target.Target, _ ...umake.MakeOption) error {
+	return fmt.Errorf("not yet implemented for v0.7 schema")
+}
+
+func (a *applicationV07) Fetch(_ context.Context, _ target.Target, _ ...umake.MakeOption) error {
+	return fmt.Errorf("not yet implemented for v0.7 schema")
+}
+
+func (a *applicationV07) Set(_ context.Context, _ target.Target, _ kconfig.KeyValueMap, _ ...umake.MakeOption) error {
+	return fmt.Errorf("not yet implemented for v0.7 schema")
+}
+
+func (a *applicationV07) Unset(_ context.Context, _ target.Target, _ kconfig.KeyValueMap, _ ...umake.MakeOption) error {
+	return fmt.Errorf("not yet implemented for v0.7 schema")
+}
+
+func (a *applicationV07) Build(_ context.Context, _ target.Target, _ ...BuildOption) error {
+	return fmt.Errorf("not yet implemented for v0.7 schema")
+}
+
+func (a *applicationV07) MergeTemplate(_ context.Context, _ Application) (Application, error) {
+	return nil, fmt.Errorf("not yet implemented for v0.7 schema")
+}
+
+func (a *applicationV07) Components(_ context.Context, _ ...target.Target) ([]component.Component, error) {
+	return nil, fmt.Errorf("not yet implemented for v0.7 schema")
+}
+
+func (a *applicationV07) WithTarget(_ target.Target) (Application, error) {
+	return nil, fmt.Errorf("not yet implemented for v0.7 schema")
+}
+
+func (a *applicationV07) Save(_ context.Context) error {
+	return fmt.Errorf("not yet implemented for v0.7 schema")
+}
+
+func (a *applicationV07) RemoveLibrary(_ context.Context, _ string) error {
+	return fmt.Errorf("not yet implemented for v0.7 schema")
+}
+
+func (a *applicationV07) AddLibrary(_ context.Context, _ lib.LibraryConfig) error {
+	return fmt.Errorf("not yet implemented for v0.7 schema")
+}

--- a/unikraft/app/project.go
+++ b/unikraft/app/project.go
@@ -22,6 +22,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"gopkg.in/yaml.v2"
 	"kraftkit.sh/kconfig"
 	"kraftkit.sh/log"
 	"kraftkit.sh/schema"
@@ -83,6 +84,23 @@ func NewProjectFromOptions(ctx context.Context, opts ...ProjectOption) (Applicat
 		outdir = popts.RelativePath(unikraft.BuildDir)
 	} else {
 		outdir = popts.outDir
+	}
+
+	if popts.kraftfile.content != nil {
+		var header struct {
+			Spec          string `yaml:"spec"`
+			Specification string `yaml:"specification"`
+		}
+		// if unmarshal fails we fall through to legacy logic
+		if err := yaml.Unmarshal(popts.kraftfile.content, &header); err == nil {
+			spec := header.Spec
+			if spec == "" {
+				spec = header.Specification
+			}
+			if spec == "v0.7" {
+				return newApplicationV07(ctx, popts)
+			}
+		}
 	}
 
 	iface := popts.kraftfile.config


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes locally.

### Description of changes

Addresses (#673, #2682)

- The[ unikraft.com/x/kraftfile package ](https://github.com/unikraft-cloud/x/pull/143/changes) is a new schema validated parser for `spec v0.7` Kraftfiles. 
- This PR wires it into KraftKit.
- `unikraft/app/project.go` now peeks at the raw file bytes and checks the spec field and if spec: v0.7 is found, it delegates to the new parser immediately
- `applicationV07` is a new struct that wraps `*kraftfile.Kraftfile` and implements the Application interface 
- Methods that require converting [x/kraftfile ](https://github.com/unikraft-cloud/x/pull/143/changes#diff-2124145ff2d1da9dc00b97a8b6160c79ebbb554e0944ab2f94134a368ac29b08R88-R94)types into kraftkit specific struct types are stubbed and will be filled in follow up work.
### Files changed

- `go.mod` / `go.sum`  add [unikraft.com/x/kraftfile](https://github.com/unikraft-cloud/x)
- `unikraft/app/project.go` for  spec detection
- `unikraft/app/application_v07.go` as new file

### Roadmap for #2682

- [x] **PR 1 (this PR):** Version detection, interface satisfaction, and primitive getters.
- [ ] **PR 2 (follow up ( next PR ) ):** Implement the rest of method bodies  converting`x/kraftfile` types into KraftKit's internal types
