### PR TITLE
fix: Avoid panic on failure on running buildkit error cleanup

### DIFF
--- a/buildkit/connect.go
+++ b/buildkit/connect.go
@@ -152,11 +152,11 @@ func ConnectToBuildkit(ctx context.Context) (c *client.Client, cleanup func(), r
 
 		c, connerr = client.New(ctx, buildkitAddr)
 		if connerr != nil {
-			return nil, nil, fmt.Errorf("creating container buildkit client: %w", connerr)
+			return nil, cleanup, fmt.Errorf("creating container buildkit client: %w", connerr)
 		}
 		buildkitInfo, connerr = c.Info(ctx)
 		if connerr != nil {
-			return nil, nil, fmt.Errorf("connecting to buildkit client: %w", connerr)
+			return nil, cleanup, fmt.Errorf("connecting to buildkit client: %w", connerr)
 		}
 	}
 


### PR DESCRIPTION
### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes locally.

### Description of changes

Urgh. If we just return `nil`, we actually clear the `cleanup` value so we're trying to call a `nil` value.