### PR TITLE
feat(config): Add configurable toolchain profiles

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -56,6 +56,8 @@ type KraftKit struct {
 	Aliases map[string]map[string]string `yaml:"aliases" noattribute:"true"`
 
 	Toolchain map[string]string `yaml:"toolchain,omitempty" noattribute:"true"`
+
+	ToolchainProfiles map[string]map[string]string `yaml:"toolchain_profiles,omitempty" noattribute:"true"`
 }
 
 type ConfigDetail struct {

--- a/config/manager.go
+++ b/config/manager.go
@@ -339,7 +339,7 @@ func (cm *ConfigManager[C]) traverse(key string, createIfNil bool) (reflect.Valu
 		if field.Kind() == reflect.Ptr {
 			if field.IsNil() {
 				if !createIfNil {
-					return reflect.Value{}, nil, 0, nil
+					return reflect.Value{}, nil, 0, errors.New("cannot traverse nil pointer: " + k)
 				}
 				field.Set(reflect.New(field.Type().Elem()))
 			}

--- a/config/manager.go
+++ b/config/manager.go
@@ -189,82 +189,121 @@ func getYAMLTag(field reflect.StructField, ok bool) string {
 
 // Set updates any field in the config struct using a dot-separated key.
 func (cm *ConfigManager[C]) Set(key string, val any) error {
-	v := reflect.ValueOf(cm.Config)
-	if v.Kind() != reflect.Ptr || v.Elem().Kind() != reflect.Struct {
-		return errors.New("cfg must be a pointer to a struct")
+	field, keys, i, err := cm.traverse(key, true)
+	if err != nil || !field.IsValid() {
+		return err
 	}
 
-	v = v.Elem() // Dereference the pointer
-	keys := strings.Split(key, ".")
+	// Handle map[string]map[string]string fields.
+	if field.Kind() == reflect.Map && field.Type().Elem().Kind() == reflect.Map {
+		if i+2 != len(keys)-1 {
+			return errors.New("invalid nested map key path length: " + keys[i])
+		}
+		outerKey := keys[i+1]
+		innerKey := keys[i+2]
 
-	for i, k := range keys {
-		field := v.FieldByNameFunc(func(f string) bool {
-			return getYAMLTag(v.Type().FieldByName(f)) == k
-		})
-
-		if !field.IsValid() {
-			return errors.New("invalid key: " + k)
+		if field.IsNil() {
+			field.Set(reflect.MakeMap(field.Type()))
 		}
 
-		if i == len(keys)-1 {
-			if !field.CanSet() {
-				return errors.New("cannot set field: " + k)
-			}
-			convertedVal, err := convertType(val, field.Type())
-			if err != nil {
-				return err
-			}
-			field.Set(convertedVal)
-			return nil
+		innerMap := field.MapIndex(reflect.ValueOf(outerKey))
+		if !innerMap.IsValid() || innerMap.IsNil() {
+			innerMap = reflect.MakeMap(field.Type().Elem())
 		}
 
-		// Handle map[string]string fields: the next key is the map key.
-		if field.Kind() == reflect.Map &&
-			field.Type().Key().Kind() == reflect.String &&
-			field.Type().Elem().Kind() == reflect.String {
-
-			if i+1 != len(keys)-1 {
-				// ensure we are exactly one level deep into the map.
-				// for a map[string]string, we can't traverse past the immediate key.
-				// e.g.keys = ["toolchain", "CC"] , len is 2 ,At i = 0 the next key is the final one.
-				// e.g.keys = ["toolchain", "CC", "extra"]  len is 3 , We have leftover keys, so we error out.
-
-				return errors.New("cannot traverse further into map: " + k)
-			}
-			mapKey := keys[i+1]
-			if field.IsNil() {
-				field.Set(reflect.MakeMap(field.Type()))
-			}
-			strVal, ok := val.(string)
-			if !ok {
-				strVal = fmt.Sprintf("%v", val)
-			}
-			field.SetMapIndex(
-				reflect.ValueOf(mapKey),
-				reflect.ValueOf(strVal),
-			)
-			return nil
+		strVal, ok := val.(string)
+		if !ok {
+			strVal = fmt.Sprintf("%v", val)
 		}
-
-		if field.Kind() == reflect.Ptr {
-			if field.IsNil() {
-				field.Set(reflect.New(field.Type().Elem()))
-			}
-			v = field.Elem()
-		} else {
-			v = field
-		}
+		innerMap.SetMapIndex(reflect.ValueOf(innerKey), reflect.ValueOf(strVal))
+		field.SetMapIndex(reflect.ValueOf(outerKey), innerMap)
+		return nil
 	}
 
+	// Handle map[string]string fields: the next key is the map key.
+	if field.Kind() == reflect.Map {
+		if i+1 != len(keys)-1 {
+			return errors.New("cannot traverse further into map: " + keys[i])
+		}
+		mapKey := keys[i+1]
+		if field.IsNil() {
+			field.Set(reflect.MakeMap(field.Type()))
+		}
+		strVal, ok := val.(string)
+		if !ok {
+			strVal = fmt.Sprintf("%v", val)
+		}
+		field.SetMapIndex(
+			reflect.ValueOf(mapKey),
+			reflect.ValueOf(strVal),
+		)
+		return nil
+	}
+
+	if !field.CanSet() {
+		return errors.New("cannot set field: " + keys[i])
+	}
+	convertedVal, err := convertType(val, field.Type())
+	if err != nil {
+		return err
+	}
+	field.Set(convertedVal)
 	return nil
 }
 
 // Unset removes a key from the config. For map fields (e.g. toolchain.CC) it
 // deletes the map entry. For scalar fields it resets them to the zero value.
 func (cm *ConfigManager[C]) Unset(key string) error {
+	field, keys, i, err := cm.traverse(key, false)
+	if err != nil || !field.IsValid() {
+		return err
+	}
+
+	// Handle map[string]map[string]string fields.
+	if field.Kind() == reflect.Map && field.Type().Elem().Kind() == reflect.Map {
+		if i+2 != len(keys)-1 {
+			return errors.New("invalid nested map key path length: " + keys[i])
+		}
+		outerKey := keys[i+1]
+		innerKey := keys[i+2]
+
+		if !field.IsNil() {
+			innerMap := field.MapIndex(reflect.ValueOf(outerKey))
+			if innerMap.IsValid() && !innerMap.IsNil() {
+				innerMap.SetMapIndex(reflect.ValueOf(innerKey), reflect.Value{})
+				if innerMap.Len() == 0 {
+					field.SetMapIndex(reflect.ValueOf(outerKey), reflect.Value{})
+				}
+			}
+		}
+		return nil
+	}
+
+	// Handle map[string]string fields.
+	if field.Kind() == reflect.Map {
+		if i+1 != len(keys)-1 {
+			return errors.New("cannot traverse further into map: " + keys[i])
+		}
+		if !field.IsNil() {
+			field.SetMapIndex(reflect.ValueOf(keys[i+1]), reflect.Value{})
+		}
+		return nil
+	}
+
+	if !field.CanSet() {
+		return errors.New("cannot unset field: " + keys[i])
+	}
+	field.Set(reflect.Zero(field.Type()))
+	return nil
+}
+
+// traverse walks the config struct to find the target field and leaf key(s).
+// It returns the reflect.Value of the parent structure/map containing the target,
+// the remaining key slice, and the current index inside the keys.
+func (cm *ConfigManager[C]) traverse(key string, createIfNil bool) (reflect.Value, []string, int, error) {
 	v := reflect.ValueOf(cm.Config)
 	if v.Kind() != reflect.Ptr || v.Elem().Kind() != reflect.Struct {
-		return errors.New("cfg must be a pointer to a struct")
+		return reflect.Value{}, nil, 0, errors.New("cfg must be a pointer to a struct")
 	}
 
 	v = v.Elem()
@@ -276,33 +315,33 @@ func (cm *ConfigManager[C]) Unset(key string) error {
 		})
 
 		if !field.IsValid() {
-			return errors.New("invalid key: " + k)
+			return reflect.Value{}, nil, 0, errors.New("invalid key: " + k)
 		}
 
-		if field.Kind() == reflect.Map &&
+		// Handle nested map or map fields at the parent level
+		isNestedMap := field.Kind() == reflect.Map &&
 			field.Type().Key().Kind() == reflect.String &&
-			field.Type().Elem().Kind() == reflect.String {
+			field.Type().Elem().Kind() == reflect.Map
+		isSimpleMap := field.Kind() == reflect.Map &&
+			field.Type().Key().Kind() == reflect.String &&
+			field.Type().Elem().Kind() == reflect.String
 
-			if i+1 != len(keys)-1 {
-				return errors.New("cannot traverse further into map: " + k)
-			}
-			if !field.IsNil() {
-				field.SetMapIndex(reflect.ValueOf(keys[i+1]), reflect.Value{})
-			}
-			return nil
+		if isNestedMap || isSimpleMap {
+			return field, keys, i, nil
 		}
 
+		// Handle leaf node
 		if i == len(keys)-1 {
-			if !field.CanSet() {
-				return errors.New("cannot unset field: " + k)
-			}
-			field.Set(reflect.Zero(field.Type()))
-			return nil
+			return field, keys, i, nil
 		}
 
+		// Traverse pointer
 		if field.Kind() == reflect.Ptr {
 			if field.IsNil() {
-				return nil
+				if !createIfNil {
+					return reflect.Value{}, nil, 0, nil
+				}
+				field.Set(reflect.New(field.Type().Elem()))
 			}
 			v = field.Elem()
 		} else {
@@ -310,7 +349,7 @@ func (cm *ConfigManager[C]) Unset(key string) error {
 		}
 	}
 
-	return nil
+	return v, keys, len(keys) - 1, nil
 }
 
 // SetupListener adds an OS signal listener to the Config instance. The listener

--- a/config/manager_test.go
+++ b/config/manager_test.go
@@ -67,6 +67,46 @@ func TestConfigManagerUnset_MapField(t *testing.T) {
 			t.Error("expected error for toolchain.CC.extra, got nil")
 		}
 	})
+
+	t.Run("Remove nested map key", func(t *testing.T) {
+		cfg := &KraftKit{
+			ToolchainProfiles: map[string]map[string]string{
+				"clang-debug": {
+					"CC":        "clang",
+					"UK_CFLAGS": "-O2",
+				},
+			},
+		}
+		unset(t, cfg, "toolchain_profiles.clang-debug.CC")
+		if _, ok := cfg.ToolchainProfiles["clang-debug"]["CC"]; ok {
+			t.Error("expected toolchain_profiles.clang-debug.CC to be removed")
+		}
+		if got := cfg.ToolchainProfiles["clang-debug"]["UK_CFLAGS"]; got != "-O2" {
+			t.Errorf("expected UK_CFLAGS to be '-O2', got %q", got)
+		}
+	})
+
+	t.Run("Remove nested map key cleans up profile", func(t *testing.T) {
+		cfg := &KraftKit{
+			ToolchainProfiles: map[string]map[string]string{
+				"clang-debug": {
+					"CC": "clang",
+				},
+			},
+		}
+		unset(t, cfg, "toolchain_profiles.clang-debug.CC")
+		if _, ok := cfg.ToolchainProfiles["clang-debug"]; ok {
+			t.Error("expected toolchain_profiles.clang-debug to be removed entirely when empty")
+		}
+	})
+
+	t.Run("Unset on nested map error on invalid key path length", func(t *testing.T) {
+		cfg := &KraftKit{}
+		cm := &ConfigManager[KraftKit]{Config: cfg}
+		if err := cm.Unset("toolchain_profiles.clang-debug.CC.extra"); err == nil {
+			t.Error("expected error for too deep key path, got nil")
+		}
+	})
 }
 
 func TestConfigManagerSet_MapField(t *testing.T) {
@@ -142,6 +182,43 @@ func TestConfigManagerSet_MapField(t *testing.T) {
 		cm := &ConfigManager[KraftKit]{Config: cfg}
 		if err := cm.Set("nonexistent", "value"); err == nil {
 			t.Error("expected error for unknown key, got nil")
+		}
+	})
+
+	t.Run("Nested map field set on nil map", func(t *testing.T) {
+		cfg := &KraftKit{}
+		set(t, cfg, "toolchain_profiles.clang-debug.CC", "clang")
+		if cfg.ToolchainProfiles == nil {
+			t.Fatal("expected ToolchainProfiles to be initialized")
+		}
+		if expect, got := "clang", cfg.ToolchainProfiles["clang-debug"]["CC"]; expect != got {
+			t.Errorf("expected CC to be %q, got %q", expect, got)
+		}
+	})
+
+	t.Run("Nested map field overwrite/addition", func(t *testing.T) {
+		cfg := &KraftKit{
+			ToolchainProfiles: map[string]map[string]string{
+				"clang-debug": {
+					"CC": "gcc",
+				},
+			},
+		}
+		set(t, cfg, "toolchain_profiles.clang-debug.CC", "clang")
+		set(t, cfg, "toolchain_profiles.clang-debug.UK_CFLAGS", "-O2")
+		if expect, got := "clang", cfg.ToolchainProfiles["clang-debug"]["CC"]; expect != got {
+			t.Errorf("expected CC to be %q, got %q", expect, got)
+		}
+		if expect, got := "-O2", cfg.ToolchainProfiles["clang-debug"]["UK_CFLAGS"]; expect != got {
+			t.Errorf("expected UK_CFLAGS to be %q, got %q", expect, got)
+		}
+	})
+
+	t.Run("Set on nested map error on invalid key path length", func(t *testing.T) {
+		cfg := &KraftKit{}
+		cm := &ConfigManager[KraftKit]{Config: cfg}
+		if err := cm.Set("toolchain_profiles.clang-debug.CC.extra", "val"); err == nil {
+			t.Error("expected error for too deep key path, got nil")
 		}
 	})
 }

--- a/internal/cli/kraft/build/build.go
+++ b/internal/cli/kraft/build/build.go
@@ -19,6 +19,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"kraftkit.sh/cmdfactory"
+	"kraftkit.sh/config"
 	"kraftkit.sh/initrd"
 	"kraftkit.sh/internal/fancymap"
 	"kraftkit.sh/iostreams"
@@ -37,35 +38,36 @@ import (
 var ErrContextNotBuildable = fmt.Errorf("could not determine what or how to build from the given context")
 
 type BuildOptions struct {
-	All            bool                  `long:"all" usage:"Build all targets"`
-	Architecture   string                `long:"arch" short:"m" usage:"Filter the creation of the build by architecture of known targets (x86_64/arm64/arm)"`
-	DotConfig      string                `long:"config" short:"c" usage:"Override the path to the KConfig .config file"`
-	Env            []string              `long:"env" short:"e" usage:"Set environment variables to be built in the unikernel" split:"false"`
-	Toolchain      []string              `long:"toolchain" short:"T" usage:"Override toolchain variables for this build (e.g. CC=clang LD=ld.lld)" split:"false"`
-	ForcePull      bool                  `long:"force-pull" usage:"Force pulling packages before building"`
-	InitrdOptions  []initrd.InitrdOption `noattribute:"true"`
-	Jobs           int                   `long:"jobs" short:"j" usage:"Allow N jobs at once"`
-	Kernel         string                `long:"kernel" short:"k" usage:"Set the output path of the built kernel image"`
-	KernelDbg      bool                  `long:"dbg" usage:"Build the debuggable (symbolic) kernel image instead of the stripped image"`
-	Kraftfile      string                `long:"kraftfile" short:"K" usage:"Set an alternative path of the Kraftfile"`
-	NoCache        bool                  `long:"no-cache" short:"F" usage:"Force a rebuild even if existing intermediate artifacts already exist"`
-	NoConfigure    bool                  `long:"no-configure" usage:"Do not run Unikraft's configure step before building"`
-	NoFast         bool                  `long:"no-fast" usage:"Do not use maximum parallelization when performing the build"`
-	NoFetch        bool                  `long:"no-fetch" usage:"Do not run Unikraft's fetch step before building"`
-	NoRootfs       bool                  `long:"no-rootfs" usage:"Do not build the root file system (initramfs)"`
-	NoUpdate       bool                  `long:"no-update" usage:"Do not update package index before running the build"`
-	Output         string                `long:"output" short:"o" usage:"Set the output directory for the build artifacts"`
-	Platform       string                `long:"plat" short:"p" usage:"Filter the creation of the build by platform of known targets (fc/qemu/xen)"`
-	PrintStats     bool                  `long:"print-stats" usage:"Print build statistics"`
-	Project        app.Application       `noattribute:"true"`
-	Rootfs         string                `long:"rootfs" usage:"Specify a path to use as root file system (can be volume or initramfs)"`
-	RootfsType     kraftfilev07.FsType   `noattribute:"true"`
-	KeepFileOwners bool                  `local:"true" long:"keep-file-owners" usage:"Keep file owners (user:group) in the rootfs (false sets 'root:root')"`
-	SaveBuildLog   string                `long:"build-log" usage:"Use the specified file to save the output from the build"`
-	Target         *target.Target        `noattribute:"true"`
-	TargetName     string                `long:"target" short:"t" usage:"Build a particular known target"`
-	Validate       bool                  `long:"validate" short:"C" usage:"Validate KConfig options against known symbols"`
-	Workdir        string                `noattribute:"true"`
+	All              bool                  `long:"all" usage:"Build all targets"`
+	Architecture     string                `long:"arch" short:"m" usage:"Filter the creation of the build by architecture of known targets (x86_64/arm64/arm)"`
+	DotConfig        string                `long:"config" short:"c" usage:"Override the path to the KConfig .config file"`
+	Env              []string              `long:"env" short:"e" usage:"Set environment variables to be built in the unikernel" split:"false"`
+	Toolchain        []string              `long:"toolchain" short:"T" usage:"Override toolchain variables for this build (e.g. CC=clang LD=ld.lld)" split:"false"`
+	ToolchainProfile string                `long:"toolchain-profile" usage:"Use a pre-configured toolchain profile"`
+	ForcePull        bool                  `long:"force-pull" usage:"Force pulling packages before building"`
+	InitrdOptions    []initrd.InitrdOption `noattribute:"true"`
+	Jobs             int                   `long:"jobs" short:"j" usage:"Allow N jobs at once"`
+	Kernel           string                `long:"kernel" short:"k" usage:"Set the output path of the built kernel image"`
+	KernelDbg        bool                  `long:"dbg" usage:"Build the debuggable (symbolic) kernel image instead of the stripped image"`
+	Kraftfile        string                `long:"kraftfile" short:"K" usage:"Set an alternative path of the Kraftfile"`
+	NoCache          bool                  `long:"no-cache" short:"F" usage:"Force a rebuild even if existing intermediate artifacts already exist"`
+	NoConfigure      bool                  `long:"no-configure" usage:"Do not run Unikraft's configure step before building"`
+	NoFast           bool                  `long:"no-fast" usage:"Do not use maximum parallelization when performing the build"`
+	NoFetch          bool                  `long:"no-fetch" usage:"Do not run Unikraft's fetch step before building"`
+	NoRootfs         bool                  `long:"no-rootfs" usage:"Do not build the root file system (initramfs)"`
+	NoUpdate         bool                  `long:"no-update" usage:"Do not update package index before running the build"`
+	Output           string                `long:"output" short:"o" usage:"Set the output directory for the build artifacts"`
+	Platform         string                `long:"plat" short:"p" usage:"Filter the creation of the build by platform of known targets (fc/qemu/xen)"`
+	PrintStats       bool                  `long:"print-stats" usage:"Print build statistics"`
+	Project          app.Application       `noattribute:"true"`
+	Rootfs           string                `long:"rootfs" usage:"Specify a path to use as root file system (can be volume or initramfs)"`
+	RootfsType       kraftfilev07.FsType   `noattribute:"true"`
+	KeepFileOwners   bool                  `local:"true" long:"keep-file-owners" usage:"Keep file owners (user:group) in the rootfs (false sets 'root:root')"`
+	SaveBuildLog     string                `long:"build-log" usage:"Use the specified file to save the output from the build"`
+	Target           *target.Target        `noattribute:"true"`
+	TargetName       string                `long:"target" short:"t" usage:"Build a particular known target"`
+	Validate         bool                  `long:"validate" short:"C" usage:"Validate KConfig options against known symbols"`
+	Workdir          string                `noattribute:"true"`
 
 	statistics map[string]string
 }
@@ -412,10 +414,17 @@ func moveFile(src, dst string) error {
 	return nil
 }
 
-func mergeToolchain(global map[string]string, flags []string) map[string]string {
+func mergeToolchain(ctx context.Context, global map[string]string, profileName string, flags []string) map[string]string {
 	result := map[string]string{}
 	for k, v := range global {
 		result[k] = v
+	}
+	if profileName != "" {
+		if profile, ok := config.G[config.KraftKit](ctx).ToolchainProfiles[profileName]; ok {
+			for k, v := range profile {
+				result[k] = v
+			}
+		}
 	}
 	for _, f := range flags {
 		parts := strings.SplitN(f, "=", 2)

--- a/internal/cli/kraft/build/build.go
+++ b/internal/cli/kraft/build/build.go
@@ -229,6 +229,10 @@ func (opts *BuildOptions) Pre(cmd *cobra.Command, args []string) error {
 
 	cmd.SetContext(ctx)
 
+	if err := validateToolchainProfile(ctx, opts.ToolchainProfile); err != nil {
+		return err
+	}
+
 	if cmd.Flag("rootfs-type").Changed && cmd.Flag("rootfs-type").Value.String() != "" {
 		opts.RootfsType = kraftfilev07.FsType(cmd.Flag("rootfs-type").Value.String())
 	}
@@ -433,4 +437,16 @@ func mergeToolchain(ctx context.Context, global map[string]string, profileName s
 		}
 	}
 	return result
+}
+
+func validateToolchainProfile(ctx context.Context, profileName string) error {
+	if profileName == "" {
+		return nil
+	}
+
+	if _, ok := config.G[config.KraftKit](ctx).ToolchainProfiles[profileName]; !ok {
+		return fmt.Errorf("toolchain profile %q does not exist", profileName)
+	}
+
+	return nil
 }

--- a/internal/cli/kraft/build/build_toolchain_test.go
+++ b/internal/cli/kraft/build/build_toolchain_test.go
@@ -16,10 +16,12 @@ import (
 
 func TestMergeToolchain(t *testing.T) {
 	for _, tc := range []struct {
-		name   string
-		global map[string]string
-		flags  []string
-		expect map[string]string
+		name        string
+		global      map[string]string
+		profiles    map[string]map[string]string
+		profileName string
+		flags       []string
+		expect      map[string]string
 	}{
 		{
 			name:   "flags only",
@@ -63,9 +65,42 @@ func TestMergeToolchain(t *testing.T) {
 			flags:  []string{"UK_CFLAGS=-O2 -DFOO=1"},
 			expect: map[string]string{"UK_CFLAGS": "-O2 -DFOO=1"},
 		},
+		{
+			name: "profile only",
+			profiles: map[string]map[string]string{
+				"myprofile": {"CC": "clang", "UK_CFLAGS": "-O3"},
+			},
+			profileName: "myprofile",
+			expect:      map[string]string{"CC": "clang", "UK_CFLAGS": "-O3"},
+		},
+		{
+			name:   "profile overrides global but flag overrides profile",
+			global: map[string]string{"CC": "gcc", "LD": "ld.bfd"},
+			profiles: map[string]map[string]string{
+				"myprofile": {"CC": "clang", "UK_CFLAGS": "-O3"},
+			},
+			profileName: "myprofile",
+			flags:       []string{"UK_CFLAGS=-O0"},
+			expect:      map[string]string{"CC": "clang", "LD": "ld.bfd", "UK_CFLAGS": "-O0"},
+		},
+		{
+			name: "profile name does not exist",
+			profiles: map[string]map[string]string{
+				"other": {"CC": "clang"},
+			},
+			profileName: "nonexistent",
+			global:      map[string]string{"CC": "gcc"},
+			expect:      map[string]string{"CC": "gcc"},
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			got := mergeToolchain(tc.global, tc.flags)
+			ctx := config.WithConfigManager(context.Background(), &config.ConfigManager[config.KraftKit]{
+				Config: &config.KraftKit{
+					Toolchain:         tc.global,
+					ToolchainProfiles: tc.profiles,
+				},
+			})
+			got := mergeToolchain(ctx, tc.global, tc.profileName, tc.flags)
 			if !reflect.DeepEqual(got, tc.expect) {
 				t.Errorf("mergeToolchain() = %v, want %v", got, tc.expect)
 			}
@@ -75,10 +110,12 @@ func TestMergeToolchain(t *testing.T) {
 
 func TestMakeOptionsForBuildIncludesResolvedToolchain(t *testing.T) {
 	for _, tc := range []struct {
-		name   string
-		global map[string]string
-		flags  []string
-		expect []string
+		name        string
+		global      map[string]string
+		profiles    map[string]map[string]string
+		profileName string
+		flags       []string
+		expect      []string
 	}{
 		{
 			name:   "global values are forwarded to make",
@@ -90,6 +127,16 @@ func TestMakeOptionsForBuildIncludesResolvedToolchain(t *testing.T) {
 			global: map[string]string{"CC": "gcc", "LD": "ld"},
 			flags:  []string{"CC=clang", "UK_CFLAGS=-O0 -g"},
 			expect: []string{"CC=clang", "LD=ld", "UK_CFLAGS=-O0 -g"},
+		},
+		{
+			name:        "profile overrides win over global, and cli overrides win over profile",
+			global:      map[string]string{"CC": "gcc", "LD": "ld"},
+			profileName: "myprofile",
+			profiles: map[string]map[string]string{
+				"myprofile": {"CC": "clang", "EXTRA_CFLAGS": "-O3"},
+			},
+			flags:  []string{"CC=gcc-12"},
+			expect: []string{"CC=gcc-12", "LD=ld", "EXTRA_CFLAGS=-O3"},
 		},
 		{
 			name:   "malformed flags are ignored",
@@ -104,11 +151,15 @@ func TestMakeOptionsForBuildIncludesResolvedToolchain(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			ctx := config.WithConfigManager(context.Background(), &config.ConfigManager[config.KraftKit]{
-				Config: &config.KraftKit{Toolchain: tc.global},
+				Config: &config.KraftKit{
+					Toolchain:         tc.global,
+					ToolchainProfiles: tc.profiles,
+				},
 			})
 
 			mo, err := make.NewMakeOptions(makeOptionsForBuild(ctx, &BuildOptions{
-				Toolchain: tc.flags,
+				Toolchain:        tc.flags,
+				ToolchainProfile: tc.profileName,
 			})...)
 			if err != nil {
 				t.Fatalf("NewMakeOptions() returned unexpected error: %v", err)

--- a/internal/cli/kraft/build/build_toolchain_test.go
+++ b/internal/cli/kraft/build/build_toolchain_test.go
@@ -83,15 +83,6 @@ func TestMergeToolchain(t *testing.T) {
 			flags:       []string{"UK_CFLAGS=-O0"},
 			expect:      map[string]string{"CC": "clang", "LD": "ld.bfd", "UK_CFLAGS": "-O0"},
 		},
-		{
-			name: "profile name does not exist",
-			profiles: map[string]map[string]string{
-				"other": {"CC": "clang"},
-			},
-			profileName: "nonexistent",
-			global:      map[string]string{"CC": "gcc"},
-			expect:      map[string]string{"CC": "gcc"},
-		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			ctx := config.WithConfigManager(context.Background(), &config.ConfigManager[config.KraftKit]{
@@ -103,6 +94,48 @@ func TestMergeToolchain(t *testing.T) {
 			got := mergeToolchain(ctx, tc.global, tc.profileName, tc.flags)
 			if !reflect.DeepEqual(got, tc.expect) {
 				t.Errorf("mergeToolchain() = %v, want %v", got, tc.expect)
+			}
+		})
+	}
+}
+
+func TestValidateToolchainProfile(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		profiles    map[string]map[string]string
+		profileName string
+		wantErr     string
+	}{
+		{
+			name: "no profile selected",
+		},
+		{
+			name: "configured profile",
+			profiles: map[string]map[string]string{
+				"clang": {"CC": "clang"},
+			},
+			profileName: "clang",
+		},
+		{
+			name:        "unknown profile",
+			profileName: "clang",
+			wantErr:     `toolchain profile "clang" does not exist`,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := config.WithConfigManager(context.Background(), &config.ConfigManager[config.KraftKit]{
+				Config: &config.KraftKit{ToolchainProfiles: tc.profiles},
+			})
+
+			err := validateToolchainProfile(ctx, tc.profileName)
+			if tc.wantErr == "" {
+				if err != nil {
+					t.Fatalf("validateToolchainProfile() returned unexpected error: %v", err)
+				}
+				return
+			}
+			if err == nil || err.Error() != tc.wantErr {
+				t.Fatalf("validateToolchainProfile() error = %v, want %q", err, tc.wantErr)
 			}
 		})
 	}

--- a/internal/cli/kraft/build/builder_kraftfile_unikraft.go
+++ b/internal/cli/kraft/build/builder_kraftfile_unikraft.go
@@ -111,7 +111,7 @@ func makeOptionsForBuild(ctx context.Context, opts *BuildOptions) []make.MakeOpt
 		mopts = append(mopts, make.WithMaxJobs(!opts.NoFast && !config.G[config.KraftKit](ctx).NoParallel))
 	}
 
-	if toolchain := mergeToolchain(config.G[config.KraftKit](ctx).Toolchain, opts.Toolchain); len(toolchain) > 0 {
+	if toolchain := mergeToolchain(ctx, config.G[config.KraftKit](ctx).Toolchain, opts.ToolchainProfile, opts.Toolchain); len(toolchain) > 0 {
 		mopts = append(mopts, make.WithVars(toolchain))
 	}
 

--- a/internal/cli/kraft/system/list/list.go
+++ b/internal/cli/kraft/system/list/list.go
@@ -89,7 +89,14 @@ func flattenConfig(v reflect.Value, prefix string) []string {
 		case reflect.Map:
 			for _, mapKey := range fieldVal.MapKeys() {
 				mapVal := fieldVal.MapIndex(mapKey)
-				pairs = append(pairs, fmt.Sprintf("%s.%s=%v", key, mapKey, mapVal))
+				if mapVal.Kind() == reflect.Map {
+					for _, innerKey := range mapVal.MapKeys() {
+						innerVal := mapVal.MapIndex(innerKey)
+						pairs = append(pairs, fmt.Sprintf("%s.%s.%s=%v", key, mapKey, innerKey, innerVal))
+					}
+				} else {
+					pairs = append(pairs, fmt.Sprintf("%s.%s=%v", key, mapKey, mapVal))
+				}
 			}
 
 		default:


### PR DESCRIPTION
### Prerequisite checklist
  
  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes
to the project;
  - [x] Tested your changes locally.
  
  ### Description of changes
  
  This PR implements the initial configuration and build-merging infrastructure to support configurable toolchain
profiles (Closes #673). It introduces `ToolchainProfiles` to allow users to define named compiler/build environments
in their global configuration, and implements a 3-level toolchain merging precedence.
  
  The toolchain precedence resolves as:
  
  
CLI flags (e.g., -T CC=clang) > Selected Profile (e.g., --toolchain-profile=clang-debug) > Global Config Defaults
(e.g., toolchain.CC)

  
  
  | Component / File | Description of Changes |
  |---|---|
  | **`config/config.go`** | Added `ToolchainProfiles map[string]map[string]string` to the global configuration schema.
  | **`config/manager.go`** | Refactored `Set`/`Unset` methods to use a unified `traverse` helper, and added recursive validation/mutation for two-level nested maps. |
  | **`internal/cli/kraft/system/list/list.go`** | Updated `flattenConfig` to recursively format and print nested map elements (making them visible via `kraft system list`). |
  | **`internal/cli/kraft/build/build.go`** | Added the `--toolchain-profile` CLI flag to `BuildOptions` and updated `mergeToolchain` to enforce the 3-level precedence hierarchy. |
  | **`internal/cli/kraft/build/builder_kraftfile_unikraft.go`** | Propagated the selected profile options to the underlying GNU Make options generator. |
  | **`config/manager_test.go`** | Added unit test coverage for setting, unsetting, and edge cases (e.g., too-deep paths) of nested maps. |
  | **`internal/cli/kraft/build/build_toolchain_test.go`** | Updated toolchain unit tests to verify precedence resolution across global defaults, profiles, and CLI overrides. |
  
  ### Verification
  
  All unit tests compiled and passed locally:
  - `go test ./config/...`
  - `go test ./internal/cli/kraft/build/...`