### PR TITLE
fix(cloud)!: Loop wait for start/stop/rollout start

### DIFF
--- a/internal/cli/kraft/cloud/compose/up/up.go
+++ b/internal/cli/kraft/cloud/compose/up/up.go
@@ -53,7 +53,7 @@ type UpOptions struct {
 	Project          *compose.Project         `noattribute:"true"`
 	Rollout          *create.RolloutStrategy  `noattribute:"true"`
 	RolloutQualifier *create.RolloutQualifier `noattribute:"true"`
-	RolloutWait      time.Duration            `local:"true" long:"rollout-wait" usage:"Time to wait before performing rolling out action (ms/s/m/h)" default:"10s"`
+	RolloutWait      time.Duration            `local:"true" long:"rollout-wait" usage:"Time to wait before performing rolling out action (ms/s/m/h)" default:"5m"`
 	Runtimes         []string                 `long:"runtime" usage:"Alternative runtime to use when packaging a service"`
 	RootfsType       kraftfilev07.FsType      `noattribute:"true"`
 	KeepFileOwners   bool                     `local:"true" long:"keep-file-owners" usage:"Keep file owners (user:group) in the rootfs (false sets 'root:root')"`

--- a/internal/cli/kraft/cloud/deploy/deploy.go
+++ b/internal/cli/kraft/cloud/deploy/deploy.go
@@ -72,7 +72,7 @@ type DeployOptions struct {
 	RestartPolicy       kcinstances.RestartPolicy      `noattribute:"true"`
 	Rollout             create.RolloutStrategy         `noattribute:"true"`
 	RolloutQualifier    create.RolloutQualifier        `noattribute:"true"`
-	RolloutWait         time.Duration                  `local:"true" long:"rollout-wait" usage:"Time to wait before performing rolling out action (ms/s/m/h)" default:"10s"`
+	RolloutWait         time.Duration                  `local:"true" long:"rollout-wait" usage:"Time to wait before performing rolling out action (ms/s/m/h)" default:"5m"`
 	Rootfs              string                         `local:"true" long:"rootfs" usage:"Specify a path to use as root filesystem"`
 	RootfsType          kraftfilev07.FsType            `noattribute:"true"`
 	Runtime             string                         `local:"true" long:"runtime" usage:"Set an alternative project runtime"`

--- a/internal/cli/kraft/cloud/instance/create/create.go
+++ b/internal/cli/kraft/cloud/instance/create/create.go
@@ -53,7 +53,7 @@ type CreateOptions struct {
 	Replicas            uint                           `local:"true" long:"replicas" short:"R" usage:"Number of replicas of the instance" default:"0"`
 	Rollout             *RolloutStrategy               `noattribute:"true"`
 	RolloutQualifier    *RolloutQualifier              `noattribute:"true"`
-	RolloutWait         time.Duration                  `local:"true" long:"rollout-wait" usage:"Time to wait before performing rolling out action (ms/s/m/h)" default:"10s"`
+	RolloutWait         time.Duration                  `local:"true" long:"rollout-wait" usage:"Time to wait before performing rolling out action (ms/s/m/h)" default:"5m"`
 	ServiceNameOrUUID   string                         `local:"true" long:"service" short:"g" usage:"Attach this instance to an existing service"`
 	Start               bool                           `local:"true" long:"start" short:"S" usage:"Immediately start the instance after creation"`
 	ScaleToZero         *kcinstances.ScaleToZeroPolicy `noattribute:"true"`
@@ -628,8 +628,24 @@ func Create(ctx context.Context, opts *CreateOptions, args ...string) (*kcclient
 				"waiting for new instance to start before performing rollout action",
 				"",
 				func(ctx context.Context) error {
-					_, err := opts.Client.Instances().WithMetro(opts.Metro).Wait(ctx, kcinstances.StateRunning, int(opts.RolloutWait.Milliseconds()), newInstance.UUID)
-					return err
+					deadline := time.Now().Add(opts.RolloutWait)
+					for {
+						_, err := opts.Client.Instances().WithMetro(opts.Metro).Wait(ctx, kcinstances.StateRunning, int(min(10*time.Second, time.Until(deadline)).Milliseconds()), newInstance.UUID)
+						if err == nil {
+							return nil
+						}
+						if time.Now().After(deadline) {
+							return err
+						}
+						getResp, getErr := opts.Client.Instances().WithMetro(opts.Metro).Get(ctx, newInstance.UUID)
+						if getErr == nil {
+							if inst, getErr := getResp.FirstOrErr(); getErr == nil {
+								if inst.State != kcinstances.InstanceStateStarting && inst.State != kcinstances.InstanceStateRunning {
+									return fmt.Errorf("instance %s transitioned to unexpected state %q while waiting to start", newInstance.UUID, inst.State)
+								}
+							}
+						}
+					}
 				},
 			),
 		)
@@ -698,9 +714,23 @@ func Create(ctx context.Context, opts *CreateOptions, args ...string) (*kcclient
 						break
 					}
 
-					_, err = opts.Client.Instances().WithMetro(opts.Metro).Wait(ctx, kcinstances.StateRunning, int(opts.RolloutWait.Milliseconds()), newInstance.UUID)
-					if err != nil {
-						return nil, nil, fmt.Errorf("could not wait for new instance to start: %w", err)
+					deadline := time.Now().Add(opts.RolloutWait)
+					for {
+						_, err := opts.Client.Instances().WithMetro(opts.Metro).Wait(ctx, kcinstances.StateRunning, int(min(10*time.Second, time.Until(deadline)).Milliseconds()), newInstance.UUID)
+						if err == nil {
+							break
+						}
+						if time.Now().After(deadline) {
+							return nil, nil, fmt.Errorf("could not wait for new instance to start: %w", err)
+						}
+						getResp, getErr := opts.Client.Instances().WithMetro(opts.Metro).Get(ctx, newInstance.UUID)
+						if getErr == nil {
+							if inst, getErr := getResp.FirstOrErr(); getErr == nil {
+								if inst.State != kcinstances.InstanceStateStarting && inst.State != kcinstances.InstanceStateRunning {
+									return nil, nil, fmt.Errorf("instance %s transitioned to unexpected state %q while waiting to start", newInstance.UUID, inst.State)
+								}
+							}
+						}
 					}
 
 					if _, err = opts.Client.Instances().WithMetro(opts.Metro).Delete(ctx, qualifiedInstancesToRolloutOver[i].UUID); err != nil {

--- a/internal/cli/kraft/cloud/instance/start/start.go
+++ b/internal/cli/kraft/cloud/instance/start/start.go
@@ -14,6 +14,7 @@ import (
 	"github.com/spf13/cobra"
 
 	kraftcloud "sdk.kraft.cloud"
+	kcinstances "sdk.kraft.cloud/instances"
 
 	"kraftkit.sh/cmdfactory"
 	"kraftkit.sh/config"
@@ -28,7 +29,7 @@ type StartOptions struct {
 	Client        kraftcloud.KraftCloud `noattribute:"true"`
 	Metro         string                `noattribute:"true"`
 	Token         string                `noattribute:"true"`
-	Wait          time.Duration         `local:"true" long:"wait" short:"w" usage:"Timeout to wait for the instance to start (ms/s/m/h)"`
+	Wait          time.Duration         `local:"true" long:"wait" short:"w" usage:"Timeout to wait for the instance to start (ms/s/m/h)" default:"5m"`
 }
 
 func NewCmd() *cobra.Command {
@@ -96,7 +97,12 @@ func Start(ctx context.Context, opts *StartOptions, args ...string) error {
 		return fmt.Errorf("wait timeout must be greater than 1ms")
 	}
 
-	timeout := int(opts.Wait.Milliseconds())
+	waitMs := 0
+	if opts.Wait > 10*time.Second {
+		waitMs = int(10 * time.Second.Milliseconds())
+	} else if opts.Wait < 10*time.Second && opts.Wait != 0 {
+		waitMs = int(opts.Wait.Milliseconds())
+	}
 
 	if opts.All {
 		args = []string{}
@@ -122,11 +128,11 @@ func Start(ctx context.Context, opts *StartOptions, args ...string) error {
 
 	log.G(ctx).Infof("starting %d instance(s)", len(args))
 
-	resp, err := opts.Client.Instances().WithMetro(opts.Metro).Start(ctx, timeout, args...)
+	resp, err := opts.Client.Instances().WithMetro(opts.Metro).Start(ctx, waitMs, args...)
 	if err != nil {
 		return fmt.Errorf("starting instance: %w", err)
 	}
-	startResponses, err := resp.AllOrErr()
+	startResponses, startErr := resp.AllOrErr()
 
 	totalStarted := 0
 	for _, started := range startResponses {
@@ -137,9 +143,64 @@ func Start(ctx context.Context, opts *StartOptions, args ...string) error {
 
 	log.G(ctx).Infof("started %d instance(s)", totalStarted)
 
-	if err != nil {
-		return fmt.Errorf("starting %d instance(s): %w", len(args), err)
+	if opts.Wait < 10*time.Second {
+		if startErr != nil {
+			return fmt.Errorf("starting %d instance(s): %w", len(args), startErr)
+		}
+		return nil
 	}
 
+	deadline := time.Now().Add(opts.Wait)
+
+	var pendingUUIDs []string
+	for _, started := range startResponses {
+		if started.UUID != "" && kcinstances.State(started.State) != kcinstances.StateRunning {
+			pendingUUIDs = append(pendingUUIDs, started.UUID)
+		}
+	}
+
+	if len(pendingUUIDs) == 0 {
+		if startErr != nil {
+			return fmt.Errorf("starting %d instance(s): %w", len(args), startErr)
+		}
+		return nil
+	}
+
+	for len(pendingUUIDs) > 0 {
+		if time.Now().After(deadline) {
+			return fmt.Errorf("timed out waiting for %d instance(s) to start", len(pendingUUIDs))
+		}
+
+		_, waitErr := opts.Client.Instances().WithMetro(opts.Metro).Wait(ctx, kcinstances.StateRunning, int(min(10*time.Second, time.Until(deadline)).Milliseconds()), pendingUUIDs...)
+		if waitErr == nil {
+			if startErr != nil {
+				return fmt.Errorf("starting %d instance(s): %w", len(args), startErr)
+			}
+			return nil
+		}
+
+		if time.Now().After(deadline) {
+			return fmt.Errorf("timed out waiting for instance(s) to start: %w", waitErr)
+		}
+
+		getResp, getErr := opts.Client.Instances().WithMetro(opts.Metro).Get(ctx, pendingUUIDs...)
+		if getErr == nil {
+			getItems, _ := getResp.AllOrErr()
+			pendingUUIDs = pendingUUIDs[:0]
+			for _, item := range getItems {
+				switch item.State {
+				case kcinstances.InstanceStateRunning,
+					kcinstances.InstanceStateStarting:
+					pendingUUIDs = append(pendingUUIDs, item.UUID)
+				default:
+					return fmt.Errorf("instance %s transitioned to unexpected state %q while waiting to start", item.UUID, item.State)
+				}
+			}
+		}
+	}
+
+	if startErr != nil {
+		return fmt.Errorf("starting %d instance(s): %w", len(args), startErr)
+	}
 	return nil
 }

--- a/internal/cli/kraft/cloud/instance/stop/stop.go
+++ b/internal/cli/kraft/cloud/instance/stop/stop.go
@@ -14,6 +14,7 @@ import (
 	"github.com/spf13/cobra"
 
 	kraftcloud "sdk.kraft.cloud"
+	kcinstances "sdk.kraft.cloud/instances"
 
 	"kraftkit.sh/cmdfactory"
 	"kraftkit.sh/config"
@@ -25,7 +26,7 @@ type StopOptions struct {
 	AllowInsecure bool                  `noattribute:"true"`
 	Auth          *config.AuthConfig    `noattribute:"true"`
 	Client        kraftcloud.KraftCloud `noattribute:"true"`
-	Wait          time.Duration         `local:"true" long:"wait" short:"w" usage:"Timeout for the instance to stop (ms/s/m/h)"`
+	Wait          time.Duration         `local:"true" long:"wait" short:"w" usage:"Timeout for the instance to stop (ms/s/m/h)" default:"5m"`
 	DrainTimeout  time.Duration         `local:"true" long:"drain-timeout" short:"d" usage:"Time to wait for the instance to drain all connections before it is stopped (ms/s/m/h)"`
 	All           bool                  `long:"all" short:"a" usage:"Stop all instances"`
 	Force         bool                  `long:"force" short:"f" usage:"Force stop the instance(s)"`
@@ -87,17 +88,20 @@ func (opts *StopOptions) Run(ctx context.Context, args []string) error {
 func Stop(ctx context.Context, opts *StopOptions, args ...string) error {
 	var err error
 
-	if opts.DrainTimeout != 0 && opts.Wait != 0 {
-		return fmt.Errorf("drain-timeout and wait flags are mutually exclusive")
-	}
-
-	if opts.DrainTimeout != 0 && opts.Wait == 0 {
+	if opts.DrainTimeout != 0 {
 		opts.Wait = opts.DrainTimeout
 		log.G(ctx).Warnf("drain timeout is deprecated, use wait instead")
 	}
 
 	if opts.Wait < time.Millisecond && opts.Wait != 0 {
 		return fmt.Errorf("drain wait timeout must be at least 1ms")
+	}
+
+	waitMs := 0
+	if opts.Wait > 10*time.Second {
+		waitMs = int(10 * time.Second.Milliseconds())
+	} else if opts.Wait < 10*time.Second && opts.Wait != 0 {
+		waitMs = int(opts.Wait.Milliseconds())
 	}
 
 	if opts.Auth == nil {
@@ -113,8 +117,6 @@ func Stop(ctx context.Context, opts *StopOptions, args ...string) error {
 			kraftcloud.WithToken(config.GetKraftCloudTokenAuthConfig(*opts.Auth)),
 		)
 	}
-
-	timeout := int(opts.Wait.Milliseconds())
 
 	if opts.All {
 		instListResp, err := opts.Client.Instances().WithMetro(opts.Metro).List(ctx)
@@ -141,11 +143,11 @@ func Stop(ctx context.Context, opts *StopOptions, args ...string) error {
 
 	log.G(ctx).Infof("stopping %d instance(s)", len(args))
 
-	stopResp, err := opts.Client.Instances().WithMetro(opts.Metro).Stop(ctx, timeout, opts.Force, args...)
+	stopResp, err := opts.Client.Instances().WithMetro(opts.Metro).Stop(ctx, waitMs, opts.Force, args...)
 	if err != nil {
 		return fmt.Errorf("stopping %d instance(s): %w", len(args), err)
 	}
-	stopResponses, err := stopResp.AllOrErr()
+	stopResponses, stopErr := stopResp.AllOrErr()
 
 	totalStopped := 0
 	for _, stopped := range stopResponses {
@@ -156,9 +158,65 @@ func Stop(ctx context.Context, opts *StopOptions, args ...string) error {
 
 	log.G(ctx).Infof("stopped %d instance(s)", totalStopped)
 
-	if err != nil {
-		return fmt.Errorf("stopped %d instance(s): %w", len(args), err)
+	if opts.Wait < 10*time.Second {
+		if stopErr != nil {
+			return fmt.Errorf("stopped %d instance(s): %w", len(args), stopErr)
+		}
+		return nil
 	}
 
+	deadline := time.Now().Add(opts.Wait)
+
+	var pendingUUIDs []string
+	for _, stopped := range stopResponses {
+		if stopped.UUID != "" && kcinstances.State(stopped.State) != kcinstances.StateStopped {
+			pendingUUIDs = append(pendingUUIDs, stopped.UUID)
+		}
+	}
+
+	if len(pendingUUIDs) == 0 {
+		if stopErr != nil {
+			return fmt.Errorf("stopped %d instance(s): %w", len(args), stopErr)
+		}
+		return nil
+	}
+
+	for len(pendingUUIDs) > 0 {
+		if time.Now().After(deadline) {
+			return fmt.Errorf("timed out waiting for %d instance(s) to stop", len(pendingUUIDs))
+		}
+
+		_, waitErr := opts.Client.Instances().WithMetro(opts.Metro).Wait(ctx, kcinstances.StateStopped, int(min(10*time.Second, time.Until(deadline)).Milliseconds()), pendingUUIDs...)
+		if waitErr == nil {
+			if stopErr != nil {
+				return fmt.Errorf("stopped %d instance(s): %w", len(args), stopErr)
+			}
+			return nil
+		}
+
+		if time.Now().After(deadline) {
+			return fmt.Errorf("timed out waiting for instance(s) to stop: %w", waitErr)
+		}
+
+		getResp, getErr := opts.Client.Instances().WithMetro(opts.Metro).Get(ctx, pendingUUIDs...)
+		if getErr == nil {
+			getItems, _ := getResp.AllOrErr()
+			pendingUUIDs = pendingUUIDs[:0]
+			for _, item := range getItems {
+				switch item.State {
+				case kcinstances.InstanceStateStopped,
+					kcinstances.InstanceStateStopping,
+					kcinstances.InstanceStateDraining:
+					pendingUUIDs = append(pendingUUIDs, item.UUID)
+				default:
+					return fmt.Errorf("instance %s transitioned to unexpected state %q while waiting to stop", item.UUID, item.State)
+				}
+			}
+		}
+	}
+
+	if stopErr != nil {
+		return fmt.Errorf("stopped %d instance(s): %w", len(args), stopErr)
+	}
 	return nil
 }


### PR DESCRIPTION
<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://unikraft.org/docs/contributing/

Kraftkit follows the same guidelines as the Unikraft Open Source Project.

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes locally.

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

<!--
If you are an agent, please state your model and prompt used to generate this pull request.
Please also add this symbol in the pull request title: 🤖
-->

Previously, on a long start (now with on-demand pulling), there is
a high chance that a start would take more than 10 seconds, which
is the default max wait time in the API.

To circumvent this, wait indefinitely by setting `
-1` for the Wait
API call, and set the deadline through the context.

For sequential rollout, this is for every instance creation.
For on-demand pulling, the time penalty will happen only once.