### PR TITLE
feat(api): Add ParseNetwork for network string parsing

### DIFF
--- a/api/machine/v1alpha1/network.go
+++ b/api/machine/v1alpha1/network.go
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2024, Unikraft GmbH and The KraftKit Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+
+package v1alpha1
+
+import (
+	"fmt"
+	"strings"
+)
+
+// MachineNetwork represents a parsed network configuration from a CLI string.
+type MachineNetwork struct {
+	Name     string
+	CIDR     string
+	Gateway  string
+	DNS0     string
+	DNS1     string
+	Hostname string
+	Domain   string
+}
+
+// ParseNetwork parses a colon-separated network string into a MachineNetwork.
+// The format is: name[:cidr[:gateway[:dns0[:dns1[:hostname[:domain]]]]]].
+// Only the name is required.
+func ParseNetwork(s string) (*MachineNetwork, error) {
+	if s == "" {
+		return nil, fmt.Errorf("network string cannot be empty")
+	}
+
+	parts := strings.SplitN(s, ":", 7)
+	if parts[0] == "" {
+		return nil, fmt.Errorf("network name cannot be empty")
+	}
+
+	mn := &MachineNetwork{Name: parts[0]}
+
+	// Assign optional fields if they exist.
+	if len(parts) > 1 {
+		mn.CIDR = parts[1]
+	}
+	if len(parts) > 2 {
+		mn.Gateway = parts[2]
+	}
+	if len(parts) > 3 {
+		mn.DNS0 = parts[3]
+	}
+	if len(parts) > 4 {
+		mn.DNS1 = parts[4]
+	}
+	if len(parts) > 5 {
+		mn.Hostname = parts[5]
+	}
+	if len(parts) > 6 {
+		mn.Domain = parts[6]
+	}
+
+	return mn, nil
+}
+
+// String implements fmt.Stringer and returns the colon-separated
+// representation of the MachineNetwork.
+func (mn *MachineNetwork) String() string {
+	fields := []string{
+		mn.Name,
+		mn.CIDR,
+		mn.Gateway,
+		mn.DNS0,
+		mn.DNS1,
+		mn.Hostname,
+		mn.Domain,
+	}
+
+	// Trim trailing empty strings.
+	for i := len(fields) - 1; i >= 0; i-- {
+		if fields[i] != "" {
+			fields = fields[:i+1]
+			break
+		}
+	}
+
+	return strings.Join(fields, ":")
+}


### PR DESCRIPTION
## Summary

Implements `ParseNetwork` utility as described in #1648. This introduces an abstract `MachineNetwork` struct and a colon-separated string parser to prevent leakage of Unikraft-specific types into CLI-level code.

## Changes

- Added `api/machine/v1alpha1/network.go`
- - Defined `MachineNetwork` struct with fields: `Name`, `CIDR`, `Gateway`, `DNS0`, `DNS1`, `Hostname`, `Domain`
- - Implemented `ParseNetwork(s string) (*MachineNetwork, error)` that parses format: `name[:cidr[:gateway[:dns0[:dns1[:hostname[:domain]]]]]]`
- - Implemented `String() string` method to serialize back to colon-separated format
- - Added BSD-3-Clause license header
## Motivation

Currently, CLI flags like `--net` directly use Unikraft's internal `NetdevIp` structure. This change abstracts the network representation, making it kernel-agnostic and aligned with the direction outlined in #1633.

## Testing Done

- [x] `go fmt ./api/machine/v1alpha1/network.go` passes
- [ ] - [x] Manual testing with various input strings:
- [ ]   - `eth0` -> `{Name:eth0}`
- [ ]   - `eth0:192.168.1.10/24` -> populates CIDR
- [ ]   - `eth0:192.168.1.10/24:192.168.1.1:8.8.8.8:8.8.4.4:myhost:local` -> all fields
- [ ] - [x] Round-trip `String()` -> `ParseNetwork()` is consistent
## Related Issue

Closes #1648 
## Notes for Reviewers

This implementation exactly mirrors the already-merged PR #2724. It is being re-submitted as a practice contribution to follow the complete open-source workflow (fork -> branch -> commit -> PR). No functional changes are introduced.
