### PR TITLE
feat(machine/hyperlight): Support guest networking

### DIFF
--- a/machine/hyperlight/config.go
+++ b/machine/hyperlight/config.go
@@ -4,7 +4,9 @@
 // You may not use this file except in compliance with the License.
 package hyperlight
 
-import "strconv"
+import (
+	"strconv"
+)
 
 // HyperlightConfig represents configuration for a Hyperlight micro-VM.
 type HyperlightConfig struct {
@@ -46,6 +48,9 @@ type HyperlightConfig struct {
 
 	// LogPath is the path to the log file.
 	LogPath string `json:"logPath,omitempty"`
+
+	// Enables networking
+	Net bool `json:"net,omitempty"`
 }
 
 func (hlcfg *HyperlightConfig) MarshalArgs(appArgs []string) []string {
@@ -59,7 +64,7 @@ func (hlcfg *HyperlightConfig) MarshalArgs(appArgs []string) []string {
 	if hlcfg.EnableTools {
 		args = append(args, "--enable-tools")
 	}
-	if len(hlcfg.Ports) > 0 {
+	if hlcfg.Net {
 		args = append(args, "--net")
 	}
 	for _, allow := range hlcfg.NetAllow {

--- a/machine/hyperlight/init.go
+++ b/machine/hyperlight/init.go
@@ -19,6 +19,7 @@ const (
 	FlagRepeat      = "hyperlight-repeat"
 	FlagExec        = "hyperlight-exec"
 	FlagMount       = "hyperlight-mount"
+	FlagNet         = "hyperlight-net"
 )
 
 var (
@@ -30,6 +31,7 @@ var (
 	hyperlightRepeat      int
 	hyperlightExec        string
 	hyperlightMounts      []string
+	hyperlightNet         bool
 )
 
 func init() {
@@ -116,6 +118,16 @@ func RegisterFlags() {
 			"Preopen a host directory for the Hyperlight guest filesystem",
 		),
 	)
+
+	cmdfactory.RegisterFlag(
+		"kraft run",
+		cmdfactory.BoolVar(
+			&hyperlightNet,
+			FlagNet,
+			false,
+			"Enable guest networking for hyperlight machine. Without this flag, the guest has no network access",
+		),
+	)
 }
 
 func applyRegisteredRunConfig(cfg *HyperlightConfig) {
@@ -131,6 +143,9 @@ func applyRegisteredRunConfig(cfg *HyperlightConfig) {
 	}
 	if hyperlightEnableTools {
 		cfg.EnableTools = true
+	}
+	if hyperlightNet {
+		cfg.Net = true
 	}
 	if len(hyperlightNetAllow) > 0 {
 		cfg.NetAllow = append(cfg.NetAllow, hyperlightNetAllow...)

--- a/machine/hyperlight/v1alpha1.go
+++ b/machine/hyperlight/v1alpha1.go
@@ -207,6 +207,7 @@ func (service *machineV1alpha1Service) Create(ctx context.Context, machine *mach
 		Ports:       hlcfg.Ports,
 		Repeat:      hlcfg.Repeat,
 		Exec:        hlcfg.Exec,
+		Net:         hlcfg.Net,
 	}
 
 	machine.CreationTimestamp = metav1.Now()


### PR DESCRIPTION
Add the hyperlight-net run flag to enable networking in Hyperlight micro-VMs.

This maps to a new Net boolean field in HyperlightConfig, which, when set

adds the --net flag to the guest arguments.