### PR TITLE
feat: Support Kraftfile v0.7 templates and OCI runtime refs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -90,6 +90,8 @@ require (
 	oras.land/oras-go/v2 v2.6.0
 	sdk.kraft.cloud v0.6.1
 	sigs.k8s.io/kustomize/kyaml v0.21.1
+	sigs.k8s.io/yaml v1.6.0
+	unikraft.com/x/kraftfile v0.0.0-20260402111140-cceb3ed69aff
 	xenbits.xenproject.org/git-http/xen.git/tools/golang/xenlight v0.0.0-20240729172045-026c9fa29716
 )
 
@@ -109,10 +111,12 @@ require (
 	github.com/anchore/go-logger v0.0.0-20220728155337-03b66a5207d8 // indirect
 	github.com/atotto/clipboard v0.1.4 // indirect
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
+	github.com/bahlo/generic-list-go v0.2.0 // indirect
 	github.com/becheran/wildmatch-go v1.0.0 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/blang/semver/v4 v4.0.0 // indirect
 	github.com/bmatcuk/doublestar/v4 v4.10.0 // indirect
+	github.com/buger/jsonparser v1.1.1 // indirect
 	github.com/cenkalti/backoff/v4 v4.3.0 // indirect
 	github.com/cespare/xxhash v1.1.0 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
@@ -204,6 +208,7 @@ require (
 	github.com/in-toto/attestation v1.1.2 // indirect
 	github.com/in-toto/in-toto-golang v0.10.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
+	github.com/invopop/jsonschema v0.13.0 // indirect
 	github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/kevinburke/ssh_config v1.2.0 // indirect
@@ -211,6 +216,7 @@ require (
 	github.com/lucasb-eyer/go-colorful v1.3.0 // indirect
 	github.com/lufia/plan9stats v0.0.0-20230110061619-bbe2e5e100de // indirect
 	github.com/magiconair/properties v1.8.10 // indirect
+	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/mattn/go-localereader v0.0.1 // indirect
 	github.com/mattn/go-runewidth v0.0.21 // indirect
 	github.com/moby/docker-image-spec v1.3.1 // indirect
@@ -246,6 +252,7 @@ require (
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/rootless-containers/rootlesskit/v2 v2.3.6 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
+	github.com/santhosh-tekuri/jsonschema/v5 v5.3.1 // indirect
 	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 // indirect
 	github.com/sasha-s/go-deadlock v0.3.5 // indirect
 	github.com/scylladb/go-set v1.0.3-0.20200225121959-cc7b2070d91e // indirect
@@ -270,6 +277,7 @@ require (
 	github.com/vishvananda/netns v0.0.5 // indirect
 	github.com/wagoodman/go-partybus v0.0.0-20200526224238-eb215533f07d // indirect
 	github.com/wagoodman/go-progress v0.0.0-20260303201901-10176f79b2c0 // indirect
+	github.com/wk8/go-ordered-map/v2 v2.1.8 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
 	github.com/xanzy/ssh-agent v0.3.3 // indirect
 	github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb // indirect
@@ -306,8 +314,8 @@ require (
 	k8s.io/klog/v2 v2.130.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20250910181357-589584f1c912 // indirect
 	k8s.io/utils v0.0.0-20251002143259-bc988d571ff4 // indirect
+	mvdan.cc/sh/v3 v3.12.0 // indirect
 	sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 // indirect
 	sigs.k8s.io/randfill v1.0.0 // indirect
 	sigs.k8s.io/structured-merge-diff/v6 v6.3.0 // indirect
-	sigs.k8s.io/yaml v1.6.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -130,6 +130,8 @@ github.com/aymanbagabas/go-osc52/v2 v2.0.1 h1:HwpRHbFMcZLEVr42D4p7XBqjyuxQH5SMiE
 github.com/aymanbagabas/go-osc52/v2 v2.0.1/go.mod h1:uYgXzlJ7ZpABp8OJ+exZzJJhRNQ2ASbcXHWsFqH8hp8=
 github.com/aymanbagabas/go-udiff v0.4.1 h1:OEIrQ8maEeDBXQDoGCbbTTXYJMYRCRO1fnodZ12Gv5o=
 github.com/aymanbagabas/go-udiff v0.4.1/go.mod h1:0L9PGwj20lrtmEMeyw4WKJ/TMyDtvAoK9bf2u/mNo3w=
+github.com/bahlo/generic-list-go v0.2.0 h1:5sz/EEAK+ls5wF+NeqDpk5+iNdMDXrh3z3nPnH1Wvgk=
+github.com/bahlo/generic-list-go v0.2.0/go.mod h1:2KvAjgMlE5NNynlg/5iLrrCCZ2+5xWbdbCW3pNTGyYg=
 github.com/becheran/wildmatch-go v1.0.0 h1:mE3dGGkTmpKtT4Z+88t8RStG40yN9T+kFEGj2PZFSzA=
 github.com/becheran/wildmatch-go v1.0.0/go.mod h1:gbMvj0NtVdJ15Mg/mH9uxk2R1QCistMyU7d9KFzroX4=
 github.com/beorn7/perks v0.0.0-20160804104726-4c0e84591b9a/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
@@ -150,6 +152,7 @@ github.com/briandowns/spinner v1.23.2 h1:Zc6ecUnI+YzLmJniCfDNaMbW0Wid1d5+qcTq4L2
 github.com/briandowns/spinner v1.23.2/go.mod h1:LaZeM4wm2Ywy6vO571mvhQNRcWfRUnXOs0RcKV0wYKM=
 github.com/bshuster-repo/logrus-logstash-hook v0.4.1/go.mod h1:zsTqEiSzDgAa/8GZR7E1qaXrhYNDKBYy5/dWPTIflbk=
 github.com/buger/jsonparser v0.0.0-20180808090653-f4dd9f5a6b44/go.mod h1:bbYlZJ7hK1yFx9hf58LP0zeX7UjIGs20ufpu3evjr+s=
+github.com/buger/jsonparser v1.1.1 h1:2PnMjfWD7wBILjqQbt530v576A/cAbQvEW9gGIpYMUs=
 github.com/buger/jsonparser v1.1.1/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx27UK13J/0=
 github.com/bugsnag/bugsnag-go v0.0.0-20141110184014-b1d153021fcd/go.mod h1:2oa8nejYd4cQ/b0hMIopN0lCRxU0bueqREvZLWFrtK8=
 github.com/bugsnag/osext v0.0.0-20130617224835-0dd3f918b21b/go.mod h1:obH5gd0BsqsP2LwDJ9aOkm/6J86V6lyAXCoQWGw3K50=
@@ -581,6 +584,8 @@ github.com/go-openapi/validate v0.25.2 h1:12NsfLAwGegqbGWr2CnvT65X/Q2USJipmJ9b7x
 github.com/go-openapi/validate v0.25.2/go.mod h1:Pgl1LpPPGFnZ+ys4/hTlDiRYQdI1ocKypgE+8Q8BLfY=
 github.com/go-ping/ping v0.0.0-20211130115550-779d1e919534 h1:dhy9OQKGBh4zVXbjwbxxHjRxMJtLXj3zfgpBYQaR4Q4=
 github.com/go-ping/ping v0.0.0-20211130115550-779d1e919534/go.mod h1:xIFjORFzTxqIV/tDVGO4eDy/bLuSyawEeojSm3GfRGk=
+github.com/go-quicktest/qt v1.101.0 h1:O1K29Txy5P2OK0dGo59b7b0LR6wKfIhttaAhHUyn7eI=
+github.com/go-quicktest/qt v1.101.0/go.mod h1:14Bz/f7NwaXPtdYEgzsx46kqSxVwTbzVZsDC26tQJow=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/go-stack/stack v1.8.1/go.mod h1:dcoOX6HbPZSZptuspn9bctJ+N/CnF5gGygcUP3XYfe4=
 github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0/go.mod h1:fyg7847qk6SyHyPtNmDHnmrv/HOrqktSC+C9fM+CJOE=
@@ -776,6 +781,8 @@ github.com/in-toto/in-toto-golang v0.10.0/go.mod h1:wjT4RiyFlLWCmLUJjwB8oZcjaq7H
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/invopop/jsonschema v0.13.0 h1:KvpoAJWEjR3uD9Kbm2HWJmqsEaHt8lBUpd0qHcIi21E=
+github.com/invopop/jsonschema v0.13.0/go.mod h1:ffZ5Km5SWWRAIN6wbDXItl95euhFz2uON45H2qjYt+0=
 github.com/j-keck/arping v0.0.0-20160618110441-2cf9dc699c56/go.mod h1:ymszkNOg6tORTn+6F6j+Jc8TOr5osrynvN6ivFWZ2GA=
 github.com/j-keck/arping v1.0.2/go.mod h1:aJbELhR92bSk7tp79AWM/ftfc90EfEi2bQJrbBFOsPw=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 h1:BQSFePA1RWJOlocH6Fxy8MmwDt+yVQYULKfN0RoTN8A=
@@ -842,6 +849,7 @@ github.com/mailru/easyjson v0.0.0-20190614124828-94de47d64c63/go.mod h1:C1wdFJiN
 github.com/mailru/easyjson v0.0.0-20190626092158-b2ccc519800e/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
 github.com/mailru/easyjson v0.7.0/go.mod h1:KAzv3t3aY1NaHWoQz1+4F1ccyAH66Jk7yos7ldAVICs=
 github.com/mailru/easyjson v0.7.6/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
+github.com/mailru/easyjson v0.7.7 h1:UGYAvKxe3sBsEDzO8ZeWOSlIQfWFlxbzLZe7hwFURr0=
 github.com/mailru/easyjson v0.7.7/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
 github.com/markbates/oncer v0.0.0-20181203154359-bf2de49a0be2/go.mod h1:Ld9puTsIW75CHf65OeIOkyKbteujpZVXDpWK6YGZbxE=
 github.com/markbates/safe v1.0.1/go.mod h1:nAqgmRi7cY2nqMc92/bSEeQA+R4OheNU2T1kNSCBdG0=
@@ -1095,6 +1103,8 @@ github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/safchain/ethtool v0.0.0-20190326074333-42ed695e3de8/go.mod h1:Z0q5wiBQGYcxhMZ6gUqHn6pYNLypFAvaL3UvgZLR0U4=
 github.com/safchain/ethtool v0.0.0-20210803160452-9aa261dae9b1/go.mod h1:Z0q5wiBQGYcxhMZ6gUqHn6pYNLypFAvaL3UvgZLR0U4=
+github.com/santhosh-tekuri/jsonschema/v5 v5.3.1 h1:lZUw3E0/J3roVtGQ+SCrUrg3ON6NgVqpn3+iol9aGu4=
+github.com/santhosh-tekuri/jsonschema/v5 v5.3.1/go.mod h1:uToXkOrWAZ6/Oc07xWQrPOhJotwFIyu2bBVN41fcDUY=
 github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 h1:KRzFb2m7YtdldCEkzs6KqmJw4nqEVZGK7IN2kJkjTuQ=
 github.com/santhosh-tekuri/jsonschema/v6 v6.0.2/go.mod h1:JXeL+ps8p7/KNMjDQk3TCwPpBy0wYklyWTfbkIzdIFU=
 github.com/sasha-s/go-deadlock v0.3.5 h1:tNCOEEDG6tBqrNDOX35j/7hL5FcFViG6awUGROb2NsU=
@@ -1259,6 +1269,8 @@ github.com/wagoodman/go-progress v0.0.0-20260303201901-10176f79b2c0 h1:EHsPe0Q0A
 github.com/wagoodman/go-progress v0.0.0-20260303201901-10176f79b2c0/go.mod h1:g/D9uEUFp5YLyciwCpVsSOZOm56hfv4rzGJod6MlqIM=
 github.com/willf/bitset v1.1.11-0.20200630133818-d5bec3311243/go.mod h1:RjeCKbqT1RxIR/KWY6phxZiaY1IyutSBfGjNPySAYV4=
 github.com/willf/bitset v1.1.11/go.mod h1:83CECat5yLh5zVOf4P1ErAgKA5UDvKtgyUABdr3+MjI=
+github.com/wk8/go-ordered-map/v2 v2.1.8 h1:5h/BUHu93oj4gIdvHHHGsScSTMijfx5PeYkE/fJgbpc=
+github.com/wk8/go-ordered-map/v2 v2.1.8/go.mod h1:5nJHM5DyteebpVlHnWMV0rPz6Zp7+xBAnxjb1X5vnTw=
 github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=
 github.com/x448/float16 v0.8.4/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcYsOfg=
 github.com/xanzy/ssh-agent v0.3.3 h1:+/15pJfg/RsTxqYcX6fHqOXZwwMP+2VyYWJeWM2qQFM=
@@ -1787,6 +1799,8 @@ k8s.io/kubernetes v1.13.0/go.mod h1:ocZa8+6APFNC2tX1DZASIbocyYT5jHzqFVsY5aoB7Jk=
 k8s.io/utils v0.0.0-20201110183641-67b214c5f920/go.mod h1:jPW/WVKK9YHAvNhRxK0md/EJ228hCsBRufyofKtW8HA=
 k8s.io/utils v0.0.0-20251002143259-bc988d571ff4 h1:SjGebBtkBqHFOli+05xYbK8YF1Dzkbzn+gDM4X9T4Ck=
 k8s.io/utils v0.0.0-20251002143259-bc988d571ff4/go.mod h1:OLgZIPagt7ERELqWJFomSt595RzquPNLL48iOWgYOg0=
+mvdan.cc/sh/v3 v3.12.0 h1:ejKUR7ONP5bb+UGHGEG/k9V5+pRVIyD+LsZz7o8KHrI=
+mvdan.cc/sh/v3 v3.12.0/go.mod h1:Se6Cj17eYSn+sNooLZiEUnNNmNxg0imoYlTu4CyaGyg=
 oras.land/oras-go/v2 v2.6.0 h1:X4ELRsiGkrbeox69+9tzTu492FMUu7zJQW6eJU+I2oc=
 oras.land/oras-go/v2 v2.6.0/go.mod h1:magiQDfG6H1O9APp+rOsvCPcW1GD2MM7vgnKY0Y+u1o=
 pgregory.net/rapid v1.2.0 h1:keKAYRcjm+e1F0oAuU5F5+YPAWcyxNNRK2wud503Gnk=
@@ -1812,5 +1826,7 @@ sigs.k8s.io/yaml v1.1.0/go.mod h1:UJmg0vDUVViEyp3mgSv9WPwZCDxu4rQW1olrI1uml+o=
 sigs.k8s.io/yaml v1.2.0/go.mod h1:yfXDCHCao9+ENCvLSE62v9VSji2MKu5jeNfTrofGhJc=
 sigs.k8s.io/yaml v1.6.0 h1:G8fkbMSAFqgEFgh4b1wmtzDnioxFCUgTZhlbj5P9QYs=
 sigs.k8s.io/yaml v1.6.0/go.mod h1:796bPqUfzR/0jLAl6XjHl3Ck7MiyVv8dbTdyT3/pMf4=
+unikraft.com/x/kraftfile v0.0.0-20260402111140-cceb3ed69aff h1:RkBfZnScANJEvHAT6CdXab6s2M9oFt6yM+bHu67cO7o=
+unikraft.com/x/kraftfile v0.0.0-20260402111140-cceb3ed69aff/go.mod h1:OYaIMOzV1IpbZCe2J3SuC5jvT4tAfR0XG9uOPPD+p50=
 xenbits.xenproject.org/git-http/xen.git/tools/golang/xenlight v0.0.0-20240729172045-026c9fa29716 h1:y52AcO4BZop/FrR523z47VCLFViGmMJqY21uL+FxXXI=
 xenbits.xenproject.org/git-http/xen.git/tools/golang/xenlight v0.0.0-20240729172045-026c9fa29716/go.mod h1:tbZ4iMnk8RWkXPxTiCGdAw3hCOa3feShlf3sBh50uIc=

--- a/initrd/file.go
+++ b/initrd/file.go
@@ -13,6 +13,8 @@ import (
 	"kraftkit.sh/fs/cpio"
 	"kraftkit.sh/fs/erofs"
 	"kraftkit.sh/fsutils"
+
+	kraftfilev07 "unikraft.com/x/kraftfile"
 )
 
 type file struct {
@@ -96,7 +98,7 @@ reevaluateFsType:
 
 // detectFsType attempts to convert from the 'unknown' filesystem type to one
 // of the known types like 'cpio'/'erofs'/'file'.
-func detectFsType(source string) FsType {
+func detectFsType(source string) kraftfilev07.FsType {
 	switch {
 	case fsutils.IsErofsFile(source):
 		return FsTypeErofs

--- a/initrd/options.go
+++ b/initrd/options.go
@@ -7,6 +7,8 @@ package initrd
 import (
 	"fmt"
 
+	kraftfilev07 "unikraft.com/x/kraftfile"
+
 	"kraftkit.sh/config"
 )
 
@@ -24,7 +26,7 @@ type InitrdOptions struct {
 	buildSecrets map[string]InitrdBuildSecret
 	cacheDir     string
 	compress     bool
-	fsType       FsType
+	fsType       kraftfilev07.FsType
 	keepOwners   bool
 	output       string
 	rootfsPath   string
@@ -126,7 +128,7 @@ func WithOutput(output string) InitrdOption {
 }
 
 // WithOutputType sets the output type of the resulting root filesystem.
-func WithOutputType(fsType FsType) InitrdOption {
+func WithOutputType(fsType kraftfilev07.FsType) InitrdOption {
 	return func(opts *InitrdOptions) error {
 		if fsType == "" {
 			return nil
@@ -194,25 +196,18 @@ func WithAuths(auths map[string]config.AuthConfig) InitrdOption {
 	}
 }
 
-type FsType string
-
+// extended types on the top of kraftfilev07 defined FsTypes
 const (
-	FsTypeCpio    = FsType("cpio")
-	FsTypeErofs   = FsType("erofs")
-	FsTypeFile    = FsType("file")
-	FsTypeUnknown = FsType("unknown")
+	FsTypeFile    = kraftfilev07.FsType("file")
+	FsTypeUnknown = kraftfilev07.FsType("unknown")
+
+	FsTypeCpio  = kraftfilev07.FsTypeCpio
+	FsTypeErofs = kraftfilev07.FsTypeErofs
 )
 
-var _ fmt.Stringer = (*FsType)(nil)
-
-// String implements fmt.Stringer
-func (fsType FsType) String() string {
-	return string(fsType)
-}
-
 // FsTypes returns the list of possible fsTypes.
-func FsTypes() []FsType {
-	return []FsType{
+func FsTypes() []kraftfilev07.FsType {
+	return []kraftfilev07.FsType{
 		FsTypeCpio,
 		FsTypeErofs,
 		FsTypeFile,

--- a/initrd/rootfs.go
+++ b/initrd/rootfs.go
@@ -11,6 +11,8 @@ import (
 	"os"
 	"path/filepath"
 
+	kraftfilev07 "unikraft.com/x/kraftfile"
+
 	"kraftkit.sh/config"
 	"kraftkit.sh/log"
 	"kraftkit.sh/tui/processtree"
@@ -81,24 +83,34 @@ func BuildRootfs(ctx context.Context, opts ...InitrdOption) (Initrd, []string, [
 	return ramfs, cmds, envs, nil
 }
 
-// BuildRoms generates ROM filesystems based on the provided ROM paths.
-func BuildRoms(ctx context.Context, workdir string, roms []string, compress, keepOwners bool, arch string, fsType FsType) ([]string, error) {
-	if len(roms) == 0 || fsType == "" {
-		return roms, nil
+// BuildRoms generates ROM filesystems based on the provided ROM FS (kraftfilev07.FS).
+func BuildRoms(ctx context.Context, workdir string, roms []kraftfilev07.FS, compress, keepOwners bool, arch string, defaultFsType kraftfilev07.FsType) ([]kraftfilev07.FS, error) {
+	if len(roms) == 0 {
+		return nil, nil
 	}
 
 	var processes []*processtree.ProcessTreeItem
-	builtRoms := make([]string, len(roms))
+	builtRoms := make([]kraftfilev07.FS, len(roms))
 	for i, rom := range roms {
+		fsType := rom.Format
+		if fsType == "" {
+			fsType = defaultFsType
+		}
+
+		if fsType == "" {
+			builtRoms[i] = rom
+			continue
+		}
+
 		// Check if the ROM is a directory; if it's a file, skip building and use as-is
-		romPath := rom
-		if !filepath.IsAbs(rom) {
-			romPath = filepath.Join(workdir, rom)
+		romPath := rom.Source
+		if !filepath.IsAbs(rom.Source) {
+			romPath = filepath.Join(workdir, rom.Source)
 		}
 
 		info, err := os.Stat(romPath)
 		if err != nil {
-			return nil, fmt.Errorf("could not stat ROM path '%s': %w", rom, err)
+			return nil, fmt.Errorf("could not stat ROM path '%s': %w", rom.Source, err)
 		}
 
 		// If it's a regular file, don't try to build it as a filesystem
@@ -106,14 +118,14 @@ func BuildRoms(ctx context.Context, workdir string, roms []string, compress, kee
 			// File ROMs must be aligned to page size
 			const pageSize = 4096
 			if info.Size()%pageSize != 0 {
-				return nil, fmt.Errorf("ROM file '%s' size (%d bytes) is not aligned to page size (%d bytes)", rom, info.Size(), pageSize)
+				return nil, fmt.Errorf("ROM file '%s' size (%d bytes) is not aligned to page size (%d bytes)", rom.Source, info.Size(), pageSize)
 			}
 			builtRoms[i] = rom
 			continue
 		}
 
 		ramfs, err := New(ctx,
-			rom,
+			rom.Source,
 			WithWorkdir(workdir),
 			WithOutput(filepath.Join(
 				workdir,
@@ -131,7 +143,7 @@ func BuildRoms(ctx context.Context, workdir string, roms []string, compress, kee
 			WithOutputType(fsType),
 		)
 		if err != nil {
-			return nil, fmt.Errorf("could not initialize ROM builder for '%s': %w", rom, err)
+			return nil, fmt.Errorf("could not initialize ROM builder for '%s': %w", rom.Source, err)
 		}
 
 		processes = append(processes,
@@ -144,7 +156,10 @@ func BuildRoms(ctx context.Context, workdir string, roms []string, compress, kee
 						return err
 					}
 
-					builtRoms[i] = builtRom
+					builtRoms[i] = kraftfilev07.FS{
+						Source: builtRom,
+						Format: fsType,
+					}
 					return nil
 				},
 			),

--- a/internal/cli/kraft/build/build.go
+++ b/internal/cli/kraft/build/build.go
@@ -30,6 +30,8 @@ import (
 	"kraftkit.sh/unikraft"
 	"kraftkit.sh/unikraft/app"
 	"kraftkit.sh/unikraft/target"
+
+	kraftfilev07 "unikraft.com/x/kraftfile"
 )
 
 var ErrContextNotBuildable = fmt.Errorf("could not determine what or how to build from the given context")
@@ -57,7 +59,7 @@ type BuildOptions struct {
 	PrintStats     bool                  `long:"print-stats" usage:"Print build statistics"`
 	Project        app.Application       `noattribute:"true"`
 	Rootfs         string                `long:"rootfs" usage:"Specify a path to use as root file system (can be volume or initramfs)"`
-	RootfsType     initrd.FsType         `noattribute:"true"`
+	RootfsType     kraftfilev07.FsType   `noattribute:"true"`
 	KeepFileOwners bool                  `local:"true" long:"keep-file-owners" usage:"Keep file owners (user:group) in the rootfs (false sets 'root:root')"`
 	SaveBuildLog   string                `long:"build-log" usage:"Use the specified file to save the output from the build"`
 	Target         *target.Target        `noattribute:"true"`
@@ -128,8 +130,7 @@ func Build(ctx context.Context, opts *BuildOptions, args ...string) error {
 			initrd.WithWorkdir(opts.Workdir),
 			initrd.WithKeepOwners(opts.KeepFileOwners),
 			initrd.WithOutput(filepath.Join(
-				opts.Workdir,
-				unikraft.BuildDir,
+				buildOutputDir(opts.Project, opts.Workdir),
 				fmt.Sprintf(initrd.DefaultInitramfsArchFileName, (*opts.Target).Architecture(), opts.RootfsType),
 			)),
 			initrd.WithOutputType(opts.RootfsType),
@@ -205,7 +206,7 @@ func NewCmd() *cobra.Command {
 	}
 
 	cmd.Flags().Var(
-		cmdfactory.NewEnumFlag[initrd.FsType](
+		cmdfactory.NewEnumFlag[kraftfilev07.FsType](
 			initrd.FsTypes(),
 			initrd.FsTypeCpio,
 		),
@@ -225,7 +226,7 @@ func (opts *BuildOptions) Pre(cmd *cobra.Command, args []string) error {
 	cmd.SetContext(ctx)
 
 	if cmd.Flag("rootfs-type").Changed && cmd.Flag("rootfs-type").Value.String() != "" {
-		opts.RootfsType = initrd.FsType(cmd.Flag("rootfs-type").Value.String())
+		opts.RootfsType = kraftfilev07.FsType(cmd.Flag("rootfs-type").Value.String())
 	}
 
 	if opts.Rootfs != "" && !filepath.IsAbs(opts.Rootfs) && !strings.Contains(opts.Rootfs, "://") {
@@ -263,7 +264,7 @@ func (opts *BuildOptions) Run(ctx context.Context, args []string) error {
 		if ok {
 			standardName, err := target.KernelName(*tc)
 			if err == nil {
-				standardPath := filepath.Join(opts.Workdir, unikraft.BuildDir, standardName)
+				standardPath := filepath.Join(buildOutputDir(opts.Project, opts.Workdir), standardName)
 				desiredPath := t.Kernel()
 
 				// If they are different, it means either --kernel was used or 'output'
@@ -358,6 +359,14 @@ func (opts *BuildOptions) Run(ctx context.Context, args []string) error {
 	fmt.Fprint(iostreams.G(ctx).Out, "Learn how to package your unikernel with: kraft pkg --help\n")
 
 	return nil
+}
+
+func buildOutputDir(project app.Application, workdir string) string {
+	if project != nil && project.OutDir() != "" {
+		return project.OutDir()
+	}
+
+	return filepath.Join(workdir, unikraft.BuildDir)
 }
 
 func moveFile(src, dst string) error {

--- a/internal/cli/kraft/build/builder_kraftfile_runtime.go
+++ b/internal/cli/kraft/build/builder_kraftfile_runtime.go
@@ -15,6 +15,7 @@ import (
 	"kraftkit.sh/packmanager"
 	"kraftkit.sh/tui/processtree"
 	"kraftkit.sh/tui/selection"
+	ukruntime "kraftkit.sh/unikraft/runtime"
 	"kraftkit.sh/unikraft/target"
 )
 
@@ -60,14 +61,23 @@ func (*builderKraftfileRuntime) Prepare(ctx context.Context, opts *BuildOptions,
 		err      error
 	)
 
-	name := opts.Project.Runtime().Name()
+	queryRuntime := opts.Project.Runtime()
+	runtimeRef := queryRuntime.Reference()
+	queryName := queryRuntime.QueryName()
+	queryVersion := queryRuntime.QueryVersion()
 	if opts.Platform == "kraftcloud" || (opts.Project.Runtime().Platform() != nil && opts.Project.Runtime().Platform().Name() == "kraftcloud") {
-		name = utils.RewrapAsKraftCloudPackage(name)
+		queryRuntime = &ukruntime.Runtime{}
+		queryRuntime.SetName(utils.RewrapAsKraftCloudPackage(runtimeRef))
+		runtimeRef = queryRuntime.Reference()
+		queryName = queryRuntime.QueryName()
+		queryVersion = queryRuntime.QueryVersion()
 	}
 
 	qopts := []packmanager.QueryOption{
-		packmanager.WithName(name),
-		packmanager.WithVersion(opts.Project.Runtime().Version()),
+		packmanager.WithName(queryName),
+	}
+	if queryVersion != "" {
+		qopts = append(qopts, packmanager.WithVersion(queryVersion))
 	}
 
 	treemodel, err := processtree.NewProcessTree(
@@ -81,11 +91,7 @@ func (*builderKraftfileRuntime) Prepare(ctx context.Context, opts *BuildOptions,
 			processtree.WithHideOnSuccess(true),
 		},
 		processtree.NewProcessTreeItem(
-			fmt.Sprintf(
-				"searching for %s:%s",
-				name,
-				opts.Project.Runtime().Version(),
-			),
+			fmt.Sprintf("searching for %s", runtimeRef),
 			"",
 			func(ctx context.Context) error {
 				qopts = append(qopts,
@@ -121,31 +127,27 @@ func (*builderKraftfileRuntime) Prepare(ctx context.Context, opts *BuildOptions,
 	if len(packs) == 0 {
 		if len(opts.Platform) > 0 && len(opts.Architecture) > 0 {
 			return fmt.Errorf(
-				"could not find runtime '%s:%s' (%s/%s)",
-				opts.Project.Runtime().Name(),
-				opts.Project.Runtime().Version(),
+				"could not find runtime '%s' (%s/%s)",
+				runtimeRef,
 				opts.Platform,
 				opts.Architecture,
 			)
 		} else if len(opts.Architecture) > 0 {
 			return fmt.Errorf(
-				"could not find runtime '%s:%s' with '%s' architecture",
-				opts.Project.Runtime().Name(),
-				opts.Project.Runtime().Version(),
+				"could not find runtime '%s' with '%s' architecture",
+				runtimeRef,
 				opts.Architecture,
 			)
 		} else if len(opts.Platform) > 0 {
 			return fmt.Errorf(
-				"could not find runtime '%s:%s' with '%s' platform",
-				opts.Project.Runtime().Name(),
-				opts.Project.Runtime().Version(),
+				"could not find runtime '%s' with '%s' platform",
+				runtimeRef,
 				opts.Platform,
 			)
 		} else {
 			return fmt.Errorf(
-				"could not find runtime %s:%s",
-				opts.Project.Runtime().Name(),
-				opts.Project.Runtime().Version(),
+				"could not find runtime %s",
+				runtimeRef,
 			)
 		}
 	} else if len(packs) == 1 {

--- a/internal/cli/kraft/cloud/compose/build/build.go
+++ b/internal/cli/kraft/cloud/compose/build/build.go
@@ -31,6 +31,8 @@ import (
 	"kraftkit.sh/unikraft/app"
 	"kraftkit.sh/unikraft/runtime"
 	"kraftkit.sh/unikraft/target"
+
+	kraftfilev07 "unikraft.com/x/kraftfile"
 )
 
 type BuildOptions struct {
@@ -43,7 +45,7 @@ type BuildOptions struct {
 	Project        *compose.Project      `noattribute:"true"`
 	Push           bool                  `long:"push" usage:"Push the built service images"`
 	Runtimes       []string              `long:"runtime" usage:"Alternative runtime to use when packaging a service"`
-	RootfsType     initrd.FsType         `noattribute:"true"`
+	RootfsType     kraftfilev07.FsType   `noattribute:"true"`
 	KeepFileOwners bool                  `local:"true" long:"keep-file-owners" usage:"Keep file owners (user:group) in the rootfs (false sets 'root:root')"`
 	Token          string                `noattribute:"true"`
 }
@@ -76,9 +78,9 @@ func NewCmd() *cobra.Command {
 	}
 
 	cmd.Flags().Var(
-		cmdfactory.NewEnumFlag[initrd.FsType](
+		cmdfactory.NewEnumFlag[kraftfilev07.FsType](
 			initrd.FsTypes(),
-			initrd.FsTypeCpio,
+			kraftfilev07.FsTypeCpio,
 		),
 		"rootfs-type",
 		"Set the type of the format of the rootfs (cpio/erofs)",
@@ -397,7 +399,7 @@ func (opts *BuildOptions) Pre(cmd *cobra.Command, args []string) error {
 	}
 
 	if cmd.Flag("rootfs-type").Changed && cmd.Flag("rootfs-type").Value.String() != "" {
-		opts.RootfsType = initrd.FsType(cmd.Flag("rootfs-type").Value.String())
+		opts.RootfsType = kraftfilev07.FsType(cmd.Flag("rootfs-type").Value.String())
 	}
 
 	return nil

--- a/internal/cli/kraft/cloud/compose/up/up.go
+++ b/internal/cli/kraft/cloud/compose/up/up.go
@@ -36,6 +36,8 @@ import (
 	"kraftkit.sh/internal/cli/kraft/cloud/utils"
 	"kraftkit.sh/log"
 	"kraftkit.sh/packmanager"
+
+	kraftfilev07 "unikraft.com/x/kraftfile"
 )
 
 type UpOptions struct {
@@ -53,7 +55,7 @@ type UpOptions struct {
 	RolloutQualifier *create.RolloutQualifier `noattribute:"true"`
 	RolloutWait      time.Duration            `local:"true" long:"rollout-wait" usage:"Time to wait before performing rolling out action (ms/s/m/h)" default:"10s"`
 	Runtimes         []string                 `long:"runtime" usage:"Alternative runtime to use when packaging a service"`
-	RootfsType       initrd.FsType            `noattribute:"true"`
+	RootfsType       kraftfilev07.FsType      `noattribute:"true"`
 	KeepFileOwners   bool                     `local:"true" long:"keep-file-owners" usage:"Keep file owners (user:group) in the rootfs (false sets 'root:root')"`
 	Token            string                   `noattribute:"true"`
 	Wait             time.Duration            `local:"true" long:"wait" short:"w" usage:"Timeout to wait for the instance to start (ms/s/m/h)"`
@@ -94,9 +96,9 @@ func NewCmd() *cobra.Command {
 	}
 
 	cmd.Flags().Var(
-		cmdfactory.NewEnumFlag[initrd.FsType](
+		cmdfactory.NewEnumFlag[kraftfilev07.FsType](
 			initrd.FsTypes(),
-			initrd.FsTypeCpio,
+			kraftfilev07.FsTypeCpio,
 		),
 		"rootfs-type",
 		"Set the type of the format of the rootfs (cpio/erofs)",
@@ -127,7 +129,7 @@ func (opts *UpOptions) Pre(cmd *cobra.Command, args []string) error {
 	}
 
 	if cmd.Flag("rootfs-type").Changed && cmd.Flag("rootfs-type").Value.String() != "" {
-		opts.RootfsType = initrd.FsType(cmd.Flag("rootfs-type").Value.String())
+		opts.RootfsType = kraftfilev07.FsType(cmd.Flag("rootfs-type").Value.String())
 	}
 
 	return nil

--- a/internal/cli/kraft/cloud/deploy/deploy.go
+++ b/internal/cli/kraft/cloud/deploy/deploy.go
@@ -33,6 +33,8 @@ import (
 
 	kraftcloud "sdk.kraft.cloud"
 	kcinstances "sdk.kraft.cloud/instances"
+
+	kraftfilev07 "unikraft.com/x/kraftfile"
 )
 
 type DeployOptions struct {
@@ -72,7 +74,7 @@ type DeployOptions struct {
 	RolloutQualifier    create.RolloutQualifier        `noattribute:"true"`
 	RolloutWait         time.Duration                  `local:"true" long:"rollout-wait" usage:"Time to wait before performing rolling out action (ms/s/m/h)" default:"10s"`
 	Rootfs              string                         `local:"true" long:"rootfs" usage:"Specify a path to use as root filesystem"`
-	RootfsType          initrd.FsType                  `noattribute:"true"`
+	RootfsType          kraftfilev07.FsType            `noattribute:"true"`
 	Runtime             string                         `local:"true" long:"runtime" usage:"Set an alternative project runtime"`
 	SaveBuildLog        string                         `long:"build-log" usage:"Use the specified file to save the output from the build"`
 	ScaleToZero         *kcinstances.ScaleToZeroPolicy `noattribute:"true"`
@@ -171,7 +173,7 @@ func NewCmd() *cobra.Command {
 	)
 
 	cmd.Flags().Var(
-		cmdfactory.NewEnumFlag[initrd.FsType](
+		cmdfactory.NewEnumFlag[kraftfilev07.FsType](
 			initrd.FsTypes(),
 			initrd.FsTypeCpio,
 		),
@@ -194,7 +196,7 @@ func (opts *DeployOptions) Pre(cmd *cobra.Command, _ []string) error {
 	opts.Strategy = packmanager.MergeStrategy(cmd.Flag("strategy").Value.String())
 
 	if cmd.Flag("rootfs-type").Changed && cmd.Flag("rootfs-type").Value.String() != "" {
-		opts.RootfsType = initrd.FsType(cmd.Flag("rootfs-type").Value.String())
+		opts.RootfsType = kraftfilev07.FsType(cmd.Flag("rootfs-type").Value.String())
 	}
 
 	if opts.Rootfs != "" && !filepath.IsAbs(opts.Rootfs) && !strings.Contains(opts.Rootfs, "://") {

--- a/internal/cli/kraft/fetch/fetch.go
+++ b/internal/cli/kraft/fetch/fetch.go
@@ -133,20 +133,21 @@ func (opts *FetchOptions) pull(ctx context.Context, project app.Application, wor
 	var searches []*processtree.ProcessTreeItem
 	parallel := !config.G[config.KraftKit](ctx).NoParallel
 	auths := config.G[config.KraftKit](ctx).Auth
+	template := opts.project.Template()
 
-	if _, err := opts.project.Components(ctx); err != nil && opts.project.Template().Name() != "" {
+	if _, err := opts.project.Components(ctx); err != nil && template != nil && template.Name() != "" {
 		var packages []pack.Package
 		var pullPack pack.Package
 
 		search := processtree.NewProcessTreeItem(
 			fmt.Sprintf("finding %s",
-				unikraft.TypeNameVersion(opts.project.Template()),
+				unikraft.TypeNameVersion(template),
 			), "",
 			func(ctx context.Context) error {
 				packages, err = packmanager.G(ctx).Catalog(ctx,
-					packmanager.WithName(opts.project.Template().Name()),
+					packmanager.WithName(template.Name()),
 					packmanager.WithTypes(unikraft.ComponentTypeApp),
-					packmanager.WithVersion(opts.project.Template().Version()),
+					packmanager.WithVersion(template.Version()),
 					packmanager.WithRemote(opts.NoCache),
 					packmanager.WithAuthConfig(config.G[config.KraftKit](ctx).Auth),
 				)
@@ -156,7 +157,7 @@ func (opts *FetchOptions) pull(ctx context.Context, project app.Application, wor
 
 				if len(packages) == 0 {
 					return fmt.Errorf("could not find: %s",
-						unikraft.TypeNameVersion(opts.project.Template()),
+						unikraft.TypeNameVersion(template),
 					)
 				}
 
@@ -192,7 +193,7 @@ func (opts *FetchOptions) pull(ctx context.Context, project app.Application, wor
 				}
 
 				return fmt.Errorf("too many options for %s and prompting has been disabled",
-					opts.project.Template().String(),
+					template.String(),
 				)
 			}
 
@@ -238,8 +239,8 @@ func (opts *FetchOptions) pull(ctx context.Context, project app.Application, wor
 		}
 	}
 
-	if opts.project.Template().Name() != "" {
-		templateWorkdir, err := unikraft.PlaceComponent(workdir, opts.project.Template().Type(), opts.project.Template().Name())
+	if template != nil && template.Name() != "" {
+		templateWorkdir, err := unikraft.PlaceComponent(workdir, template.Type(), template.Name())
 		if err != nil {
 			return err
 		}

--- a/internal/cli/kraft/menu/menu.go
+++ b/internal/cli/kraft/menu/menu.go
@@ -118,20 +118,21 @@ func (opts *MenuOptions) pull(ctx context.Context, project app.Application, work
 	var searches []*processtree.ProcessTreeItem
 	parallel := !config.G[config.KraftKit](ctx).NoParallel
 	auths := config.G[config.KraftKit](ctx).Auth
+	template := opts.project.Template()
 
-	if _, err := opts.project.Components(ctx); err != nil && opts.project.Template().Name() != "" {
+	if _, err := opts.project.Components(ctx); err != nil && template != nil && template.Name() != "" {
 		var packages []pack.Package
 		var pullPack pack.Package
 
 		search := processtree.NewProcessTreeItem(
 			fmt.Sprintf("finding %s",
-				unikraft.TypeNameVersion(opts.project.Template()),
+				unikraft.TypeNameVersion(template),
 			), "",
 			func(ctx context.Context) error {
 				packages, err = packmanager.G(ctx).Catalog(ctx,
-					packmanager.WithName(opts.project.Template().Name()),
+					packmanager.WithName(template.Name()),
 					packmanager.WithTypes(unikraft.ComponentTypeApp),
-					packmanager.WithVersion(opts.project.Template().Version()),
+					packmanager.WithVersion(template.Version()),
 					packmanager.WithRemote(opts.NoCache),
 					packmanager.WithAuthConfig(config.G[config.KraftKit](ctx).Auth),
 				)
@@ -141,7 +142,7 @@ func (opts *MenuOptions) pull(ctx context.Context, project app.Application, work
 
 				if len(packages) == 0 {
 					return fmt.Errorf("could not find: %s",
-						unikraft.TypeNameVersion(opts.project.Template()),
+						unikraft.TypeNameVersion(template),
 					)
 				}
 
@@ -177,7 +178,7 @@ func (opts *MenuOptions) pull(ctx context.Context, project app.Application, work
 				}
 
 				return fmt.Errorf("too many options for %s and prompting has been disabled",
-					opts.project.Template().String(),
+					template.String(),
 				)
 			}
 
@@ -223,8 +224,8 @@ func (opts *MenuOptions) pull(ctx context.Context, project app.Application, work
 		}
 	}
 
-	if opts.project.Template() != nil && opts.project.Template().Name() != "" {
-		templateWorkdir, err := unikraft.PlaceComponent(workdir, opts.project.Template().Type(), opts.project.Template().Name())
+	if template != nil && template.Name() != "" {
+		templateWorkdir, err := unikraft.PlaceComponent(workdir, template.Type(), template.Name())
 		if err != nil {
 			return err
 		}

--- a/internal/cli/kraft/pkg/packager_kraftfile_runtime.go
+++ b/internal/cli/kraft/pkg/packager_kraftfile_runtime.go
@@ -25,6 +25,8 @@ import (
 	"kraftkit.sh/unikraft/arch"
 	"kraftkit.sh/unikraft/plat"
 	"kraftkit.sh/unikraft/target"
+
+	kraftfilev07 "unikraft.com/x/kraftfile"
 )
 
 type packagerKraftfileRuntime struct {
@@ -37,7 +39,7 @@ type packagerKraftfileRuntime struct {
 	kconfig      kconfig.KeyValueMap
 	args         []string
 	env          []string
-	roms         []string
+	roms         []kraftfilev07.FS
 	rootfs       initrd.Initrd
 	architecture arch.Architecture
 	platform     plat.Platform
@@ -415,11 +417,15 @@ func (p *packagerKraftfileRuntime) Pack(ctx context.Context, opts *PkgOptions, a
 		}
 	}
 
-	var rawRoms []string
+	var rawRoms []kraftfilev07.FS
 	if opts.Project != nil {
 		rawRoms = opts.Project.Roms()
 	} else if len(opts.Roms) > 0 {
-		rawRoms = opts.Roms
+		for _, rom := range opts.Roms {
+			rawRoms = append(rawRoms, kraftfilev07.FS{
+				Source: rom,
+			})
+		}
 	} else if p.target != nil && len(p.target.Roms()) > 0 {
 		rawRoms = p.target.Roms()
 	}

--- a/internal/cli/kraft/pkg/pkg.go
+++ b/internal/cli/kraft/pkg/pkg.go
@@ -36,6 +36,8 @@ import (
 	"kraftkit.sh/internal/cli/kraft/pkg/source"
 	"kraftkit.sh/internal/cli/kraft/pkg/unsource"
 	"kraftkit.sh/internal/cli/kraft/pkg/update"
+
+	kraftfilev07 "unikraft.com/x/kraftfile"
 )
 
 type PkgOptions struct {
@@ -60,7 +62,7 @@ type PkgOptions struct {
 	Project        app.Application           `noattribute:"true"`
 	Push           bool                      `local:"true" long:"push" short:"P" usage:"Push the package on if successfully packaged"`
 	Rootfs         string                    `local:"true" long:"rootfs" usage:"Specify a path to use as root file system (can be volume or initramfs)"`
-	RootfsType     initrd.FsType             `noattribute:"true"`
+	RootfsType     kraftfilev07.FsType       `noattribute:"true"`
 	Roms           []string                  `local:"true" long:"rom" short:"R" usage:"Specify a path to an auxiliary ROM to include in the package"`
 	Runtime        string                    `local:"true" long:"runtime" short:"r" usage:"Set the runtime to use for the package"`
 	Strategy       packmanager.MergeStrategy `noattribute:"true"`
@@ -303,9 +305,9 @@ func NewCmd() *cobra.Command {
 	)
 
 	cmd.Flags().Var(
-		cmdfactory.NewEnumFlag[initrd.FsType](
+		cmdfactory.NewEnumFlag[kraftfilev07.FsType](
 			initrd.FsTypes(),
-			initrd.FsTypeCpio,
+			kraftfilev07.FsTypeCpio,
 		),
 		"rootfs-type",
 		"Set the type of the format of the rootfs (cpio/erofs)",
@@ -323,8 +325,8 @@ func (opts *PkgOptions) Pre(cmd *cobra.Command, args []string) error {
 	cmd.SetContext(ctx)
 
 	opts.Strategy = packmanager.MergeStrategy(cmd.Flag("strategy").Value.String())
-	if cmd.Flag("rootfs-type").Changed && cmd.Flag("rootfs-type").Value.String() != "" {
-		opts.RootfsType = initrd.FsType(cmd.Flag("rootfs-type").Value.String())
+	if cmd.Flag("rootfs-type").Value.String() != "" {
+		opts.RootfsType = kraftfilev07.FsType(cmd.Flag("rootfs-type").Value.String())
 	}
 
 	return nil

--- a/internal/cli/kraft/pkg/pull/pull.go
+++ b/internal/cli/kraft/pkg/pull/pull.go
@@ -184,20 +184,25 @@ func (opts *PullOptions) Run(ctx context.Context, args []string) error {
 		}
 
 		if _, err = project.Components(ctx); err != nil {
+			template := project.Template()
+			if template == nil {
+				return err
+			}
+
 			var pullPack pack.Package
 			var packages []pack.Package
 
 			// Pull the template from the package manager
-			if project.Template() != nil {
+			if template != nil {
 				search := processtree.NewProcessTreeItem(
 					fmt.Sprintf("finding %s",
-						unikraft.TypeNameVersion(project.Template()),
+						unikraft.TypeNameVersion(template),
 					), "",
 					func(ctx context.Context) error {
 						qopts := []packmanager.QueryOption{
-							packmanager.WithName(project.Template().Name()),
+							packmanager.WithName(template.Name()),
 							packmanager.WithTypes(unikraft.ComponentTypeApp),
-							packmanager.WithVersion(project.Template().Version()),
+							packmanager.WithVersion(template.Version()),
 							packmanager.WithRemote(opts.Update),
 							packmanager.WithPlatform(opts.Platform),
 							packmanager.WithArchitecture(opts.Architecture),
@@ -209,7 +214,7 @@ func (opts *PullOptions) Run(ctx context.Context, args []string) error {
 						}
 
 						if len(packages) == 0 {
-							return fmt.Errorf("could not find: %s based on %s", unikraft.TypeNameVersion(project.Template()), packmanager.NewQuery(qopts...).String())
+							return fmt.Errorf("could not find: %s based on %s", unikraft.TypeNameVersion(template), packmanager.NewQuery(qopts...).String())
 						}
 
 						return nil
@@ -244,7 +249,7 @@ func (opts *PullOptions) Run(ctx context.Context, args []string) error {
 						}
 
 						return fmt.Errorf("too many options for %s and prompting has been disabled",
-							project.Template().String(),
+							template.String(),
 						)
 					}
 
@@ -289,7 +294,7 @@ func (opts *PullOptions) Run(ctx context.Context, args []string) error {
 				}
 			}
 
-			templateWorkdir, err := unikraft.PlaceComponent(opts.Output, project.Template().Type(), project.Template().Name())
+			templateWorkdir, err := unikraft.PlaceComponent(opts.Output, template.Type(), template.Name())
 			if err != nil {
 				return err
 			}

--- a/internal/cli/kraft/run/run.go
+++ b/internal/cli/kraft/run/run.go
@@ -30,35 +30,37 @@ import (
 	"kraftkit.sh/packmanager"
 	"kraftkit.sh/tui/selection"
 	ukarch "kraftkit.sh/unikraft/arch"
+
+	kraftfilev07 "unikraft.com/x/kraftfile"
 )
 
 type RunOptions struct {
-	Architecture   string        `long:"arch" short:"m" usage:"Set the architecture"`
-	Detach         bool          `long:"detach" short:"d" usage:"Run unikernel in background"`
-	DisableAccel   bool          `long:"disable-acceleration" short:"W" usage:"Disable acceleration of CPU (usually enables TCG)"`
-	Env            []string      `long:"env" short:"e" usage:"Set environment variables, int the format key[=value]" split:"false"`
-	InitRd         string        `long:"initrd" usage:"Use the specified initrd (readonly)" hidden:"true"`
-	IP             string        `long:"ip" usage:"Assign the provided IP address"`
-	KeepFileOwners bool          `noattribute:"true"`
-	KernelArgs     []string      `long:"kernel-arg" short:"a" usage:"Set additional kernel arguments"`
-	Kraftfile      string        `long:"kraftfile" short:"K" usage:"Set an alternative path of the Kraftfile"`
-	MacAddress     string        `long:"mac" usage:"Assign the provided MAC address"`
-	Memory         string        `long:"memory" short:"M" usage:"Assign memory to the unikernel (K/Ki, M/Mi, G/Gi)" default:"64Mi"`
-	Name           string        `long:"name" short:"n" usage:"Name of the instance"`
-	Networks       []string      `long:"network" usage:"Attach instance to the provided network, in the format <network>[:ip[/mask][:gw[:dns0[:dns1[:hostname[:domain]]]]]], e.g. kraft0:172.100.0.2"`
-	NoStart        bool          `long:"no-start" usage:"Do not start the machine"`
-	Platform       string        `noattribute:"true"`
-	Ports          []string      `long:"port" short:"p" usage:"Publish a machine's port(s) to the host" split:"false"`
-	Prefix         string        `long:"prefix" usage:"Prefix each log line with the given string"`
-	PrefixName     bool          `long:"prefix-name" usage:"Prefix each log line with the machine name"`
-	Remove         bool          `long:"rm" usage:"Automatically remove the unikernel when it shutsdown"`
-	Rootfs         string        `long:"rootfs" usage:"Specify a path to use as root file system (can be volume or initramfs)"`
-	RootfsType     initrd.FsType `noattribute:"true"`
-	RunAs          string        `long:"as" usage:"Force a specific runner"`
-	Runtime        string        `long:"runtime" short:"r" usage:"Set an alternative unikernel runtime"`
-	Target         string        `long:"target" short:"t" usage:"Explicitly use the defined project target"`
-	Volumes        []string      `long:"volume" short:"v" usage:"Bind a volume to the instance"`
-	WithKernelDbg  bool          `long:"symbolic" usage:"Use the debuggable (symbolic) unikernel"`
+	Architecture   string              `long:"arch" short:"m" usage:"Set the architecture"`
+	Detach         bool                `long:"detach" short:"d" usage:"Run unikernel in background"`
+	DisableAccel   bool                `long:"disable-acceleration" short:"W" usage:"Disable acceleration of CPU (usually enables TCG)"`
+	Env            []string            `long:"env" short:"e" usage:"Set environment variables, int the format key[=value]" split:"false"`
+	InitRd         string              `long:"initrd" usage:"Use the specified initrd (readonly)" hidden:"true"`
+	IP             string              `long:"ip" usage:"Assign the provided IP address"`
+	KeepFileOwners bool                `noattribute:"true"`
+	KernelArgs     []string            `long:"kernel-arg" short:"a" usage:"Set additional kernel arguments"`
+	Kraftfile      string              `long:"kraftfile" short:"K" usage:"Set an alternative path of the Kraftfile"`
+	MacAddress     string              `long:"mac" usage:"Assign the provided MAC address"`
+	Memory         string              `long:"memory" short:"M" usage:"Assign memory to the unikernel (K/Ki, M/Mi, G/Gi)" default:"64Mi"`
+	Name           string              `long:"name" short:"n" usage:"Name of the instance"`
+	Networks       []string            `long:"network" usage:"Attach instance to the provided network, in the format <network>[:ip[/mask][:gw[:dns0[:dns1[:hostname[:domain]]]]]], e.g. kraft0:172.100.0.2"`
+	NoStart        bool                `long:"no-start" usage:"Do not start the machine"`
+	Platform       string              `noattribute:"true"`
+	Ports          []string            `long:"port" short:"p" usage:"Publish a machine's port(s) to the host" split:"false"`
+	Prefix         string              `long:"prefix" usage:"Prefix each log line with the given string"`
+	PrefixName     bool                `long:"prefix-name" usage:"Prefix each log line with the machine name"`
+	Remove         bool                `long:"rm" usage:"Automatically remove the unikernel when it shutsdown"`
+	Rootfs         string              `long:"rootfs" usage:"Specify a path to use as root file system (can be volume or initramfs)"`
+	RootfsType     kraftfilev07.FsType `noattribute:"true"`
+	RunAs          string              `long:"as" usage:"Force a specific runner"`
+	Runtime        string              `long:"runtime" short:"r" usage:"Set an alternative unikernel runtime"`
+	Target         string              `long:"target" short:"t" usage:"Explicitly use the defined project target"`
+	Volumes        []string            `long:"volume" short:"v" usage:"Bind a volume to the instance"`
+	WithKernelDbg  bool                `long:"symbolic" usage:"Use the debuggable (symbolic) unikernel"`
 
 	workdir           string
 	platform          mplatform.Platform
@@ -145,7 +147,7 @@ func NewCmd() *cobra.Command {
 	)
 
 	cmd.Flags().Var(
-		cmdfactory.NewEnumFlag[initrd.FsType](
+		cmdfactory.NewEnumFlag[kraftfilev07.FsType](
 			initrd.FsTypes(),
 			initrd.FsTypeCpio,
 		),
@@ -164,7 +166,7 @@ func (opts *RunOptions) Pre(cmd *cobra.Command, _ []string) error {
 	opts.hostPlatform = mplatform.PlatformUnknown
 	opts.hostMode = mplatform.SystemUnknown
 	if cmd.Flag("rootfs-type").Changed && cmd.Flag("rootfs-type").Value.String() != "" {
-		opts.RootfsType = initrd.FsType(cmd.Flag("rootfs-type").Value.String())
+		opts.RootfsType = kraftfilev07.FsType(cmd.Flag("rootfs-type").Value.String())
 	}
 
 	if opts.RunAs == "" || !set.NewStringSet("kernel", "project").Contains(opts.RunAs) {

--- a/internal/cli/kraft/run/runner_kraftfile_runtime.go
+++ b/internal/cli/kraft/run/runner_kraftfile_runtime.go
@@ -24,6 +24,7 @@ import (
 	"kraftkit.sh/tui/selection"
 	"kraftkit.sh/unikraft/app"
 	"kraftkit.sh/unikraft/export/v0/ukrandom"
+	ukruntime "kraftkit.sh/unikraft/runtime"
 	"kraftkit.sh/unikraft/target"
 )
 
@@ -98,19 +99,22 @@ func (runner *runnerKraftfileRuntime) Prepare(ctx context.Context, opts *RunOpti
 	var targ target.Target
 
 	targets := runner.project.Targets()
-	var qopts []packmanager.QueryOption
-	var runtimeName string
+
+	queryRuntime := runner.project.Runtime()
 	if len(opts.Runtime) > 0 {
-		runtimeName = opts.Runtime
-		qopts = []packmanager.QueryOption{
-			packmanager.WithName(opts.Runtime),
-		}
-	} else {
-		runtimeName = fmt.Sprintf("%s:%s", runner.project.Runtime().Name(), runner.project.Runtime().Version())
-		qopts = []packmanager.QueryOption{
-			packmanager.WithName(runner.project.Runtime().Name()),
-			packmanager.WithVersion(runner.project.Runtime().Version()),
-		}
+		queryRuntime = &ukruntime.Runtime{}
+		queryRuntime.SetName(opts.Runtime)
+	}
+
+	runtimeName := queryRuntime.Reference()
+	queryName := queryRuntime.QueryName()
+	queryVersion := queryRuntime.QueryVersion()
+
+	qopts := []packmanager.QueryOption{
+		packmanager.WithName(queryName),
+	}
+	if queryVersion != "" {
+		qopts = append(qopts, packmanager.WithVersion(queryVersion))
 	}
 
 	if len(targets) == 1 {

--- a/oci/pack.go
+++ b/oci/pack.go
@@ -53,6 +53,8 @@ import (
 	"kraftkit.sh/unikraft/arch"
 	"kraftkit.sh/unikraft/plat"
 	"kraftkit.sh/unikraft/target"
+
+	kraftfilev07 "unikraft.com/x/kraftfile"
 )
 
 const ConfigFilename = "config.json"
@@ -75,7 +77,7 @@ type ociPackage struct {
 	kernel    string
 	kernelDbg string
 	initrd    initrd.Initrd
-	roms      []string
+	roms      []kraftfilev07.FS
 	command   []string
 	env       []string
 	labels    map[string]string
@@ -406,10 +408,10 @@ func (ocipack *ociPackage) build(ctx context.Context) (*ociPackage, error) {
 
 	for _, rom := range ocipack.Roms() {
 		log.G(ctx).
-			WithField("rom", rom).
+			WithField("rom", rom.Source).
 			Trace("layer")
-		if err := ocipack.manifest.AddRom(ctx, rom); err != nil {
-			return nil, fmt.Errorf("could not add ROM '%s' to manifest: %w", rom, err)
+		if err := ocipack.manifest.AddRom(ctx, rom.Source); err != nil {
+			return nil, fmt.Errorf("could not add ROM '%s' to manifest: %w", rom.Source, err)
 		}
 	}
 
@@ -1455,7 +1457,7 @@ func (ocipack *ociPackage) Initrd() initrd.Initrd {
 }
 
 // Roms implements unikraft.target.Target
-func (ocipack *ociPackage) Roms() []string {
+func (ocipack *ociPackage) Roms() []kraftfilev07.FS {
 	return ocipack.roms
 }
 

--- a/packmanager/pack_options.go
+++ b/packmanager/pack_options.go
@@ -9,6 +9,8 @@ import (
 	"kraftkit.sh/kconfig"
 	"kraftkit.sh/unikraft/arch"
 	"kraftkit.sh/unikraft/plat"
+
+	kraftfilev07 "unikraft.com/x/kraftfile"
 )
 
 // PackOptions contains the list of options which can be set when packaging a
@@ -20,7 +22,7 @@ type PackOptions struct {
 	args           []string
 	env            []string
 	initrd         initrd.Initrd
-	roms           []string
+	roms           []kraftfilev07.FS
 	kconfig        kconfig.KeyValueMap
 	kernel         string
 	kernelDbg      string
@@ -76,7 +78,7 @@ func (popts *PackOptions) Initrd() initrd.Initrd {
 }
 
 // Auxiliary read-only memory blobs.
-func (popts *PackOptions) Roms() []string {
+func (popts *PackOptions) Roms() []kraftfilev07.FS {
 	return popts.roms
 }
 
@@ -168,7 +170,7 @@ func PackInitrd(rootfs initrd.Initrd) PackOption {
 }
 
 // PackRoms includes auxiliary read-only memory blobs in the package.
-func PackRoms(roms ...string) PackOption {
+func PackRoms(roms ...kraftfilev07.FS) PackOption {
 	return func(popts *PackOptions) {
 		popts.roms = roms
 	}

--- a/unikraft/app/application.go
+++ b/unikraft/app/application.go
@@ -19,6 +19,8 @@ import (
 	"github.com/xlab/treeprint"
 	"gopkg.in/yaml.v3"
 
+	kraftfilev07 "unikraft.com/x/kraftfile"
+
 	"kraftkit.sh/exec"
 	"kraftkit.sh/initrd"
 	"kraftkit.sh/internal/yamlmerger"
@@ -66,13 +68,13 @@ type Application interface {
 
 	// Auxiliary read-only memory blobs.  Used for arbitrary data which are
 	// mounted at runtime.
-	Roms() []string
+	Roms() []kraftfilev07.FS
 
 	// InitrdFsType returns the type of root filesystem to be used during runtime.
-	InitrdFsType() initrd.FsType
+	InitrdFsType() kraftfilev07.FsType
 
 	// SetInitrdFsType sets the type of root filesystem to be used during runtime.
-	SetInitrdFsType(initrd.FsType)
+	SetInitrdFsType(kraftfilev07.FsType)
 
 	// SetRootfs sets the root filesystem path for the application to the given
 	// value path.
@@ -182,7 +184,7 @@ type application struct {
 	workingDir    string
 	filename      string
 	outDir        string
-	fsType        initrd.FsType
+	fsType        kraftfilev07.FsType
 	template      *template.TemplateConfig
 	runtime       *runtime.Runtime
 	unikraft      *core.UnikraftConfig
@@ -193,7 +195,7 @@ type application struct {
 	env           target.Env
 	command       []string
 	rootfs        string
-	roms          []string
+	roms          []kraftfilev07.FS
 	kraftfile     *Kraftfile
 	loaderKind    ProjectLoader
 	specVersion   string
@@ -230,6 +232,10 @@ func (app *application) OutDir() string {
 }
 
 func (app *application) Template() *template.TemplateConfig {
+	// if the loader kind is v07, then template is already merged on project initialization, so returning nil to avoid triggering the legacy template merger
+	if app.LoaderKind() == ProjectLoaderV07 {
+		return nil
+	}
 	return app.template
 }
 
@@ -279,7 +285,7 @@ func (app *application) Rootfs() string {
 	return app.rootfs
 }
 
-func (app *application) Roms() []string {
+func (app *application) Roms() []kraftfilev07.FS {
 	return app.roms
 }
 
@@ -287,11 +293,11 @@ func (app *application) SetRootfs(rootfs string) {
 	app.rootfs = rootfs
 }
 
-func (app *application) SetInitrdFsType(fsType initrd.FsType) {
+func (app *application) SetInitrdFsType(fsType kraftfilev07.FsType) {
 	app.fsType = fsType
 }
 
-func (app *application) InitrdFsType() initrd.FsType {
+func (app *application) InitrdFsType() kraftfilev07.FsType {
 	return app.fsType
 }
 

--- a/unikraft/app/application.go
+++ b/unikraft/app/application.go
@@ -87,6 +87,12 @@ type Application interface {
 	// Kraftfile returns the application's kraft configuration file
 	Kraftfile() *Kraftfile
 
+	// LoaderKind returns which project loader produced this application.
+	LoaderKind() ProjectLoader
+
+	// SpecVersion returns the parsed Kraftfile specification version.
+	SpecVersion() string
+
 	// MergeTemplate merges the application's configuration with the given
 	// configuration
 	MergeTemplate(context.Context, Application) (Application, error)
@@ -189,6 +195,8 @@ type application struct {
 	rootfs        string
 	roms          []string
 	kraftfile     *Kraftfile
+	loaderKind    ProjectLoader
+	specVersion   string
 	configuration kconfig.KeyValueMap
 	extensions    component.Extensions
 }
@@ -238,14 +246,18 @@ func (app *application) Labels() map[string]string {
 }
 
 func (app *application) Libraries(ctx context.Context) (map[string]*lib.LibraryConfig, error) {
-	uklibs, err := app.Unikraft(ctx).Libraries(ctx)
-	if err != nil {
-		return nil, err
-	}
-
 	libs := map[string]*lib.LibraryConfig{}
 	for key, lib := range app.libraries {
 		libs[key] = lib
+	}
+
+	if app.Unikraft(ctx) == nil {
+		return libs, nil
+	}
+
+	uklibs, err := app.Unikraft(ctx).Libraries(ctx)
+	if err != nil {
+		return nil, err
 	}
 
 	for _, uklib := range uklibs {
@@ -293,6 +305,14 @@ func (app *application) Extensions() component.Extensions {
 
 func (app *application) Kraftfile() *Kraftfile {
 	return app.kraftfile
+}
+
+func (app *application) LoaderKind() ProjectLoader {
+	return app.loaderKind
+}
+
+func (app *application) SpecVersion() string {
+	return app.specVersion
 }
 
 func (app *application) MergeTemplate(ctx context.Context, merge Application) (Application, error) {
@@ -1102,6 +1122,10 @@ func saveNewKraftfile(ctx context.Context, app Application) error {
 }
 
 func (app *application) Save(ctx context.Context) error {
+	if app.LoaderKind() != ProjectLoaderLegacy {
+		return fmt.Errorf("%w: save requires the legacy Kraftfile loader", ErrProjectMutationNotSupported)
+	}
+
 	// Open the kratfile for reading
 	kraftfile, err := os.ReadFile(app.kraftfile.path)
 
@@ -1127,6 +1151,10 @@ func (app *application) Env() map[string]string {
 }
 
 func (app *application) RemoveLibrary(ctx context.Context, libraryName string) error {
+	if app.LoaderKind() != ProjectLoaderLegacy {
+		return fmt.Errorf("%w: removing libraries requires the legacy Kraftfile loader", ErrProjectMutationNotSupported)
+	}
+
 	isLibraryExistInProject := false
 	for libKey, lib := range app.libraries {
 		if lib.Name() == libraryName {
@@ -1167,6 +1195,10 @@ func (app *application) RemoveLibrary(ctx context.Context, libraryName string) e
 }
 
 func (app *application) AddLibrary(ctx context.Context, library lib.LibraryConfig) error {
+	if app.LoaderKind() != ProjectLoaderLegacy {
+		return fmt.Errorf("%w: adding libraries requires the legacy Kraftfile loader", ErrProjectMutationNotSupported)
+	}
+
 	if app.libraries == nil {
 		app.libraries = map[string]*lib.LibraryConfig{}
 	}

--- a/unikraft/app/application_options.go
+++ b/unikraft/app/application_options.go
@@ -31,6 +31,7 @@ func NewApplicationFromOptions(aopts ...ApplicationOption) (Application, error) 
 	var err error
 	ac := &application{
 		configuration: kconfig.KeyValueMap{},
+		loaderKind:    ProjectLoaderLegacy,
 	}
 
 	for _, o := range aopts {
@@ -196,6 +197,22 @@ func WithExtensions(extensions component.Extensions) ApplicationOption {
 func WithKraftfile(kraftfile *Kraftfile) ApplicationOption {
 	return func(ac *application) error {
 		ac.kraftfile = kraftfile
+		return nil
+	}
+}
+
+// WithLoaderKind records which loader produced the application.
+func WithLoaderKind(loaderKind ProjectLoader) ApplicationOption {
+	return func(ac *application) error {
+		ac.loaderKind = loaderKind
+		return nil
+	}
+}
+
+// WithSpecVersion records the parsed spec version of the underlying Kraftfile.
+func WithSpecVersion(specVersion string) ApplicationOption {
+	return func(ac *application) error {
+		ac.specVersion = specVersion
 		return nil
 	}
 }

--- a/unikraft/app/application_options.go
+++ b/unikraft/app/application_options.go
@@ -9,7 +9,6 @@ import (
 	"os"
 	"path/filepath"
 
-	"kraftkit.sh/initrd"
 	"kraftkit.sh/kconfig"
 	"kraftkit.sh/unikraft"
 	"kraftkit.sh/unikraft/app/volume"
@@ -19,6 +18,7 @@ import (
 	"kraftkit.sh/unikraft/runtime"
 	"kraftkit.sh/unikraft/target"
 	"kraftkit.sh/unikraft/template"
+	kraftfilev07 "unikraft.com/x/kraftfile"
 )
 
 // ApplicationOption is a function that manipulates the instantiation of an
@@ -130,15 +130,15 @@ func WithRootfs(rootfs string) ApplicationOption {
 }
 
 // WithFsType sets the application's rootfs filesystem type
-func WithFsType(fsType initrd.FsType) ApplicationOption {
+func WithFsType(fsType kraftfilev07.FsType) ApplicationOption {
 	return func(ac *application) error {
 		ac.fsType = fsType
 		return nil
 	}
 }
 
-// WithRoms sets the application's auxiliary read-only memory blobs.
-func WithRoms(roms ...string) ApplicationOption {
+// WithRomFilesystems sets the application's ROM filesystem descriptors.
+func WithRoms(roms ...kraftfilev07.FS) ApplicationOption {
 	return func(ac *application) error {
 		ac.roms = roms
 		return nil

--- a/unikraft/app/loader.go
+++ b/unikraft/app/loader.go
@@ -28,6 +28,8 @@ import (
 	"gopkg.in/yaml.v2"
 	"kraftkit.sh/initrd"
 	"kraftkit.sh/unikraft"
+
+	kraftfilev07 "unikraft.com/x/kraftfile"
 )
 
 const (
@@ -79,9 +81,9 @@ func NewApplicationFromInterface(ctx context.Context, iface map[string]interface
 				if !ok {
 					return nil, errors.New("rootfs type must be a string")
 				}
-				app.fsType = initrd.FsType(strings.ToLower(fsTypeStr))
+				app.fsType = kraftfilev07.FsType(strings.ToLower(fsTypeStr))
 			} else {
-				app.fsType = initrd.FsTypeCpio
+				app.fsType = kraftfilev07.FsTypeCpio
 			}
 
 			if s, ok := rootfsMap["source"]; ok {
@@ -98,13 +100,23 @@ func NewApplicationFromInterface(ctx context.Context, iface map[string]interface
 		}
 	}
 
-	romsSectionList := getSectionList(iface, "roms")
-	for _, rom := range romsSectionList {
-		romStr, ok := rom.(string)
-		if !ok {
-			return nil, errors.New("rom must be a string")
+	if romsSectionList := getSectionList(iface, "roms"); romsSectionList != nil {
+		for _, rom := range romsSectionList {
+			switch v := rom.(type) {
+			case string:
+				app.roms = append(app.roms, kraftfilev07.FS{
+					Source: v,
+				})
+			case map[string]any, map[any]any:
+				var fs kraftfilev07.FS
+				if err := Transform(ctx, v, &fs); err != nil {
+					return nil, err
+				}
+				app.roms = append(app.roms, fs)
+			default:
+				return nil, errors.Errorf("invalid type for rom: %T", v)
+			}
 		}
-		app.roms = append(app.roms, romStr)
 	}
 
 	if n, ok := iface["cmd"]; ok {

--- a/unikraft/app/loader_kind.go
+++ b/unikraft/app/loader_kind.go
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2026, Unikraft GmbH.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+
+package app
+
+import "fmt"
+
+// ProjectLoader identifies which Kraftfile loader path produced an Application.
+type ProjectLoader string
+
+const (
+	ProjectLoaderLegacy ProjectLoader = "legacy"
+	ProjectLoaderV07    ProjectLoader = "v0.7"
+)
+
+var ErrProjectMutationNotSupported = fmt.Errorf("project mutation is not supported for this Kraftfile loader")

--- a/unikraft/app/normalize.go
+++ b/unikraft/app/normalize.go
@@ -33,8 +33,8 @@ package app
 
 import (
 	"path/filepath"
-	"regexp"
-	"strings"
+
+	"kraftkit.sh/unikraft"
 )
 
 // normalize a kraft project by moving deprecated attributes to their canonical
@@ -71,8 +71,5 @@ func absKraftfile(kraftFile *Kraftfile) (*Kraftfile, error) {
 }
 
 func normalizeProjectName(s string) string {
-	r := regexp.MustCompile("[a-z0-9_-]")
-	s = strings.ToLower(s)
-	s = strings.Join(r.FindAllString(s, -1), "")
-	return strings.TrimLeft(s, "_-")
+	return unikraft.NormalizeProjectName(s)
 }

--- a/unikraft/app/project.go
+++ b/unikraft/app/project.go
@@ -49,34 +49,12 @@ func IsWorkdirInitialized(dir string) bool {
 	return len(findFiles(DefaultFileNames, dir)) > 0
 }
 
-// NewProjectFromOptions load a kraft project based on command line options
-func NewProjectFromOptions(ctx context.Context, opts ...ProjectOption) (Application, error) {
-	popts, err := NewProjectOptions(opts...)
-	if err != nil {
-		return nil, fmt.Errorf("could not apply project options: %v", err)
-	}
-
-	workdir, err := popts.Workdir()
-	if err != nil {
-		return nil, err
-	}
-
-	absWorkdir, err := filepath.Abs(workdir)
-	if err != nil {
-		return nil, err
-	}
-
-	if popts.name != "" {
-		popts.SetProjectName(popts.name, false)
-	} else {
-		popts.SetProjectName(filepath.Base(absWorkdir), true)
-	}
-
-	if popts.kraftfile == nil {
-		return nil, ErrNoKraftfile
-	}
-
+func newLegacyProjectFromOptions(ctx context.Context, popts *ProjectOptions) (Application, error) {
 	name, _ := popts.GetProjectName()
+	specVersion, err := sniffKraftfileSpecVersion(popts.kraftfile.content)
+	if err != nil {
+		return nil, err
+	}
 
 	var outdir string
 	if popts.outDir == "" {
@@ -123,7 +101,7 @@ func NewProjectFromOptions(ctx context.Context, opts ...ProjectOption) (Applicat
 
 	uk := &unikraft.Context{
 		UK_NAME:   name,
-		UK_BASE:   popts.RelativePath(workdir),
+		UK_BASE:   popts.workdir,
 		BUILD_DIR: outdir,
 	}
 
@@ -192,6 +170,8 @@ func NewProjectFromOptions(ctx context.Context, opts ...ProjectOption) (Applicat
 		WithKraftfile(popts.kraftfile),
 		WithVolumes(app.volumes...),
 		WithEnv(app.env),
+		WithLoaderKind(ProjectLoaderLegacy),
+		WithSpecVersion(specVersion),
 	)
 	if err != nil {
 		return nil, err

--- a/unikraft/app/project_loader.go
+++ b/unikraft/app/project_loader.go
@@ -68,7 +68,7 @@ func sniffKraftfileSpecVersion(content []byte) (string, error) {
 	spec := firstNonEmpty(header.Spec, header.Specification)
 	spec = strings.TrimSpace(spec)
 	if spec == "" {
-		return "", fmt.Errorf("missing 'spec' version attribute")
+		return "", nil
 	}
 
 	if !strings.HasPrefix(spec, "v") {

--- a/unikraft/app/project_loader.go
+++ b/unikraft/app/project_loader.go
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2026, Unikraft GmbH.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+
+package app
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"sigs.k8s.io/yaml"
+)
+
+// NewProjectFromOptions load a kraft project based on command line options.
+func NewProjectFromOptions(ctx context.Context, opts ...ProjectOption) (Application, error) {
+	popts, err := NewProjectOptions(opts...)
+	if err != nil {
+		return nil, fmt.Errorf("could not apply project options: %v", err)
+	}
+
+	workdir, err := popts.Workdir()
+	if err != nil {
+		return nil, err
+	}
+
+	absWorkdir, err := filepath.Abs(workdir)
+	if err != nil {
+		return nil, err
+	}
+
+	popts.workdir = absWorkdir
+
+	if popts.name != "" {
+		popts.SetProjectName(popts.name, false)
+	} else {
+		popts.SetProjectName(filepath.Base(absWorkdir), true)
+	}
+
+	if popts.kraftfile == nil {
+		return nil, ErrNoKraftfile
+	}
+
+	spec, err := sniffKraftfileSpecVersion(popts.kraftfile.content)
+	if err != nil {
+		return nil, err
+	}
+
+	if isV07SpecVersion(spec) {
+		return newProjectFromOptionsV07(ctx, popts)
+	}
+
+	return newLegacyProjectFromOptions(ctx, popts)
+}
+
+func sniffKraftfileSpecVersion(content []byte) (string, error) {
+	var header struct {
+		Spec          string `json:"spec,omitempty"`
+		Specification string `json:"specification,omitempty"`
+	}
+
+	if err := yaml.Unmarshal(content, &header); err != nil {
+		return "", err
+	}
+
+	spec := firstNonEmpty(header.Spec, header.Specification)
+	spec = strings.TrimSpace(spec)
+	if spec == "" {
+		return "", fmt.Errorf("missing 'spec' version attribute")
+	}
+
+	if !strings.HasPrefix(spec, "v") {
+		spec = "v" + spec
+	}
+
+	parts := strings.Split(strings.TrimPrefix(spec, "v"), ".")
+	if len(parts) < 2 {
+		return spec, nil
+	}
+
+	return "v" + parts[0] + "." + parts[1], nil
+}
+
+func isV07SpecVersion(spec string) bool {
+	return spec == ProjectLoaderV07.String()
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if value != "" {
+			return value
+		}
+	}
+
+	return ""
+}
+
+func (loader ProjectLoader) String() string {
+	return string(loader)
+}

--- a/unikraft/app/project_v07.go
+++ b/unikraft/app/project_v07.go
@@ -17,7 +17,6 @@ import (
 
 	kraftfilev07 "unikraft.com/x/kraftfile"
 
-	"kraftkit.sh/initrd"
 	"kraftkit.sh/kconfig"
 	"kraftkit.sh/log"
 	"kraftkit.sh/unikraft"
@@ -35,13 +34,36 @@ func newProjectFromOptionsV07(ctx context.Context, popts *ProjectOptions) (Appli
 		return nil, err
 	}
 
-	popts.kraftfile.config = map[string]interface{}{
-		"spec": doc.Spec,
-	}
-
 	name, _ := popts.GetProjectName()
 	if doc.Name != "" {
 		name = doc.Name
+	}
+
+	ukContext := &unikraft.Context{
+		UK_NAME: name,
+		UK_BASE: popts.workdir,
+	}
+	ctx = unikraft.WithContext(ctx, ukContext)
+
+	if doc.Template != nil {
+		opts := []TemplateResolutionOption{}
+		if popts.workdir != "" {
+			opts = append(opts, WithTemplateResolutionWorkdir(popts.workdir))
+		}
+		doc, err = ResolveTemplate(ctx, doc, opts...)
+		if err != nil {
+			return nil, err
+		}
+
+		// Update name if the template resolution changed it or populated it.
+		if doc.Name != "" {
+			name = doc.Name
+			ukContext.UK_NAME = doc.Name
+		}
+	}
+
+	popts.kraftfile.config = map[string]any{
+		"spec": doc.Spec,
 	}
 
 	outdir, err := v07OutDirFromProjectOptions(popts)
@@ -49,14 +71,8 @@ func newProjectFromOptionsV07(ctx context.Context, popts *ProjectOptions) (Appli
 		return nil, err
 	}
 
-	ukContext := &unikraft.Context{
-		UK_NAME:   name,
-		UK_BASE:   popts.workdir,
-		BUILD_DIR: outdir,
-	}
+	ukContext.BUILD_DIR = outdir
 
-	// Phase 1 keeps a KraftKit-managed build directory to avoid destabilizing the
-	// current build/run/pkg flows while v0.7 support lands.
 	if _, err := os.Stat(ukContext.BUILD_DIR); err != nil && os.IsNotExist(err) {
 		if err := os.MkdirAll(ukContext.BUILD_DIR, 0o755); err != nil {
 			return nil, fmt.Errorf("creating build directory: %w", err)
@@ -66,11 +82,6 @@ func newProjectFromOptionsV07(ctx context.Context, popts *ProjectOptions) (Appli
 	ctx = unikraft.WithContext(ctx, ukContext)
 
 	unikraftConfig, err := v07CoreFromDocument(ctx, doc.Unikraft)
-	if err != nil {
-		return nil, err
-	}
-
-	templateConfig, err := v07TemplateFromDocument(ctx, doc.Template)
 	if err != nil {
 		return nil, err
 	}
@@ -115,7 +126,6 @@ func newProjectFromOptionsV07(ctx context.Context, popts *ProjectOptions) (Appli
 		WithRootfs(rootfs),
 		WithFsType(fsType),
 		WithRoms(roms...),
-		WithTemplate(templateConfig),
 		WithCommand(doc.Cmd...),
 		WithLabels(maps.Clone(doc.Labels)),
 		WithLibraries(libraries),
@@ -157,7 +167,7 @@ func v07CoreFromDocument(ctx context.Context, doc *kraftfilev07.Unikraft) (*core
 		return nil, nil
 	}
 
-	value := map[string]interface{}{}
+	value := map[string]any{}
 	if doc.Source != "" {
 		value["source"] = doc.Source
 	}
@@ -182,7 +192,7 @@ func v07TemplateFromDocument(ctx context.Context, doc *kraftfilev07.Template) (*
 		return nil, nil
 	}
 
-	value := map[string]interface{}{}
+	value := map[string]any{}
 	if name := guessNameFromSource(doc.Source); name != "" {
 		value["name"] = name
 	}
@@ -230,7 +240,7 @@ func v07LibrariesFromDocument(ctx context.Context, docs map[string]kraftfilev07.
 
 	libraries := make(map[string]*lib.LibraryConfig, len(docs))
 	for name, doc := range docs {
-		value := map[string]interface{}{}
+		value := map[string]any{}
 		if doc.Source != "" {
 			value["source"] = doc.Source
 		}
@@ -260,7 +270,7 @@ func v07TargetsFromDocument(ctx context.Context, docs []kraftfilev07.Target) ([]
 
 	targets := make([]*target.TargetConfig, 0, len(docs))
 	for _, doc := range docs {
-		value := map[string]interface{}{}
+		value := map[string]any{}
 		if doc.Arch != "" {
 			value["arch"] = doc.Arch
 		}
@@ -290,7 +300,7 @@ func v07VolumesFromDocument(ctx context.Context, docs kraftfilev07.Volumes) ([]*
 
 	volumes := make([]*volume.VolumeConfig, 0, len(docs))
 	for _, doc := range docs {
-		value := map[string]interface{}{}
+		value := map[string]any{}
 		if doc.Driver != "" {
 			value["driver"] = doc.Driver
 		}
@@ -319,25 +329,25 @@ func v07VolumesFromDocument(ctx context.Context, docs kraftfilev07.Volumes) ([]*
 	return volumes, nil
 }
 
-func v07RootfsAndRomsFromDocument(rootfs *kraftfilev07.FS, roms []kraftfilev07.FS) (string, initrd.FsType, []string) {
+func v07RootfsAndRomsFromDocument(rootfs *kraftfilev07.FS, roms []kraftfilev07.FS) (string, kraftfilev07.FsType, []kraftfilev07.FS) {
 	var (
 		rootfsPath string
-		fsType     initrd.FsType
-		rawRoms    []string
+		fsType     kraftfilev07.FsType
+		rawRoms    []kraftfilev07.FS
 	)
 
 	if rootfs != nil {
 		rootfsPath = rootfs.Source
 		if rootfs.Format != "" {
-			fsType = initrd.FsType(rootfs.Format.String())
+			fsType = kraftfilev07.FsType(rootfs.Format.String())
 		}
 	}
 
 	for _, rom := range roms {
-		rawRoms = append(rawRoms, rom.Source)
-		if fsType == "" && rom.Format != "" {
-			fsType = initrd.FsType(rom.Format.String())
-		}
+		rawRoms = append(rawRoms, kraftfilev07.FS{
+			Source: rom.Source,
+			Format: kraftfilev07.FsType(rom.Format.String()),
+		})
 	}
 
 	return rootfsPath, fsType, rawRoms

--- a/unikraft/app/project_v07.go
+++ b/unikraft/app/project_v07.go
@@ -1,0 +1,367 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2026, Unikraft GmbH.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+
+package app
+
+import (
+	"context"
+	"fmt"
+	"maps"
+	"net/url"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+
+	kraftfilev07 "unikraft.com/x/kraftfile"
+
+	"kraftkit.sh/initrd"
+	"kraftkit.sh/kconfig"
+	"kraftkit.sh/log"
+	"kraftkit.sh/unikraft"
+	"kraftkit.sh/unikraft/app/volume"
+	"kraftkit.sh/unikraft/core"
+	"kraftkit.sh/unikraft/lib"
+	"kraftkit.sh/unikraft/runtime"
+	"kraftkit.sh/unikraft/target"
+	"kraftkit.sh/unikraft/template"
+)
+
+func newProjectFromOptionsV07(ctx context.Context, popts *ProjectOptions) (Application, error) {
+	doc, err := kraftfilev07.ParseBytes(popts.kraftfile.content)
+	if err != nil {
+		return nil, err
+	}
+
+	popts.kraftfile.config = map[string]interface{}{
+		"spec": doc.Spec,
+	}
+
+	name, _ := popts.GetProjectName()
+	if doc.Name != "" {
+		name = doc.Name
+	}
+
+	outdir, err := v07OutDirFromProjectOptions(popts)
+	if err != nil {
+		return nil, err
+	}
+
+	ukContext := &unikraft.Context{
+		UK_NAME:   name,
+		UK_BASE:   popts.workdir,
+		BUILD_DIR: outdir,
+	}
+
+	// Phase 1 keeps a KraftKit-managed build directory to avoid destabilizing the
+	// current build/run/pkg flows while v0.7 support lands.
+	if _, err := os.Stat(ukContext.BUILD_DIR); err != nil && os.IsNotExist(err) {
+		if err := os.MkdirAll(ukContext.BUILD_DIR, 0o755); err != nil {
+			return nil, fmt.Errorf("creating build directory: %w", err)
+		}
+	}
+
+	ctx = unikraft.WithContext(ctx, ukContext)
+
+	unikraftConfig, err := v07CoreFromDocument(ctx, doc.Unikraft)
+	if err != nil {
+		return nil, err
+	}
+
+	templateConfig, err := v07TemplateFromDocument(ctx, doc.Template)
+	if err != nil {
+		return nil, err
+	}
+
+	runtimeConfig, err := v07RuntimeFromDocument(doc.Runtime)
+	if err != nil {
+		return nil, err
+	}
+
+	libraries, err := v07LibrariesFromDocument(ctx, doc.Libraries)
+	if err != nil {
+		return nil, err
+	}
+
+	if unikraftConfig != nil {
+		popts.kconfig.OverrideBy(unikraftConfig.KConfig())
+	}
+
+	for _, library := range libraries {
+		popts.kconfig.OverrideBy(library.KConfig())
+	}
+
+	targets, err := v07TargetsFromDocument(ctx, doc.Targets)
+	if err != nil {
+		return nil, err
+	}
+
+	volumes, err := v07VolumesFromDocument(ctx, doc.Volumes)
+	if err != nil {
+		return nil, err
+	}
+
+	rootfs, fsType, roms := v07RootfsAndRomsFromDocument(doc.Rootfs, doc.Roms)
+
+	project, err := NewApplicationFromOptions(
+		WithName(name),
+		WithWorkingDir(popts.workdir),
+		WithFilename(popts.kraftfile.path),
+		WithOutDir(outdir),
+		WithUnikraft(unikraftConfig),
+		WithRuntime(runtimeConfig),
+		WithRootfs(rootfs),
+		WithFsType(fsType),
+		WithRoms(roms...),
+		WithTemplate(templateConfig),
+		WithCommand(doc.Cmd...),
+		WithLabels(maps.Clone(doc.Labels)),
+		WithLibraries(libraries),
+		WithTargets(targets),
+		WithConfiguration(popts.kconfig.Slice()...),
+		WithKraftfile(popts.kraftfile),
+		WithVolumes(volumes...),
+		WithEnv(doc.Env.AsStringMap()),
+		WithLoaderKind(ProjectLoaderV07),
+		WithSpecVersion(doc.Spec),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, targ := range project.Targets() {
+		kvmap, err := kconfig.NewKeyValueMapFromFile(filepath.Join(popts.workdir, targ.ConfigFilename()))
+		if err != nil {
+			log.G(ctx).Tracef("skipping uninitialized target config file: %v", err)
+			continue
+		}
+
+		targ.KConfig().OverrideBy(kvmap)
+	}
+
+	return project, nil
+}
+
+func v07OutDirFromProjectOptions(popts *ProjectOptions) (string, error) {
+	if popts.outDir == "" {
+		return popts.RelativePath(unikraft.BuildDir), nil
+	}
+
+	return filepath.Abs(popts.outDir)
+}
+
+func v07CoreFromDocument(ctx context.Context, doc *kraftfilev07.Unikraft) (*core.UnikraftConfig, error) {
+	if doc == nil {
+		return nil, nil
+	}
+
+	value := map[string]interface{}{}
+	if doc.Source != "" {
+		value["source"] = doc.Source
+	}
+	if doc.Version != "" {
+		value["version"] = doc.Version
+	}
+	if kconf := doc.KConfig.AsMap(); len(kconf) > 0 {
+		value["kconfig"] = kconf
+	}
+
+	transformed, err := core.TransformFromSchema(ctx, value)
+	if err != nil {
+		return nil, err
+	}
+
+	config := transformed.(core.UnikraftConfig)
+	return &config, nil
+}
+
+func v07TemplateFromDocument(ctx context.Context, doc *kraftfilev07.Template) (*template.TemplateConfig, error) {
+	if doc == nil {
+		return nil, nil
+	}
+
+	value := map[string]interface{}{}
+	if name := guessNameFromSource(doc.Source); name != "" {
+		value["name"] = name
+	}
+	if doc.Source != "" {
+		value["source"] = doc.Source
+	}
+	if doc.Version != "" {
+		value["version"] = doc.Version
+	}
+
+	transformed, err := template.TransformFromSchema(ctx, value)
+	if err != nil {
+		return nil, err
+	}
+
+	config := transformed.(template.TemplateConfig)
+	return &config, nil
+}
+
+func v07RuntimeFromDocument(doc *kraftfilev07.Runtime) (*runtime.Runtime, error) {
+	if doc == nil {
+		return nil, nil
+	}
+
+	ref := string(*doc)
+	if ref == "" {
+		return nil, nil
+	}
+
+	config := &runtime.Runtime{}
+	if err := runtime.WithName(ref)(config); err != nil {
+		return nil, err
+	}
+	if err := runtime.WithSource(ref)(config); err != nil {
+		return nil, err
+	}
+
+	return config, nil
+}
+
+func v07LibrariesFromDocument(ctx context.Context, docs map[string]kraftfilev07.Library) (map[string]*lib.LibraryConfig, error) {
+	if len(docs) == 0 {
+		return nil, nil
+	}
+
+	libraries := make(map[string]*lib.LibraryConfig, len(docs))
+	for name, doc := range docs {
+		value := map[string]interface{}{}
+		if doc.Source != "" {
+			value["source"] = doc.Source
+		}
+		if doc.Version != "" {
+			value["version"] = doc.Version
+		}
+		if kconf := doc.KConfig.AsMap(); len(kconf) > 0 {
+			value["kconfig"] = kconf
+		}
+
+		config, err := lib.TransformFromSchema(ctx, name, value)
+		if err != nil {
+			return nil, err
+		}
+
+		library := config
+		libraries[name] = &library
+	}
+
+	return libraries, nil
+}
+
+func v07TargetsFromDocument(ctx context.Context, docs []kraftfilev07.Target) ([]*target.TargetConfig, error) {
+	if len(docs) == 0 {
+		return nil, nil
+	}
+
+	targets := make([]*target.TargetConfig, 0, len(docs))
+	for _, doc := range docs {
+		value := map[string]interface{}{}
+		if doc.Arch != "" {
+			value["arch"] = doc.Arch
+		}
+		if doc.Plat != "" {
+			value["plat"] = doc.Plat
+		}
+		if kconf := doc.KConfig.AsMap(); len(kconf) > 0 {
+			value["kconfig"] = kconf
+		}
+
+		transformed, err := target.TransformFromSchema(ctx, value)
+		if err != nil {
+			return nil, err
+		}
+
+		config := transformed.(target.TargetConfig)
+		targets = append(targets, &config)
+	}
+
+	return targets, nil
+}
+
+func v07VolumesFromDocument(ctx context.Context, docs kraftfilev07.Volumes) ([]*volume.VolumeConfig, error) {
+	if len(docs) == 0 {
+		return nil, nil
+	}
+
+	volumes := make([]*volume.VolumeConfig, 0, len(docs))
+	for _, doc := range docs {
+		value := map[string]interface{}{}
+		if doc.Driver != "" {
+			value["driver"] = doc.Driver
+		}
+		if doc.Source != "" {
+			value["source"] = doc.Source
+		}
+		if doc.Destination != "" {
+			value["destination"] = doc.Destination
+		}
+		if doc.Mode != nil {
+			value["mode"] = doc.Mode
+		}
+		if doc.ReadOnly {
+			value["readonly"] = doc.ReadOnly
+		}
+
+		transformed, err := volume.TransformFromSchema(ctx, value)
+		if err != nil {
+			return nil, err
+		}
+
+		config := transformed.(volume.VolumeConfig)
+		volumes = append(volumes, &config)
+	}
+
+	return volumes, nil
+}
+
+func v07RootfsAndRomsFromDocument(rootfs *kraftfilev07.FS, roms []kraftfilev07.FS) (string, initrd.FsType, []string) {
+	var (
+		rootfsPath string
+		fsType     initrd.FsType
+		rawRoms    []string
+	)
+
+	if rootfs != nil {
+		rootfsPath = rootfs.Source
+		if rootfs.Format != "" {
+			fsType = initrd.FsType(rootfs.Format.String())
+		}
+	}
+
+	for _, rom := range roms {
+		rawRoms = append(rawRoms, rom.Source)
+		if fsType == "" && rom.Format != "" {
+			fsType = initrd.FsType(rom.Format.String())
+		}
+	}
+
+	return rootfsPath, fsType, rawRoms
+}
+
+func guessNameFromSource(source string) string {
+	if source == "" {
+		return ""
+	}
+
+	candidate := source
+	if parsed, err := url.Parse(source); err == nil && parsed.Host != "" {
+		candidate = parsed.Path
+	}
+
+	candidate = strings.TrimSuffix(candidate, ".git")
+	candidate = strings.TrimSuffix(candidate, ".tar.gz")
+	candidate = strings.TrimSuffix(candidate, "/")
+
+	name := path.Base(candidate)
+	switch name {
+	case ".", "/", "":
+		return ""
+	default:
+		return name
+	}
+}

--- a/unikraft/app/project_v07_test.go
+++ b/unikraft/app/project_v07_test.go
@@ -7,13 +7,12 @@ package app
 
 import (
 	"context"
-	"errors"
 	"os"
 	"path/filepath"
 	"testing"
 
 	"kraftkit.sh/initrd"
-	uklib "kraftkit.sh/unikraft/lib"
+	kraftfilev07 "unikraft.com/x/kraftfile"
 )
 
 func Test_sniffKraftfileSpecVersion(t *testing.T) {
@@ -39,9 +38,9 @@ func Test_sniffKraftfileSpecVersion(t *testing.T) {
 			want:  "v0.6",
 		},
 		{
-			name:    "missing spec attribute",
-			input:   "runtime: base:latest\n",
-			wantErr: true,
+			name:  "missing spec attribute defaults to legacy dispatch",
+			input: "runtime: base:latest\n",
+			want:  "",
 		},
 	}
 
@@ -63,7 +62,7 @@ func Test_sniffKraftfileSpecVersion(t *testing.T) {
 	}
 }
 
-func TestNewProjectFromOptionsDispatchesBySpecVersion(t *testing.T) {
+func Test_NewProjectFromOptions_SpecVersionDispatch(t *testing.T) {
 	tests := []struct {
 		name       string
 		content    string
@@ -90,6 +89,16 @@ runtime: base:latest
 			wantLoader: ProjectLoaderV07,
 			wantSpec:   "v0.7",
 		},
+		{
+			name: "missing spec uses legacy loader",
+			content: `
+runtime: base:latest
+rootfs: ./Dockerfile
+cmd: ["/app"]
+`,
+			wantLoader: ProjectLoaderLegacy,
+			wantSpec:   "",
+		},
 	}
 
 	for _, tt := range tests {
@@ -107,7 +116,7 @@ runtime: base:latest
 	}
 }
 
-func TestV07ProjectNameSemantics(t *testing.T) {
+func Test_NewProjectFromOptionsV07_ProjectNameSemantics(t *testing.T) {
 	tests := []struct {
 		name    string
 		content string
@@ -151,7 +160,68 @@ runtime: base:latest
 	}
 }
 
-func TestV07ComponentStringsDoNotUseFilesystemHeuristics(t *testing.T) {
+func Test_NewProjectFromOptionsV07_TargetArtifactNames(t *testing.T) {
+	project := mustProjectFromBytes(t, t.TempDir(), `
+spec: v0.7
+name: My App_01
+unikraft: stable
+targets:
+  - plat: qemu
+    arch: x86_64
+`)
+
+	targets := project.Targets()
+	if len(targets) != 1 {
+		t.Fatalf("len(Targets()) = %d, want 1", len(targets))
+	}
+
+	wantKernel := filepath.Join(project.OutDir(), "myapp_01_qemu-x86_64")
+	if targets[0].Kernel() != wantKernel {
+		t.Errorf("targets[0].Kernel() = %q, want %q", targets[0].Kernel(), wantKernel)
+	}
+
+	if targets[0].ConfigFilename() != ".config.myapp_01_qemu-x86_64" {
+		t.Errorf("targets[0].ConfigFilename() = %q, want %q", targets[0].ConfigFilename(), ".config.myapp_01_qemu-x86_64")
+	}
+}
+
+func Test_NewProjectFromOptionsV07_CustomOutDir(t *testing.T) {
+	workdir := t.TempDir()
+	outdir := filepath.Join(workdir, "artifacts")
+
+	project, err := NewProjectFromOptions(
+		context.Background(),
+		WithProjectWorkdir(workdir),
+		WithProjectOutDir(outdir),
+		WithProjectKraftfileFromBytes([]byte(`
+spec: v0.7
+name: demo
+unikraft: stable
+targets:
+  - plat: qemu
+    arch: x86_64
+`)),
+	)
+	if err != nil {
+		t.Fatalf("NewProjectFromOptions() error = %v", err)
+	}
+
+	if project.OutDir() != outdir {
+		t.Errorf("OutDir() = %q, want %q", project.OutDir(), outdir)
+	}
+
+	targets := project.Targets()
+	if len(targets) != 1 {
+		t.Fatalf("len(Targets()) = %d, want 1", len(targets))
+	}
+
+	wantKernel := filepath.Join(outdir, "demo_qemu-x86_64")
+	if targets[0].Kernel() != wantKernel {
+		t.Errorf("targets[0].Kernel() = %q, want %q", targets[0].Kernel(), wantKernel)
+	}
+}
+
+func Test_NewProjectFromOptionsV07_ComponentStrings(t *testing.T) {
 	workdir := t.TempDir()
 	existingPath := filepath.Join(workdir, "stable")
 	if err := os.Mkdir(existingPath, 0o755); err != nil {
@@ -198,7 +268,7 @@ libraries:
 	}
 }
 
-func TestV07RuntimeReferenceIsPreserved(t *testing.T) {
+func Test_NewProjectFromOptionsV07_RuntimeReference(t *testing.T) {
 	project := mustProjectFromBytes(t, t.TempDir(), `
 spec: v0.7
 runtime: index.unikraft.io/official/base:latest
@@ -217,37 +287,67 @@ runtime: index.unikraft.io/official/base:latest
 	}
 }
 
-func TestV07TemplateSourceMapsToTemplateFields(t *testing.T) {
-	project := mustProjectFromBytes(t, t.TempDir(), `
-spec: v0.7
-template:
-  source: https://github.com/unikraft/catalog.git
-  version: stable
-unikraft: stable
-`)
-
-	if project.Template() == nil {
-		t.Fatal("expected template to be present")
+func Test_v07TemplateFromDocument(t *testing.T) {
+	// Test the v07 template converter directly since template resolution
+	// now happens at project load time and requires a package manager.
+	doc := &kraftfilev07.Template{
+		Source:  "https://github.com/unikraft/catalog.git",
+		Version: "stable",
 	}
 
-	if project.Template().Name() != "catalog" {
-		t.Errorf("Template().Name() = %q, want %q", project.Template().Name(), "catalog")
+	templateConfig, err := v07TemplateFromDocument(context.Background(), doc)
+	if err != nil {
+		t.Fatalf("v07TemplateFromDocument() error = %v", err)
 	}
 
-	if project.Template().Source() != "https://github.com/unikraft/catalog.git" {
-		t.Errorf("Template().Source() = %q, want original source", project.Template().Source())
+	if templateConfig == nil {
+		t.Fatal("expected template config to be present")
 	}
 
-	if project.Template().Version() != "stable" {
-		t.Errorf("Template().Version() = %q, want %q", project.Template().Version(), "stable")
+	if templateConfig.Name() != "catalog" {
+		t.Errorf("Name() = %q, want %q", templateConfig.Name(), "catalog")
 	}
 
-	if len(project.Template().KConfig()) != 0 {
-		t.Errorf("Template().KConfig() len = %d, want 0", len(project.Template().KConfig()))
+	if templateConfig.Source() != "https://github.com/unikraft/catalog.git" {
+		t.Errorf("Source() = %q, want original source", templateConfig.Source())
+	}
+
+	if templateConfig.Version() != "stable" {
+		t.Errorf("Version() = %q, want %q", templateConfig.Version(), "stable")
+	}
+
+	if len(templateConfig.KConfig()) != 0 {
+		t.Errorf("KConfig() len = %d, want 0", len(templateConfig.KConfig()))
 	}
 }
 
-func TestV07RootfsFormatMapsToInitrdFsType(t *testing.T) {
+func Test_NewProjectFromOptionsV07_TemplateProvidesName(t *testing.T) {
+	workdir := t.TempDir()
+	templateDir := filepath.Join(workdir, "template")
+	if err := os.MkdirAll(templateDir, 0o755); err != nil {
+		t.Fatalf("could not create template directory: %v", err)
+	}
+
+	if err := os.WriteFile(filepath.Join(templateDir, "kraft.yaml"), []byte(`
+spec: v0.7
+name: template-name
+runtime: base:latest
+`), 0o644); err != nil {
+		t.Fatalf("could not write template kraftfile: %v", err)
+	}
+
+	project := mustProjectFromBytes(t, workdir, `
+spec: v0.7
+template:
+  source: `+templateDir+`
+`)
+
+	if project.Name() != "template-name" {
+		t.Errorf("Name() = %q, want %q", project.Name(), "template-name")
+	}
+}
+
+func Test_NewProjectFromOptionsV07_RootfsFormat(t *testing.T) {
 	project := mustProjectFromBytes(t, t.TempDir(), `
 spec: v0.7
 runtime: base:latest
@@ -265,7 +365,7 @@ rootfs:
 	}
 }
 
-func TestV07VolumesMapModeAndReadonly(t *testing.T) {
+func Test_NewProjectFromOptionsV07_Volumes(t *testing.T) {
 	project := mustProjectFromBytes(t, t.TempDir(), `
 spec: v0.7
 runtime: base:latest
@@ -298,46 +398,6 @@ volumes:
 	}
 }
 
-func TestV07MutationOperationsAreRejected(t *testing.T) {
-	project := mustProjectFromBytes(t, t.TempDir(), `
-spec: v0.7
-runtime: base:latest
-`)
-
-	tests := []struct {
-		name string
-		run  func(Application) error
-	}{
-		{
-			name: "save",
-			run: func(project Application) error {
-				return project.Save(context.Background())
-			},
-		},
-		{
-			name: "add library",
-			run: func(project Application) error {
-				return project.AddLibrary(context.Background(), uklib.LibraryConfig{})
-			},
-		},
-		{
-			name: "remove library",
-			run: func(project Application) error {
-				return project.RemoveLibrary(context.Background(), "libfoo")
-			},
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			err := tt.run(project)
-			if !errors.Is(err, ErrProjectMutationNotSupported) {
-				t.Errorf("operation error = %v, want %v", err, ErrProjectMutationNotSupported)
-			}
-		})
-	}
-}
-
 func mustProjectFromBytes(t *testing.T, workdir string, content string) Application {
 	t.Helper()
 
@@ -345,6 +405,7 @@ func mustProjectFromBytes(t *testing.T, workdir string, content string) Applicat
 		context.Background(),
 		WithProjectWorkdir(workdir),
 		WithProjectKraftfileFromBytes([]byte(content)),
+		WithProjectSkipValidation(true),
 	)
 	if err != nil {
 		t.Fatalf("could not create project: %v", err)

--- a/unikraft/app/project_v07_test.go
+++ b/unikraft/app/project_v07_test.go
@@ -1,0 +1,354 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2026, Unikraft GmbH.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+
+package app
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"kraftkit.sh/initrd"
+	uklib "kraftkit.sh/unikraft/lib"
+)
+
+func Test_sniffKraftfileSpecVersion(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    string
+		wantErr bool
+	}{
+		{
+			name:  "spec field with v prefix",
+			input: "spec: v0.7\nruntime: base:latest\n",
+			want:  "v0.7",
+		},
+		{
+			name:  "spec field without v prefix",
+			input: "spec: 0.7\nruntime: base:latest\n",
+			want:  "v0.7",
+		},
+		{
+			name:  "specification field",
+			input: "specification: v0.6\nruntime: base:latest\n",
+			want:  "v0.6",
+		},
+		{
+			name:    "missing spec attribute",
+			input:   "runtime: base:latest\n",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := sniffKraftfileSpecVersion([]byte(tt.input))
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("sniffKraftfileSpecVersion() error = %v, wantErr %v", err, tt.wantErr)
+			}
+
+			if tt.wantErr {
+				return
+			}
+
+			if got != tt.want {
+				t.Errorf("sniffKraftfileSpecVersion() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNewProjectFromOptionsDispatchesBySpecVersion(t *testing.T) {
+	tests := []struct {
+		name       string
+		content    string
+		wantLoader ProjectLoader
+		wantSpec   string
+	}{
+		{
+			name: "legacy spec uses legacy loader",
+			content: `
+spec: v0.6
+runtime: base:latest
+rootfs: ./Dockerfile
+cmd: ["/app"]
+`,
+			wantLoader: ProjectLoaderLegacy,
+			wantSpec:   "v0.6",
+		},
+		{
+			name: "v0.7 spec uses v0.7 loader",
+			content: `
+spec: v0.7
+runtime: base:latest
+`,
+			wantLoader: ProjectLoaderV07,
+			wantSpec:   "v0.7",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			project := mustProjectFromBytes(t, t.TempDir(), tt.content)
+
+			if project.LoaderKind() != tt.wantLoader {
+				t.Errorf("LoaderKind() = %q, want %q", project.LoaderKind(), tt.wantLoader)
+			}
+
+			if project.SpecVersion() != tt.wantSpec {
+				t.Errorf("SpecVersion() = %q, want %q", project.SpecVersion(), tt.wantSpec)
+			}
+		})
+	}
+}
+
+func TestV07ProjectNameSemantics(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		envKey  string
+		envVal  string
+		want    string
+	}{
+		{
+			name: "does not interpolate compose style variables",
+			content: `
+spec: v0.7
+name: ${APP_NAME}
+runtime: base:latest
+`,
+			envKey: "APP_NAME",
+			envVal: "expanded",
+			want:   "${APP_NAME}",
+		},
+		{
+			name: "does not normalize project name at load time",
+			content: `
+spec: v0.7
+name: My App_01
+runtime: base:latest
+`,
+			want: "My App_01",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.envKey != "" {
+				t.Setenv(tt.envKey, tt.envVal)
+			}
+
+			project := mustProjectFromBytes(t, t.TempDir(), tt.content)
+			if project.Name() != tt.want {
+				t.Errorf("Name() = %q, want %q", project.Name(), tt.want)
+			}
+		})
+	}
+}
+
+func TestV07ComponentStringsDoNotUseFilesystemHeuristics(t *testing.T) {
+	workdir := t.TempDir()
+	existingPath := filepath.Join(workdir, "stable")
+	if err := os.Mkdir(existingPath, 0o755); err != nil {
+		t.Fatalf("could not create sentinel directory: %v", err)
+	}
+
+	project := mustProjectFromBytes(t, workdir, `
+spec: v0.7
+name: demo
+unikraft: `+existingPath+`
+libraries:
+  libfoo: `+existingPath+`
+`)
+
+	unikraftConfig := project.Unikraft(context.Background())
+	if unikraftConfig == nil {
+		t.Fatal("expected unikraft config to be present")
+	}
+
+	if unikraftConfig.Version() != existingPath {
+		t.Errorf("Unikraft().Version() = %q, want %q", unikraftConfig.Version(), existingPath)
+	}
+
+	if unikraftConfig.Source() != "" {
+		t.Errorf("Unikraft().Source() = %q, want empty", unikraftConfig.Source())
+	}
+
+	libraries, err := project.Libraries(context.Background())
+	if err != nil {
+		t.Fatalf("Libraries() error = %v", err)
+	}
+
+	library, ok := libraries["libfoo"]
+	if !ok {
+		t.Fatal("expected libfoo to be present")
+	}
+
+	if library.Version() != existingPath {
+		t.Errorf("library.Version() = %q, want %q", library.Version(), existingPath)
+	}
+
+	if library.Source() != "" {
+		t.Errorf("library.Source() = %q, want empty", library.Source())
+	}
+}
+
+func TestV07RuntimeReferenceIsPreserved(t *testing.T) {
+	project := mustProjectFromBytes(t, t.TempDir(), `
+spec: v0.7
+runtime: index.unikraft.io/official/base:latest
+`)
+
+	if project.Runtime() == nil {
+		t.Fatal("expected runtime to be present")
+	}
+
+	if project.Runtime().Name() != "index.unikraft.io/official/base:latest" {
+		t.Errorf("Runtime().Name() = %q, want full OCI ref", project.Runtime().Name())
+	}
+
+	if project.Runtime().Version() != "" {
+		t.Errorf("Runtime().Version() = %q, want empty", project.Runtime().Version())
+	}
+}
+
+func TestV07TemplateSourceMapsToTemplateFields(t *testing.T) {
+	project := mustProjectFromBytes(t, t.TempDir(), `
+spec: v0.7
+template:
+  source: https://github.com/unikraft/catalog.git
+  version: stable
+unikraft: stable
+`)
+
+	if project.Template() == nil {
+		t.Fatal("expected template to be present")
+	}
+
+	if project.Template().Name() != "catalog" {
+		t.Errorf("Template().Name() = %q, want %q", project.Template().Name(), "catalog")
+	}
+
+	if project.Template().Source() != "https://github.com/unikraft/catalog.git" {
+		t.Errorf("Template().Source() = %q, want original source", project.Template().Source())
+	}
+
+	if project.Template().Version() != "stable" {
+		t.Errorf("Template().Version() = %q, want %q", project.Template().Version(), "stable")
+	}
+
+	if len(project.Template().KConfig()) != 0 {
+		t.Errorf("Template().KConfig() len = %d, want 0", len(project.Template().KConfig()))
+	}
+}
+
+func TestV07RootfsFormatMapsToInitrdFsType(t *testing.T) {
+	project := mustProjectFromBytes(t, t.TempDir(), `
+spec: v0.7
+runtime: base:latest
+rootfs:
+  source: ./rootfs
+  format: erofs
+`)
+
+	if project.Rootfs() != "./rootfs" {
+		t.Errorf("Rootfs() = %q, want %q", project.Rootfs(), "./rootfs")
+	}
+
+	if project.InitrdFsType() != initrd.FsTypeErofs {
+		t.Errorf("InitrdFsType() = %q, want %q", project.InitrdFsType(), initrd.FsTypeErofs)
+	}
+}
+
+func TestV07VolumesMapModeAndReadonly(t *testing.T) {
+	project := mustProjectFromBytes(t, t.TempDir(), `
+spec: v0.7
+runtime: base:latest
+volumes:
+  - source: ./data
+    destination: /mnt/data
+    mode: ro
+    readonly: true
+`)
+
+	volumes := project.Volumes()
+	if len(volumes) != 1 {
+		t.Fatalf("len(Volumes()) = %d, want 1", len(volumes))
+	}
+
+	if volumes[0].Source() != "./data" {
+		t.Errorf("volumes[0].Source() = %q, want %q", volumes[0].Source(), "./data")
+	}
+
+	if volumes[0].Destination() != "/mnt/data" {
+		t.Errorf("volumes[0].Destination() = %q, want %q", volumes[0].Destination(), "/mnt/data")
+	}
+
+	if volumes[0].Mode() != "ro" {
+		t.Errorf("volumes[0].Mode() = %q, want %q", volumes[0].Mode(), "ro")
+	}
+
+	if !volumes[0].ReadOnly() {
+		t.Error("volumes[0].ReadOnly() = false, want true")
+	}
+}
+
+func TestV07MutationOperationsAreRejected(t *testing.T) {
+	project := mustProjectFromBytes(t, t.TempDir(), `
+spec: v0.7
+runtime: base:latest
+`)
+
+	tests := []struct {
+		name string
+		run  func(Application) error
+	}{
+		{
+			name: "save",
+			run: func(project Application) error {
+				return project.Save(context.Background())
+			},
+		},
+		{
+			name: "add library",
+			run: func(project Application) error {
+				return project.AddLibrary(context.Background(), uklib.LibraryConfig{})
+			},
+		},
+		{
+			name: "remove library",
+			run: func(project Application) error {
+				return project.RemoveLibrary(context.Background(), "libfoo")
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.run(project)
+			if !errors.Is(err, ErrProjectMutationNotSupported) {
+				t.Errorf("operation error = %v, want %v", err, ErrProjectMutationNotSupported)
+			}
+		})
+	}
+}
+
+func mustProjectFromBytes(t *testing.T, workdir string, content string) Application {
+	t.Helper()
+
+	project, err := NewProjectFromOptions(
+		context.Background(),
+		WithProjectWorkdir(workdir),
+		WithProjectKraftfileFromBytes([]byte(content)),
+	)
+	if err != nil {
+		t.Fatalf("could not create project: %v", err)
+	}
+
+	return project
+}

--- a/unikraft/app/template_resolver.go
+++ b/unikraft/app/template_resolver.go
@@ -1,0 +1,206 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2026, Unikraft GmbH.
+// Licensed under the BSD-3-Clause License (the "License").
+
+package app
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	kraftfilev07 "unikraft.com/x/kraftfile"
+
+	"kraftkit.sh/pack"
+	"kraftkit.sh/packmanager"
+	"kraftkit.sh/unikraft"
+	"kraftkit.sh/unikraft/template"
+)
+
+type TemplatePackageSelector func([]pack.Package) (pack.Package, error)
+
+type TemplateResolutionOptions struct {
+	allowPull    bool
+	forcePull    bool
+	workdir      string
+	queryOptions []packmanager.QueryOption
+	pullOptions  []pack.PullOption
+	selector     TemplatePackageSelector
+}
+
+type TemplateResolutionOption func(*TemplateResolutionOptions) error
+
+func WithTemplateResolutionAllowPull(allow bool) TemplateResolutionOption {
+	return func(opts *TemplateResolutionOptions) error {
+		opts.allowPull = allow
+		return nil
+	}
+}
+
+func WithTemplateResolutionForcePull(force bool) TemplateResolutionOption {
+	return func(opts *TemplateResolutionOptions) error {
+		opts.forcePull = force
+		return nil
+	}
+}
+
+func WithTemplateResolutionWorkdir(workdir string) TemplateResolutionOption {
+	return func(opts *TemplateResolutionOptions) error {
+		opts.workdir = workdir
+		return nil
+	}
+}
+
+func WithTemplateResolutionQueryOptions(queryOptions ...packmanager.QueryOption) TemplateResolutionOption {
+	return func(opts *TemplateResolutionOptions) error {
+		opts.queryOptions = append(opts.queryOptions, queryOptions...)
+		return nil
+	}
+}
+
+func WithTemplateResolutionPullOptions(pullOptions ...pack.PullOption) TemplateResolutionOption {
+	return func(opts *TemplateResolutionOptions) error {
+		opts.pullOptions = append(opts.pullOptions, pullOptions...)
+		return nil
+	}
+}
+
+func WithTemplateResolutionSelector(selector TemplatePackageSelector) TemplateResolutionOption {
+	return func(opts *TemplateResolutionOptions) error {
+		opts.selector = selector
+		return nil
+	}
+}
+
+// ResolveTemplate resolves the template declared in a v0.7 Kraftfile,
+// pulling it if necessary, and merges the template document with the provided
+// project document. Project fields always take precedence over template fields,
+// following upstream Kraftfile.Merge semantics.
+//
+// The template's Kraftfile must declare spec v0.7 or later; an error is returned
+// otherwise. Returns doc unchanged when no template is declared.
+func ResolveTemplate(ctx context.Context, doc *kraftfilev07.Kraftfile, opts ...TemplateResolutionOption) (*kraftfilev07.Kraftfile, error) {
+	if doc == nil || doc.Template == nil {
+		return doc, nil
+	}
+
+	ropts := &TemplateResolutionOptions{
+		allowPull: true,
+	}
+	for _, opt := range opts {
+		if err := opt(ropts); err != nil {
+			return nil, err
+		}
+	}
+
+	// Convert kraftfilev07.Template → TemplateConfig. TransformFromSchema queries
+	// the local pack store, so Path() is set when the template is already pulled.
+	templateConfig, err := v07TemplateFromDocument(ctx, doc.Template)
+	if err != nil {
+		return nil, fmt.Errorf("could not initialize template config: %w", err)
+	}
+	if templateConfig == nil {
+		return doc, nil
+	}
+
+	if shouldPullTemplate(templateConfig.Path(), ropts.forcePull) {
+		if !ropts.allowPull {
+			return nil, fmt.Errorf("template is not available locally: %s", unikraft.TypeNameVersion(templateConfig))
+		}
+
+		templatePack, err := resolveTemplatePackage(ctx, templateConfig, ropts)
+		if err != nil {
+			return nil, err
+		}
+
+		pullOptions := append([]pack.PullOption{}, ropts.pullOptions...)
+		if ropts.workdir != "" {
+			pullOptions = append([]pack.PullOption{pack.WithPullWorkdir(ropts.workdir)}, pullOptions...)
+		}
+
+		if err := templatePack.Pull(ctx, pullOptions...); err != nil {
+			return nil, fmt.Errorf("could not pull template %s: %w", unikraft.TypeNameVersion(templateConfig), err)
+		}
+
+		// Re-initialize after pulling so TransformFromSchema queries the updated
+		// local store and populates Path().
+		templateConfig, err = v07TemplateFromDocument(ctx, doc.Template)
+		if err != nil {
+			return nil, fmt.Errorf("could not re-initialize template config after pull: %w", err)
+		}
+	}
+
+	if templateConfig.Path() == "" {
+		return nil, fmt.Errorf("template path is not known: %s", unikraft.TypeNameVersion(templateConfig))
+	}
+
+	templateDoc, err := kraftfilev07.ParseDirectory(templateConfig.Path())
+	if err != nil {
+		return nil, fmt.Errorf("could not parse template Kraftfile at %s: %w", templateConfig.Path(), err)
+	}
+
+	// Template is the base; project fields always override.
+	templateDoc.Merge(doc)
+
+	return templateDoc, nil
+}
+
+func shouldPullTemplate(path string, forcePull bool) bool {
+	if forcePull {
+		return true
+	}
+
+	if path == "" {
+		return true
+	}
+
+	stat, err := os.Stat(path)
+	return err != nil || !stat.IsDir()
+}
+
+func resolveTemplatePackage(ctx context.Context, template *template.TemplateConfig, opts *TemplateResolutionOptions) (pack.Package, error) {
+	pm := packmanager.G(ctx)
+	if pm == nil {
+		return nil, fmt.Errorf("package manager is not initialized")
+	}
+
+	queryOptions := []packmanager.QueryOption{
+		packmanager.WithName(template.Name()),
+		packmanager.WithTypes(template.Type()),
+	}
+
+	if version := template.Version(); version != "" {
+		queryOptions = append(queryOptions, packmanager.WithVersion(version))
+	}
+	if source := template.Source(); source != "" {
+		queryOptions = append(queryOptions, packmanager.WithSource(source))
+	}
+
+	queryOptions = append(queryOptions, opts.queryOptions...)
+
+	packages, err := pm.Catalog(ctx, queryOptions...)
+	if err != nil {
+		return nil, err
+	}
+
+	switch len(packages) {
+	case 0:
+		return nil, fmt.Errorf("could not find: %s", template.String())
+	case 1:
+		return packages[0], nil
+	default:
+		if opts.selector == nil {
+			return nil, fmt.Errorf("too many options for %s", template.String())
+		}
+
+		selected, err := opts.selector(packages)
+		if err != nil {
+			return nil, err
+		}
+		if selected == nil {
+			return nil, fmt.Errorf("no template package selected for %s", template.String())
+		}
+
+		return selected, nil
+	}
+}

--- a/unikraft/app/volume/transform.go
+++ b/unikraft/app/volume/transform.go
@@ -58,6 +58,13 @@ func TransformFromSchema(ctx context.Context, data interface{}) (interface{}, er
 				}
 				volume.destination = destStr
 
+			case "mode":
+				modeStr, ok := prop.(string)
+				if !ok {
+					return nil, fmt.Errorf("malformed Kraftfile: 'volumes.mode' must be a string, got %T", prop)
+				}
+				volume.mode = modeStr
+
 			case "readonly":
 				readOnlyBool, ok := prop.(bool)
 				if !ok {

--- a/unikraft/runtime/runtime.go
+++ b/unikraft/runtime/runtime.go
@@ -59,13 +59,7 @@ func (elfloader *Runtime) Name() string {
 
 // SetName overwrites the name of the runtime.
 func (elfloader *Runtime) SetName(name string) {
-	if runtime := strings.Split(name, ":"); len(runtime) == 2 {
-		elfloader.name = runtime[0]
-		elfloader.version = runtime[1]
-		return
-	}
-
-	elfloader.name = name
+	elfloader.name, elfloader.version = splitRuntimeNameVersion(name)
 }
 
 // String implements fmt.Stringer
@@ -78,9 +72,62 @@ func (elfloader *Runtime) Version() string {
 	return elfloader.version
 }
 
+// QueryName is the catalog key used to resolve the runtime package.
+func (elfloader *Runtime) QueryName() string {
+	if elfloader.name != "" {
+		return elfloader.name
+	}
+
+	return elfloader.source
+}
+
+// QueryVersion is the catalog tag used to resolve the runtime package.
+func (elfloader *Runtime) QueryVersion() string {
+	return elfloader.version
+}
+
+// Reference returns the full runtime reference as supplied by the user or
+// reconstructed from split name/version fields.
+func (elfloader *Runtime) Reference() string {
+	name := elfloader.QueryName()
+	if name == "" {
+		return ""
+	}
+
+	if elfloader.version != "" {
+		return name + ":" + elfloader.version
+	}
+
+	return name
+}
+
 // Source of the ELF Loader runtime.
 func (elfloader *Runtime) Source() string {
 	return elfloader.source
+}
+
+func splitRuntimeNameVersion(name string) (string, string) {
+	if name == "" {
+		return "", ""
+	}
+
+	if strings.Contains(name, "@") {
+		return name, ""
+	}
+
+	slash := strings.LastIndex(name, "/")
+	colon := strings.LastIndex(name, ":")
+	if colon <= slash {
+		return name, ""
+	}
+
+	if firstSegment, _, ok := strings.Cut(name, "/"); ok {
+		if strings.Contains(firstSegment, ".") || strings.Contains(firstSegment, ":") || firstSegment == "localhost" {
+			return name, ""
+		}
+	}
+
+	return name[:colon], name[colon+1:]
 }
 
 func (elfloader *Runtime) MarshalYAML() (interface{}, error) {

--- a/unikraft/runtime/runtime_test.go
+++ b/unikraft/runtime/runtime_test.go
@@ -1,0 +1,106 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2026, Unikraft GmbH.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+
+package runtime
+
+import (
+	"context"
+	"testing"
+)
+
+func TestRuntime_SetName(t *testing.T) {
+	tests := []struct {
+		name        string
+		input       string
+		wantName    string
+		wantVersion string
+		wantQuery   string
+		wantRef     string
+	}{
+		{
+			name:        "shorthand tag is split",
+			input:       "base:latest",
+			wantName:    "base",
+			wantVersion: "latest",
+			wantQuery:   "base",
+			wantRef:     "base:latest",
+		},
+		{
+			name:        "namespaced shorthand tag is split",
+			input:       "team/base:stable",
+			wantName:    "team/base",
+			wantVersion: "stable",
+			wantQuery:   "team/base",
+			wantRef:     "team/base:stable",
+		},
+		{
+			name:        "full registry ref stays atomic",
+			input:       "index.unikraft.io/official/base:latest",
+			wantName:    "index.unikraft.io/official/base:latest",
+			wantVersion: "",
+			wantQuery:   "index.unikraft.io/official/base:latest",
+			wantRef:     "index.unikraft.io/official/base:latest",
+		},
+		{
+			name:        "registry ref with port stays atomic",
+			input:       "localhost:5000/acme/base:latest",
+			wantName:    "localhost:5000/acme/base:latest",
+			wantVersion: "",
+			wantQuery:   "localhost:5000/acme/base:latest",
+			wantRef:     "localhost:5000/acme/base:latest",
+		},
+		{
+			name:        "digest ref stays atomic",
+			input:       "ghcr.io/acme/base@sha256:deadbeef",
+			wantName:    "ghcr.io/acme/base@sha256:deadbeef",
+			wantVersion: "",
+			wantQuery:   "ghcr.io/acme/base@sha256:deadbeef",
+			wantRef:     "ghcr.io/acme/base@sha256:deadbeef",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rt := &Runtime{}
+			rt.SetName(tt.input)
+
+			if rt.Name() != tt.wantName {
+				t.Errorf("Name() = %q, want %q", rt.Name(), tt.wantName)
+			}
+
+			if rt.Version() != tt.wantVersion {
+				t.Errorf("Version() = %q, want %q", rt.Version(), tt.wantVersion)
+			}
+
+			if rt.QueryName() != tt.wantQuery {
+				t.Errorf("QueryName() = %q, want %q", rt.QueryName(), tt.wantQuery)
+			}
+
+			if rt.Reference() != tt.wantRef {
+				t.Errorf("Reference() = %q, want %q", rt.Reference(), tt.wantRef)
+			}
+		})
+	}
+}
+
+func TestTransformFromSchema_OCIReference(t *testing.T) {
+	got, err := TransformFromSchema(context.Background(), "oci://index.unikraft.io/official/base:latest")
+	if err != nil {
+		t.Fatalf("TransformFromSchema() error = %v", err)
+	}
+
+	rt := got.(Runtime)
+	if rt.Name() != "index.unikraft.io/official/base:latest" {
+		t.Errorf("Name() = %q, want full OCI ref", rt.Name())
+	}
+
+	if rt.Version() != "" {
+		t.Errorf("Version() = %q, want empty", rt.Version())
+	}
+
+	if rt.Source() != "index.unikraft.io/official/base:latest" {
+		t.Errorf("Source() = %q, want full OCI ref", rt.Source())
+	}
+}

--- a/unikraft/runtime/transform.go
+++ b/unikraft/runtime/transform.go
@@ -20,30 +20,18 @@ func TransformFromSchema(ctx context.Context, props interface{}) (interface{}, e
 
 	switch entry := props.(type) {
 	case string:
-		var split []string
 		// Is there a schema specifier?
 		if strings.Contains(entry, "://") {
-			split = strings.Split(entry, "://")
+			split := strings.SplitN(entry, "://", 2)
 			switch split[0] {
 			case "oci":
-				split = strings.Split(split[1], ":")
-				runtime.source = split[0]
-				if len(split) > 1 {
-					runtime.version = split[1]
-				}
+				runtime.name, runtime.version = splitRuntimeNameVersion(split[1])
+				runtime.source = runtime.QueryName()
 			case "kernel":
 				runtime.kernel = split[1]
 			}
 		} else {
-			// The following sequence parses the format:
-			split = strings.Split(entry, ":")
-			if len(split) > 2 {
-				return nil, fmt.Errorf("expected format template value to be <oci>:<tag>")
-			}
-			runtime.name = split[0]
-			if len(split) > 1 {
-				runtime.version = split[1]
-			}
+			runtime.name, runtime.version = splitRuntimeNameVersion(entry)
 		}
 
 	case map[string]interface{}:

--- a/unikraft/target/target.go
+++ b/unikraft/target/target.go
@@ -15,6 +15,8 @@ import (
 	"kraftkit.sh/unikraft/arch"
 	"kraftkit.sh/unikraft/component"
 	"kraftkit.sh/unikraft/plat"
+
+	kraftfilev07 "unikraft.com/x/kraftfile"
 )
 
 // DefaultKraftCloudTarget is the default target for KraftCloud.
@@ -42,7 +44,7 @@ type Target interface {
 	Initrd() initrd.Initrd
 
 	// Auxiliary read-only memory blobs for this target.
-	Roms() []string
+	Roms() []kraftfilev07.FS
 
 	// Command is the command-line arguments set for this target.
 	Command() []string
@@ -79,7 +81,7 @@ type TargetConfig struct {
 	initrd initrd.Initrd
 
 	// auxiliary read-only memory blobs for this target.
-	roms []string
+	roms []kraftfilev07.FS
 
 	// command is the command-line arguments set for this target.
 	command []string
@@ -136,7 +138,7 @@ func (tc *TargetConfig) Initrd() initrd.Initrd {
 	return tc.initrd
 }
 
-func (tc *TargetConfig) Roms() []string {
+func (tc *TargetConfig) Roms() []kraftfilev07.FS {
 	return tc.roms
 }
 
@@ -170,7 +172,7 @@ func (tc *TargetConfig) KConfig() kconfig.KeyValueMap {
 func (tc *TargetConfig) ConfigFilename() string {
 	var name string
 	if tc.kernel == "" {
-		name = fmt.Sprintf("%s_%s-%s", tc.Name(), tc.platform.Name(), tc.architecture.Name())
+		name = fmt.Sprintf("%s_%s-%s", normalizedTargetName(tc.Name()), tc.platform.Name(), tc.architecture.Name())
 	} else {
 		name = filepath.Base(tc.kernel)
 	}
@@ -195,7 +197,7 @@ func KernelName(target TargetConfig) (string, error) {
 
 	return fmt.Sprintf(
 		"%s_%s-%s",
-		target.Name(),
+		normalizedTargetName(target.Name()),
 		target.platform.Name(),
 		target.architecture.Name(),
 	), nil
@@ -240,4 +242,12 @@ func (tc TargetConfig) MarshalYAML() (interface{}, error) {
 	}
 
 	return ret, nil
+}
+
+func normalizedTargetName(name string) string {
+	if normalized := unikraft.NormalizeProjectName(name); normalized != "" {
+		return normalized
+	}
+
+	return name
 }

--- a/unikraft/type.go
+++ b/unikraft/type.go
@@ -127,3 +127,11 @@ func TypeNameVersion(entity Nameable) string {
 
 	return ret.String()
 }
+
+// NormalizeProjectName returns a filesystem- and identifier-safe project name.
+func NormalizeProjectName(name string) string {
+	r := regexp.MustCompile("[a-z0-9_-]")
+	name = strings.ToLower(name)
+	name = strings.Join(r.FindAllString(name, -1), "")
+	return strings.TrimLeft(name, "_-")
+}


### PR DESCRIPTION
### PR Title

feat: add Kraftfile v0.7 project loading, template resolution, and OCI runtime ref support

### Description of changes

This PR adds end-to-end support for Kraftfile `v0.7` projects across project loading, template resolution, runtime lookup, and packaging/build flows.

The first part of the change teaches project initialization to dispatch by Kraftfile spec version and introduces a dedicated `v0.7` loader built on `unikraft.com/x/kraftfile`. The new loader maps `v0.7` documents into the existing application model, records the loader/spec version on the project, supports parsing unikraft/runtime/library/target/rootfs/rom/volume fields, preserves project naming semantics from the source document, normalizes target artifact names, and keeps `v0.7` projects read-only by rejecting legacy mutation paths such as `Save`, `AddLibrary`, and `RemoveLibrary`.

The second part resolves `v0.7` templates before project construction so template defaults are merged first and project values still take precedence. It also preserves full OCI runtime references instead of incorrectly splitting registry-based refs into name/tag pairs, adds helper query/reference methods to runtime resolution, and updates build/run/pkg flows to use those helpers consistently when searching for runtime packages.

Root filesystem and ROM handling are updated to carry filesystem metadata from the `v0.7` schema through initrd and OCI packaging paths. ROM inputs now travel as structured filesystem descriptors instead of bare strings, allowing format-aware packaging while still reusing the existing initrd build pipeline. The build, run, pkg, compose, and deploy commands also switch their rootfs-type handling to the `v0.7` filesystem enum and reuse the project output directory so artifacts land in the configured build location.

The change is covered with focused tests for spec sniffing, loader dispatch, project naming/outdir behavior, component parsing, runtime reference preservation, rootfs format handling, volume mapping, and runtime OCI parsing.

### Validation

- unit tests passed
- `make fmt` passed

### Note
- PR is still not mergeable. It is for approval purposes