### PR TITLE
fix: Several fixes for docker config fetching

### DIFF
--- a/config/defaults.go
+++ b/config/defaults.go
@@ -21,7 +21,7 @@ const (
 	DefaultManifestIndex = "https://manifests.kraftkit.sh/index.yaml"
 )
 
-func NewDefaultKraftKitConfig() (*KraftKit, error) {
+func NewDefaultKraftKitConfig(ctx context.Context) (*KraftKit, error) {
 	var err error
 	c := &KraftKit{}
 
@@ -29,7 +29,7 @@ func NewDefaultKraftKitConfig() (*KraftKit, error) {
 		return nil, fmt.Errorf("could not set defaults for config: %s", err)
 	}
 
-	c.Auth, err = defaultAuths()
+	c.Auth, err = defaultAuths(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("could not get default auths: %s", err)
 	}
@@ -125,7 +125,7 @@ func setDefaultValue(v reflect.Value, def string) error {
 
 // defaultAuths uses the provided context to locate possible authentication
 // values which can be used when speaking with remote registries.
-func defaultAuths() (map[string]AuthConfig, error) {
+func defaultAuths(ctx context.Context) (map[string]AuthConfig, error) {
 	auths := make(map[string]AuthConfig)
 
 	// Podman users may have their container registry auth configured in a

--- a/config/defaults.go
+++ b/config/defaults.go
@@ -5,6 +5,7 @@
 package config
 
 import (
+	"context"
 	"fmt"
 	"net/url"
 	"os"
@@ -14,7 +15,10 @@ import (
 
 	cliconfig "github.com/docker/cli/cli/config"
 	"github.com/docker/cli/cli/config/configfile"
+	"github.com/docker/cli/cli/config/credentials"
+	"github.com/docker/cli/cli/config/types"
 	"github.com/mitchellh/go-homedir"
+	"kraftkit.sh/log"
 )
 
 const (
@@ -185,9 +189,38 @@ func defaultAuths(ctx context.Context) (map[string]AuthConfig, error) {
 	}
 
 	if cf != nil {
-		a, err := cf.GetAllCredentials()
+		a, err := credentials.NewFileStore(cf).GetAll()
 		if err != nil {
 			return nil, err
+		}
+
+		devNull, err := os.OpenFile(os.DevNull, os.O_WRONLY, 0)
+		if err != nil {
+			return nil, fmt.Errorf("could not open %s to suppress stderr output from credential helpers: %s", os.DevNull, err)
+		}
+		defer devNull.Close()
+
+		for registryHostname := range cf.CredentialHelpers {
+			var newAuth types.AuthConfig
+			savedStderr := os.Stderr
+
+			// NOTE(craciunoiuc): Credential helpers might log to stderr directly
+			// and the underlying library does not catch the output to log it properly.
+			// If the error is not caught by the library, suppress it.
+			// We need to do this because configs are fetched for every command.
+			if devNull != nil {
+				os.Stderr = devNull
+			}
+			newAuth, err = cf.GetAuthConfig(registryHostname)
+			if devNull != nil {
+				os.Stderr = savedStderr
+			}
+			if err != nil {
+				log.G(ctx).Debugf("failed to fetch auth for registry: %s", registryHostname)
+				log.G(ctx).Tracef("failed to get credentials for registry %q: %v", registryHostname, err)
+				continue
+			}
+			a[registryHostname] = newAuth
 		}
 
 		for domain, cfg := range a {

--- a/config/defaults.go
+++ b/config/defaults.go
@@ -5,13 +5,16 @@
 package config
 
 import (
+	"bytes"
 	"context"
 	"fmt"
+	"io"
 	"net/url"
 	"os"
 	"path/filepath"
 	"reflect"
 	"strconv"
+	"strings"
 
 	cliconfig "github.com/docker/cli/cli/config"
 	"github.com/docker/cli/cli/config/credentials"
@@ -130,14 +133,6 @@ func setDefaultValue(v reflect.Value, def string) error {
 func defaultAuths(ctx context.Context) (map[string]AuthConfig, error) {
 	auths := make(map[string]AuthConfig)
 
-	devNull, err := os.OpenFile(os.DevNull, os.O_WRONLY, 0)
-	if err != nil {
-		log.G(ctx).Debugf("could not open %s to suppress stderr output from credential helpers: %s", os.DevNull, err)
-		devNull = nil
-	} else {
-		defer devNull.Close()
-	}
-
 	cf := cliconfig.LoadDefaultConfigFile(os.Stderr)
 	if cf == nil {
 		return nil, fmt.Errorf("could not load default config file")
@@ -150,24 +145,21 @@ func defaultAuths(ctx context.Context) (map[string]AuthConfig, error) {
 
 	for registryHostname := range cf.CredentialHelpers {
 		var newAuth types.AuthConfig
-		savedStderr := os.Stderr
 
-		// NOTE(craciunoiuc): Credential helpers might log to stderr directly
-		// and the underlying library does not catch the output to log it properly.
-		// If the error is not caught by the library, suppress it.
-		// We need to do this because configs are fetched for every command.
-		if devNull != nil {
-			os.Stderr = devNull
+		helperOutput, helperErr := captureStderr(func() error {
+			var innerErr error
+			newAuth, innerErr = cf.GetAuthConfig(registryHostname)
+			return innerErr
+		})
+
+		if len(helperOutput) > 0 {
+			log.G(ctx).Debugf("credential helper output for %s: %s", registryHostname, helperOutput)
 		}
-		newAuth, err = cf.GetAuthConfig(registryHostname)
-		if devNull != nil {
-			os.Stderr = savedStderr
-		}
-		if err != nil {
-			log.G(ctx).Debugf("failed to fetch auth for registry: %s", registryHostname)
-			log.G(ctx).Tracef("failed to get credentials for registry %q: %v", registryHostname, err)
+		if helperErr != nil {
+			log.G(ctx).Debugf("failed to get credentials for registry %q: %v", registryHostname, helperErr)
 			continue
 		}
+
 		a[registryHostname] = newAuth
 	}
 
@@ -200,4 +192,34 @@ func defaultAuths(ctx context.Context) (map[string]AuthConfig, error) {
 	}
 
 	return auths, nil
+}
+
+// captureStderr temporarily redirects os.Stderr to an internal pipe, runs fn,
+// then returns any text the helper wrote to stderr (trimmed). os.Stderr is
+// restored before this function returns.
+// NOTE(craciunoiuc): Workaround for subprocesses that write to stderr
+func captureStderr(fn func() error) (output string, err error) {
+	r, w, pipeErr := os.Pipe()
+	if pipeErr != nil {
+		return "", fn()
+	}
+
+	orig := os.Stderr
+	os.Stderr = w
+
+	var buf bytes.Buffer
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		io.Copy(&buf, r) //nolint:errcheck
+	}()
+
+	err = fn()
+
+	os.Stderr = orig
+	w.Close()
+	<-done
+	r.Close()
+
+	return strings.TrimSpace(buf.String()), err
 }

--- a/config/defaults.go
+++ b/config/defaults.go
@@ -14,10 +14,8 @@ import (
 	"strconv"
 
 	cliconfig "github.com/docker/cli/cli/config"
-	"github.com/docker/cli/cli/config/configfile"
 	"github.com/docker/cli/cli/config/credentials"
 	"github.com/docker/cli/cli/config/types"
-	"github.com/mitchellh/go-homedir"
 	"kraftkit.sh/log"
 )
 
@@ -132,123 +130,72 @@ func setDefaultValue(v reflect.Value, def string) error {
 func defaultAuths(ctx context.Context) (map[string]AuthConfig, error) {
 	auths := make(map[string]AuthConfig)
 
-	// Podman users may have their container registry auth configured in a
-	// different location, that Docker packages aren't aware of.
-	// If the Docker config file isn't found, we'll fallback to look where
-	// Podman configures it, and parse that as a Docker auth config instead.
-
-	// First, check $HOME/.docker/
-	var home string
-	var err error
-	var configPath string
-	foundDockerConfig := false
-
-	// If this is run in the context of GitHub actions, use an alternative path
-	// for the $HOME.
-	if os.Getenv("GITUB_ACTION") == "yes" {
-		home = "/github/home"
+	devNull, err := os.OpenFile(os.DevNull, os.O_WRONLY, 0)
+	if err != nil {
+		log.G(ctx).Debugf("could not open %s to suppress stderr output from credential helpers: %s", os.DevNull, err)
+		devNull = nil
 	} else {
-		home, err = homedir.Dir()
+		defer devNull.Close()
 	}
-	if err == nil {
-		foundDockerConfig = fileExists(filepath.Join(home, ".docker", "config.json"))
 
-		if foundDockerConfig {
-			configPath = filepath.Join(home, ".docker")
+	cf := cliconfig.LoadDefaultConfigFile(os.Stderr)
+	if cf == nil {
+		return nil, fmt.Errorf("could not load default config file")
+	}
+
+	a, err := credentials.NewFileStore(cf).GetAll()
+	if err != nil {
+		return nil, err
+	}
+
+	for registryHostname := range cf.CredentialHelpers {
+		var newAuth types.AuthConfig
+		savedStderr := os.Stderr
+
+		// NOTE(craciunoiuc): Credential helpers might log to stderr directly
+		// and the underlying library does not catch the output to log it properly.
+		// If the error is not caught by the library, suppress it.
+		// We need to do this because configs are fetched for every command.
+		if devNull != nil {
+			os.Stderr = devNull
 		}
-	}
-
-	// If $HOME/.docker/config.json isn't found, check $DOCKER_CONFIG (if set)
-	if !foundDockerConfig && os.Getenv("DOCKER_CONFIG") != "" {
-		foundDockerConfig = fileExists(filepath.Join(os.Getenv("DOCKER_CONFIG"), "config.json"))
-
-		if foundDockerConfig {
-			configPath = os.Getenv("DOCKER_CONFIG")
+		newAuth, err = cf.GetAuthConfig(registryHostname)
+		if devNull != nil {
+			os.Stderr = savedStderr
 		}
-	}
-
-	// If either of those locations are found, load it using Docker's
-	// config.Load, which may fail if the config can't be parsed.
-	//
-	// If neither was found, look for Podman's auth at
-	// $XDG_RUNTIME_DIR/containers/auth.json and attempt to load it as a
-	// Docker config.
-	var cf *configfile.ConfigFile
-	if foundDockerConfig {
-		cf, err = cliconfig.Load(configPath)
 		if err != nil {
-			return nil, fmt.Errorf("could not load config from Docker daemon: %s", err)
+			log.G(ctx).Debugf("failed to fetch auth for registry: %s", registryHostname)
+			log.G(ctx).Tracef("failed to get credentials for registry %q: %v", registryHostname, err)
+			continue
 		}
-	} else if f, err := os.Open(filepath.Join(os.Getenv("XDG_RUNTIME_DIR"), "containers", "auth.json")); err == nil {
-		defer f.Close()
-
-		cf, err = cliconfig.LoadFromReader(f)
-		if err != nil {
-			return nil, fmt.Errorf("could not load config from Docker daemon: %s", err)
-		}
+		a[registryHostname] = newAuth
 	}
 
-	if cf != nil {
-		a, err := credentials.NewFileStore(cf).GetAll()
+	for domain, cfg := range a {
+		if cfg.Username == "" && cfg.Password == "" {
+			continue
+		}
+
+		purl, err := url.Parse(domain)
 		if err != nil {
 			return nil, err
 		}
 
-		devNull, err := os.OpenFile(os.DevNull, os.O_WRONLY, 0)
-		if err != nil {
-			return nil, fmt.Errorf("could not open %s to suppress stderr output from credential helpers: %s", os.DevNull, err)
+		u := purl.Host
+		if u == "" {
+			domain = purl.Path // Sometimes occurs with ghcr.io
 		}
-		defer devNull.Close()
-
-		for registryHostname := range cf.CredentialHelpers {
-			var newAuth types.AuthConfig
-			savedStderr := os.Stderr
-
-			// NOTE(craciunoiuc): Credential helpers might log to stderr directly
-			// and the underlying library does not catch the output to log it properly.
-			// If the error is not caught by the library, suppress it.
-			// We need to do this because configs are fetched for every command.
-			if devNull != nil {
-				os.Stderr = devNull
-			}
-			newAuth, err = cf.GetAuthConfig(registryHostname)
-			if devNull != nil {
-				os.Stderr = savedStderr
-			}
-			if err != nil {
-				log.G(ctx).Debugf("failed to fetch auth for registry: %s", registryHostname)
-				log.G(ctx).Tracef("failed to get credentials for registry %q: %v", registryHostname, err)
-				continue
-			}
-			a[registryHostname] = newAuth
+		if u == "" {
+			u = cfg.ServerAddress
+		}
+		if u == "" {
+			u = domain
 		}
 
-		for domain, cfg := range a {
-			if cfg.Username == "" && cfg.Password == "" {
-				continue
-			}
-
-			purl, err := url.Parse(domain)
-			if err != nil {
-				return nil, err
-			}
-
-			u := purl.Host
-			if u == "" {
-				domain = purl.Path // Sometimes occurs with ghcr.io
-			}
-			if u == "" {
-				u = cfg.ServerAddress
-			}
-			if u == "" {
-				u = domain
-			}
-
-			auths[u] = AuthConfig{
-				Endpoint: u,
-				User:     cfg.Username,
-				Token:    cfg.Password,
-			}
+		auths[u] = AuthConfig{
+			Endpoint: u,
+			User:     cfg.Username,
+			Token:    cfg.Password,
 		}
 	}
 

--- a/config/defaults.go
+++ b/config/defaults.go
@@ -143,6 +143,27 @@ func defaultAuths(ctx context.Context) (map[string]AuthConfig, error) {
 		return nil, err
 	}
 
+	if cf.CredentialsStore != "" {
+		storeOutput, storeErr := captureStderr(func() error {
+			globalAuths, innerErr := cf.GetCredentialsStore("").GetAll()
+			if innerErr != nil {
+				return innerErr
+			}
+			for k, v := range globalAuths {
+				if _, already := a[k]; !already {
+					a[k] = v
+				}
+			}
+			return nil
+		})
+		if len(storeOutput) > 0 {
+			log.G(ctx).Debugf("global credential store output (%s): %s", cf.CredentialsStore, storeOutput)
+		}
+		if storeErr != nil {
+			log.G(ctx).Debugf("external credential store %q failed: %v", cf.CredentialsStore, storeErr)
+		}
+	}
+
 	for registryHostname := range cf.CredentialHelpers {
 		var newAuth types.AuthConfig
 
@@ -153,7 +174,7 @@ func defaultAuths(ctx context.Context) (map[string]AuthConfig, error) {
 		})
 
 		if len(helperOutput) > 0 {
-			log.G(ctx).Debugf("credential helper output for %s: %s", registryHostname, helperOutput)
+			log.G(ctx).Debugf("credential helper output (%s): %s", registryHostname, helperOutput)
 		}
 		if helperErr != nil {
 			log.G(ctx).Debugf("failed to get credentials for registry %q: %v", registryHostname, helperErr)

--- a/config/manager.go
+++ b/config/manager.go
@@ -352,6 +352,60 @@ func AllowedValues(key string) []string {
 	return []string{}
 }
 
+// FetchLogLevelFromArgs returns the log level set via the --log-level flag or
+// the KRAFTKIT_LOG_LEVEL environment variable. This must be called before
+// flags are populated via AttributeFlags so that log messages emitted during
+// early config loading respect the user's chosen level.
+func FetchLogLevelFromArgs(args []string) (level string) {
+	if v := os.Getenv("KRAFTKIT_LOG_LEVEL"); v != "" {
+		level = v
+	}
+
+	for idx, arg := range args {
+		if !strings.HasPrefix(arg, "--log-level") {
+			continue
+		}
+		if strings.Contains(arg, "=") {
+			if split := strings.Split(arg, "="); len(split) == 2 {
+				level = split[1]
+			}
+		} else {
+			if idx+1 < len(args) && !strings.HasPrefix(args[idx+1], "-") {
+				level = args[idx+1]
+			}
+		}
+		break
+	}
+	return
+}
+
+// FetchLogTypeFromArgs returns the log type set via the --log-type flag or
+// the KRAFTKIT_LOG_TYPE environment variable. This must be called before
+// flags are populated via AttributeFlags so that log messages emitted during
+// early config loading use the user's chosen formatter.
+func FetchLogTypeFromArgs(args []string) (logType string) {
+	if v := os.Getenv("KRAFTKIT_LOG_TYPE"); v != "" {
+		logType = v
+	}
+
+	for idx, arg := range args {
+		if !strings.HasPrefix(arg, "--log-type") {
+			continue
+		}
+		if strings.Contains(arg, "=") {
+			if split := strings.Split(arg, "="); len(split) == 2 {
+				logType = split[1]
+			}
+		} else {
+			if idx+1 < len(args) && !strings.HasPrefix(args[idx+1], "-") {
+				logType = args[idx+1]
+			}
+		}
+		break
+	}
+	return
+}
+
 // FetchConfigDirFromArgs returns the path to the alternate config directory
 // that can be set via the --config-dir flag. This needs to be fetched before flags
 // are populated with AttributeFlags to ensure that the function is called only once.

--- a/go.mod
+++ b/go.mod
@@ -52,7 +52,6 @@ require (
 	github.com/mattn/go-isatty v0.0.21
 	github.com/mattn/go-shellwords v1.0.12
 	github.com/mgutz/ansi v0.0.0-20200706080929-d51e80ef957d
-	github.com/mitchellh/go-homedir v1.1.0
 	github.com/moby/buildkit v0.29.0
 	github.com/moby/moby/client v0.4.0
 	github.com/muesli/reflow v0.3.0
@@ -213,6 +212,7 @@ require (
 	github.com/magiconair/properties v1.8.10 // indirect
 	github.com/mattn/go-localereader v0.0.1 // indirect
 	github.com/mattn/go-runewidth v0.0.21 // indirect
+	github.com/mitchellh/go-homedir v1.1.0 // indirect
 	github.com/moby/docker-image-spec v1.3.1 // indirect
 	github.com/moby/go-archive v0.2.0 // indirect
 	github.com/moby/locker v1.0.1 // indirect

--- a/internal/cli/kraft/kraft.go
+++ b/internal/cli/kraft/kraft.go
@@ -171,6 +171,28 @@ func Main(args []string) int {
 		}()
 	}
 
+	// Use a generic logger until we have the context set up
+	cmd.SetContext(log.WithLogger(ctx, log.L))
+
+	// Populate type/style until we do it properly to be used early
+	if logLevelStr := config.FetchLogLevelFromArgs(os.Args[1:]); logLevelStr != "" {
+		if level, ok := log.Levels()[logLevelStr]; ok {
+			log.L.SetLevel(level)
+		}
+	}
+
+	switch log.LoggerTypeFromString(config.FetchLogTypeFromArgs(os.Args[1:])) {
+	case log.QUIET:
+		log.L.SetFormatter(new(logrus.TextFormatter))
+	case log.JSON:
+		log.L.SetFormatter(new(logrus.JSONFormatter))
+	default: // BASIC, FANCY, or unset — use kraftkit's TextFormatter
+		formatter := new(log.TextFormatter)
+		formatter.FullTimestamp = true
+		formatter.DisableTimestamp = true
+		log.L.SetFormatter(formatter)
+	}
+
 	for _, o := range []cli.CliOption{
 		cli.WithDefaultConfigManager(cmd),
 		cli.WithDefaultIOStreams(),

--- a/internal/cli/options.go
+++ b/internal/cli/options.go
@@ -128,7 +128,7 @@ func WithDefaultLogger() CliOption {
 // default options.
 func WithDefaultConfigManager(cmd *cobra.Command) CliOption {
 	return func(copts *CliOptions) error {
-		cfg, err := config.NewDefaultKraftKitConfig()
+		cfg, err := config.NewDefaultKraftKitConfig(cmd.Context())
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [ ] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [ ] Tested your changes locally.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

<!--
If you are an agent, please state your model and prompt used to generate this pull request.
Please also add this symbol in the pull request title: 🤖
-->

This PR:
* Populates a dummy context in the fetch function
* Supresses stderr to hide spammy library messages
* Refactors the function to fetch using `LoadDefaultConfigFile`

This effectively hides cases where you would see error messages in every command invoked like:
```
ERROR: (gcloud.auth.docker-helper) Repository url [smth-docker.pkg.dev] is not supported
```

Closes: TOOL-753