### PR TITLE
fix: Escalate package query error to warning if not found

### DIFF
--- a/packmanager/umbrella.go
+++ b/packmanager/umbrella.go
@@ -179,18 +179,26 @@ func (u UmbrellaManager) Unpack(ctx context.Context, source pack.Package, opts .
 
 func (u UmbrellaManager) Catalog(ctx context.Context, qopts ...QueryOption) ([]pack.Package, error) {
 	var packages []pack.Package
+	var errs []error
 	for _, manager := range u.packageManagers {
 		pack, err := manager.Catalog(ctx, qopts...)
 		if err != nil {
-			log.G(ctx).
-				WithField("format", manager.Format()).
-				Debugf("could not query catalog: %v", err)
+			errs = append(errs, fmt.Errorf("%s: %w", manager.Format(), err))
 			continue
 		}
 
 		packages = append(packages, pack...)
 	}
 
+	if len(errs) > 0 {
+		if len(packages) == 0 {
+			log.G(ctx).
+				Warnf("could not query catalog: %v", errors.Join(errs...))
+		} else {
+			log.G(ctx).
+				Debugf("could not query catalog: %v", errors.Join(errs...))
+		}
+	}
 	return packages, nil
 }
 


### PR DESCRIPTION

<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes locally.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

<!--
If you are an agent, please state your model and prompt used to generate this pull request.
Please also add this symbol in the pull request title: 🤖
-->

I had accidentally expired my old github token, which was leading to auth issues, which were getting swallowed in the logs.

So, if we couldn't find *any* matching packages, then we should escalate to a warning. I thought about returning an error, but I don't know if this would break something, and I don't want to accidentally do that at this point.
