### PR TITLE
fix(run): Ensure absolute path for workdir and validate existing rootfs

### DIFF
--- a/internal/cli/kraft/run/runner_kernel.go
+++ b/internal/cli/kraft/run/runner_kernel.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"debug/elf"
 	"fmt"
+	"os"
 	"path/filepath"
 
 	machineapi "kraftkit.sh/api/machine/v1alpha1"
@@ -53,6 +54,12 @@ func (runner *runnerKernel) Runnable(ctx context.Context, opts *RunOptions, args
 
 // Prepare implements Runner.
 func (runner *runnerKernel) Prepare(ctx context.Context, opts *RunOptions, machine *machineapi.Machine, args ...string) error {
+	var err error
+	opts.workdir, err = os.Getwd()
+	if err != nil {
+		return fmt.Errorf("could not get working directory: %w", err)
+	}
+
 	filename := filepath.Base(runner.kernelPath)
 	machine.Spec.Kernel = "kernel://" + filename
 	machine.Status.KernelPath = runner.kernelPath

--- a/internal/cli/kraft/run/runner_kraftfile_runtime.go
+++ b/internal/cli/kraft/run/runner_kraftfile_runtime.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/klauspost/cpuid/v2"
@@ -58,7 +59,10 @@ func (runner *runnerKraftfileRuntime) Runnable(ctx context.Context, opts *RunOpt
 		opts.workdir = cwd
 		runner.args = args
 		if f, err := os.Stat(args[0]); err == nil && f.IsDir() {
-			opts.workdir = args[0]
+			opts.workdir, err = filepath.Abs(args[0])
+			if err != nil {
+				return false, fmt.Errorf("getting absolute path of workdir: %w", err)
+			}
 			runner.args = args[1:]
 		}
 	}

--- a/internal/cli/kraft/run/runner_kraftfile_unikraft.go
+++ b/internal/cli/kraft/run/runner_kraftfile_unikraft.go
@@ -64,10 +64,14 @@ func (runner *runnerKraftfileUnikraft) Runnable(ctx context.Context, opts *RunOp
 		runner.workdir = cwd
 		runner.args = args
 		if f, err := os.Stat(args[0]); err == nil && f.IsDir() {
-			runner.workdir = args[0]
+			runner.workdir, err = filepath.Abs(args[0])
+			if err != nil {
+				return false, fmt.Errorf("getting absolute path of workdir: %w", err)
+			}
 			runner.args = args[1:]
 		}
 	}
+	opts.workdir = runner.workdir
 
 	popts := []app.ProjectOption{
 		app.WithProjectWorkdir(runner.workdir),

--- a/internal/cli/kraft/run/runner_package.go
+++ b/internal/cli/kraft/run/runner_package.go
@@ -97,6 +97,12 @@ func (runner *runnerPackage) Runnable(ctx context.Context, opts *RunOptions, arg
 
 // Prepare implements Runner.
 func (runner *runnerPackage) Prepare(ctx context.Context, opts *RunOptions, machine *machineapi.Machine, args ...string) error {
+	var err error
+	opts.workdir, err = os.Getwd()
+	if err != nil {
+		return fmt.Errorf("could not get working directory: %w", err)
+	}
+
 	parallel := !config.G[config.KraftKit](ctx).NoParallel
 	norender := log.LoggerTypeFromString(config.G[config.KraftKit](ctx).Log.Type) != log.FANCY
 

--- a/internal/cli/kraft/run/utils.go
+++ b/internal/cli/kraft/run/utils.go
@@ -356,6 +356,18 @@ func (opts *RunOptions) prepareRootfs(ctx context.Context, machine *machineapi.M
 		fmt.Sprintf(initrd.DefaultInitramfsArchFileName, machine.Spec.Architecture, opts.RootfsType),
 	)
 
+	if machine.Status.InitrdPath == opts.Rootfs {
+		stat, err := os.Stat(opts.Rootfs)
+		if err != nil {
+			return fmt.Errorf("using existing rootfs: %w", err)
+		}
+
+		if !stat.Mode().IsRegular() {
+			return fmt.Errorf("using existing rootfs: %s is not a regular file", opts.Rootfs)
+		}
+		return nil
+	}
+
 	ramfs, err := initrd.New(ctx,
 		opts.Rootfs,
 		initrd.WithOutput(machine.Status.InitrdPath),


### PR DESCRIPTION
# Run: Ensure Absolute Path for Workdir and Validate Existing Rootfs

## Overview
This PR introduces path resolution improvements for the `kraft run` command, ensuring that the working directory (`workdir`) is resolved to an absolute path, and optimizes the rootfs preparation phase by skipping unnecessary builds when an already-built rootfs is present and valid.