### PR TITLE
feat: Add `--hyperlight-net` flag to enable networking in Hyperlight micro-vms

### DIFF
--- a/internal/bootstrap/init.go
+++ b/internal/bootstrap/init.go
@@ -10,6 +10,7 @@ import (
 	"context"
 
 	"kraftkit.sh/api"
+	"kraftkit.sh/machine/hyperlight"
 	"kraftkit.sh/machine/qemu"
 	"kraftkit.sh/manifest"
 	"kraftkit.sh/oci"
@@ -31,6 +32,7 @@ func InitKraftkit(ctx context.Context) error {
 
 func registerAdditionalFlags() {
 	manifest.RegisterFlags()
+	hyperlight.RegisterFlags()
 	qemu.RegisterFlags()
 }
 

--- a/internal/cli/kraft/events/events.go
+++ b/internal/cli/kraft/events/events.go
@@ -57,7 +57,7 @@ func NewCmd() *cobra.Command {
 
 	cmd.Flags().VarP(
 		cmdfactory.NewEnumFlag[mplatform.Platform](
-			mplatform.Platforms(),
+			mplatform.PlatformNames(mplatform.Platform("auto")),
 			mplatform.Platform("auto"),
 		),
 		"plat",

--- a/internal/cli/kraft/logs/logs.go
+++ b/internal/cli/kraft/logs/logs.go
@@ -60,7 +60,7 @@ func NewCmd() *cobra.Command {
 
 	cmd.Flags().VarP(
 		cmdfactory.NewEnumFlag(
-			mplatform.Platforms(),
+			mplatform.PlatformNames(mplatform.Platform("all")),
 			mplatform.Platform("all"),
 		),
 		"plat",

--- a/internal/cli/kraft/logs/logs.go
+++ b/internal/cli/kraft/logs/logs.go
@@ -161,8 +161,10 @@ func (opts *LogOptions) Run(ctx context.Context, args []string) error {
 			errGroup = append(errGroup, err)
 		}
 
-		// Sometimes the kernel can boot and exit faster than we can start tailing the logs
-		if opts.Follow && (machine.Status.State == machineapi.MachineStateRunning || machine.Status.State == machineapi.MachineStateExited) {
+		// Sometimes the kernel can boot and exit faster than we can start tailing
+		// the logs.  If the machine is already terminal, read the finite log file
+		// below instead of following forever.
+		if opts.Follow && machine.Status.State == machineapi.MachineStateRunning {
 			observations.Add(machine)
 			go func(machine *machineapi.Machine) {
 				defer func() {

--- a/internal/cli/kraft/pause/pause.go
+++ b/internal/cli/kraft/pause/pause.go
@@ -54,7 +54,7 @@ func NewCmd() *cobra.Command {
 
 	cmd.Flags().VarP(
 		cmdfactory.NewEnumFlag(
-			mplatform.Platforms(),
+			mplatform.PlatformNames(mplatform.Platform("all")),
 			mplatform.Platform("all"),
 		),
 		"plat",

--- a/internal/cli/kraft/pause/pause.go
+++ b/internal/cli/kraft/pause/pause.go
@@ -6,6 +6,7 @@ package pause
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/MakeNowJust/heredoc"
@@ -14,7 +15,6 @@ import (
 	machineapi "kraftkit.sh/api/machine/v1alpha1"
 	"kraftkit.sh/cmdfactory"
 	"kraftkit.sh/iostreams"
-	"kraftkit.sh/log"
 	mplatform "kraftkit.sh/machine/platform"
 )
 
@@ -127,15 +127,17 @@ func (opts *PauseOptions) Run(ctx context.Context, args []string) error {
 		return fmt.Errorf("machine(s) not found")
 	}
 
+	var pauseErrs []error
+
 	for _, machine := range pause {
 		if machine.Status.State != machineapi.MachineStateRunning {
 			continue
 		} else if _, err := controller.Pause(ctx, &machine); err != nil {
-			log.G(ctx).Errorf("could not pause machine %s: %v", machine.Name, err)
+			pauseErrs = append(pauseErrs, fmt.Errorf("could not pause machine %s: %w", machine.Name, err))
 		} else {
 			fmt.Fprintln(iostreams.G(ctx).Out, machine.Name)
 		}
 	}
 
-	return nil
+	return errors.Join(pauseErrs...)
 }

--- a/internal/cli/kraft/ps/ps.go
+++ b/internal/cli/kraft/ps/ps.go
@@ -63,7 +63,7 @@ func NewCmd() *cobra.Command {
 
 	cmd.Flags().VarP(
 		cmdfactory.NewEnumFlag[mplatform.Platform](
-			mplatform.Platforms(),
+			mplatform.PlatformNames(mplatform.Platform("all")),
 			mplatform.Platform("all"),
 		),
 		"plat",

--- a/internal/cli/kraft/remove/remove.go
+++ b/internal/cli/kraft/remove/remove.go
@@ -59,7 +59,7 @@ func NewCmd() *cobra.Command {
 
 	cmd.Flags().VarP(
 		cmdfactory.NewEnumFlag(
-			mplatform.Platforms(),
+			mplatform.PlatformNames(mplatform.Platform("all")),
 			mplatform.Platform("all"),
 		),
 		"plat",

--- a/internal/cli/kraft/run/run.go
+++ b/internal/cli/kraft/run/run.go
@@ -139,7 +139,7 @@ func NewCmd() *cobra.Command {
 
 	cmd.Flags().Var(
 		cmdfactory.NewEnumFlag[mplatform.Platform](
-			mplatform.Platforms(),
+			mplatform.PlatformNames(mplatform.Platform("auto")),
 			mplatform.Platform("auto"),
 		),
 		"plat",
@@ -249,6 +249,7 @@ func (opts *RunOptions) detectAndSetHostPlatform(ctx context.Context) error {
 		if !ok {
 			return fmt.Errorf("unknown platform driver '%s', however your system supports '%s'", opts.Platform, opts.hostPlatform.String())
 		}
+		opts.Platform = opts.platform.String()
 	}
 	if opts.hostPlatform.String() == opts.Platform && opts.hostMode == mplatform.SystemGuest && !opts.DisableAccel {
 		log.G(ctx).Warn("using hardware emulation")

--- a/internal/cli/kraft/start/start.go
+++ b/internal/cli/kraft/start/start.go
@@ -54,7 +54,7 @@ func NewCmd() *cobra.Command {
 
 	cmd.Flags().VarP(
 		cmdfactory.NewEnumFlag(
-			mplatform.Platforms(),
+			mplatform.PlatformNames(mplatform.Platform("all")),
 			mplatform.Platform("all"),
 		),
 		"plat",

--- a/internal/cli/kraft/start/start.go
+++ b/internal/cli/kraft/start/start.go
@@ -137,7 +137,7 @@ func Start(ctx context.Context, opts *StartOptions, machineNames ...string) erro
 		return fmt.Errorf("instantiating volume service controller iterator: %w", err)
 	}
 
-	for _, machine := range machines {
+	for i, machine := range machines {
 		machine := machine // Go closures
 
 		// Check if the machine's requested ports are not already in use by an
@@ -150,8 +150,13 @@ func Start(ctx context.Context, opts *StartOptions, machineNames ...string) erro
 			WithField("machine", machine.Name).
 			Trace("starting")
 
-		if _, err := machineController.Start(ctx, &machine); err != nil {
+		started, err := machineController.Start(ctx, &machine)
+		if err != nil {
 			return err
+		}
+		if started != nil {
+			machine = *started
+			machines[i] = machine
 		}
 
 		for _, vol := range machine.Spec.Volumes {

--- a/internal/cli/kraft/stop/stop.go
+++ b/internal/cli/kraft/stop/stop.go
@@ -54,7 +54,7 @@ func NewCmd() *cobra.Command {
 
 	cmd.Flags().VarP(
 		cmdfactory.NewEnumFlag(
-			mplatform.Platforms(),
+			mplatform.PlatformNames(mplatform.Platform("all")),
 			mplatform.Platform("all"),
 		),
 		"plat",

--- a/machine/hyperlight/README.md
+++ b/machine/hyperlight/README.md
@@ -42,7 +42,8 @@ kraft run   --plat hl ...
 
 ### Defaults
 
-- `DefaultMemory`: `16Mi`. Override with `--memory` for heavier guests.
+- `DefaultMemory`: `32Mi`, matching the `hyperlight-unikraft` default.
+  Override with `--memory` for guests that need a different allocation.
 - `DefaultStack`: `8Mi`. Not yet exposed through the CLI or Kraftfile.
 
 ### Limitations

--- a/machine/hyperlight/README.md
+++ b/machine/hyperlight/README.md
@@ -11,11 +11,11 @@ across separate kraft invocations via standard PID tracking.
 - Linux host with `/dev/kvm` read/write access, or Windows host with the
   Windows Hypervisor Platform (WHP) enabled.
 - The `hyperlight-unikraft` binary (from
-  [danbugs/hyperlight-unikraft](https://github.com/danbugs/hyperlight-unikraft))
+  [hyperlight-dev/hyperlight-unikraft](https://github.com/hyperlight-dev/hyperlight-unikraft))
   installed on `$PATH`:
 
   ```bash
-  cargo install --git https://github.com/danbugs/hyperlight-unikraft \
+  cargo install --git https://github.com/hyperlight-dev/hyperlight-unikraft \
       --branch main hyperlight-unikraft-host --bin hyperlight-unikraft
   ```
 
@@ -67,18 +67,19 @@ Hyperlight-specific host options are exposed with a `--hyperlight-*` prefix on
 - `--hyperlight-mount`
 - `--hyperlight-exec`
 
-Dockerfile and OCI rootfs metadata can contain default environment variables.
 `hyperlight-unikraft` does not currently expose a runtime environment-injection
-interface. If the guest needs environment variables, compile them into the
-unikernel configuration or application.
+interface. Avoid runtime environment metadata for Hyperlight guests, including
+Dockerfile/OCI env metadata, `--env`, and Kraftfile `env:` entries; compile
+required values into the unikernel configuration or application.
 
 ### Limitations
 
 - `kraft pause` is not supported; Hyperlight has no pause semantics.
 - The child process is terminated on `kraft stop` via SIGTERM; there is no
   in-VM quiesce step.
-- Runtime environment injection is not supported. Explicit `kraft run --env`
-  and Kraftfile `env:` entries fail with a clear error.
+- Runtime environment injection is not supported. Explicit `kraft run --env`,
+  Kraftfile `env:` entries, and rootfs metadata environment entries fail with
+  a clear error.
 - Network attachments, port publishing, emulation mode, and kernel arguments
   are rejected because `hyperlight-unikraft` does not support those KraftKit
   interfaces.

--- a/machine/hyperlight/README.md
+++ b/machine/hyperlight/README.md
@@ -56,6 +56,12 @@ The driver maps the common KraftKit run surface that Hyperlight can execute:
 - Application arguments after `--` are passed after the kernel path.
 - Writable `9pfs` directory volumes are passed as repeatable
   `hyperlight-unikraft --mount HOST:GUEST` entries.
+- Same-port guest listen permissions from `--port GUEST_PORT:GUEST_PORT` are
+  passed as `hyperlight-unikraft --net --port GUEST_PORT`. Hyperlight ports are
+  sandbox bind permissions, not Docker-style host forwarding.
+- Hyperlight sandbox networking policy is configured with
+  `--hyperlight-net-allow` and `--hyperlight-net-block`; allow/block entries
+  imply networking in `hyperlight-unikraft`.
 
 Hyperlight-specific host options are exposed with a `--hyperlight-*` prefix on
 `kraft run` and are ignored by other platform drivers:
@@ -63,6 +69,8 @@ Hyperlight-specific host options are exposed with a `--hyperlight-*` prefix on
 - `--hyperlight-stack`
 - `--hyperlight-quiet`
 - `--hyperlight-enable-tools`
+- `--hyperlight-net-allow`
+- `--hyperlight-net-block`
 - `--hyperlight-repeat`
 - `--hyperlight-mount`
 - `--hyperlight-exec`
@@ -80,8 +88,10 @@ required values into the unikernel configuration or application.
 - Runtime environment injection is not supported. Explicit `kraft run --env`,
   Kraftfile `env:` entries, and rootfs metadata environment entries fail with
   a clear error.
-- Network attachments, port publishing, emulation mode, and kernel arguments
-  are rejected because `hyperlight-unikraft` does not support those KraftKit
-  interfaces.
+- Network attachments (`--network`, `--ip`, `--mac`), host port forwarding,
+  emulation mode, and kernel arguments are rejected because
+  `hyperlight-unikraft` does not support those KraftKit interfaces.
+- `--hyperlight-net-allow` and `--hyperlight-net-block` are mutually exclusive
+  sandbox policies.
 - Read-only volumes and non-`9pfs` volume drivers are rejected. Rootfs/initrd
   volumes are supported only when they represent the main initrd at `/`.

--- a/machine/hyperlight/README.md
+++ b/machine/hyperlight/README.md
@@ -44,10 +44,43 @@ kraft run   --plat hl ...
 
 - `DefaultMemory`: `32Mi`, matching the `hyperlight-unikraft` default.
   Override with `--memory` for guests that need a different allocation.
-- `DefaultStack`: `8Mi`. Not yet exposed through the CLI or Kraftfile.
+- `DefaultStack`: `8Mi`. Override with `--hyperlight-stack`.
+
+### Supported run options
+
+The driver maps the common KraftKit run surface that Hyperlight can execute:
+
+- `--memory` is passed to `hyperlight-unikraft --memory`.
+- `--rootfs`/`--initrd` CPIO archives are passed as
+  `hyperlight-unikraft --initrd`.
+- Application arguments after `--` are passed after the kernel path.
+- Writable `9pfs` directory volumes are passed as repeatable
+  `hyperlight-unikraft --mount HOST:GUEST` entries.
+
+Hyperlight-specific host options are exposed with a `--hyperlight-*` prefix on
+`kraft run` and are ignored by other platform drivers:
+
+- `--hyperlight-stack`
+- `--hyperlight-quiet`
+- `--hyperlight-enable-tools`
+- `--hyperlight-repeat`
+- `--hyperlight-mount`
+- `--hyperlight-exec`
+
+Dockerfile and OCI rootfs metadata can contain default environment variables.
+`hyperlight-unikraft` does not currently expose a runtime environment-injection
+interface. If the guest needs environment variables, compile them into the
+unikernel configuration or application.
 
 ### Limitations
 
 - `kraft pause` is not supported; Hyperlight has no pause semantics.
 - The child process is terminated on `kraft stop` via SIGTERM; there is no
   in-VM quiesce step.
+- Runtime environment injection is not supported. Explicit `kraft run --env`
+  and Kraftfile `env:` entries fail with a clear error.
+- Network attachments, port publishing, emulation mode, and kernel arguments
+  are rejected because `hyperlight-unikraft` does not support those KraftKit
+  interfaces.
+- Read-only volumes and non-`9pfs` volume drivers are rejected. Rootfs/initrd
+  volumes are supported only when they represent the main initrd at `/`.

--- a/machine/hyperlight/README.md
+++ b/machine/hyperlight/README.md
@@ -1,0 +1,52 @@
+## Hyperlight Machine Driver
+
+A kraftkit machine driver that runs Unikraft unikernels on
+[Hyperlight](https://github.com/hyperlight-dev/hyperlight) micro-VMs. Each
+machine created through this driver is a child `hyperlight-unikraft` process,
+so `kraft ps`, `kraft stop`, `kraft rm`, and `kraft logs` all work across
+separate kraft invocations via standard PID tracking.
+
+### Requirements
+
+- Linux host with `/dev/kvm` read/write access.
+- The `hyperlight-unikraft` binary (from
+  [hyperlight-unikraft](https://github.com/hyperlight-dev/hyperlight-unikraft))
+  installed on `$PATH`:
+
+  ```bash
+  cd hyperlight-unikraft/host
+  cargo build --release
+  sudo cp target/release/hyperlight-unikraft /usr/local/bin/
+  ```
+
+- Unikraft kernels built for the `hyperlight` platform target.
+
+No cgo, no linker flags, no shared libraries — kraftkit just needs to find
+`hyperlight-unikraft` in `$PATH` at runtime.
+
+### Platform selection
+
+The driver registers two names:
+
+- `hyperlight` (canonical)
+- `hl` (shorthand)
+
+Either can be used with `--plat`:
+
+```bash
+kraft build --plat hyperlight --arch x86_64
+kraft run   --plat hl ...
+```
+
+### Defaults
+
+- `DefaultMemory`: `16Mi` — median of the hyperlight-unikraft example
+  workloads. Heavier guests (Python, Node.js, .NET, PowerShell) require
+  `--memory` overrides.
+- `DefaultStack`: `8Mi`.
+
+### Limitations
+
+- `kraft pause` is not supported; Hyperlight has no pause semantics.
+- The child process is terminated on `kraft stop` via SIGTERM; there is no
+  in-VM quiesce step.

--- a/machine/hyperlight/README.md
+++ b/machine/hyperlight/README.md
@@ -40,10 +40,8 @@ kraft run   --plat hl ...
 
 ### Defaults
 
-- `DefaultMemory`: `16Mi` — median of the hyperlight-unikraft example
-  workloads. Heavier guests (Python, Node.js, .NET, PowerShell) require
-  `--memory` overrides.
-- `DefaultStack`: `8Mi`.
+- `DefaultMemory`: `16Mi`. Override with `--memory` for heavier guests.
+- `DefaultStack`: `8Mi`. Not yet exposed through the CLI or Kraftfile.
 
 ### Limitations
 

--- a/machine/hyperlight/README.md
+++ b/machine/hyperlight/README.md
@@ -2,27 +2,29 @@
 
 A kraftkit machine driver that runs Unikraft unikernels on
 [Hyperlight](https://github.com/hyperlight-dev/hyperlight) micro-VMs. Each
-machine created through this driver is a child `hyperlight-unikraft` process,
-so `kraft ps`, `kraft stop`, `kraft rm`, and `kraft logs` all work across
-separate kraft invocations via standard PID tracking.
+machine created through this driver is a detached `hyperlight-unikraft` child
+process, so `kraft ps`, `kraft stop`, `kraft rm`, and `kraft logs` all work
+across separate kraft invocations via standard PID tracking.
 
 ### Requirements
 
-- Linux host with `/dev/kvm` read/write access.
+- Linux host with `/dev/kvm` read/write access, or Windows host with the
+  Windows Hypervisor Platform (WHP) enabled.
 - The `hyperlight-unikraft` binary (from
-  [hyperlight-unikraft](https://github.com/hyperlight-dev/hyperlight-unikraft))
+  [danbugs/hyperlight-unikraft](https://github.com/danbugs/hyperlight-unikraft))
   installed on `$PATH`:
 
   ```bash
-  cd hyperlight-unikraft/host
-  cargo build --release
-  sudo cp target/release/hyperlight-unikraft /usr/local/bin/
+  cargo install --git https://github.com/danbugs/hyperlight-unikraft \
+      --branch main hyperlight-unikraft-host --bin hyperlight-unikraft
   ```
 
 - Unikraft kernels built for the `hyperlight` platform target.
 
 No cgo, no linker flags, no shared libraries — kraftkit just needs to find
-`hyperlight-unikraft` in `$PATH` at runtime.
+`hyperlight-unikraft` on `$PATH` at runtime. A future iteration may link the
+Hyperlight host library in-process via cgo for tighter lifecycle control and
+lower per-call overhead; the subprocess model is a deliberate first step.
 
 ### Platform selection
 

--- a/machine/hyperlight/config.go
+++ b/machine/hyperlight/config.go
@@ -4,6 +4,8 @@
 // You may not use this file except in compliance with the License.
 package hyperlight
 
+import "strconv"
+
 // HyperlightConfig represents configuration for a Hyperlight micro-VM.
 type HyperlightConfig struct {
 	// KernelPath is the path to the unikernel binary.
@@ -14,6 +16,18 @@ type HyperlightConfig struct {
 
 	// Stack is the stack size (e.g. "8Mi").
 	Stack string `json:"stack,omitempty"`
+
+	// Quiet suppresses hyperlight-unikraft host-side status messages.
+	Quiet bool `json:"quiet,omitempty"`
+
+	// EnableTools enables tool dispatch via the __dispatch host function.
+	EnableTools bool `json:"enableTools,omitempty"`
+
+	// Repeat runs the application N additional times.
+	Repeat int `json:"repeat,omitempty"`
+
+	// Exec is an inline code snippet for the guest interpreter.
+	Exec string `json:"exec,omitempty"`
 
 	// InitRd is the path to the initramfs/rootfs CPIO archive.
 	InitRd string `json:"initrd,omitempty"`
@@ -30,14 +44,27 @@ func (hlcfg *HyperlightConfig) MarshalArgs(appArgs []string) []string {
 		"--memory", hlcfg.Memory,
 		"--stack", hlcfg.Stack,
 	}
+	if hlcfg.Quiet {
+		args = append(args, "--quiet")
+	}
+	if hlcfg.EnableTools {
+		args = append(args, "--enable-tools")
+	}
+	if hlcfg.Repeat > 0 {
+		args = append(args, "--repeat", strconv.Itoa(hlcfg.Repeat))
+	}
 	if hlcfg.InitRd != "" {
 		args = append(args, "--initrd", hlcfg.InitRd)
 	}
 	for _, mount := range hlcfg.Mounts {
 		args = append(args, "--mount", mount)
 	}
+	if hlcfg.Exec != "" {
+		args = append(args, "--exec", hlcfg.Exec)
+	}
 	args = append(args, hlcfg.KernelPath)
-	if len(appArgs) > 0 {
+
+	if hlcfg.Exec == "" && len(appArgs) > 0 {
 		args = append(args, "--")
 		args = append(args, appArgs...)
 	}
@@ -93,6 +120,34 @@ func WithStack(stack string) HyperlightOption {
 func WithMounts(mounts ...string) HyperlightOption {
 	return func(c *HyperlightConfig) error {
 		c.Mounts = mounts
+		return nil
+	}
+}
+
+func WithQuiet(quiet bool) HyperlightOption {
+	return func(c *HyperlightConfig) error {
+		c.Quiet = quiet
+		return nil
+	}
+}
+
+func WithEnableTools(enableTools bool) HyperlightOption {
+	return func(c *HyperlightConfig) error {
+		c.EnableTools = enableTools
+		return nil
+	}
+}
+
+func WithRepeat(repeat int) HyperlightOption {
+	return func(c *HyperlightConfig) error {
+		c.Repeat = repeat
+		return nil
+	}
+}
+
+func WithExec(code string) HyperlightOption {
+	return func(c *HyperlightConfig) error {
+		c.Exec = code
 		return nil
 	}
 }

--- a/machine/hyperlight/config.go
+++ b/machine/hyperlight/config.go
@@ -18,6 +18,9 @@ type HyperlightConfig struct {
 	// InitRd is the path to the initramfs/rootfs CPIO archive.
 	InitRd string `json:"initrd,omitempty"`
 
+	// Mounts are host directory preopens in HOST:GUEST form.
+	Mounts []string `json:"mounts,omitempty"`
+
 	// LogPath is the path to the log file.
 	LogPath string `json:"logPath,omitempty"`
 }
@@ -63,6 +66,13 @@ func WithInitRd(initrd string) HyperlightOption {
 func WithStack(stack string) HyperlightOption {
 	return func(c *HyperlightConfig) error {
 		c.Stack = stack
+		return nil
+	}
+}
+
+func WithMounts(mounts ...string) HyperlightOption {
+	return func(c *HyperlightConfig) error {
+		c.Mounts = mounts
 		return nil
 	}
 }

--- a/machine/hyperlight/config.go
+++ b/machine/hyperlight/config.go
@@ -4,7 +4,9 @@
 // You may not use this file except in compliance with the License.
 package hyperlight
 
-import "strconv"
+import (
+	"strconv"
+)
 
 // HyperlightConfig represents configuration for a Hyperlight micro-VM.
 type HyperlightConfig struct {
@@ -46,6 +48,9 @@ type HyperlightConfig struct {
 
 	// LogPath is the path to the log file.
 	LogPath string `json:"logPath,omitempty"`
+
+	// Enables networking
+	Net bool `json:"net,omitempty"`
 }
 
 func (hlcfg *HyperlightConfig) MarshalArgs(appArgs []string) []string {
@@ -59,7 +64,7 @@ func (hlcfg *HyperlightConfig) MarshalArgs(appArgs []string) []string {
 	if hlcfg.EnableTools {
 		args = append(args, "--enable-tools")
 	}
-	if len(hlcfg.Ports) > 0 {
+	if hlcfg.Net {
 		args = append(args, "--net")
 	}
 	for _, allow := range hlcfg.NetAllow {

--- a/machine/hyperlight/config.go
+++ b/machine/hyperlight/config.go
@@ -25,6 +25,26 @@ type HyperlightConfig struct {
 	LogPath string `json:"logPath,omitempty"`
 }
 
+func (hlcfg *HyperlightConfig) MarshalArgs(appArgs []string) []string {
+	args := []string{
+		"--memory", hlcfg.Memory,
+		"--stack", hlcfg.Stack,
+	}
+	if hlcfg.InitRd != "" {
+		args = append(args, "--initrd", hlcfg.InitRd)
+	}
+	for _, mount := range hlcfg.Mounts {
+		args = append(args, "--mount", mount)
+	}
+	args = append(args, hlcfg.KernelPath)
+	if len(appArgs) > 0 {
+		args = append(args, "--")
+		args = append(args, appArgs...)
+	}
+
+	return args
+}
+
 type HyperlightOption func(*HyperlightConfig) error
 
 func NewHyperlightConfig(opts ...HyperlightOption) (*HyperlightConfig, error) {

--- a/machine/hyperlight/config.go
+++ b/machine/hyperlight/config.go
@@ -23,6 +23,15 @@ type HyperlightConfig struct {
 	// EnableTools enables tool dispatch via the __dispatch host function.
 	EnableTools bool `json:"enableTools,omitempty"`
 
+	// NetAllow restricts guest networking to the listed hosts/IPs.
+	NetAllow []string `json:"netAllow,omitempty"`
+
+	// NetBlock blocks guest networking to the listed hosts/IPs.
+	NetBlock []string `json:"netBlock,omitempty"`
+
+	// Ports are guest ports the sandbox may bind/listen on.
+	Ports []int32 `json:"ports,omitempty"`
+
 	// Repeat runs the application N additional times.
 	Repeat int `json:"repeat,omitempty"`
 
@@ -49,6 +58,18 @@ func (hlcfg *HyperlightConfig) MarshalArgs(appArgs []string) []string {
 	}
 	if hlcfg.EnableTools {
 		args = append(args, "--enable-tools")
+	}
+	if len(hlcfg.Ports) > 0 {
+		args = append(args, "--net")
+	}
+	for _, allow := range hlcfg.NetAllow {
+		args = append(args, "--net-allow", allow)
+	}
+	for _, block := range hlcfg.NetBlock {
+		args = append(args, "--net-block", block)
+	}
+	for _, port := range hlcfg.Ports {
+		args = append(args, "--port", strconv.Itoa(int(port)))
 	}
 	if hlcfg.Repeat > 0 {
 		args = append(args, "--repeat", strconv.Itoa(hlcfg.Repeat))
@@ -134,6 +155,27 @@ func WithQuiet(quiet bool) HyperlightOption {
 func WithEnableTools(enableTools bool) HyperlightOption {
 	return func(c *HyperlightConfig) error {
 		c.EnableTools = enableTools
+		return nil
+	}
+}
+
+func WithNetAllow(allow ...string) HyperlightOption {
+	return func(c *HyperlightConfig) error {
+		c.NetAllow = allow
+		return nil
+	}
+}
+
+func WithNetBlock(block ...string) HyperlightOption {
+	return func(c *HyperlightConfig) error {
+		c.NetBlock = block
+		return nil
+	}
+}
+
+func WithPorts(ports ...int32) HyperlightOption {
+	return func(c *HyperlightConfig) error {
+		c.Ports = ports
 		return nil
 	}
 }

--- a/machine/hyperlight/config.go
+++ b/machine/hyperlight/config.go
@@ -26,8 +26,8 @@ type HyperlightOption func(*HyperlightConfig) error
 
 func NewHyperlightConfig(opts ...HyperlightOption) (*HyperlightConfig, error) {
 	cfg := &HyperlightConfig{
-		Memory: "16Mi",
-		Stack:  "8Mi",
+		Memory: DefaultMemory,
+		Stack:  DefaultStack,
 	}
 
 	for _, o := range opts {

--- a/machine/hyperlight/config.go
+++ b/machine/hyperlight/config.go
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2026, Unikraft GmbH and The KraftKit Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+package hyperlight
+
+// HyperlightConfig represents configuration for a Hyperlight micro-VM.
+type HyperlightConfig struct {
+	// KernelPath is the path to the unikernel binary.
+	KernelPath string `json:"kernelPath,omitempty"`
+
+	// Memory is the amount of memory allocated to the VM (e.g. "512Mi").
+	Memory string `json:"memory,omitempty"`
+
+	// Stack is the stack size (e.g. "8Mi").
+	Stack string `json:"stack,omitempty"`
+
+	// InitRd is the path to the initramfs/rootfs CPIO archive.
+	InitRd string `json:"initrd,omitempty"`
+
+	// LogPath is the path to the log file.
+	LogPath string `json:"logPath,omitempty"`
+}
+
+type HyperlightOption func(*HyperlightConfig) error
+
+func NewHyperlightConfig(opts ...HyperlightOption) (*HyperlightConfig, error) {
+	cfg := &HyperlightConfig{
+		Memory: "16Mi",
+		Stack:  "8Mi",
+	}
+
+	for _, o := range opts {
+		if err := o(cfg); err != nil {
+			return nil, err
+		}
+	}
+
+	return cfg, nil
+}
+
+func WithKernel(kernel string) HyperlightOption {
+	return func(c *HyperlightConfig) error {
+		c.KernelPath = kernel
+		return nil
+	}
+}
+
+func WithMemory(memory string) HyperlightOption {
+	return func(c *HyperlightConfig) error {
+		c.Memory = memory
+		return nil
+	}
+}
+
+func WithInitRd(initrd string) HyperlightOption {
+	return func(c *HyperlightConfig) error {
+		c.InitRd = initrd
+		return nil
+	}
+}
+
+func WithStack(stack string) HyperlightOption {
+	return func(c *HyperlightConfig) error {
+		c.Stack = stack
+		return nil
+	}
+}

--- a/machine/hyperlight/init.go
+++ b/machine/hyperlight/init.go
@@ -14,6 +14,8 @@ const (
 	FlagStack       = "hyperlight-stack"
 	FlagQuiet       = "hyperlight-quiet"
 	FlagEnableTools = "hyperlight-enable-tools"
+	FlagNetAllow    = "hyperlight-net-allow"
+	FlagNetBlock    = "hyperlight-net-block"
 	FlagRepeat      = "hyperlight-repeat"
 	FlagExec        = "hyperlight-exec"
 	FlagMount       = "hyperlight-mount"
@@ -23,6 +25,8 @@ var (
 	hyperlightStack       string
 	hyperlightQuiet       bool
 	hyperlightEnableTools bool
+	hyperlightNetAllow    []string
+	hyperlightNetBlock    []string
 	hyperlightRepeat      int
 	hyperlightExec        string
 	hyperlightMounts      []string
@@ -60,6 +64,26 @@ func RegisterFlags() {
 			FlagEnableTools,
 			false,
 			"Enable Hyperlight tool dispatch via __dispatch host function",
+		),
+	)
+
+	cmdfactory.RegisterFlag(
+		"kraft run",
+		cmdfactory.StringArrayVar(
+			&hyperlightNetAllow,
+			FlagNetAllow,
+			nil,
+			"Restrict Hyperlight guest networking to the listed hosts/IPs",
+		),
+	)
+
+	cmdfactory.RegisterFlag(
+		"kraft run",
+		cmdfactory.StringArrayVar(
+			&hyperlightNetBlock,
+			FlagNetBlock,
+			nil,
+			"Block Hyperlight guest networking to the listed hosts/IPs",
 		),
 	)
 
@@ -107,6 +131,12 @@ func applyRegisteredRunConfig(cfg *HyperlightConfig) {
 	}
 	if hyperlightEnableTools {
 		cfg.EnableTools = true
+	}
+	if len(hyperlightNetAllow) > 0 {
+		cfg.NetAllow = append(cfg.NetAllow, hyperlightNetAllow...)
+	}
+	if len(hyperlightNetBlock) > 0 {
+		cfg.NetBlock = append(cfg.NetBlock, hyperlightNetBlock...)
 	}
 	if hyperlightRepeat != 0 {
 		cfg.Repeat = hyperlightRepeat

--- a/machine/hyperlight/init.go
+++ b/machine/hyperlight/init.go
@@ -4,8 +4,117 @@
 // You may not use this file except in compliance with the License.
 package hyperlight
 
-import "encoding/gob"
+import (
+	"encoding/gob"
+
+	"kraftkit.sh/cmdfactory"
+)
+
+const (
+	FlagStack       = "hyperlight-stack"
+	FlagQuiet       = "hyperlight-quiet"
+	FlagEnableTools = "hyperlight-enable-tools"
+	FlagRepeat      = "hyperlight-repeat"
+	FlagExec        = "hyperlight-exec"
+	FlagMount       = "hyperlight-mount"
+)
+
+var (
+	hyperlightStack       string
+	hyperlightQuiet       bool
+	hyperlightEnableTools bool
+	hyperlightRepeat      int
+	hyperlightExec        string
+	hyperlightMounts      []string
+)
 
 func init() {
 	gob.Register(HyperlightConfig{})
+}
+
+func RegisterFlags() {
+	cmdfactory.RegisterFlag(
+		"kraft run",
+		cmdfactory.StringVar(
+			&hyperlightStack,
+			FlagStack,
+			"",
+			"Set the Hyperlight guest stack size",
+		),
+	)
+
+	cmdfactory.RegisterFlag(
+		"kraft run",
+		cmdfactory.BoolVar(
+			&hyperlightQuiet,
+			FlagQuiet,
+			false,
+			"Suppress hyperlight-unikraft host-side status messages",
+		),
+	)
+
+	cmdfactory.RegisterFlag(
+		"kraft run",
+		cmdfactory.BoolVar(
+			&hyperlightEnableTools,
+			FlagEnableTools,
+			false,
+			"Enable Hyperlight tool dispatch via __dispatch host function",
+		),
+	)
+
+	cmdfactory.RegisterFlag(
+		"kraft run",
+		cmdfactory.IntVar(
+			&hyperlightRepeat,
+			FlagRepeat,
+			0,
+			"Run the Hyperlight application N additional times",
+		),
+	)
+
+	cmdfactory.RegisterFlag(
+		"kraft run",
+		cmdfactory.StringVar(
+			&hyperlightExec,
+			FlagExec,
+			"",
+			"Run an inline code snippet through the guest interpreter",
+		),
+	)
+
+	cmdfactory.RegisterFlag(
+		"kraft run",
+		cmdfactory.StringArrayVar(
+			&hyperlightMounts,
+			FlagMount,
+			nil,
+			"Preopen a host directory for the Hyperlight guest filesystem",
+		),
+	)
+}
+
+func applyRegisteredRunConfig(cfg *HyperlightConfig) {
+	if cfg == nil {
+		return
+	}
+
+	if hyperlightStack != "" {
+		cfg.Stack = hyperlightStack
+	}
+	if hyperlightQuiet {
+		cfg.Quiet = true
+	}
+	if hyperlightEnableTools {
+		cfg.EnableTools = true
+	}
+	if hyperlightRepeat != 0 {
+		cfg.Repeat = hyperlightRepeat
+	}
+	if hyperlightExec != "" {
+		cfg.Exec = hyperlightExec
+	}
+	if len(hyperlightMounts) > 0 {
+		cfg.Mounts = append(cfg.Mounts, hyperlightMounts...)
+	}
 }

--- a/machine/hyperlight/init.go
+++ b/machine/hyperlight/init.go
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2026, Unikraft GmbH and The KraftKit Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+package hyperlight
+
+import "encoding/gob"
+
+func init() {
+	gob.Register(HyperlightConfig{})
+}

--- a/machine/hyperlight/init.go
+++ b/machine/hyperlight/init.go
@@ -19,6 +19,7 @@ const (
 	FlagRepeat      = "hyperlight-repeat"
 	FlagExec        = "hyperlight-exec"
 	FlagMount       = "hyperlight-mount"
+	FlagNet         = "hyperlight-net"
 )
 
 var (
@@ -30,6 +31,7 @@ var (
 	hyperlightRepeat      int
 	hyperlightExec        string
 	hyperlightMounts      []string
+	hyperlightNet         bool
 )
 
 func init() {
@@ -116,6 +118,16 @@ func RegisterFlags() {
 			"Preopen a host directory for the Hyperlight guest filesystem",
 		),
 	)
+
+	cmdfactory.RegisterFlag(
+		"kraft run",
+		cmdfactory.BoolVar(
+			&hyperlightNet,
+			FlagNet,
+			false,
+			"Enable guest networking for hyperlight machine. Without this flag, the guest has no network access",
+		),
+	)
 }
 
 func applyRegisteredRunConfig(cfg *HyperlightConfig) {
@@ -131,6 +143,9 @@ func applyRegisteredRunConfig(cfg *HyperlightConfig) {
 	}
 	if hyperlightEnableTools {
 		cfg.EnableTools = true
+	}
+	if hyperlightNet {
+		cfg.Net = true
 	}
 	if len(hyperlightNetAllow) > 0 {
 		cfg.NetAllow = append(cfg.NetAllow, hyperlightNetAllow...)

--- a/machine/hyperlight/options.go
+++ b/machine/hyperlight/options.go
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2026, Unikraft GmbH and The KraftKit Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+
+package hyperlight
+
+// MachineServiceV1alpha1Option is a functional option for configuring the
+// Hyperlight machine service.
+type MachineServiceV1alpha1Option func(*machineV1alpha1Service) error

--- a/machine/hyperlight/v1alpha1.go
+++ b/machine/hyperlight/v1alpha1.go
@@ -115,10 +115,26 @@ func (service *machineV1alpha1Service) Create(ctx context.Context, machine *mach
 		return machine, fmt.Errorf("%s not found in $PATH: %w", HostBinary, err)
 	}
 
-	mounts, err := hyperlightMountsFromMachine(machine)
+	hlcfg, err := getHyperlightConfigFromPlatformConfig(machine.Status.PlatformConfig)
 	if err != nil {
 		return machine, err
 	}
+
+	applyRegisteredRunConfig(hlcfg)
+	if err := validateHyperlightRuntimeConfig(hlcfg); err != nil {
+		return machine, err
+	}
+
+	guestPaths := map[string]struct{}{}
+	mounts, err := hyperlightMountsFromMachine(machine, guestPaths)
+	if err != nil {
+		return machine, err
+	}
+	extraMounts, err := hyperlightMountsFromSpecs(hlcfg.Mounts, guestPaths)
+	if err != nil {
+		return machine, err
+	}
+	mounts = append(mounts, extraMounts...)
 
 	if machine.ObjectMeta.UID == "" {
 		machineID, err := name.NewRandomMachineID()
@@ -169,13 +185,22 @@ func (service *machineV1alpha1Service) Create(ctx context.Context, machine *mach
 		f.Close()
 	}
 
+	stack := DefaultStack
+	if hlcfg.Stack != "" {
+		stack = hlcfg.Stack
+	}
+
 	machine.Status.PlatformConfig = HyperlightConfig{
-		KernelPath: machine.Status.KernelPath,
-		Memory:     machine.Spec.Resources.Requests.Memory().String(),
-		Stack:      DefaultStack,
-		InitRd:     machine.Status.InitrdPath,
-		Mounts:     mounts,
-		LogPath:    logFile,
+		KernelPath:  machine.Status.KernelPath,
+		Memory:      machine.Spec.Resources.Requests.Memory().String(),
+		Stack:       stack,
+		InitRd:      machine.Status.InitrdPath,
+		Mounts:      mounts,
+		LogPath:     logFile,
+		Quiet:       hlcfg.Quiet,
+		EnableTools: hlcfg.EnableTools,
+		Repeat:      hlcfg.Repeat,
+		Exec:        hlcfg.Exec,
 	}
 
 	machine.CreationTimestamp = metav1.Now()
@@ -243,6 +268,11 @@ func (service *machineV1alpha1Service) Start(ctx context.Context, machine *machi
 	if err := validateHyperlightPaths(hlcfg.KernelPath, hlcfg.InitRd); err != nil {
 		machine.Status.State = machinev1alpha1.MachineStateFailed
 		return machine, err
+	}
+
+	if hlcfg.Exec != "" && len(machine.Spec.ApplicationArgs) > 0 {
+		machine.Status.State = machinev1alpha1.MachineStateFailed
+		return machine, fmt.Errorf("hyperlight-unikraft --exec conflicts with application arguments (passed after -- ). You can't set both at the same time")
 	}
 
 	args := hlcfg.MarshalArgs(machine.Spec.ApplicationArgs)
@@ -438,6 +468,10 @@ func (service *machineV1alpha1Service) Logs(ctx context.Context, machine *machin
 }
 
 func getHyperlightConfigFromPlatformConfig(platformConfig interface{}) (*HyperlightConfig, error) {
+	if platformConfig == nil {
+		return &HyperlightConfig{}, nil
+	}
+
 	if p, ok := platformConfig.(*HyperlightConfig); ok {
 		return p, nil
 	}
@@ -494,6 +528,28 @@ func validateHyperlightPaths(kernelPath, initrdPath string) error {
 	return nil
 }
 
+func validateHyperlightRuntimeConfig(hlcfg *HyperlightConfig) error {
+	if hlcfg == nil {
+		return nil
+	}
+
+	if hlcfg.Stack != "" {
+		qty, err := resource.ParseQuantity(hlcfg.Stack)
+		if err != nil {
+			return fmt.Errorf("could not parse hyperlight stack quantity: %w", err)
+		}
+		if qty.Value() <= 0 {
+			return fmt.Errorf("hyperlight stack must be greater than 0")
+		}
+	}
+
+	if hlcfg.Repeat < 0 {
+		return fmt.Errorf("hyperlight repeat must be non-negative")
+	}
+
+	return nil
+}
+
 func validateExistingFile(path, description string) error {
 	info, err := os.Stat(path)
 	if err != nil {
@@ -507,13 +563,12 @@ func validateExistingFile(path, description string) error {
 	return nil
 }
 
-func hyperlightMountsFromMachine(machine *machinev1alpha1.Machine) ([]string, error) {
+func hyperlightMountsFromMachine(machine *machinev1alpha1.Machine, guestPaths map[string]struct{}) ([]string, error) {
 	if len(machine.Spec.Volumes) == 0 {
 		return nil, nil
 	}
 
 	mounts := make([]string, 0, len(machine.Spec.Volumes))
-	guestPaths := map[string]struct{}{}
 
 	for _, volume := range machine.Spec.Volumes {
 		switch volume.Spec.Driver {
@@ -567,6 +622,66 @@ func hyperlightMountsFromMachine(machine *machinev1alpha1.Machine) ([]string, er
 	}
 
 	return mounts, nil
+}
+
+func hyperlightMountsFromSpecs(specs []string, guestPaths map[string]struct{}) ([]string, error) {
+	if len(specs) == 0 {
+		return nil, nil
+	}
+
+	mounts := make([]string, 0, len(specs))
+	for _, spec := range specs {
+		mount, guestPath, err := normalizeHyperlightMountSpec(spec)
+		if err != nil {
+			return nil, err
+		}
+
+		if _, exists := guestPaths[guestPath]; exists {
+			return nil, fmt.Errorf("hyperlight mount guest path %q is duplicated", guestPath)
+		}
+		guestPaths[guestPath] = struct{}{}
+
+		mounts = append(mounts, mount)
+	}
+
+	return mounts, nil
+}
+
+func normalizeHyperlightMountSpec(spec string) (string, string, error) {
+	if spec == "" {
+		return "", "", fmt.Errorf("hyperlight mount cannot be empty")
+	}
+
+	hostPath, guestPath, hasGuestPath := strings.Cut(spec, ":")
+	if hostPath == "" {
+		return "", "", fmt.Errorf("hyperlight mount source cannot be empty")
+	}
+	if !hasGuestPath {
+		guestPath = "/host"
+	} else if guestPath == "" {
+		return "", "", fmt.Errorf("hyperlight mount destination cannot be empty")
+	}
+
+	hostPath, err := filepath.Abs(hostPath)
+	if err != nil {
+		return "", "", fmt.Errorf("could not resolve hyperlight mount source %q: %w", hostPath, err)
+	}
+
+	info, err := os.Stat(hostPath)
+	if err != nil {
+		return "", "", fmt.Errorf("hyperlight mount source %q is not accessible: %w", hostPath, err)
+	}
+
+	if !info.IsDir() {
+		return "", "", fmt.Errorf("hyperlight mount source %q is not a directory", hostPath)
+	}
+
+	guestPath, err = normalizeHyperlightGuestMountPath(guestPath)
+	if err != nil {
+		return "", "", err
+	}
+
+	return fmt.Sprintf("%s:%s", hostPath, guestPath), guestPath, nil
 }
 
 func normalizeHyperlightGuestMountPath(guestPath string) (string, error) {

--- a/machine/hyperlight/v1alpha1.go
+++ b/machine/hyperlight/v1alpha1.go
@@ -7,11 +7,12 @@ package hyperlight
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
-	pathpkg "path"
 	"path/filepath"
+	"strings"
 	"time"
 
 	zip "api.zip"
@@ -244,21 +245,7 @@ func (service *machineV1alpha1Service) Start(ctx context.Context, machine *machi
 		return machine, err
 	}
 
-	args := []string{
-		"--memory", hlcfg.Memory,
-		"--stack", hlcfg.Stack,
-	}
-	if hlcfg.InitRd != "" {
-		args = append(args, "--initrd", hlcfg.InitRd)
-	}
-	for _, mount := range hlcfg.Mounts {
-		args = append(args, "--mount", mount)
-	}
-	args = append(args, hlcfg.KernelPath)
-	if len(machine.Spec.ApplicationArgs) > 0 {
-		args = append(args, "--")
-		args = append(args, machine.Spec.ApplicationArgs...)
-	}
+	args := hlcfg.MarshalArgs(machine.Spec.ApplicationArgs)
 
 	logFile, err := os.OpenFile(hlcfg.LogPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o644)
 	if err != nil {
@@ -292,13 +279,11 @@ func (service *machineV1alpha1Service) Start(ctx context.Context, machine *machi
 		return machine, fmt.Errorf("could not read pid of spawned %s: %w", HostBinary, err)
 	}
 
-	// Release the Go-side handle so the child doesn't need a Wait()
-	// and isn't kept alive through kraft's address space. Matches the
-	// "fire and forget PID-tracked lifecycle" the firecracker driver
-	// relies on.
-	if err := proc.Release(); err != nil {
-		log.G(ctx).WithError(err).Debug("releasing hyperlight process handle")
-	}
+	go func() {
+		if err := proc.Wait(); err != nil {
+			log.G(ctx).WithError(err).Debug("waiting for hyperlight process")
+		}
+	}()
 
 	machine.Status.Pid = int32(pid)
 	machine.Status.State = machinev1alpha1.MachineStateRunning
@@ -335,6 +320,15 @@ func (service *machineV1alpha1Service) Stop(ctx context.Context, machine *machin
 		return machine, nil
 	}
 
+	active, err := isHyperlightProcessActive(proc)
+	if err != nil || !active {
+		machine.Status.State = machinev1alpha1.MachineStateExited
+		if machine.Status.ExitedAt.IsZero() {
+			machine.Status.ExitedAt = time.Now()
+		}
+		return machine, nil
+	}
+
 	if err := proc.Terminate(); err != nil {
 		return machine, fmt.Errorf("could not terminate hyperlight process %d: %w", machine.Status.Pid, err)
 	}
@@ -346,13 +340,14 @@ func (service *machineV1alpha1Service) Stop(ctx context.Context, machine *machin
 
 // Delete implements kraftkit.sh/api/machine/v1alpha1.MachineService.
 func (service *machineV1alpha1Service) Delete(ctx context.Context, machine *machinev1alpha1.Machine) (*machinev1alpha1.Machine, error) {
-	machine, _ = service.Stop(ctx, machine)
+	machine, stopErr := service.Stop(ctx, machine)
 
+	var removeErr error
 	if machine.Status.StateDir != "" {
-		os.RemoveAll(machine.Status.StateDir)
+		removeErr = os.RemoveAll(machine.Status.StateDir)
 	}
 
-	return machine, nil
+	return machine, errors.Join(stopErr, removeErr)
 }
 
 // Get implements kraftkit.sh/api/machine/v1alpha1.MachineService.Get.
@@ -403,8 +398,8 @@ func (service *machineV1alpha1Service) Get(ctx context.Context, machine *machine
 		return machine, nil
 	}
 
-	running, err := proc.IsRunning()
-	if err != nil || !running {
+	active, err := isHyperlightProcessActive(proc)
+	if err != nil || !active {
 		machine.Status.State = machinev1alpha1.MachineStateExited
 		if machine.Status.ExitedAt.IsZero() {
 			machine.Status.ExitedAt = time.Now()
@@ -459,6 +454,26 @@ func getHyperlightConfigFromPlatformConfig(platformConfig interface{}) (*Hyperli
 		return nil, err
 	}
 	return &hlcfg, nil
+}
+
+func isHyperlightProcessActive(proc *goprocess.Process) (bool, error) {
+	running, err := proc.IsRunning()
+	if err != nil || !running {
+		return false, err
+	}
+
+	statuses, err := proc.Status()
+	if err != nil {
+		return true, nil
+	}
+
+	for _, status := range statuses {
+		if status == goprocess.Zombie {
+			return false, nil
+		}
+	}
+
+	return true, nil
 }
 
 func validateHyperlightPaths(kernelPath, initrdPath string) error {
@@ -559,9 +574,23 @@ func normalizeHyperlightGuestMountPath(guestPath string) (string, error) {
 		return "", fmt.Errorf("hyperlight volume destination cannot be empty")
 	}
 
-	if !pathpkg.IsAbs(guestPath) {
+	if !filepath.IsAbs(guestPath) {
 		return "", fmt.Errorf("hyperlight volume destination %q must be absolute", guestPath)
 	}
 
-	return guestPath, nil
+	cleaned := filepath.Clean(guestPath)
+	if _, reserved := reservedGuestMountPaths[cleaned]; reserved {
+		return "", fmt.Errorf("hyperlight volume destination %q shadows a reserved guest directory", guestPath)
+	}
+
+	for reserved := range reservedGuestMountPaths {
+		if reserved == "/" {
+			continue
+		}
+		if strings.HasPrefix(cleaned, reserved+string(filepath.Separator)) {
+			return "", fmt.Errorf("hyperlight volume destination %q shadows a reserved guest directory", guestPath)
+		}
+	}
+
+	return cleaned, nil
 }

--- a/machine/hyperlight/v1alpha1.go
+++ b/machine/hyperlight/v1alpha1.go
@@ -207,6 +207,7 @@ func (service *machineV1alpha1Service) Create(ctx context.Context, machine *mach
 		Ports:       hlcfg.Ports,
 		Repeat:      hlcfg.Repeat,
 		Exec:        hlcfg.Exec,
+		Net:         hlcfg.Net,
 	}
 
 	machine.CreationTimestamp = metav1.Now()

--- a/machine/hyperlight/v1alpha1.go
+++ b/machine/hyperlight/v1alpha1.go
@@ -11,7 +11,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"strings"
 	"time"
 
 	zip "api.zip"
@@ -24,6 +23,7 @@ import (
 
 	machinev1alpha1 "kraftkit.sh/api/machine/v1alpha1"
 	"kraftkit.sh/config"
+	kraftexec "kraftkit.sh/exec"
 	"kraftkit.sh/internal/logtail"
 	"kraftkit.sh/log"
 	"kraftkit.sh/machine/name"
@@ -190,7 +190,9 @@ func (service *machineV1alpha1Service) Watch(ctx context.Context, machine *machi
 
 // Start implements kraftkit.sh/api/machine/v1alpha1.MachineService. It spawns
 // the hyperlight-unikraft subprocess, redirects its stdout/stderr to the log
-// file, and records the child PID in machine.Status.
+// file, and records the child PID in machine.Status. The process is detached
+// (own process group) so the VMM continues running after kraft exits, matching
+// the firecracker driver's lifecycle.
 func (service *machineV1alpha1Service) Start(ctx context.Context, machine *machinev1alpha1.Machine) (*machinev1alpha1.Machine, error) {
 	hlcfg, err := getHyperlightConfigFromPlatformConfig(machine.Status.PlatformConfig)
 	if err != nil {
@@ -215,30 +217,49 @@ func (service *machineV1alpha1Service) Start(ctx context.Context, machine *machi
 		machine.Status.State = machinev1alpha1.MachineStateFailed
 		return machine, fmt.Errorf("could not open log file: %w", err)
 	}
+	// We duplicate this fd into the child via stdout; safe to close our
+	// own copy once the child is running.
 	defer logFile.Close()
 
-	cmd := exec.Command(HostBinary, args...)
-	cmd.Stdout = logFile
-	cmd.Stderr = logFile
+	// Use kraftkit's exec wrapper with WithDetach so the child gets its
+	// own process group and survives kraft exiting — same pattern the
+	// firecracker driver uses.
+	proc, err := kraftexec.NewProcess(HostBinary, args,
+		kraftexec.WithStdout(logFile),
+		kraftexec.WithDetach(true),
+	)
+	if err != nil {
+		machine.Status.State = machinev1alpha1.MachineStateFailed
+		return machine, fmt.Errorf("could not prepare %s process: %w", HostBinary, err)
+	}
 
-	if err := cmd.Start(); err != nil {
+	if err := proc.Start(ctx); err != nil {
 		machine.Status.State = machinev1alpha1.MachineStateFailed
 		return machine, fmt.Errorf("could not spawn %s: %w", HostBinary, err)
 	}
 
-	machine.Status.Pid = int32(cmd.Process.Pid)
+	pid, err := proc.Pid()
+	if err != nil {
+		machine.Status.State = machinev1alpha1.MachineStateFailed
+		return machine, fmt.Errorf("could not read pid of spawned %s: %w", HostBinary, err)
+	}
+
+	// Release the Go-side handle so the child doesn't need a Wait()
+	// and isn't kept alive through kraft's address space. Matches the
+	// "fire and forget PID-tracked lifecycle" the firecracker driver
+	// relies on.
+	if err := proc.Release(); err != nil {
+		log.G(ctx).WithError(err).Debug("releasing hyperlight process handle")
+	}
+
+	machine.Status.Pid = int32(pid)
 	machine.Status.State = machinev1alpha1.MachineStateRunning
 	machine.Status.StartedAt = time.Now()
 
-	// Reap the child in the background so it doesn't sit as a zombie. If kraft
-	// itself exits, the VMM process continues and eventually finishes on its
-	// own — just like the firecracker driver.
-	go func() { _ = cmd.Wait() }()
-
 	log.G(ctx).
 		WithField("uid", machine.ObjectMeta.UID).
-		WithField("pid", cmd.Process.Pid).
-		WithField("cmd", strings.Join(append([]string{HostBinary}, args...), " ")).
+		WithField("pid", pid).
+		WithField("cmd", proc.Cmdline()).
 		Debug("hyperlight instance started")
 
 	return machine, nil

--- a/machine/hyperlight/v1alpha1.go
+++ b/machine/hyperlight/v1alpha1.go
@@ -30,14 +30,14 @@ import (
 )
 
 const (
-	// DefaultMemory is the default memory allocation for Hyperlight VMs.
-	// Chosen as the median of the memory sizes used by the hyperlight-unikraft
-	// example workloads (helloworld-c/rust/go/shell/dotnet comfortably fit in
-	// 16Mi; heavier interpreters like Python, Node, PowerShell require an
-	// explicit override upward).
+	// DefaultMemory is the default memory allocation for Hyperlight VMs when
+	// --memory is not supplied. Small guests fit comfortably; heavier
+	// interpreters need an explicit override upward.
 	DefaultMemory = "16Mi"
 
-	// DefaultStack is the default stack size for Hyperlight VMs.
+	// DefaultStack is the default guest stack size. Not yet surfaced through
+	// the kraft CLI or Kraftfile; adjust via the WithStack functional option.
+	// TODO: wire through Kraftfile platform config.
 	DefaultStack = "8Mi"
 
 	// HostBinary is the external command that runs a Unikraft unikernel on

--- a/machine/hyperlight/v1alpha1.go
+++ b/machine/hyperlight/v1alpha1.go
@@ -31,9 +31,9 @@ import (
 
 const (
 	// DefaultMemory is the default memory allocation for Hyperlight VMs when
-	// --memory is not supplied. Small guests fit comfortably; heavier
-	// interpreters need an explicit override upward.
-	DefaultMemory = "16Mi"
+	// --memory is not supplied. This matches hyperlight-unikraft's host-side
+	// default.
+	DefaultMemory = "32Mi"
 
 	// DefaultStack is the default guest stack size. Not yet surfaced through
 	// the kraft CLI or Kraftfile; adjust via the WithStack functional option.
@@ -76,8 +76,28 @@ func (service *machineV1alpha1Service) Create(ctx context.Context, machine *mach
 		return machine, fmt.Errorf("cannot create hyperlight instance without kernel")
 	}
 
+	if err := validateHyperlightPaths(machine.Status.KernelPath, machine.Status.InitrdPath); err != nil {
+		return machine, err
+	}
+
 	if machine.Spec.Emulation {
-		return machine, fmt.Errorf("hyperlight does not support emulation mode")
+		return machine, fmt.Errorf("hyperlight-unikraft does not support emulation mode (--disable-acceleration)")
+	}
+
+	if len(machine.Spec.Ports) > 0 {
+		return machine, fmt.Errorf("hyperlight-unikraft does not support port publishing (--port)")
+	}
+
+	if len(machine.Spec.Networks) > 0 {
+		return machine, fmt.Errorf("hyperlight-unikraft does not support network attachments (--network, --ip, --mac)")
+	}
+
+	if len(machine.Spec.Env) > 0 {
+		return machine, fmt.Errorf("hyperlight-unikraft does not support environment injection (--env)")
+	}
+
+	if len(machine.Spec.KernelArgs) > 0 {
+		return machine, fmt.Errorf("hyperlight-unikraft does not support kernel arguments (--kernel-arg); pass application arguments after --")
 	}
 
 	if _, err := exec.LookPath(HostBinary); err != nil {
@@ -101,6 +121,10 @@ func (service *machineV1alpha1Service) Create(ctx context.Context, machine *mach
 
 	if err := os.MkdirAll(machine.Status.StateDir, 0o755); err != nil {
 		return machine, fmt.Errorf("could not create state directory: %w", err)
+	}
+
+	if machine.Spec.Resources.Requests == nil {
+		machine.Spec.Resources.Requests = corev1.ResourceList{}
 	}
 
 	if machine.Spec.Resources.Requests.Memory().Value() == 0 {
@@ -196,6 +220,11 @@ func (service *machineV1alpha1Service) Watch(ctx context.Context, machine *machi
 func (service *machineV1alpha1Service) Start(ctx context.Context, machine *machinev1alpha1.Machine) (*machinev1alpha1.Machine, error) {
 	hlcfg, err := getHyperlightConfigFromPlatformConfig(machine.Status.PlatformConfig)
 	if err != nil {
+		return machine, err
+	}
+
+	if err := validateHyperlightPaths(hlcfg.KernelPath, hlcfg.InitRd); err != nil {
+		machine.Status.State = machinev1alpha1.MachineStateFailed
 		return machine, err
 	}
 
@@ -314,6 +343,10 @@ func (service *machineV1alpha1Service) Get(ctx context.Context, machine *machine
 		return machine, err
 	}
 
+	if machine.Spec.Resources.Requests == nil {
+		machine.Spec.Resources.Requests = corev1.ResourceList{}
+	}
+
 	if hlcfg.Memory != "" {
 		q, err := resource.ParseQuantity(hlcfg.Memory)
 		if err != nil {
@@ -407,4 +440,35 @@ func getHyperlightConfigFromPlatformConfig(platformConfig interface{}) (*Hyperli
 		return nil, err
 	}
 	return &hlcfg, nil
+}
+
+func validateHyperlightPaths(kernelPath, initrdPath string) error {
+	if kernelPath == "" {
+		return fmt.Errorf("cannot create hyperlight instance without kernel")
+	}
+
+	if err := validateExistingFile(kernelPath, "hyperlight kernel"); err != nil {
+		return err
+	}
+
+	if initrdPath != "" {
+		if err := validateExistingFile(initrdPath, "hyperlight initrd"); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func validateExistingFile(path, description string) error {
+	info, err := os.Stat(path)
+	if err != nil {
+		return fmt.Errorf("%s path %q is not accessible: %w", description, path, err)
+	}
+
+	if info.IsDir() {
+		return fmt.Errorf("%s path %q is a directory", description, path)
+	}
+
+	return nil
 }

--- a/machine/hyperlight/v1alpha1.go
+++ b/machine/hyperlight/v1alpha1.go
@@ -1,0 +1,389 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2026, Unikraft GmbH and The KraftKit Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+
+package hyperlight
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+
+	zip "api.zip"
+	"github.com/go-viper/mapstructure/v2"
+	goprocess "github.com/shirou/gopsutil/v3/process"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	machinev1alpha1 "kraftkit.sh/api/machine/v1alpha1"
+	"kraftkit.sh/config"
+	"kraftkit.sh/internal/logtail"
+	"kraftkit.sh/log"
+	"kraftkit.sh/machine/name"
+)
+
+const (
+	// DefaultMemory is the default memory allocation for Hyperlight VMs.
+	// Chosen as the median of the memory sizes used by the hyperlight-unikraft
+	// example workloads (helloworld-c/rust/go/shell/dotnet comfortably fit in
+	// 16Mi; heavier interpreters like Python, Node, PowerShell require an
+	// explicit override upward).
+	DefaultMemory = "16Mi"
+
+	// DefaultStack is the default stack size for Hyperlight VMs.
+	DefaultStack = "8Mi"
+
+	// HostBinary is the external command that runs a Unikraft unikernel on
+	// Hyperlight. It must be installed in $PATH for this driver to work.
+	HostBinary = "hyperlight-unikraft"
+)
+
+// machineV1alpha1Service drives Hyperlight unikernels via the hyperlight-unikraft
+// binary. Each machine corresponds to a child process that owns the in-process
+// Hyperlight sandbox; PID tracking mirrors the firecracker driver so kraft ps,
+// stop, rm, logs, etc. work across kraft invocations.
+type machineV1alpha1Service struct{}
+
+// NewMachineV1alpha1Service creates a new Hyperlight machine service.
+func NewMachineV1alpha1Service(ctx context.Context, opts ...any) (machinev1alpha1.MachineService, error) {
+	service := machineV1alpha1Service{}
+
+	for _, opt := range opts {
+		hopt, ok := opt.(MachineServiceV1alpha1Option)
+		if !ok {
+			continue
+		}
+		if err := hopt(&service); err != nil {
+			return nil, err
+		}
+	}
+
+	return &service, nil
+}
+
+// Create implements kraftkit.sh/api/machine/v1alpha1.MachineService.Create.
+// It does not spawn the hyperlight-unikraft subprocess yet — that happens in
+// Start, matching the firecracker/qemu lifecycle.
+func (service *machineV1alpha1Service) Create(ctx context.Context, machine *machinev1alpha1.Machine) (*machinev1alpha1.Machine, error) {
+	if machine.Status.KernelPath == "" {
+		return machine, fmt.Errorf("cannot create hyperlight instance without kernel")
+	}
+
+	if machine.Spec.Emulation {
+		return machine, fmt.Errorf("hyperlight does not support emulation mode")
+	}
+
+	if _, err := exec.LookPath(HostBinary); err != nil {
+		return machine, fmt.Errorf("%s not found in $PATH: %w", HostBinary, err)
+	}
+
+	if machine.ObjectMeta.UID == "" {
+		machineID, err := name.NewRandomMachineID()
+		if err != nil {
+			return nil, fmt.Errorf("could not generate machine UID: %w", err)
+		}
+		machine.ObjectMeta.UID = types.UID(machineID.ShortString())
+	}
+
+	if machine.Status.StateDir == "" {
+		machine.Status.StateDir = filepath.Join(
+			config.G[config.KraftKit](ctx).RuntimeDir,
+			string(machine.ObjectMeta.UID),
+		)
+	}
+
+	if err := os.MkdirAll(machine.Status.StateDir, 0o755); err != nil {
+		return machine, fmt.Errorf("could not create state directory: %w", err)
+	}
+
+	if machine.Spec.Resources.Requests.Memory().Value() == 0 {
+		q, err := resource.ParseQuantity(DefaultMemory)
+		if err != nil {
+			machine.Status.State = machinev1alpha1.MachineStateFailed
+			return machine, err
+		}
+		machine.Spec.Resources.Requests[corev1.ResourceMemory] = q
+	}
+
+	if machine.Spec.Resources.Requests.Cpu().Value() == 0 {
+		q, err := resource.ParseQuantity("1")
+		if err != nil {
+			machine.Status.State = machinev1alpha1.MachineStateFailed
+			return machine, err
+		}
+		machine.Spec.Resources.Requests[corev1.ResourceCPU] = q
+	}
+
+	logFile := filepath.Join(machine.Status.StateDir, "vmm.log")
+	machine.Status.LogFile = logFile
+	// Create the log file up front so `kraft logs --follow` can tail it the
+	// moment Start returns, even before the child process has written output.
+	if f, err := os.OpenFile(logFile, os.O_CREATE|os.O_WRONLY, 0o644); err == nil {
+		f.Close()
+	}
+
+	machine.Status.PlatformConfig = HyperlightConfig{
+		KernelPath: machine.Status.KernelPath,
+		Memory:     machine.Spec.Resources.Requests.Memory().String(),
+		Stack:      DefaultStack,
+		InitRd:     machine.Status.InitrdPath,
+		LogPath:    logFile,
+	}
+
+	machine.CreationTimestamp = metav1.Now()
+	machine.Status.State = machinev1alpha1.MachineStateCreated
+
+	log.G(ctx).
+		WithField("uid", machine.ObjectMeta.UID).
+		WithField("kernel", machine.Status.KernelPath).
+		Debug("hyperlight instance created")
+
+	return machine, nil
+}
+
+// Update implements kraftkit.sh/api/machine/v1alpha1.MachineService.
+func (service *machineV1alpha1Service) Update(ctx context.Context, machine *machinev1alpha1.Machine) (*machinev1alpha1.Machine, error) {
+	return machine, nil
+}
+
+// Watch implements kraftkit.sh/api/machine/v1alpha1.MachineService.
+func (service *machineV1alpha1Service) Watch(ctx context.Context, machine *machinev1alpha1.Machine) (chan *machinev1alpha1.Machine, chan error, error) {
+	events := make(chan *machinev1alpha1.Machine)
+	errs := make(chan error)
+
+	go func() {
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			default:
+				updated, err := service.Get(ctx, machine)
+				if err != nil {
+					errs <- err
+					return
+				}
+
+				if updated.Status.State != machine.Status.State {
+					events <- updated
+					machine = updated
+				}
+
+				if updated.Status.State == machinev1alpha1.MachineStateExited ||
+					updated.Status.State == machinev1alpha1.MachineStateFailed {
+					return
+				}
+
+				time.Sleep(100 * time.Millisecond)
+			}
+		}
+	}()
+
+	return events, errs, nil
+}
+
+// Start implements kraftkit.sh/api/machine/v1alpha1.MachineService. It spawns
+// the hyperlight-unikraft subprocess, redirects its stdout/stderr to the log
+// file, and records the child PID in machine.Status.
+func (service *machineV1alpha1Service) Start(ctx context.Context, machine *machinev1alpha1.Machine) (*machinev1alpha1.Machine, error) {
+	hlcfg, err := getHyperlightConfigFromPlatformConfig(machine.Status.PlatformConfig)
+	if err != nil {
+		return machine, err
+	}
+
+	args := []string{
+		"--memory", hlcfg.Memory,
+		"--stack", hlcfg.Stack,
+	}
+	if hlcfg.InitRd != "" {
+		args = append(args, "--initrd", hlcfg.InitRd)
+	}
+	args = append(args, hlcfg.KernelPath)
+	if len(machine.Spec.ApplicationArgs) > 0 {
+		args = append(args, "--")
+		args = append(args, machine.Spec.ApplicationArgs...)
+	}
+
+	logFile, err := os.OpenFile(hlcfg.LogPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o644)
+	if err != nil {
+		machine.Status.State = machinev1alpha1.MachineStateFailed
+		return machine, fmt.Errorf("could not open log file: %w", err)
+	}
+	defer logFile.Close()
+
+	cmd := exec.Command(HostBinary, args...)
+	cmd.Stdout = logFile
+	cmd.Stderr = logFile
+
+	if err := cmd.Start(); err != nil {
+		machine.Status.State = machinev1alpha1.MachineStateFailed
+		return machine, fmt.Errorf("could not spawn %s: %w", HostBinary, err)
+	}
+
+	machine.Status.Pid = int32(cmd.Process.Pid)
+	machine.Status.State = machinev1alpha1.MachineStateRunning
+	machine.Status.StartedAt = time.Now()
+
+	// Reap the child in the background so it doesn't sit as a zombie. If kraft
+	// itself exits, the VMM process continues and eventually finishes on its
+	// own — just like the firecracker driver.
+	go func() { _ = cmd.Wait() }()
+
+	log.G(ctx).
+		WithField("uid", machine.ObjectMeta.UID).
+		WithField("pid", cmd.Process.Pid).
+		WithField("cmd", strings.Join(append([]string{HostBinary}, args...), " ")).
+		Debug("hyperlight instance started")
+
+	return machine, nil
+}
+
+// Pause implements kraftkit.sh/api/machine/v1alpha1.MachineService.
+func (service *machineV1alpha1Service) Pause(ctx context.Context, machine *machinev1alpha1.Machine) (*machinev1alpha1.Machine, error) {
+	return machine, fmt.Errorf("hyperlight does not support pause")
+}
+
+// Stop implements kraftkit.sh/api/machine/v1alpha1.MachineService.
+func (service *machineV1alpha1Service) Stop(ctx context.Context, machine *machinev1alpha1.Machine) (*machinev1alpha1.Machine, error) {
+	if machine.Status.State == machinev1alpha1.MachineStateExited {
+		return machine, nil
+	}
+
+	if machine.Status.Pid <= 0 {
+		machine.Status.State = machinev1alpha1.MachineStateExited
+		return machine, nil
+	}
+
+	proc, err := goprocess.NewProcess(machine.Status.Pid)
+	if err != nil {
+		machine.Status.State = machinev1alpha1.MachineStateExited
+		return machine, nil
+	}
+
+	if err := proc.Terminate(); err != nil {
+		return machine, fmt.Errorf("could not terminate hyperlight process %d: %w", machine.Status.Pid, err)
+	}
+
+	machine.Status.State = machinev1alpha1.MachineStateExited
+	machine.Status.ExitedAt = time.Now()
+	return machine, nil
+}
+
+// Delete implements kraftkit.sh/api/machine/v1alpha1.MachineService.
+func (service *machineV1alpha1Service) Delete(ctx context.Context, machine *machinev1alpha1.Machine) (*machinev1alpha1.Machine, error) {
+	machine, _ = service.Stop(ctx, machine)
+
+	if machine.Status.StateDir != "" {
+		os.RemoveAll(machine.Status.StateDir)
+	}
+
+	return machine, nil
+}
+
+// Get implements kraftkit.sh/api/machine/v1alpha1.MachineService.Get.
+func (service *machineV1alpha1Service) Get(ctx context.Context, machine *machinev1alpha1.Machine) (*machinev1alpha1.Machine, error) {
+	hlcfg, err := getHyperlightConfigFromPlatformConfig(machine.Status.PlatformConfig)
+	if err != nil {
+		return machine, err
+	}
+
+	if hlcfg.Memory != "" {
+		q, err := resource.ParseQuantity(hlcfg.Memory)
+		if err != nil {
+			return machine, fmt.Errorf("invalid memory quantity %q in platform config: %w", hlcfg.Memory, err)
+		}
+		machine.Spec.Resources.Requests[corev1.ResourceMemory] = q
+	}
+	cpu, err := resource.ParseQuantity("1")
+	if err != nil {
+		return machine, err
+	}
+	machine.Spec.Resources.Requests[corev1.ResourceCPU] = cpu
+
+	machine.Status.PlatformConfig = *hlcfg
+
+	// If the state is already terminal, don't second-guess it.
+	switch machine.Status.State {
+	case machinev1alpha1.MachineStateExited,
+		machinev1alpha1.MachineStateFailed,
+		machinev1alpha1.MachineStateErrored:
+		return machine, nil
+	}
+
+	if machine.Status.Pid <= 0 {
+		// Not yet started.
+		return machine, nil
+	}
+
+	proc, err := goprocess.NewProcess(machine.Status.Pid)
+	if err != nil {
+		machine.Status.State = machinev1alpha1.MachineStateExited
+		if machine.Status.ExitedAt.IsZero() {
+			machine.Status.ExitedAt = time.Now()
+		}
+		return machine, nil
+	}
+
+	running, err := proc.IsRunning()
+	if err != nil || !running {
+		machine.Status.State = machinev1alpha1.MachineStateExited
+		if machine.Status.ExitedAt.IsZero() {
+			machine.Status.ExitedAt = time.Now()
+		}
+		return machine, nil
+	}
+
+	machine.Status.State = machinev1alpha1.MachineStateRunning
+	return machine, nil
+}
+
+// List implements kraftkit.sh/api/machine/v1alpha1.MachineService.List.
+func (service *machineV1alpha1Service) List(ctx context.Context, machines *machinev1alpha1.MachineList) (*machinev1alpha1.MachineList, error) {
+	cached := machines.Items
+	machines.Items = make([]zip.Object[machinev1alpha1.MachineSpec, machinev1alpha1.MachineStatus], 0, len(cached))
+
+	for _, machine := range cached {
+		updated, err := service.Get(ctx, &machine)
+		if err != nil {
+			machines.Items = cached
+			return machines, err
+		}
+		machines.Items = append(machines.Items, *updated)
+	}
+
+	return machines, nil
+}
+
+// Logs implements kraftkit.sh/api/machine/v1alpha1.MachineService.
+func (service *machineV1alpha1Service) Logs(ctx context.Context, machine *machinev1alpha1.Machine) (chan string, chan error, error) {
+	hlcfg, err := getHyperlightConfigFromPlatformConfig(machine.Status.PlatformConfig)
+	if err != nil {
+		return nil, nil, err
+	}
+	return logtail.NewLogTail(ctx, hlcfg.LogPath)
+}
+
+func getHyperlightConfigFromPlatformConfig(platformConfig interface{}) (*HyperlightConfig, error) {
+	if p, ok := platformConfig.(*HyperlightConfig); ok {
+		return p, nil
+	}
+	if p, ok := platformConfig.(HyperlightConfig); ok {
+		return &p, nil
+	}
+
+	var hlcfg HyperlightConfig
+	decoder, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{Result: &hlcfg})
+	if err != nil {
+		return nil, err
+	}
+	if err := decoder.Decode(platformConfig); err != nil {
+		return nil, err
+	}
+	return &hlcfg, nil
+}

--- a/machine/hyperlight/v1alpha1.go
+++ b/machine/hyperlight/v1alpha1.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	pathpkg "path"
 	"path/filepath"
 	"time"
 
@@ -44,6 +45,15 @@ const (
 	// Hyperlight. It must be installed in $PATH for this driver to work.
 	HostBinary = "hyperlight-unikraft"
 )
+
+var reservedGuestMountPaths = map[string]struct{}{
+	"/":     {},
+	"/bin":  {},
+	"/dev":  {},
+	"/proc": {},
+	"/sys":  {},
+	"/usr":  {},
+}
 
 // machineV1alpha1Service drives Hyperlight unikernels via the hyperlight-unikraft
 // binary. Each machine corresponds to a child process that owns the in-process
@@ -104,6 +114,11 @@ func (service *machineV1alpha1Service) Create(ctx context.Context, machine *mach
 		return machine, fmt.Errorf("%s not found in $PATH: %w", HostBinary, err)
 	}
 
+	mounts, err := hyperlightMountsFromMachine(machine)
+	if err != nil {
+		return machine, err
+	}
+
 	if machine.ObjectMeta.UID == "" {
 		machineID, err := name.NewRandomMachineID()
 		if err != nil {
@@ -158,6 +173,7 @@ func (service *machineV1alpha1Service) Create(ctx context.Context, machine *mach
 		Memory:     machine.Spec.Resources.Requests.Memory().String(),
 		Stack:      DefaultStack,
 		InitRd:     machine.Status.InitrdPath,
+		Mounts:     mounts,
 		LogPath:    logFile,
 	}
 
@@ -234,6 +250,9 @@ func (service *machineV1alpha1Service) Start(ctx context.Context, machine *machi
 	}
 	if hlcfg.InitRd != "" {
 		args = append(args, "--initrd", hlcfg.InitRd)
+	}
+	for _, mount := range hlcfg.Mounts {
+		args = append(args, "--mount", mount)
 	}
 	args = append(args, hlcfg.KernelPath)
 	if len(machine.Spec.ApplicationArgs) > 0 {
@@ -471,4 +490,78 @@ func validateExistingFile(path, description string) error {
 	}
 
 	return nil
+}
+
+func hyperlightMountsFromMachine(machine *machinev1alpha1.Machine) ([]string, error) {
+	if len(machine.Spec.Volumes) == 0 {
+		return nil, nil
+	}
+
+	mounts := make([]string, 0, len(machine.Spec.Volumes))
+	guestPaths := map[string]struct{}{}
+
+	for _, volume := range machine.Spec.Volumes {
+		switch volume.Spec.Driver {
+		case "initrd":
+			if volume.Spec.Destination == "/" && machine.Status.InitrdPath != "" {
+				continue
+			}
+			if volume.Spec.Destination == "/" {
+				return nil, fmt.Errorf("hyperlight initrd volume requires an initrd path")
+			}
+			return nil, fmt.Errorf("hyperlight-unikraft does not support KraftKit initrd volumes mounted at %q", volume.Spec.Destination)
+
+		case "9pfs":
+		default:
+			return nil, fmt.Errorf("hyperlight-unikraft does not support KraftKit volume driver %q", volume.Spec.Driver)
+		}
+
+		if volume.Spec.ReadOnly {
+			return nil, fmt.Errorf("hyperlight-unikraft does not support read-only KraftKit volumes")
+		}
+
+		if volume.Spec.Source == "" {
+			return nil, fmt.Errorf("hyperlight volume source cannot be empty")
+		}
+
+		hostPath, err := filepath.Abs(volume.Spec.Source)
+		if err != nil {
+			return nil, fmt.Errorf("could not resolve hyperlight volume source %q: %w", volume.Spec.Source, err)
+		}
+
+		info, err := os.Stat(hostPath)
+		if err != nil {
+			return nil, fmt.Errorf("hyperlight volume source %q is not accessible: %w", hostPath, err)
+		}
+
+		if !info.IsDir() {
+			return nil, fmt.Errorf("hyperlight volume source %q is not a directory", hostPath)
+		}
+
+		guestPath, err := normalizeHyperlightGuestMountPath(volume.Spec.Destination)
+		if err != nil {
+			return nil, err
+		}
+
+		if _, exists := guestPaths[guestPath]; exists {
+			return nil, fmt.Errorf("hyperlight volume guest mount %q is duplicated", guestPath)
+		}
+		guestPaths[guestPath] = struct{}{}
+
+		mounts = append(mounts, fmt.Sprintf("%s:%s", hostPath, guestPath))
+	}
+
+	return mounts, nil
+}
+
+func normalizeHyperlightGuestMountPath(guestPath string) (string, error) {
+	if guestPath == "" {
+		return "", fmt.Errorf("hyperlight volume destination cannot be empty")
+	}
+
+	if !pathpkg.IsAbs(guestPath) {
+		return "", fmt.Errorf("hyperlight volume destination %q must be absolute", guestPath)
+	}
+
+	return guestPath, nil
 }

--- a/machine/hyperlight/v1alpha1.go
+++ b/machine/hyperlight/v1alpha1.go
@@ -377,7 +377,7 @@ func (service *machineV1alpha1Service) Delete(ctx context.Context, machine *mach
 		removeErr = os.RemoveAll(machine.Status.StateDir)
 	}
 
-	return machine, errors.Join(stopErr, removeErr)
+	return nil, errors.Join(stopErr, removeErr)
 }
 
 // Get implements kraftkit.sh/api/machine/v1alpha1.MachineService.Get.

--- a/machine/hyperlight/v1alpha1.go
+++ b/machine/hyperlight/v1alpha1.go
@@ -38,7 +38,7 @@ const (
 	DefaultMemory = "32Mi"
 
 	// DefaultStack is the default guest stack size. Not yet surfaced through
-	// the kraft CLI or Kraftfile; adjust via the WithStack functional option.
+	// the Kraftfile; adjust via --hyperlight-stack or the WithStack option.
 	// TODO: wire through Kraftfile platform config.
 	DefaultStack = "8Mi"
 
@@ -95,10 +95,6 @@ func (service *machineV1alpha1Service) Create(ctx context.Context, machine *mach
 		return machine, fmt.Errorf("hyperlight-unikraft does not support emulation mode (--disable-acceleration)")
 	}
 
-	if len(machine.Spec.Ports) > 0 {
-		return machine, fmt.Errorf("hyperlight-unikraft does not support port publishing (--port)")
-	}
-
 	if len(machine.Spec.Networks) > 0 {
 		return machine, fmt.Errorf("hyperlight-unikraft does not support network attachments (--network, --ip, --mac)")
 	}
@@ -121,6 +117,13 @@ func (service *machineV1alpha1Service) Create(ctx context.Context, machine *mach
 	}
 
 	applyRegisteredRunConfig(hlcfg)
+
+	ports, err := hyperlightPortsFromMachine(machine)
+	if err != nil {
+		return machine, err
+	}
+	hlcfg.Ports = append(hlcfg.Ports, ports...)
+
 	if err := validateHyperlightRuntimeConfig(hlcfg); err != nil {
 		return machine, err
 	}
@@ -199,6 +202,9 @@ func (service *machineV1alpha1Service) Create(ctx context.Context, machine *mach
 		LogPath:     logFile,
 		Quiet:       hlcfg.Quiet,
 		EnableTools: hlcfg.EnableTools,
+		NetAllow:    hlcfg.NetAllow,
+		NetBlock:    hlcfg.NetBlock,
+		Ports:       hlcfg.Ports,
 		Repeat:      hlcfg.Repeat,
 		Exec:        hlcfg.Exec,
 	}
@@ -549,7 +555,68 @@ func validateHyperlightRuntimeConfig(hlcfg *HyperlightConfig) error {
 		return fmt.Errorf("hyperlight repeat must be non-negative")
 	}
 
+	if len(hlcfg.NetAllow) > 0 && len(hlcfg.NetBlock) > 0 {
+		return fmt.Errorf("hyperlight net allowlist and blocklist cannot both be set")
+	}
+
+	var err error
+	hlcfg.NetAllow, err = normalizeHyperlightNetworkList(hlcfg.NetAllow, "allow")
+	if err != nil {
+		return err
+	}
+	hlcfg.NetBlock, err = normalizeHyperlightNetworkList(hlcfg.NetBlock, "block")
+	if err != nil {
+		return err
+	}
+	hlcfg.Ports, err = normalizeHyperlightPorts(hlcfg.Ports)
+	if err != nil {
+		return err
+	}
+
 	return nil
+}
+
+func normalizeHyperlightNetworkList(entries []string, mode string) ([]string, error) {
+	if len(entries) == 0 {
+		return nil, nil
+	}
+
+	seen := map[string]struct{}{}
+	normalized := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		entry = strings.TrimSpace(entry)
+		if entry == "" {
+			return nil, fmt.Errorf("hyperlight net %s entry cannot be empty", mode)
+		}
+		if _, exists := seen[entry]; exists {
+			continue
+		}
+		seen[entry] = struct{}{}
+		normalized = append(normalized, entry)
+	}
+
+	return normalized, nil
+}
+
+func normalizeHyperlightPorts(ports []int32) ([]int32, error) {
+	if len(ports) == 0 {
+		return nil, nil
+	}
+
+	seen := map[int32]struct{}{}
+	normalized := make([]int32, 0, len(ports))
+	for _, port := range ports {
+		if port <= 0 || port > 65535 {
+			return nil, fmt.Errorf("hyperlight port %d is outside the valid range 1-65535", port)
+		}
+		if _, exists := seen[port]; exists {
+			return nil, fmt.Errorf("hyperlight port %d is duplicated", port)
+		}
+		seen[port] = struct{}{}
+		normalized = append(normalized, port)
+	}
+
+	return normalized, nil
 }
 
 func validateExistingFile(path, description string) error {
@@ -563,6 +630,31 @@ func validateExistingFile(path, description string) error {
 	}
 
 	return nil
+}
+
+func hyperlightPortsFromMachine(machine *machinev1alpha1.Machine) ([]int32, error) {
+	if len(machine.Spec.Ports) == 0 {
+		return nil, nil
+	}
+
+	ports := make([]int32, 0, len(machine.Spec.Ports))
+	for _, port := range machine.Spec.Ports {
+		if port.HostIP != "" && port.HostIP != "0.0.0.0" {
+			return nil, fmt.Errorf("hyperlight-unikraft does not support host IP binding for --port; use HOST_PORT:GUEST_PORT without an IP address")
+		}
+
+		if port.HostPort != port.MachinePort {
+			return nil, fmt.Errorf("hyperlight-unikraft does not support host port forwarding; use a same-port mapping like --port %d:%d", port.MachinePort, port.MachinePort)
+		}
+
+		if port.Protocol != "" && !strings.EqualFold(string(port.Protocol), string(corev1.ProtocolTCP)) {
+			return nil, fmt.Errorf("hyperlight-unikraft only supports TCP guest listen permissions, got %s", port.Protocol)
+		}
+
+		ports = append(ports, port.MachinePort)
+	}
+
+	return ports, nil
 }
 
 func hyperlightMountsFromMachine(machine *machinev1alpha1.Machine, guestPaths map[string]struct{}) ([]string, error) {

--- a/machine/hyperlight/v1alpha1.go
+++ b/machine/hyperlight/v1alpha1.go
@@ -225,6 +225,8 @@ func (service *machineV1alpha1Service) Watch(ctx context.Context, machine *machi
 	errs := make(chan error)
 
 	go func() {
+		lastState := machine.Status.State
+
 		for {
 			select {
 			case <-ctx.Done():
@@ -236,9 +238,9 @@ func (service *machineV1alpha1Service) Watch(ctx context.Context, machine *machi
 					return
 				}
 
-				if updated.Status.State != machine.Status.State {
+				if updated.Status.State != lastState {
 					events <- updated
-					machine = updated
+					lastState = updated.Status.State
 				}
 
 				if updated.Status.State == machinev1alpha1.MachineStateExited ||

--- a/machine/platform/platform.go
+++ b/machine/platform/platform.go
@@ -12,6 +12,7 @@ const (
 	PlatformQEMU        = Platform("qemu")
 	PlatformKVM         = PlatformQEMU
 	PlatformXen         = Platform("xen")
+	PlatformHyperlight  = Platform("hyperlight")
 )
 
 // String implements fmt.Stringer
@@ -37,6 +38,8 @@ func PlatformsByName() map[string]Platform {
 		"kvm":         PlatformQEMU,
 		"qemu":        PlatformQEMU,
 		"xen":         PlatformXen,
+		"hyperlight":  PlatformHyperlight,
+		"hl":          PlatformHyperlight,
 	}
 }
 
@@ -46,6 +49,7 @@ func Platforms() []Platform {
 		PlatformFirecracker,
 		PlatformQEMU,
 		PlatformXen,
+		PlatformHyperlight,
 	}
 }
 

--- a/machine/platform/platform.go
+++ b/machine/platform/platform.go
@@ -4,6 +4,8 @@
 // You may not use this file except in compliance with the License.
 package platform
 
+import "sort"
+
 type Platform string
 
 const (
@@ -51,6 +53,37 @@ func Platforms() []Platform {
 		PlatformXen,
 		PlatformHyperlight,
 	}
+}
+
+// PlatformNames returns all platform names and aliases suitable for user input.
+func PlatformNames(extra ...Platform) []Platform {
+	seen := map[Platform]struct{}{}
+	ret := make([]Platform, 0, len(PlatformsByName())+len(extra))
+
+	names := make([]string, 0, len(PlatformsByName()))
+	for name := range PlatformsByName() {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	for _, name := range names {
+		platform := Platform(name)
+		if _, ok := seen[platform]; ok {
+			continue
+		}
+		seen[platform] = struct{}{}
+		ret = append(ret, platform)
+	}
+
+	for _, platform := range extra {
+		if _, ok := seen[platform]; ok {
+			continue
+		}
+		seen[platform] = struct{}{}
+		ret = append(ret, platform)
+	}
+
+	return ret
 }
 
 // PlatformAliases returns all the name alises for a given platform.

--- a/machine/platform/register_linux.go
+++ b/machine/platform/register_linux.go
@@ -13,6 +13,7 @@ import (
 	"kraftkit.sh/config"
 	"kraftkit.sh/internal/set"
 	"kraftkit.sh/machine/firecracker"
+	"kraftkit.sh/machine/hyperlight"
 	"kraftkit.sh/machine/xen"
 	"kraftkit.sh/store"
 )
@@ -68,6 +69,30 @@ var xenV1alpha1Driver = func(ctx context.Context, opts ...any) (machinev1alpha1.
 	)
 }
 
+var hyperlightV1alpha1Driver = func(ctx context.Context, opts ...any) (machinev1alpha1.MachineService, error) {
+	service, err := hyperlight.NewMachineV1alpha1Service(ctx, opts...)
+	if err != nil {
+		return nil, err
+	}
+
+	embeddedStore, err := store.NewEmbeddedStore[machinev1alpha1.MachineSpec, machinev1alpha1.MachineStatus](
+		filepath.Join(
+			config.G[config.KraftKit](ctx).RuntimeDir,
+			"machinev1alpha1",
+		),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return machinev1alpha1.NewMachineServiceHandler(
+		ctx,
+		service,
+		zip.WithStore[machinev1alpha1.MachineSpec, machinev1alpha1.MachineStatus](embeddedStore, zip.StoreRehydrationSpecNil),
+		zip.WithBefore(storePlatformFilter(PlatformHyperlight)),
+	)
+}
+
 func unixVariantStrategies() map[Platform]*Strategy {
 	// TODO(jake-ciolek): The firecracker driver has a dependency on github.com/containernetworking/plugins/pkg/ns via
 	// github.com/firecracker-microvm/firecracker-go-sdk
@@ -75,6 +100,9 @@ func unixVariantStrategies() map[Platform]*Strategy {
 	unixMap := map[Platform]*Strategy{
 		PlatformFirecracker: {
 			NewMachineV1alpha1: firecrackerV1alpha1Driver,
+		},
+		PlatformHyperlight: {
+			NewMachineV1alpha1: hyperlightV1alpha1Driver,
 		},
 	}
 

--- a/machine/platform/register_windows.go
+++ b/machine/platform/register_windows.go
@@ -4,11 +4,49 @@
 // You may not use this file except in compliance with the License.
 package platform
 
-// hostSupportedStrategies returns the map of known supported drivers for the
-// given host.
-// No drivers are supported on Windows currently. Future HyperV support is possible.
-func hostSupportedStrategies() map[Platform]*Strategy {
-	s := map[Platform]*Strategy{}
+import (
+	"context"
+	"path/filepath"
 
-	return s
+	zip "api.zip"
+	machinev1alpha1 "kraftkit.sh/api/machine/v1alpha1"
+	"kraftkit.sh/config"
+	"kraftkit.sh/machine/hyperlight"
+	"kraftkit.sh/store"
+)
+
+var hyperlightV1alpha1DriverWindows = func(ctx context.Context, opts ...any) (machinev1alpha1.MachineService, error) {
+	service, err := hyperlight.NewMachineV1alpha1Service(ctx, opts...)
+	if err != nil {
+		return nil, err
+	}
+
+	embeddedStore, err := store.NewEmbeddedStore[machinev1alpha1.MachineSpec, machinev1alpha1.MachineStatus](
+		filepath.Join(
+			config.G[config.KraftKit](ctx).RuntimeDir,
+			"machinev1alpha1",
+		),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return machinev1alpha1.NewMachineServiceHandler(
+		ctx,
+		service,
+		zip.WithStore[machinev1alpha1.MachineSpec, machinev1alpha1.MachineStatus](embeddedStore, zip.StoreRehydrationSpecNil),
+		zip.WithBefore(storePlatformFilter(PlatformHyperlight)),
+	)
+}
+
+// hostSupportedStrategies returns the map of known supported drivers for the
+// given host. On Windows, only Hyperlight is supported (via the
+// hyperlight-unikraft subprocess, which uses Windows Hypervisor Platform or
+// Hyper-V beneath it).
+func hostSupportedStrategies() map[Platform]*Strategy {
+	return map[Platform]*Strategy{
+		PlatformHyperlight: {
+			NewMachineV1alpha1: hyperlightV1alpha1DriverWindows,
+		},
+	}
 }

--- a/unikraft/app/application.go
+++ b/unikraft/app/application.go
@@ -538,6 +538,24 @@ func (app *application) MakeArgs(ctx context.Context, tc target.Target) (*core.M
 	orderedLibraries := []string{}
 	for _, library := range unformattedLibraries {
 		if !library.IsUnpacked() {
+			// If the library name starts with "app-", it may have been pulled as an
+			// application (e.g., app-elfloader is pulled to .unikraft/apps/elfloader).
+			// Try finding it there instead.
+			if strings.HasPrefix(library.Name(), "app-") {
+				altPath, err := unikraft.PlaceComponent(
+					app.workingDir,
+					unikraft.ComponentTypeApp,
+					strings.TrimPrefix(library.Name(), "app-"),
+				)
+				if err == nil {
+					if f, err := os.Stat(altPath); err == nil && f.IsDir() {
+						library.SetPath(altPath)
+					}
+				}
+			}
+		}
+
+		if !library.IsUnpacked() {
 			return nil, fmt.Errorf("cannot determine library \"%s\" path without component source", library.Name())
 		}
 

--- a/unikraft/lib/library.go
+++ b/unikraft/lib/library.go
@@ -200,6 +200,10 @@ func (lc LibraryConfig) Path() string {
 	return lc.path
 }
 
+func (lc *LibraryConfig) SetPath(path string) {
+	lc.path = path
+}
+
 func (lc LibraryConfig) Compiler() string {
 	return lc.compiler
 }

--- a/unikraft/lib/transform.go
+++ b/unikraft/lib/transform.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strings"
 
 	"kraftkit.sh/kconfig"
 	"kraftkit.sh/unikraft"
@@ -54,6 +55,26 @@ func TransformFromSchema(ctx context.Context, name string, props interface{}) (L
 				lib.source = lib.path
 			} else {
 				lib.path = lib.source
+			}
+		}
+	}
+
+	// If the library path doesn't exist but the library name starts with "app-",
+	// check if it was pulled as an application (e.g., app-elfloader is pulled to
+	// .unikraft/apps/elfloader). This handles the case where a component that is
+	// structurally a library is hosted in an "app-*" repository.
+	if uk != nil && uk.UK_BASE != "" {
+		if _, err := os.Stat(lib.path); os.IsNotExist(err) {
+			if strings.HasPrefix(lib.name, "app-") {
+				// Try finding it in apps directory without the "app-" prefix
+				altPath, _ := unikraft.PlaceComponent(
+					uk.UK_BASE,
+					unikraft.ComponentTypeApp,
+					strings.TrimPrefix(lib.name, "app-"),
+				)
+				if f, err := os.Stat(altPath); err == nil && f.IsDir() {
+					lib.path = altPath
+				}
 			}
 		}
 	}

--- a/unikraft/plat/platform.go
+++ b/unikraft/plat/platform.go
@@ -103,6 +103,8 @@ func (pc PlatformConfig) KConfig() kconfig.KeyValueMap {
 		values.Set("CONFIG_KVM_VMM_QEMU", kconfig.Yes)
 	case "xen":
 		values.Set("CONFIG_PLAT_XEN", kconfig.Yes)
+	case "hyperlight", "hl":
+		values.Set("CONFIG_PLAT_HYPERLIGHT", kconfig.Yes)
 	case "linuxu":
 		values.Set("CONFIG_PLAT_LINUXU", kconfig.Yes)
 	}


### PR DESCRIPTION
Add the hyperlight-net run flag to enable networking in Hyperlight micro-VMs.

This maps to a new Net boolean field in HyperlightConfig, which, when set

adds the --net flag to the guest arguments.