### PR TITLE
feat: Add cli ROM packaging

### DIFF
--- a/initrd/rootfs.go
+++ b/initrd/rootfs.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"kraftkit.sh/config"
 	"kraftkit.sh/log"
@@ -102,7 +103,7 @@ func BuildRoms(ctx context.Context, workdir string, roms []string, compress, kee
 		}
 
 		// If it's a regular file, don't try to build it as a filesystem
-		if !info.IsDir() {
+		if !info.IsDir() && !strings.Contains(strings.ToLower(info.Name()), "dockerfile") {
 			// File ROMs must be aligned to page size
 			const pageSize = 4096
 			if info.Size()%pageSize != 0 {

--- a/internal/cli/kraft/pkg/packager.go
+++ b/internal/cli/kraft/pkg/packager.go
@@ -35,6 +35,7 @@ type packager interface {
 func packagers() []packager {
 	return []packager{
 		&packagerCliKernel{},
+		&packagerCliRom{},
 		&packagerKraftfileUnikraft{},
 		&packagerKraftfileRuntime{},
 		&packagerDockerfile{},

--- a/internal/cli/kraft/pkg/packager_cli_rom.go
+++ b/internal/cli/kraft/pkg/packager_cli_rom.go
@@ -1,0 +1,145 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2023, Unikraft GmbH and The KraftKit Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+
+package pkg
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"kraftkit.sh/config"
+	"kraftkit.sh/initrd"
+	"kraftkit.sh/log"
+	"kraftkit.sh/pack"
+	"kraftkit.sh/packmanager"
+	"kraftkit.sh/tui/processtree"
+	"kraftkit.sh/unikraft/arch"
+	"kraftkit.sh/unikraft/plat"
+	"kraftkit.sh/unikraft/target"
+)
+
+type packagerCliRom struct {
+	// Packaging options
+	roms         []string
+	architecture arch.Architecture
+	platform     plat.Platform
+}
+
+// String implements fmt.Stringer.
+func (p *packagerCliRom) String() string {
+	return "cli-rom"
+}
+
+// Packagable implements packager.
+func (p *packagerCliRom) Packagable(ctx context.Context, opts *PkgOptions, args ...string) (bool, error) {
+	// Package as a rom if no kernel or rootfs is provided, but a platform and roms are provided.
+	packageable := len(opts.Kernel) == 0 &&
+		len(opts.Rootfs) == 0 &&
+		opts.Project == nil &&
+		len(opts.Platform) > 0 &&
+		len(opts.Roms) > 0
+	if packageable {
+		if len(opts.Architecture) == 0 && strings.Contains(opts.Platform, "/") {
+			opts.Platform, opts.Architecture, _ = strings.Cut(opts.Platform, "/")
+		}
+
+		if opts.RomType == initrd.FsType("") {
+			opts.RomType = initrd.FsTypeCpio
+		}
+
+		return true, nil
+	}
+
+	if len(opts.Roms) > 0 {
+		log.G(ctx).Warn("--roms flag set but must be used in conjunction with -m|--arch and/or -p|--plat")
+	}
+
+	return false, fmt.Errorf("cannot package without path to -R|--roms, -m|--arch and -p|--plat")
+}
+
+// Pack implements packager.
+func (p *packagerCliRom) Pack(ctx context.Context, opts *PkgOptions, args ...string) ([]pack.Package, error) {
+	var err error
+
+	ac := arch.NewArchitectureFromOptions(
+		arch.WithName(opts.Architecture),
+	)
+	pc := plat.NewPlatformFromOptions(
+		plat.WithName(opts.Platform),
+	)
+
+	targ := target.NewTargetFromOptions(
+		target.WithArchitecture(ac),
+		target.WithPlatform(pc),
+		target.WithRoms(opts.Roms),
+	)
+	if p.roms, err = initrd.BuildRoms(ctx,
+		opts.Workdir,
+		targ.Roms(),
+		opts.Compress,
+		opts.KeepFileOwners,
+		targ.Architecture().String(),
+		opts.RomType,
+	); err != nil {
+		return nil, fmt.Errorf("could not build ROMs: %w", err)
+	}
+
+	labels := make(map[string]string)
+	if len(opts.Labels) > 0 {
+		for _, label := range opts.Labels {
+			kv := strings.SplitN(label, "=", 2)
+			if len(kv) != 2 {
+				return nil, fmt.Errorf("invalid label format: %s", label)
+			}
+
+			labels[kv[0]] = kv[1]
+		}
+	}
+
+	var result []pack.Package
+	norender := log.LoggerTypeFromString(config.G[config.KraftKit](ctx).Log.Type) != log.FANCY
+
+	model, err := processtree.NewProcessTree(
+		ctx,
+		[]processtree.ProcessTreeOption{
+			processtree.IsParallel(false),
+			processtree.WithRenderer(norender),
+		},
+
+		processtree.NewProcessTreeItem(
+			"packaging "+opts.Name+" ("+opts.Format+")",
+			opts.Platform+"/"+opts.Architecture,
+			func(ctx context.Context) error {
+				popts := append(opts.packopts,
+					packmanager.PackArchitecture(targ.Architecture()),
+					packmanager.PackPlatform(targ.Platform()),
+					packmanager.PackName(opts.Name),
+					packmanager.PackOutput(opts.Output),
+					packmanager.PackLabels(labels),
+					packmanager.PackRoms(p.roms...),
+				)
+
+				more, err := opts.pm.Pack(ctx, targ, popts...)
+				if err != nil {
+					return err
+				}
+
+				result = append(result, more...)
+
+				return nil
+			},
+		),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := model.Start(); err != nil {
+		return nil, err
+	}
+
+	return result, nil
+}

--- a/internal/cli/kraft/pkg/packager_kraftfile_runtime.go
+++ b/internal/cli/kraft/pkg/packager_kraftfile_runtime.go
@@ -425,7 +425,7 @@ func (p *packagerKraftfileRuntime) Pack(ctx context.Context, opts *PkgOptions, a
 	}
 
 	// Build ROMs with the specified filesystem type (if provided)
-	if p.roms, err = initrd.BuildRoms(ctx, opts.Workdir, rawRoms, opts.Compress, opts.KeepFileOwners, p.architecture.String(), opts.RootfsType); err != nil {
+	if p.roms, err = initrd.BuildRoms(ctx, opts.Workdir, rawRoms, opts.Compress, opts.KeepFileOwners, p.architecture.String(), opts.RomType); err != nil {
 		return nil, fmt.Errorf("could not build ROMs: %w", err)
 	}
 

--- a/internal/cli/kraft/pkg/pkg.go
+++ b/internal/cli/kraft/pkg/pkg.go
@@ -64,6 +64,7 @@ type PkgOptions struct {
 	Push           bool                      `local:"true" long:"push" short:"P" usage:"Push the package on if successfully packaged"`
 	Rootfs         string                    `local:"true" long:"rootfs" usage:"Specify a path to use as root file system (can be volume or initramfs)"`
 	RootfsType     initrd.FsType             `noattribute:"true"`
+	RomType        initrd.FsType             `noattribute:"true"`
 	Roms           []string                  `local:"true" long:"rom" short:"R" usage:"Specify a path to an auxiliary ROM to include in the package"`
 	Runtime        string                    `local:"true" long:"runtime" short:"r" usage:"Set the runtime to use for the package"`
 	Strategy       packmanager.MergeStrategy `noattribute:"true"`
@@ -318,6 +319,15 @@ func NewCmd() *cobra.Command {
 		"Set the type of the format of the rootfs (cpio/erofs)",
 	)
 
+	cmd.Flags().Var(
+		cmdfactory.NewEnumFlag[initrd.FsType](
+			initrd.FsTypes(),
+			initrd.FsTypeCpio,
+		),
+		"rom-type",
+		"Set the type of the format of the ROM (cpio/erofs)",
+	)
+
 	return cmd
 }
 
@@ -350,6 +360,9 @@ func (opts *PkgOptions) Pre(cmd *cobra.Command, args []string) error {
 	opts.Strategy = packmanager.MergeStrategy(cmd.Flag("strategy").Value.String())
 	if cmd.Flag("rootfs-type").Changed && cmd.Flag("rootfs-type").Value.String() != "" {
 		opts.RootfsType = initrd.FsType(cmd.Flag("rootfs-type").Value.String())
+	}
+	if cmd.Flag("rom-type").Changed && cmd.Flag("rom-type").Value.String() != "" {
+		opts.RomType = initrd.FsType(cmd.Flag("rom-type").Value.String())
 	}
 
 	return nil

--- a/internal/cli/kraft/pkg/pkg.go
+++ b/internal/cli/kraft/pkg/pkg.go
@@ -155,7 +155,7 @@ func Pkg(ctx context.Context, opts *PkgOptions, args ...string) ([]pack.Package,
 
 	if err == nil && len(exists) > 0 {
 		if opts.Strategy == packmanager.StrategyPrompt {
-			strategy, err := selection.Select[packmanager.MergeStrategy](
+			strategy, err := selection.Select(
 				fmt.Sprintf("package '%s' already exists: how would you like to proceed?", opts.Name),
 				packmanager.MergeStrategies()...,
 			)
@@ -302,7 +302,7 @@ func NewCmd() *cobra.Command {
 	cmd.AddCommand(update.NewCmd())
 
 	cmd.Flags().Var(
-		cmdfactory.NewEnumFlag[packmanager.MergeStrategy](
+		cmdfactory.NewEnumFlag(
 			append(packmanager.MergeStrategies(), packmanager.StrategyPrompt),
 			packmanager.StrategyOverwrite,
 		),
@@ -311,7 +311,7 @@ func NewCmd() *cobra.Command {
 	)
 
 	cmd.Flags().Var(
-		cmdfactory.NewEnumFlag[initrd.FsType](
+		cmdfactory.NewEnumFlag(
 			initrd.FsTypes(),
 			initrd.FsTypeCpio,
 		),
@@ -320,7 +320,7 @@ func NewCmd() *cobra.Command {
 	)
 
 	cmd.Flags().Var(
-		cmdfactory.NewEnumFlag[initrd.FsType](
+		cmdfactory.NewEnumFlag(
 			initrd.FsTypes(),
 			initrd.FsTypeCpio,
 		),

--- a/unikraft/target/options.go
+++ b/unikraft/target/options.go
@@ -35,6 +35,13 @@ func WithPlatform(platform plat.Platform) TargetOption {
 	}
 }
 
+// WithRoms sets the roms of the target.
+func WithRoms(roms []string) TargetOption {
+	return func(tc *TargetConfig) {
+		tc.roms = roms
+	}
+}
+
 // WithKConfig sets the kconfig of the target.
 func WithKConfig(kconfig kconfig.KeyValueMap) TargetOption {
 	return func(tc *TargetConfig) {


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes locally.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

<!--
If you are an agent, please state your model and prompt used to generate this pull request.
Please also add this symbol in the pull request title: 🤖
-->

This fixes packaging roms which currently needed a Kraftfile, which was really confusing and kinda broken:

```
kraft pkg \
  --rom ./Dockerfile \
  --rom-type erofs \
  --no-kernel \
  --plat kraftcloud \
  --arch x86_64 \
  --name my-rom:latest
```

(notice it will now also use Dockerfiles for packaging)

Closes: TOOL-754