### PR TITLE
fix(kraft): Respect no-rootfs when building rootfs

### DIFF
--- a/internal/cli/kraft/build/build.go
+++ b/internal/cli/kraft/build/build.go
@@ -123,35 +123,37 @@ func Build(ctx context.Context, opts *BuildOptions, args ...string) error {
 		return fmt.Errorf("could not complete build: %w", err)
 	}
 
-	if _, _, _, err = initrd.BuildRootfs(
-		ctx,
-		append(opts.InitrdOptions,
-			initrd.WithRootfsPath(opts.Rootfs),
-			initrd.WithWorkdir(opts.Workdir),
-			initrd.WithKeepOwners(opts.KeepFileOwners),
-			initrd.WithOutput(filepath.Join(
-				buildOutputDir(opts.Project, opts.Workdir),
-				fmt.Sprintf(initrd.DefaultInitramfsArchFileName, (*opts.Target).Architecture(), opts.RootfsType),
-			)),
-			initrd.WithOutputType(opts.RootfsType),
-			initrd.WithCacheDir(filepath.Join(
-				opts.Workdir,
-				unikraft.VendorDir,
-				"rootfs-cache",
-			)),
-			initrd.WithArchitecture((*opts.Target).Architecture().String()),
-			initrd.WithCompression(false),
-		)...,
-	); err != nil {
-		return err
-	}
+	if !opts.NoRootfs {
+		if _, _, _, err = initrd.BuildRootfs(
+			ctx,
+			append(opts.InitrdOptions,
+				initrd.WithRootfsPath(opts.Rootfs),
+				initrd.WithWorkdir(opts.Workdir),
+				initrd.WithKeepOwners(opts.KeepFileOwners),
+				initrd.WithOutput(filepath.Join(
+					buildOutputDir(opts.Project, opts.Workdir),
+					fmt.Sprintf(initrd.DefaultInitramfsArchFileName, (*opts.Target).Architecture(), opts.RootfsType),
+				)),
+				initrd.WithOutputType(opts.RootfsType),
+				initrd.WithCacheDir(filepath.Join(
+					opts.Workdir,
+					unikraft.VendorDir,
+					"rootfs-cache",
+				)),
+				initrd.WithArchitecture((*opts.Target).Architecture().String()),
+				initrd.WithCompression(false),
+			)...,
+		); err != nil {
+			return err
+		}
 
-	// Set the root file system for the project, since typically a packaging step
-	// may occur after a build, and the root file system is required for packaging
-	// and the packaging step may perform a build of the rootfs again.  Ultimately
-	// this prevents re-builds.
-	opts.Project.SetRootfs(opts.Rootfs)
-	opts.Project.SetInitrdFsType(opts.RootfsType)
+		// Set the root file system for the project, since typically a packaging step
+		// may occur after a build, and the root file system is required for packaging
+		// and the packaging step may perform a build of the rootfs again.  Ultimately
+		// this prevents re-builds.
+		opts.Project.SetRootfs(opts.Rootfs)
+		opts.Project.SetInitrdFsType(opts.RootfsType)
+	}
 
 	err = build.Build(ctx, opts, args...)
 	if err != nil {
@@ -302,7 +304,7 @@ func (opts *BuildOptions) Run(ctx context.Context, args []string) error {
 		})
 	}
 
-	if opts.Rootfs != "" {
+	if opts.Rootfs != "" && !opts.NoRootfs {
 		if !filepath.IsAbs(opts.Rootfs) {
 			opts.Rootfs = filepath.Join(opts.Workdir, opts.Rootfs)
 		}

--- a/internal/cli/kraft/run/runner_package.go
+++ b/internal/cli/kraft/run/runner_package.go
@@ -330,6 +330,9 @@ func (runner *runnerPackage) Prepare(ctx context.Context, opts *RunOptions, mach
 	if opts.Rootfs == "" && targ.Initrd() != nil {
 		ramfs = targ.Initrd()
 	} else if len(opts.Rootfs) > 0 {
+		if opts.RootfsType == "" {
+			opts.RootfsType = initrd.FsTypeCpio
+		}
 		ramfs, err = initrd.New(ctx, opts.Rootfs,
 			initrd.WithWorkdir(opts.workdir),
 			initrd.WithOutputType(opts.RootfsType),


### PR DESCRIPTION
Skip initrd generation and rootfs path normalization when no-rootfs is set. Default package runner rootfs handling to cpio when no type is provided.