### PR TITLE
refactor(cloud/scale): Migrate final errors to typed vars

### DIFF
--- a/internal/cli/kraft/cloud/scale/add/add.go
+++ b/internal/cli/kraft/cloud/scale/add/add.go
@@ -7,7 +7,6 @@ package add
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"sort"
 
@@ -20,18 +19,6 @@ import (
 	"kraftkit.sh/cmdfactory"
 	"kraftkit.sh/config"
 	"kraftkit.sh/internal/cli/kraft/cloud/utils"
-)
-
-var (
-	ErrConfigIdentifierRequired = errors.New("specify a configuration UUID or NAME")
-	ErrPolicyNameRequired       = errors.New("specify a policy name")
-	ErrInvalidStepCount         = errors.New("specify between 1 and 4 steps")
-	ErrInvalidStepFormat        = errors.New("could not parse step")
-	ErrInvalidStepBounds        = errors.New("lower bound cannot be greater or equal than upper bound")
-	ErrInvalidEmptyLowerBound   = errors.New("lower bound cannot be empty in a step after the first step")
-	ErrInvalidEmptyUpperBound   = errors.New("upper bound cannot be empty in a step before the last step")
-	ErrNonContiguousSteps       = errors.New("steps are not contiguous")
-	ErrInvalidPolicyType        = errors.New("invalid policy type")
 )
 
 type AddOptions struct {

--- a/internal/cli/kraft/cloud/scale/add/add.go
+++ b/internal/cli/kraft/cloud/scale/add/add.go
@@ -7,6 +7,7 @@ package add
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sort"
 
@@ -19,6 +20,18 @@ import (
 	"kraftkit.sh/cmdfactory"
 	"kraftkit.sh/config"
 	"kraftkit.sh/internal/cli/kraft/cloud/utils"
+)
+
+var (
+	ErrConfigIdentifierRequired = errors.New("specify a configuration UUID or NAME")
+	ErrPolicyNameRequired       = errors.New("specify a policy name")
+	ErrInvalidStepCount         = errors.New("specify between 1 and 4 steps")
+	ErrInvalidStepFormat        = errors.New("could not parse step")
+	ErrInvalidStepBounds        = errors.New("lower bound cannot be greater or equal than upper bound")
+	ErrInvalidEmptyLowerBound   = errors.New("lower bound cannot be empty in a step after the first step")
+	ErrInvalidEmptyUpperBound   = errors.New("upper bound cannot be empty in a step before the last step")
+	ErrNonContiguousSteps       = errors.New("steps are not contiguous")
+	ErrInvalidPolicyType        = errors.New("invalid policy type")
 )
 
 type AddOptions struct {
@@ -70,7 +83,7 @@ func NewCmd() *cobra.Command {
 
 func (opts *AddOptions) Pre(cmd *cobra.Command, args []string) error {
 	if len(args) == 0 {
-		return fmt.Errorf("specify a configuration UUID or NAME")
+		return ErrConfigIdentifierRequired
 	}
 
 	err := utils.PopulateMetroToken(cmd, &opts.Metro, &opts.Token, &opts.AllowInsecure)
@@ -85,11 +98,11 @@ func (opts *AddOptions) Run(ctx context.Context, args []string) error {
 	var err error
 
 	if opts.Name == "" {
-		return fmt.Errorf("specify a policy name")
+		return ErrPolicyNameRequired
 	}
 
 	if kcautoscale.PolicyType(opts.Type) == kcautoscale.PolicyTypeStep && len(opts.Step) < 1 || len(opts.Step) > 4 {
-		return fmt.Errorf("specify between 1 and 4 steps")
+		return fmt.Errorf("%w: got %d", ErrInvalidStepCount, len(opts.Step))
 	}
 
 	if opts.Auth == nil {
@@ -140,17 +153,16 @@ func (opts *AddOptions) Run(ctx context.Context, args []string) error {
 			if _, err := fmt.Sscanf(step, "%d:%d/%d", &policyStep.LowerBound, &policyStep.UpperBound, &policyStep.Adjustment); err != nil {
 				if _, err := fmt.Sscanf(step, ":%d/%d", &policyStep.UpperBound, &policyStep.Adjustment); err != nil {
 					if _, err := fmt.Sscanf(step, "%d:/%d", &policyStep.LowerBound, &policyStep.Adjustment); err != nil {
-						return fmt.Errorf("could not parse step '%s': expected format 'LOWER_BOUND:UPPER_BOUND/ADJUSTMENT'", step)
-					} else {
-						policyStep.UpperEmpty = true
+						return fmt.Errorf("%w: %q", ErrInvalidStepFormat, step)
 					}
+					policyStep.UpperEmpty = true
 				} else {
 					policyStep.LowerEmpty = true
 				}
 			}
 
 			if policyStep.LowerBound >= policyStep.UpperBound && !policyStep.LowerEmpty && !policyStep.UpperEmpty {
-				return fmt.Errorf("lower bound cannot be greater or equal than upper bound")
+				return fmt.Errorf("%w: %d >= %d", ErrInvalidStepBounds, policyStep.LowerBound, policyStep.UpperBound)
 			}
 
 			steps = append(steps, policyStep)
@@ -172,15 +184,15 @@ func (opts *AddOptions) Run(ctx context.Context, args []string) error {
 			}
 
 			if step.LowerEmpty {
-				return fmt.Errorf("lower bound cannot be empty in a step after the first step")
+				return ErrInvalidEmptyLowerBound
 			}
 
 			if step.UpperEmpty && idx != len(opts.Step)-1 {
-				return fmt.Errorf("upper bound cannot be empty in a step before the last step")
+				return ErrInvalidEmptyUpperBound
 			}
 
 			if steps[idx-1].UpperBound != step.LowerBound {
-				return fmt.Errorf("steps are not contiguous, gap found between %d and %d", steps[idx-1].UpperBound, step.LowerBound)
+				return fmt.Errorf("%w: gap found between %d and %d", ErrNonContiguousSteps, steps[idx-1].UpperBound, step.LowerBound)
 			}
 		}
 
@@ -201,7 +213,7 @@ func (opts *AddOptions) Run(ctx context.Context, args []string) error {
 			Name: opts.Name,
 		}
 	default:
-		return fmt.Errorf("invalid policy type '%s'", opts.Type)
+		return fmt.Errorf("%w: %q", ErrInvalidPolicyType, opts.Type)
 	}
 
 	addPolicyResp, err := opts.Client.Autoscale().WithMetro(opts.Metro).AddPolicy(ctx, id, policy)

--- a/internal/cli/kraft/cloud/scale/add/errors.go
+++ b/internal/cli/kraft/cloud/scale/add/errors.go
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2024, Unikraft GmbH and The KraftKit Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+
+package add
+
+import "errors"
+
+var (
+	ErrConfigIdentifierRequired = errors.New("specify a configuration UUID or NAME")
+	ErrPolicyNameRequired       = errors.New("specify a policy name")
+	ErrInvalidStepCount         = errors.New("specify between 1 and 4 steps")
+	ErrInvalidStepFormat        = errors.New("could not parse step")
+	ErrInvalidStepBounds        = errors.New("lower bound cannot be greater or equal than upper bound")
+	ErrInvalidEmptyLowerBound   = errors.New("lower bound cannot be empty in a step after the first step")
+	ErrInvalidEmptyUpperBound   = errors.New("upper bound cannot be empty in a step before the last step")
+	ErrNonContiguousSteps       = errors.New("steps are not contiguous")
+	ErrInvalidPolicyType        = errors.New("invalid policy type")
+)

--- a/internal/cli/kraft/cloud/scale/get/errors.go
+++ b/internal/cli/kraft/cloud/scale/get/errors.go
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2024, Unikraft GmbH and The KraftKit Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+
+package get
+
+import "errors"
+
+var ErrServiceIdentifierRequired = errors.New("specify a service NAME or UUID")

--- a/internal/cli/kraft/cloud/scale/get/get.go
+++ b/internal/cli/kraft/cloud/scale/get/get.go
@@ -8,7 +8,6 @@ package get
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 
 	"github.com/MakeNowJust/heredoc"
@@ -24,8 +23,6 @@ import (
 	"kraftkit.sh/iostreams"
 	"kraftkit.sh/log"
 )
-
-var ErrServiceIdentifierRequired = errors.New("specify a service NAME or UUID")
 
 type GetOptions struct {
 	AllowInsecure bool                  `noattributes:"true"`

--- a/internal/cli/kraft/cloud/scale/get/get.go
+++ b/internal/cli/kraft/cloud/scale/get/get.go
@@ -8,6 +8,7 @@ package get
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 
 	"github.com/MakeNowJust/heredoc"
@@ -23,6 +24,8 @@ import (
 	"kraftkit.sh/iostreams"
 	"kraftkit.sh/log"
 )
+
+var ErrServiceIdentifierRequired = errors.New("specify a service NAME or UUID")
 
 type GetOptions struct {
 	AllowInsecure bool                  `noattributes:"true"`
@@ -67,7 +70,7 @@ func NewCmd() *cobra.Command {
 
 func (opts *GetOptions) Pre(cmd *cobra.Command, args []string) error {
 	if len(args) == 0 {
-		return fmt.Errorf("specify a service NAME or UUID")
+		return ErrServiceIdentifierRequired
 	}
 
 	err := utils.PopulateMetroToken(cmd, &opts.Metro, &opts.Token, &opts.AllowInsecure)

--- a/internal/cli/kraft/cloud/scale/initialize/errors.go
+++ b/internal/cli/kraft/cloud/scale/initialize/errors.go
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2024, Unikraft GmbH and The KraftKit Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+
+package initialize
+
+import "errors"
+
+var (
+	ErrServiceIdentifierRequired = errors.New("specify a service name or UUID")
+	ErrWarmupTimeTooLow          = errors.New("warmup time must be at least 10ms")
+	ErrCooldownTimeTooLow        = errors.New("cooldown time must be at least 10ms")
+	ErrTemplateRequiredNoPrompt  = errors.New("specify an instance template UUID or name via --template")
+	ErrNoInstanceTemplateFound   = errors.New("no instance template found in service")
+)

--- a/internal/cli/kraft/cloud/scale/initialize/initialize.go
+++ b/internal/cli/kraft/cloud/scale/initialize/initialize.go
@@ -7,7 +7,6 @@ package initialize
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"strconv"
 	"time"
@@ -23,14 +22,6 @@ import (
 	"kraftkit.sh/config"
 	"kraftkit.sh/internal/cli/kraft/cloud/utils"
 	"kraftkit.sh/tui/selection"
-)
-
-var (
-	ErrServiceIdentifierRequired = errors.New("specify a service name or UUID")
-	ErrWarmupTimeTooLow          = errors.New("warmup time must be at least 10ms")
-	ErrCooldownTimeTooLow        = errors.New("cooldown time must be at least 10ms")
-	ErrTemplateRequiredNoPrompt  = errors.New("specify an instance template UUID or name via --template")
-	ErrNoInstanceTemplateFound   = errors.New("no instance template found in service")
 )
 
 type InitOptions struct {

--- a/internal/cli/kraft/cloud/scale/initialize/initialize.go
+++ b/internal/cli/kraft/cloud/scale/initialize/initialize.go
@@ -7,6 +7,7 @@ package initialize
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strconv"
 	"time"
@@ -22,6 +23,14 @@ import (
 	"kraftkit.sh/config"
 	"kraftkit.sh/internal/cli/kraft/cloud/utils"
 	"kraftkit.sh/tui/selection"
+)
+
+var (
+	ErrServiceIdentifierRequired = errors.New("specify a service name or UUID")
+	ErrWarmupTimeTooLow          = errors.New("warmup time must be at least 10ms")
+	ErrCooldownTimeTooLow        = errors.New("cooldown time must be at least 10ms")
+	ErrTemplateRequiredNoPrompt  = errors.New("specify an instance template UUID or name via --template")
+	ErrNoInstanceTemplateFound   = errors.New("no instance template found in service")
 )
 
 type InitOptions struct {
@@ -65,7 +74,7 @@ func NewCmd() *cobra.Command {
 
 func (opts *InitOptions) Pre(cmd *cobra.Command, args []string) error {
 	if len(args) == 0 {
-		return fmt.Errorf("specify a service name or UUID")
+		return ErrServiceIdentifierRequired
 	}
 
 	err := utils.PopulateMetroToken(cmd, &opts.Metro, &opts.Token, &opts.AllowInsecure)
@@ -110,18 +119,18 @@ func (opts *InitOptions) Run(ctx context.Context, args []string) error {
 	}
 
 	if opts.WarmupTime > 0 && opts.WarmupTime < 10*time.Millisecond {
-		return fmt.Errorf("warmup time must be at least 10ms")
+		return fmt.Errorf("%w: got %s", ErrWarmupTimeTooLow, opts.WarmupTime)
 	}
 
 	if opts.CooldownTime > 0 && opts.CooldownTime < 10*time.Millisecond {
-		return fmt.Errorf("cooldown time must be at least 10ms")
+		return fmt.Errorf("%w: got %s", ErrCooldownTimeTooLow, opts.CooldownTime)
 	}
 
 	var template kcautoscale.CreateRequestTemplate
 
 	if opts.Template == "" {
 		if config.G[config.KraftKit](ctx).NoPrompt {
-			return fmt.Errorf("specify an instance template UUID or name via --template")
+			return ErrTemplateRequiredNoPrompt
 		}
 
 		instListResp, err := opts.Client.Instances().WithMetro(opts.Metro).ListTemplate(ctx)
@@ -133,7 +142,7 @@ func (opts *InitOptions) Run(ctx context.Context, args []string) error {
 			return fmt.Errorf("could not list instance templates: %w", err)
 		}
 		if len(instList) == 0 {
-			return fmt.Errorf("no instance template found in service")
+			return ErrNoInstanceTemplateFound
 		}
 
 		if len(instList) == 1 {

--- a/internal/cli/kraft/cloud/scale/remove/errors.go
+++ b/internal/cli/kraft/cloud/scale/remove/errors.go
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2024, Unikraft GmbH and The KraftKit Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+
+package remove
+
+import "errors"
+
+var (
+	ErrServiceAndPolicyRequired = errors.New("specify service UUID and policy name")
+	ErrInvalidServiceUUID       = errors.New("specify a valid service UUID")
+)

--- a/internal/cli/kraft/cloud/scale/remove/remove.go
+++ b/internal/cli/kraft/cloud/scale/remove/remove.go
@@ -7,6 +7,7 @@ package remove
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/MakeNowJust/heredoc"
@@ -18,6 +19,11 @@ import (
 	"kraftkit.sh/cmdfactory"
 	"kraftkit.sh/config"
 	"kraftkit.sh/internal/cli/kraft/cloud/utils"
+)
+
+var (
+	ErrServiceAndPolicyRequired = errors.New("specify service UUID and policy name")
+	ErrInvalidServiceUUID       = errors.New("specify a valid service UUID")
 )
 
 type RemoveOptions struct {
@@ -54,7 +60,7 @@ func NewCmd() *cobra.Command {
 
 func (opts *RemoveOptions) Pre(cmd *cobra.Command, args []string) error {
 	if len(args) == 0 || len(args) == 1 {
-		return fmt.Errorf("specify service UUID and policy name")
+		return ErrServiceAndPolicyRequired
 	}
 
 	err := utils.PopulateMetroToken(cmd, &opts.Metro, &opts.Token, &opts.AllowInsecure)
@@ -69,7 +75,7 @@ func (opts *RemoveOptions) Run(ctx context.Context, args []string) error {
 	var err error
 
 	if !utils.IsUUID(args[0]) {
-		return fmt.Errorf("specify a valid service UUID")
+		return fmt.Errorf("%w: %q", ErrInvalidServiceUUID, args[0])
 	}
 
 	if opts.Auth == nil {

--- a/internal/cli/kraft/cloud/scale/remove/remove.go
+++ b/internal/cli/kraft/cloud/scale/remove/remove.go
@@ -7,7 +7,6 @@ package remove
 
 import (
 	"context"
-	"errors"
 	"fmt"
 
 	"github.com/MakeNowJust/heredoc"
@@ -19,11 +18,6 @@ import (
 	"kraftkit.sh/cmdfactory"
 	"kraftkit.sh/config"
 	"kraftkit.sh/internal/cli/kraft/cloud/utils"
-)
-
-var (
-	ErrServiceAndPolicyRequired = errors.New("specify service UUID and policy name")
-	ErrInvalidServiceUUID       = errors.New("specify a valid service UUID")
 )
 
 type RemoveOptions struct {

--- a/internal/cli/kraft/cloud/scale/reset/errors.go
+++ b/internal/cli/kraft/cloud/scale/reset/errors.go
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2024, Unikraft GmbH and The KraftKit Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+
+package reset
+
+import "errors"
+
+var ErrServiceIdentifierRequired = errors.New("specify a service name or UUID")

--- a/internal/cli/kraft/cloud/scale/reset/reset.go
+++ b/internal/cli/kraft/cloud/scale/reset/reset.go
@@ -7,6 +7,7 @@ package reset
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/MakeNowJust/heredoc"
@@ -19,6 +20,8 @@ import (
 	"kraftkit.sh/config"
 	"kraftkit.sh/internal/cli/kraft/cloud/utils"
 )
+
+var ErrServiceIdentifierRequired = errors.New("specify a service name or UUID")
 
 type ResetOptions struct {
 	AllowInsecure bool                         `noattribute:"true"`
@@ -54,7 +57,7 @@ func NewCmd() *cobra.Command {
 
 func (opts *ResetOptions) Pre(cmd *cobra.Command, args []string) error {
 	if len(args) == 0 {
-		return fmt.Errorf("specify a service name or UUID")
+		return ErrServiceIdentifierRequired
 	}
 
 	err := utils.PopulateMetroToken(cmd, &opts.Metro, &opts.Token, &opts.AllowInsecure)

--- a/internal/cli/kraft/cloud/scale/reset/reset.go
+++ b/internal/cli/kraft/cloud/scale/reset/reset.go
@@ -7,7 +7,6 @@ package reset
 
 import (
 	"context"
-	"errors"
 	"fmt"
 
 	"github.com/MakeNowJust/heredoc"
@@ -20,8 +19,6 @@ import (
 	"kraftkit.sh/config"
 	"kraftkit.sh/internal/cli/kraft/cloud/utils"
 )
-
-var ErrServiceIdentifierRequired = errors.New("specify a service name or UUID")
 
 type ResetOptions struct {
 	AllowInsecure bool                         `noattribute:"true"`


### PR DESCRIPTION
### Prerequisite checklist
- [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
- [x] Tested your changes locally.
### Description of changes
This PR is a scoped, file-by-file contribution toward #102 , limited to the `cloud/scale` command package.
It converts **non-wrapped final errors** to **file-local typed errors** (`var Err... = errors.New(...)`) in the following files:
- `internal/cli/kraft/cloud/scale/add/add.go`
- `internal/cli/kraft/cloud/scale/remove/remove.go`
- `internal/cli/kraft/cloud/scale/get/get.go`
- `internal/cli/kraft/cloud/scale/reset/reset.go`
- `internal/cli/kraft/cloud/scale/initialize/initialize.go`

What was changed:
- Replaced final `fmt.Errorf("...")` returns with typed error vars where applicable.
- Kept wrapped operational/contextual errors (`...: %w`) unchanged.
- In some cases, preserved extra runtime context while wrapping typed errors (for future `errors.Is(...)` checks).

Validation:
- `go test ./internal/cli/kraft/cloud/scale/...`
- `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.11.4 fmt`
Notes:
- Commits are intentionally split one file at a time to keep review and `git bisect/blame` clean.
- This PR **partially addresses #102**.