### PR TITLE
config: fix YAML-tag default resolution and Default() behavior

### DIFF
--- a/config/manager.go
+++ b/config/manager.go
@@ -321,12 +321,12 @@ func FetchConfigDirFromArgs(args []string) (path string) {
 }
 
 func Default[C any](key string) string {
-	found, _, def, _, err := findConfigDefault[C](key, "", "", reflect.ValueOf(new([0]C)))
+	_, found, def, _, err := findConfigDefault[C](key, "", "", reflect.ValueOf(new(C)))
 	if err != nil || found != key {
-		return def
+		return ""
 	}
 
-	return ""
+	return def
 }
 
 func findConfigDefault[C any](needle, offset, def string, v reflect.Value) (string, string, string, reflect.Value, error) {
@@ -342,7 +342,7 @@ func findConfigDefault[C any](needle, offset, def string, v reflect.Value) (stri
 	switch v.Kind() {
 	case reflect.Struct:
 		for i := 0; i < v.NumField(); i++ {
-			name := v.Type().Field(i).Tag.Get("json")
+			name := getYAMLTag(v.Type().Field(i), true)
 			if len(name) == 0 {
 				continue
 			}

--- a/config/manager_default_test.go
+++ b/config/manager_default_test.go
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2026, Unikraft GmbH and The KraftKit Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+
+package config
+
+import "testing"
+
+type TestConfig struct {
+	Port int `yaml:"port" default:"8080"`
+}
+
+type TestConfigNoDefault struct {
+	Port int `yaml:"port"`
+}
+
+func TestDefaultReturnsYAMLTaggedDefault(t *testing.T) {
+	got := Default[TestConfig]("port")
+	if got != "8080" {
+		t.Fatalf("expected default %q, got %q", "8080", got)
+	}
+}
+
+func TestDefaultReturnsEmptyStringWhenNoDefaultTag(t *testing.T) {
+	got := Default[TestConfigNoDefault]("port")
+	if got != "" {
+		t.Fatalf("expected empty default, got %q", got)
+	}
+}

--- a/config/manager_default_test.go
+++ b/config/manager_default_test.go
@@ -27,3 +27,23 @@ func TestDefaultReturnsEmptyStringWhenNoDefaultTag(t *testing.T) {
 		t.Fatalf("expected empty default, got %q", got)
 	}
 }
+
+func TestDefaultNested(t *testing.T) {
+	type Nested struct {
+		Inner string `yaml:"inner" default:"val"`
+	}
+
+	type Config struct {
+		Nested Nested `yaml:"nested"`
+	}
+
+	got := Default[Config]("nested.inner")
+	if got != "val" {
+		t.Fatalf("expected nested default %q, got %q", "val", got)
+	}
+
+	missing := Default[Config]("nested.unknown")
+	if missing != "" {
+		t.Fatalf("expected empty default for missing nested key, got %q", missing)
+	}
+}

--- a/config/manager_regression_test.go
+++ b/config/manager_regression_test.go
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2026, Unikraft GmbH and The KraftKit Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+
+package config
+
+import (
+	"reflect"
+	"testing"
+)
+
+type regressionYAMLOnly struct {
+	Port int `yaml:"port" default:"8080"`
+}
+
+type regressionJSONOnly struct {
+	Port int `json:"port" default:"8080"`
+}
+
+type regressionNested struct {
+	Server regressionNestedServer `yaml:"server"`
+}
+
+type regressionNestedServer struct {
+	Port int `yaml:"port" default:"9090"`
+}
+
+type regressionNoDefault struct {
+	Port int `yaml:"port"`
+}
+
+func TestRegressionDefault_YAMLTagResolution(t *testing.T) {
+	// Expected behavior: Default resolves defaults by YAML key names.
+	// Before the YAML-tag fix, this fails because lookup used JSON tags.
+	// Bug exposed: wrong tag namespace in findConfigDefault.
+	got := Default[regressionYAMLOnly]("port")
+	if got != "8080" {
+		t.Fatalf("expected default %q, got %q", "8080", got)
+	}
+}
+
+func TestRegressionDefault_JSONTagFallback(t *testing.T) {
+	// Expected behavior: JSON tags should not be required or preferred for config defaults.
+	// In the broken implementation, JSON tag lookup can create an incorrect dependency.
+	// Bug exposed: behavior tied to json tags instead of yaml tags.
+	got := Default[regressionJSONOnly]("port")
+	if got != "" {
+		t.Fatalf("expected empty default for YAML key lookup on json-only tag, got %q", got)
+	}
+}
+
+func TestRegressionDefault_NestedYAMLTraversal(t *testing.T) {
+	// Expected behavior: recursive traversal resolves nested YAML-tagged fields.
+	// Before the fixes, this can fail from broken tag matching and/or broken root reflection.
+	// Bug exposed: recursive path resolution for nested defaults.
+	got := Default[regressionNested]("server.port")
+	if got != "9090" {
+		t.Fatalf("expected nested default %q, got %q", "9090", got)
+	}
+}
+
+func TestRegressionFindConfigDefault_ReflectionTraversal(t *testing.T) {
+	// Expected behavior: helper visits struct fields when started with a real pointer to C.
+	// This test is a debug-style isolation check for traversal independent of Default().
+	// Bug exposed: reflection root must be compatible with struct traversal.
+	_, found, def, _, err := findConfigDefault[regressionYAMLOnly](
+		"port",
+		"",
+		"",
+		reflect.ValueOf(new(regressionYAMLOnly)),
+	)
+	if err != nil {
+		t.Fatalf("expected traversal to succeed, got error: %v", err)
+	}
+	if found != "port" {
+		t.Fatalf("expected found key %q, got %q", "port", found)
+	}
+	if def != "8080" {
+		t.Fatalf("expected discovered default %q, got %q", "8080", def)
+	}
+}
+
+func TestRegressionDefault_MissingDefaultReturnsEmpty(t *testing.T) {
+	// Expected behavior: fields without a default tag return empty string.
+	// This guards against regressions while fixing tag resolution and traversal.
+	// Bug exposed: incorrect non-empty fallback behavior.
+	got := Default[regressionNoDefault]("port")
+	if got != "" {
+		t.Fatalf("expected empty default, got %q", got)
+	}
+}


### PR DESCRIPTION
## Summary

Fix incorrect default value resolution for config fields defined using YAML tags.

Previously, defaults were not discovered for YAML-tagged fields due to incorrect tag lookup and reflection setup. This PR corrects the resolution logic and adds comprehensive tests to validate behavior and prevent regressions.

---

## Root Cause

The issue was caused by three independent problems:

1. **Incorrect tag lookup**
   - `findConfigDefault()` used `json` tags for field resolution
   - Config structs use `yaml` tags → fields were never matched

2. **Invalid reflection root**
   - `new([0]C)` created a pointer to an array instead of a struct
   - Prevented correct traversal in `reflect.Struct` logic

3. **Incorrect return logic**
   - `Default()` returned incorrect values due to inverted condition

These combined issues caused default values to be silently ignored.

---

## Fix

- Use `getYAMLTag()` for field name resolution
- Initialize reflection with `new(C)` to enable correct struct traversal
- Correct `Default()` return logic to return discovered defaults

---

## Tests

Added comprehensive test coverage:

### Default behavior
- Verify YAML-tagged defaults are resolved correctly
- Ensure empty string is returned when no default is present

### Nested resolution
- Validate recursive lookup for nested fields (e.g. `nested.inner`)

### Regression tests
Cover previously broken behavior:
- YAML vs JSON tag resolution
- Nested struct traversal
- Reflection root correctness
- Missing default handling

---

## Impact

- Fixes broken default resolution for YAML-based config fields
- Prevents silent misconfiguration due to ignored defaults
- Adds regression coverage to ensure long-term correctness

---

## Notes

- Changes are localized to default resolution logic
- No API changes introduced
- All tests pass locally