### PR TITLE
refactor(config): Migrate final errors to typed vars

### DIFF
--- a/config/config_file.go
+++ b/config/config_file.go
@@ -115,11 +115,6 @@ func DataDir() string {
 	return path
 }
 
-var (
-	errSamePath = errors.New("same path")
-	errNotExist = errors.New("not exist")
-)
-
 // Check default path, os.UserHomeDir, for existing configs
 // If configs exist then move them to newPath
 func autoMigrateConfigDir(newPath string) error {
@@ -128,7 +123,7 @@ func autoMigrateConfigDir(newPath string) error {
 		return migrateDir(oldPath, newPath)
 	}
 
-	return errNotExist
+	return NotExist
 }
 
 // Check default path, os.UserHomeDir, for existing state file (state.yml)
@@ -139,19 +134,19 @@ func autoMigrateStateDir(newPath string) error {
 		return migrateFile(oldPath, newPath, "state.yml")
 	}
 
-	return errNotExist
+	return NotExist
 }
 
 func migrateFile(oldPath, newPath, file string) error {
 	if oldPath == newPath {
-		return errSamePath
+		return SamePath
 	}
 
 	oldFile := filepath.Join(oldPath, file)
 	newFile := filepath.Join(newPath, file)
 
 	if !fileExists(oldFile) {
-		return errNotExist
+		return NotExist
 	}
 
 	_ = os.MkdirAll(filepath.Dir(newFile), 0o755)
@@ -160,11 +155,11 @@ func migrateFile(oldPath, newPath, file string) error {
 
 func migrateDir(oldPath, newPath string) error {
 	if oldPath == newPath {
-		return errSamePath
+		return SamePath
 	}
 
 	if !dirExists(oldPath) {
-		return errNotExist
+		return NotExist
 	}
 
 	_ = os.MkdirAll(filepath.Dir(newPath), 0o755)

--- a/config/errors.go
+++ b/config/errors.go
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2026, Unikraft GmbH and The KraftKit Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+
+package config
+
+import "errors"
+
+var (
+	ConfigNil                  = errors.New("cannot instantiate ConfigManager without Config")
+	UnsupportedTypeConversion  = errors.New("unsupported type conversion")
+	ConfigMustBeStructPointer  = errors.New("cfg must be a pointer to a struct")
+	InvalidKey                 = errors.New("invalid key")
+	CannotSetField             = errors.New("cannot set field")
+	CannotUnsetField           = errors.New("cannot unset field")
+	CannotTraverseFurtherInMap = errors.New("cannot traverse further into map")
+	SamePath                   = errors.New("same path")
+	NotExist                   = errors.New("not exist")
+)

--- a/config/manager.go
+++ b/config/manager.go
@@ -5,7 +5,6 @@
 package config
 
 import (
-	"errors"
 	"fmt"
 	"os"
 	"os/signal"
@@ -67,7 +66,7 @@ func WithDefaultConfigFile[C any]() ConfigManagerOption[C] {
 
 func NewConfigManager[C any](c *C, opts ...ConfigManagerOption[C]) (*ConfigManager[C], error) {
 	if c == nil {
-		return nil, fmt.Errorf("cannot instantiate ConfigManager without Config")
+		return nil, ConfigNil
 	}
 
 	cm := &ConfigManager[C]{
@@ -172,7 +171,7 @@ func convertType(value any, targetType reflect.Type) (reflect.Value, error) {
 		}
 	}
 
-	return reflect.Value{}, errors.New("unsupported type conversion")
+	return reflect.Value{}, UnsupportedTypeConversion
 }
 
 // getYAMLTag extracts the YAML tag from a struct field.
@@ -191,7 +190,7 @@ func getYAMLTag(field reflect.StructField, ok bool) string {
 func (cm *ConfigManager[C]) Set(key string, val any) error {
 	v := reflect.ValueOf(cm.Config)
 	if v.Kind() != reflect.Ptr || v.Elem().Kind() != reflect.Struct {
-		return errors.New("cfg must be a pointer to a struct")
+		return ConfigMustBeStructPointer
 	}
 
 	v = v.Elem() // Dereference the pointer
@@ -203,12 +202,12 @@ func (cm *ConfigManager[C]) Set(key string, val any) error {
 		})
 
 		if !field.IsValid() {
-			return errors.New("invalid key: " + k)
+			return fmt.Errorf("%w: %s", InvalidKey, k)
 		}
 
 		if i == len(keys)-1 {
 			if !field.CanSet() {
-				return errors.New("cannot set field: " + k)
+				return fmt.Errorf("%w: %s", CannotSetField, k)
 			}
 			convertedVal, err := convertType(val, field.Type())
 			if err != nil {
@@ -229,7 +228,7 @@ func (cm *ConfigManager[C]) Set(key string, val any) error {
 				// e.g.keys = ["toolchain", "CC"] , len is 2 ,At i = 0 the next key is the final one.
 				// e.g.keys = ["toolchain", "CC", "extra"]  len is 3 , We have leftover keys, so we error out.
 
-				return errors.New("cannot traverse further into map: " + k)
+				return fmt.Errorf("%w: %s", CannotTraverseFurtherInMap, k)
 			}
 			mapKey := keys[i+1]
 			if field.IsNil() {
@@ -264,7 +263,7 @@ func (cm *ConfigManager[C]) Set(key string, val any) error {
 func (cm *ConfigManager[C]) Unset(key string) error {
 	v := reflect.ValueOf(cm.Config)
 	if v.Kind() != reflect.Ptr || v.Elem().Kind() != reflect.Struct {
-		return errors.New("cfg must be a pointer to a struct")
+		return ConfigMustBeStructPointer
 	}
 
 	v = v.Elem()
@@ -276,7 +275,7 @@ func (cm *ConfigManager[C]) Unset(key string) error {
 		})
 
 		if !field.IsValid() {
-			return errors.New("invalid key: " + k)
+			return fmt.Errorf("%w: %s", InvalidKey, k)
 		}
 
 		if field.Kind() == reflect.Map &&
@@ -284,7 +283,7 @@ func (cm *ConfigManager[C]) Unset(key string) error {
 			field.Type().Elem().Kind() == reflect.String {
 
 			if i+1 != len(keys)-1 {
-				return errors.New("cannot traverse further into map: " + k)
+				return fmt.Errorf("%w: %s", CannotTraverseFurtherInMap, k)
 			}
 			if !field.IsNil() {
 				field.SetMapIndex(reflect.ValueOf(keys[i+1]), reflect.Value{})
@@ -294,7 +293,7 @@ func (cm *ConfigManager[C]) Unset(key string) error {
 
 		if i == len(keys)-1 {
 			if !field.CanSet() {
-				return errors.New("cannot unset field: " + k)
+				return fmt.Errorf("%w: %s", CannotUnsetField, k)
 			}
 			field.Set(reflect.Zero(field.Type()))
 			return nil

--- a/config/manager_test.go
+++ b/config/manager_test.go
@@ -5,7 +5,10 @@
 
 package config
 
-import "testing"
+import (
+	"errors"
+	"testing"
+)
 
 func TestConfigManagerUnset_MapField(t *testing.T) {
 	unset := func(t *testing.T, cfg *KraftKit, key string) {
@@ -55,16 +58,24 @@ func TestConfigManagerUnset_MapField(t *testing.T) {
 	t.Run("Error on unknown key", func(t *testing.T) {
 		cfg := &KraftKit{}
 		cm := &ConfigManager[KraftKit]{Config: cfg}
-		if err := cm.Unset("nonexistent"); err == nil {
-			t.Error("expected error for unknown key, got nil")
+		err := cm.Unset("nonexistent")
+		if err == nil {
+			t.Fatal("expected error for unknown key, got nil")
+		}
+		if !errors.Is(err, InvalidKey) {
+			t.Fatalf("expected InvalidKey, got %v", err)
 		}
 	})
 
 	t.Run("Error on too deep map traversal", func(t *testing.T) {
 		cfg := &KraftKit{}
 		cm := &ConfigManager[KraftKit]{Config: cfg}
-		if err := cm.Unset("toolchain.CC.extra"); err == nil {
-			t.Error("expected error for toolchain.CC.extra, got nil")
+		err := cm.Unset("toolchain.CC.extra")
+		if err == nil {
+			t.Fatal("expected error for toolchain.CC.extra, got nil")
+		}
+		if !errors.Is(err, CannotTraverseFurtherInMap) {
+			t.Fatalf("expected CannotTraverseFurtherInMap, got %v", err)
 		}
 	})
 }
@@ -132,16 +143,24 @@ func TestConfigManagerSet_MapField(t *testing.T) {
 	t.Run("Error on too deep map traversal", func(t *testing.T) {
 		cfg := &KraftKit{}
 		cm := &ConfigManager[KraftKit]{Config: cfg}
-		if err := cm.Set("toolchain.CC.extra", "value"); err == nil {
-			t.Error("expected error for toolchain.CC.extra, got nil")
+		err := cm.Set("toolchain.CC.extra", "value")
+		if err == nil {
+			t.Fatal("expected error for toolchain.CC.extra, got nil")
+		}
+		if !errors.Is(err, CannotTraverseFurtherInMap) {
+			t.Fatalf("expected CannotTraverseFurtherInMap, got %v", err)
 		}
 	})
 
 	t.Run("Error on unknown key", func(t *testing.T) {
 		cfg := &KraftKit{}
 		cm := &ConfigManager[KraftKit]{Config: cfg}
-		if err := cm.Set("nonexistent", "value"); err == nil {
-			t.Error("expected error for unknown key, got nil")
+		err := cm.Set("nonexistent", "value")
+		if err == nil {
+			t.Fatal("expected error for unknown key, got nil")
+		}
+		if !errors.Is(err, InvalidKey) {
+			t.Fatalf("expected InvalidKey, got %v", err)
 		}
 	})
 }


### PR DESCRIPTION
### Prerequisite checklist
  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes locally.

  ### Description of changes

  This PR is a follow-up for #102 focused on the `config` package.

  It adds shared typed errors in `config/errors.go` and updates `config/manager.go` and `config/config_file.go` to use them for final non-wrapped errors.

  It also updates the related tests in `config/manager_test.go`.

  ### Testing
  - `go test ./config`