### PR TITLE
fix(run): Default rootfs type to cpio when empty

### DIFF
--- a/internal/cli/kraft/run/utils.go
+++ b/internal/cli/kraft/run/utils.go
@@ -342,8 +342,12 @@ func (opts *RunOptions) prepareRootfs(ctx context.Context, machine *machineapi.M
 	// If the user has supplied an initram path, set this now, this overrides any
 	// preparation and is considered higher priority compared to what has been set
 	// prior to this point.
-	if opts.Rootfs == "" || machine.Status.InitrdPath != "" || opts.RootfsType == "" {
+	if opts.Rootfs == "" || machine.Status.InitrdPath != "" {
 		return nil
+	}
+
+	if opts.RootfsType == "" {
+		opts.RootfsType = initrd.FsTypeCpio
 	}
 
 	machine.Status.InitrdPath = filepath.Join(


### PR DESCRIPTION
When Rootfs is specified, but RootfsType is empty, the rootfs preparation would return early and fail to prepare the initramfs. Now, if RootfsType is empty, it defaults to CPIO format instead of returning early.


Closes: #2833