### PR TITLE
fix(kraft/build): Fix rootfs artifact path and --rootfs CLI build

### DIFF
--- a/internal/cli/kraft/build/build.go
+++ b/internal/cli/kraft/build/build.go
@@ -124,16 +124,17 @@ func Build(ctx context.Context, opts *BuildOptions, args ...string) error {
 	}
 
 	if !opts.NoRootfs {
+		output := filepath.Join(
+			buildOutputDir(opts.Project, opts.Workdir),
+			fmt.Sprintf(initrd.DefaultInitramfsArchFileName, (*opts.Target).Architecture(), opts.RootfsType),
+		)
 		if _, _, _, err = initrd.BuildRootfs(
 			ctx,
 			append(opts.InitrdOptions,
 				initrd.WithRootfsPath(opts.Rootfs),
 				initrd.WithWorkdir(opts.Workdir),
 				initrd.WithKeepOwners(opts.KeepFileOwners),
-				initrd.WithOutput(filepath.Join(
-					buildOutputDir(opts.Project, opts.Workdir),
-					fmt.Sprintf(initrd.DefaultInitramfsArchFileName, (*opts.Target).Architecture(), opts.RootfsType),
-				)),
+				initrd.WithOutput(output),
 				initrd.WithOutputType(opts.RootfsType),
 				initrd.WithCacheDir(filepath.Join(
 					opts.Workdir,
@@ -147,6 +148,7 @@ func Build(ctx context.Context, opts *BuildOptions, args ...string) error {
 			return err
 		}
 
+		opts.Rootfs = output
 		// Set the root file system for the project, since typically a packaging step
 		// may occur after a build, and the root file system is required for packaging
 		// and the packaging step may perform a build of the rootfs again.  Ultimately
@@ -305,10 +307,6 @@ func (opts *BuildOptions) Run(ctx context.Context, args []string) error {
 	}
 
 	if opts.Rootfs != "" && !opts.NoRootfs {
-		if !filepath.IsAbs(opts.Rootfs) {
-			opts.Rootfs = filepath.Join(opts.Workdir, opts.Rootfs)
-		}
-
 		initrdStat, err := os.Stat(opts.Rootfs)
 		if err != nil {
 			return fmt.Errorf("getting initramfs size: %w", err)

--- a/internal/cli/kraft/build/build.go
+++ b/internal/cli/kraft/build/build.go
@@ -89,10 +89,6 @@ func Build(ctx context.Context, opts *BuildOptions, args ...string) error {
 		}
 	}
 
-	if opts.Project != nil && opts.Project.InitrdFsType().String() != "" && opts.RootfsType == "" {
-		opts.RootfsType = opts.Project.InitrdFsType()
-	}
-
 	opts.statistics = map[string]string{}
 
 	var build builder
@@ -123,7 +119,11 @@ func Build(ctx context.Context, opts *BuildOptions, args ...string) error {
 		return fmt.Errorf("could not complete build: %w", err)
 	}
 
-	if !opts.NoRootfs {
+	if opts.RootfsType == "" {
+		opts.RootfsType = initrd.FsTypeCpio
+	}
+
+	if !opts.NoRootfs && opts.Rootfs != "" {
 		output := filepath.Join(
 			buildOutputDir(opts.Project, opts.Workdir),
 			fmt.Sprintf(initrd.DefaultInitramfsArchFileName, (*opts.Target).Architecture(), opts.RootfsType),


### PR DESCRIPTION
## Summary

Fixes two related issues in `kraft build` rootfs handling:

- #2859 - Kraftkit shows input path of rootfs in artifacts in build
  command; it should show output.
- #2860 - Passing rootfs via cmd doesn't work in build command.

Fixes #2859
Fixes #2860

## Changes

All changes are in `internal/cli/kraft/build/build.go`.

**Commit 1:** `fix(kraft): Show rootfs output path in build artifacts`
(Fixes #2859)

- Extract the initramfs output path into an `output` variable.
- Set `opts.Rootfs = output` after `initrd.BuildRootfs` completes so
  the fancy map and downstream steps reference the built artifact.

**Commit 2:** `fix(kraft): Fix --rootfs build without --rootfs-type`
(Fixes #2860)

- Default `opts.RootfsType` to `cpio` when unset.
- Only run the rootfs build when `!opts.NoRootfs && opts.Rootfs != ""`.
- Remove the duplicate `InitrdFsType` copy from `Build()`; builders
  already apply project defaults during `Buildable()`.