### PR TITLE
build: Pass toolchain make options to configure step

### DIFF
--- a/internal/cli/kraft/build/build_toolchain_test.go
+++ b/internal/cli/kraft/build/build_toolchain_test.go
@@ -5,8 +5,13 @@
 package build
 
 import (
+	"context"
 	"reflect"
+	"slices"
 	"testing"
+
+	"kraftkit.sh/config"
+	"kraftkit.sh/make"
 )
 
 func TestMergeToolchain(t *testing.T) {
@@ -63,6 +68,58 @@ func TestMergeToolchain(t *testing.T) {
 			got := mergeToolchain(tc.global, tc.flags)
 			if !reflect.DeepEqual(got, tc.expect) {
 				t.Errorf("mergeToolchain() = %v, want %v", got, tc.expect)
+			}
+		})
+	}
+}
+
+func TestMakeOptionsForBuildIncludesResolvedToolchain(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		global map[string]string
+		flags  []string
+		expect []string
+	}{
+		{
+			name:   "global values are forwarded to make",
+			global: map[string]string{"CC": "gcc", "UK_CFLAGS": "-O2"},
+			expect: []string{"CC=gcc", "UK_CFLAGS=-O2"},
+		},
+		{
+			name:   "cli overrides win over global config",
+			global: map[string]string{"CC": "gcc", "LD": "ld"},
+			flags:  []string{"CC=clang", "UK_CFLAGS=-O0 -g"},
+			expect: []string{"CC=clang", "LD=ld", "UK_CFLAGS=-O0 -g"},
+		},
+		{
+			name:   "malformed flags are ignored",
+			global: map[string]string{"CC": "gcc"},
+			flags:  []string{"BADENTRY"},
+			expect: []string{"CC=gcc"},
+		},
+		{
+			name:   "empty config and flags produce no vars",
+			expect: nil,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := config.WithConfigManager(context.Background(), &config.ConfigManager[config.KraftKit]{
+				Config: &config.KraftKit{Toolchain: tc.global},
+			})
+
+			mo, err := make.NewMakeOptions(makeOptionsForBuild(ctx, &BuildOptions{
+				Toolchain: tc.flags,
+			})...)
+			if err != nil {
+				t.Fatalf("NewMakeOptions() returned unexpected error: %v", err)
+			}
+
+			got := mo.Vars()
+			slices.Sort(got)
+			slices.Sort(tc.expect)
+
+			if !reflect.DeepEqual(got, tc.expect) {
+				t.Fatalf("makeOptionsForBuild() vars = %v, want %v", got, tc.expect)
 			}
 		})
 	}

--- a/internal/cli/kraft/build/builder_kraftfile_unikraft.go
+++ b/internal/cli/kraft/build/builder_kraftfile_unikraft.go
@@ -102,6 +102,22 @@ func linesOfCode(ctx context.Context, opts *BuildOptions) (int64, error) {
 	return int64(len(uniqueLines)), nil
 }
 
+func makeOptionsForBuild(ctx context.Context, opts *BuildOptions) []make.MakeOption {
+	var mopts []make.MakeOption
+
+	if opts.Jobs > 0 {
+		mopts = append(mopts, make.WithJobs(opts.Jobs))
+	} else {
+		mopts = append(mopts, make.WithMaxJobs(!opts.NoFast && !config.G[config.KraftKit](ctx).NoParallel))
+	}
+
+	if toolchain := mergeToolchain(config.G[config.KraftKit](ctx).Toolchain, opts.Toolchain); len(toolchain) > 0 {
+		mopts = append(mopts, make.WithVars(toolchain))
+	}
+
+	return mopts
+}
+
 func (build *builderKraftfileUnikraft) pull(ctx context.Context, opts *BuildOptions, norender bool, nameWidth int) error {
 	var missingPacks []pack.Package
 	var processes []*paraprogress.Process
@@ -439,16 +455,7 @@ func (build *builderKraftfileUnikraft) Prepare(ctx context.Context, opts *BuildO
 
 func (build *builderKraftfileUnikraft) Build(ctx context.Context, opts *BuildOptions, args ...string) error {
 	var processes []*paraprogress.Process
-	var mopts []make.MakeOption
-	if opts.Jobs > 0 {
-		mopts = append(mopts, make.WithJobs(opts.Jobs))
-	} else {
-		mopts = append(mopts, make.WithMaxJobs(!opts.NoFast && !config.G[config.KraftKit](ctx).NoParallel))
-	}
-
-	if toolchain := mergeToolchain(config.G[config.KraftKit](ctx).Toolchain, opts.Toolchain); len(toolchain) > 0 {
-		mopts = append(mopts, make.WithVars(toolchain))
-	}
+	mopts := makeOptionsForBuild(ctx, opts)
 
 	allEnvs := map[string]string{}
 	for k, v := range opts.Project.Env() {
@@ -509,13 +516,15 @@ func (build *builderKraftfileUnikraft) Build(ctx context.Context, opts *BuildOpt
 						ctx,
 						*opts.Target, // Target-specific options
 						envKconfig,   // Extra Kconfigs for compiled in environment variables
-						make.WithProgressFunc(w),
-						make.WithSilent(true),
-						make.WithExecOptions(
-							exec.WithStdin(iostreams.G(ctx).In),
-							exec.WithStdout(log.G(ctx).Writer()),
-							exec.WithStderr(log.G(ctx).WriterLevel(logrus.WarnLevel)),
-						),
+						append(mopts,
+							make.WithProgressFunc(w),
+							make.WithSilent(true),
+							make.WithExecOptions(
+								exec.WithStdin(iostreams.G(ctx).In),
+								exec.WithStdout(log.G(ctx).Writer()),
+								exec.WithStderr(log.G(ctx).WriterLevel(logrus.WarnLevel)),
+							),
+						)...,
 					)
 				},
 			))


### PR DESCRIPTION
### Prerequisite checklist

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes locally.

  ### Description of changes

  Toolchain overrides were already resolved from persistent config and `kraft build --toolchain` flags, but they were only applied to the final build invocation.

  The configure phase in the Unikraft builder created its own make options and did not receive the same resolved toolchain overrides. As a result, variables such as `CC`, `LD`, and `UK_CFLAGS` could affect the final build step without also affecting the earlier configure phase.

This change introduces a shared helper for constructing the build make options and reuses it for both:

  - `opts.Project.Configure(...)`
  - `opts.Project.Build(...)`

  This keeps toolchain overrides and job settings consistent across the whole build pipeline.

  Tests were extended to verify that:

  - global toolchain config is forwarded to GNU Make
  - CLI `--toolchain` values override global config
  - malformed toolchain entries are ignored

  Fixes part of #673.