### PR TITLE
fix: Fix kernel path and prioritize cli `--outdir` over kraftfile

### DIFF
--- a/unikraft/app/loader.go
+++ b/unikraft/app/loader.go
@@ -39,19 +39,10 @@ const (
 func NewApplicationFromInterface(ctx context.Context, iface map[string]interface{}, popts *ProjectOptions) (Application, error) {
 	app := application{}
 
-	name := ""
-	if n, ok := iface["name"]; ok {
-		name, ok = n.(string)
-		if !ok {
-			return nil, errors.New("project name must be a string")
-		}
-	}
-
 	if err := Transform(ctx, getSection(iface, "labels"), &app.labels); err != nil {
 		return nil, err
 	}
 
-	app.name = name
 	app.path = popts.workdir
 
 	outdir := unikraft.BuildDir

--- a/unikraft/app/loader.go
+++ b/unikraft/app/loader.go
@@ -20,14 +20,12 @@ package app
 import (
 	"context"
 	"fmt"
-	"path/filepath"
 	"strings"
 
 	interp "github.com/compose-spec/compose-go/interpolation"
 	"github.com/pkg/errors"
 	"gopkg.in/yaml.v2"
 	"kraftkit.sh/initrd"
-	"kraftkit.sh/unikraft"
 
 	kraftfilev07 "unikraft.com/x/kraftfile"
 )
@@ -44,17 +42,6 @@ func NewApplicationFromInterface(ctx context.Context, iface map[string]interface
 	}
 
 	app.path = popts.workdir
-
-	outdir := unikraft.BuildDir
-	if n, ok := iface["outdir"]; ok {
-		outdir, ok = n.(string)
-		if !ok {
-			return nil, errors.New("output directory must be a string")
-		}
-	}
-	if popts.outDir != "" {
-		outdir = popts.outDir
-	}
 
 	if n, ok := iface["rootfs"]; ok {
 		switch n.(type) {
@@ -123,17 +110,6 @@ func NewApplicationFromInterface(ctx context.Context, iface map[string]interface
 				app.command = append(app.command, cmdString)
 			}
 		}
-	}
-
-	if popts.resolvePaths && popts.outDir == "" {
-		app.outDir = popts.RelativePath(outdir)
-	} else if popts.outDir != "" {
-		abs, err := filepath.Abs(outdir)
-		if err != nil {
-			return nil, err
-		}
-
-		app.outDir = abs
 	}
 
 	if err := Transform(ctx, getSection(iface, "unikraft"), &app.unikraft); err != nil {

--- a/unikraft/app/project.go
+++ b/unikraft/app/project.go
@@ -50,7 +50,6 @@ func IsWorkdirInitialized(dir string) bool {
 }
 
 func newLegacyProjectFromOptions(ctx context.Context, popts *ProjectOptions) (Application, error) {
-	name, _ := popts.GetProjectName()
 	specVersion, err := parseKraftfileSpecVersion(popts.kraftfile.content)
 	if err != nil {
 		return nil, err
@@ -81,12 +80,15 @@ func newLegacyProjectFromOptions(ctx context.Context, popts *ProjectOptions) (Ap
 	}
 
 	iface = groupXFieldsIntoExtensions(iface)
+	popts.kraftfile.config = iface
+
+	projectName, _ := popts.GetProjectName()
 	if n, ok := iface["name"]; ok {
 		nameStr, ok := n.(string)
 		if !ok {
 			return nil, fmt.Errorf("malformed Kraftfile: 'name' field must be a string, got %T", n)
 		}
-		name = nameStr
+		projectName = nameStr
 	}
 
 	if n, ok := iface["outdir"]; ok {
@@ -97,10 +99,12 @@ func newLegacyProjectFromOptions(ctx context.Context, popts *ProjectOptions) (Ap
 		outdir = outdirStr
 	}
 
-	popts.kraftfile.config = iface
+	if !popts.skipNormalization {
+		projectName = normalizeProjectName(projectName)
+	}
 
 	uk := &unikraft.Context{
-		UK_NAME:   name,
+		UK_NAME:   projectName,
 		UK_BASE:   popts.workdir,
 		BUILD_DIR: outdir,
 	}
@@ -113,21 +117,12 @@ func newLegacyProjectFromOptions(ctx context.Context, popts *ProjectOptions) (Ap
 
 	ctx = unikraft.WithContext(ctx, uk)
 
-	appl, err := NewApplicationFromInterface(ctx, popts.kraftfile.config, popts)
+	appl, err := NewApplicationFromInterface(ctx, iface, popts)
 	if err != nil {
 		return nil, err
 	}
 
 	app := appl.(*application)
-
-	projectName, _ := popts.GetProjectName()
-	if app.name != "" {
-		projectName = app.name
-	}
-
-	if !popts.skipNormalization {
-		projectName = normalizeProjectName(projectName)
-	}
 
 	if app.unikraft != nil {
 		popts.kconfig.OverrideBy(app.unikraft.KConfig())

--- a/unikraft/app/project.go
+++ b/unikraft/app/project.go
@@ -49,17 +49,29 @@ func IsWorkdirInitialized(dir string) bool {
 	return len(findFiles(DefaultFileNames, dir)) > 0
 }
 
+func outDirFromProject(iface map[string]interface{}, popts *ProjectOptions) (string, error) {
+	if popts.outDir != "" {
+		return filepath.Abs(popts.outDir)
+	}
+
+	outdir := unikraft.BuildDir
+	if n, ok := iface["outdir"]; ok {
+		outdirStr, ok := n.(string)
+		if !ok {
+			return "", fmt.Errorf("malformed Kraftfile: 'outdir' field must be a string, got %T", n)
+		}
+		if outdirStr != "" {
+			outdir = outdirStr
+		}
+	}
+
+	return popts.RelativePath(outdir), nil
+}
+
 func newLegacyProjectFromOptions(ctx context.Context, popts *ProjectOptions) (Application, error) {
 	specVersion, err := parseKraftfileSpecVersion(popts.kraftfile.content)
 	if err != nil {
 		return nil, err
-	}
-
-	var outdir string
-	if popts.outDir == "" {
-		outdir = popts.RelativePath(unikraft.BuildDir)
-	} else {
-		outdir = popts.outDir
 	}
 
 	iface := popts.kraftfile.config
@@ -82,6 +94,11 @@ func newLegacyProjectFromOptions(ctx context.Context, popts *ProjectOptions) (Ap
 	iface = groupXFieldsIntoExtensions(iface)
 	popts.kraftfile.config = iface
 
+	outdir, err := outDirFromProject(iface, popts)
+	if err != nil {
+		return nil, err
+	}
+
 	projectName, _ := popts.GetProjectName()
 	if n, ok := iface["name"]; ok {
 		nameStr, ok := n.(string)
@@ -89,14 +106,6 @@ func newLegacyProjectFromOptions(ctx context.Context, popts *ProjectOptions) (Ap
 			return nil, fmt.Errorf("malformed Kraftfile: 'name' field must be a string, got %T", n)
 		}
 		projectName = nameStr
-	}
-
-	if n, ok := iface["outdir"]; ok {
-		outdirStr, ok := n.(string)
-		if !ok {
-			return nil, fmt.Errorf("malformed Kraftfile: 'outdir' field must be a string, got %T", n)
-		}
-		outdir = outdirStr
 	}
 
 	if !popts.skipNormalization {
@@ -149,7 +158,7 @@ func newLegacyProjectFromOptions(ctx context.Context, popts *ProjectOptions) (Ap
 		WithName(projectName),
 		WithWorkingDir(popts.workdir),
 		WithFilename(app.filename),
-		WithOutDir(app.outDir),
+		WithOutDir(outdir),
 		WithUnikraft(app.unikraft),
 		WithRuntime(app.runtime),
 		WithRootfs(app.rootfs),

--- a/unikraft/app/project_options.go
+++ b/unikraft/app/project_options.go
@@ -53,7 +53,6 @@ type ProjectOptions struct {
 	skipValidation    bool
 	skipInterpolation bool
 	skipNormalization bool
-	resolvePaths      bool
 	interpolate       *interp.Options
 
 	// Indicates when the projectName was imperatively set or guessed from path
@@ -259,14 +258,6 @@ func WithProjectNormalization(normalization bool) ProjectOption {
 func WithProjectOutDir(outDir string) ProjectOption {
 	return func(popts *ProjectOptions) error {
 		popts.outDir = outDir
-		return nil
-	}
-}
-
-// WithProjectResolvedPaths set ProjectOptions to enable paths resolution
-func WithProjectResolvedPaths(resolve bool) ProjectOption {
-	return func(popts *ProjectOptions) error {
-		popts.resolvePaths = resolve
 		return nil
 	}
 }


### PR DESCRIPTION
Fixes kernel path mismatch in legacy (v0.6) projects.

KraftKit looked for the wrong artifact after build.

Example: helloworld_fc-x86_64 vs hello.world_fc-x86_64.

-------------
Prioritise cli outdir over Kraftkit
-----------

• Normalize project name before setting UK_NAME
• Resolve output directory early via outDirFromProject()
• Inject UK_BASE / BUILD_DIR before NewApplicationFromInterface
• Always populate app.outDir
• CLI --output overrides Kraftfile outdir

--------------

Issue: #2850