### PR TITLE
fix(Makefile): Use correct target name for lint rule

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -253,7 +253,7 @@ fmt: ## Format all files according to linting preferences.
 	$(GOCILINT) format
 
 .PHONY: lint
-fmt: ## Lint all files according to linting preferences.
+lint: ## Lint all files according to linting preferences.
 	$(GOCILINT) run --build-tags "osusergo,netgo"
 
 .PHONY: cicheck


### PR DESCRIPTION
### Prerequisite checklist

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes locally.

### Description of changes

The `lint` rule on line 256 was defined as `fmt:` instead of `lint:`.
This meant `make lint` and `make cicheck` were no-ops, and `make fmt`
ran the linter instead of the formatter.

Verified with `make -n lint` and `make -n fmt` after the fix.