### PR TITLE
feat(buildenvs): Add hyperlight-unikraft to github-action image

### DIFF
--- a/buildenvs/github-action.Dockerfile
+++ b/buildenvs/github-action.Dockerfile
@@ -4,6 +4,7 @@
 # You may not use this file except in compliance with the License.
 ARG GO_VERSION=1.26.2
 ARG DEBIAN_VERSION=trixie
+ARG HYPERLIGHT_UNIKRAFT_VERSION=0.12.1
 ARG KRAFTKIT_VERSION=latest
 ARG QEMU_VERSION=9.2.1
 ARG REGISTRY=kraftkit.sh
@@ -22,6 +23,16 @@ RUN set -xe; \
         --add safe.directory /go/src/kraftkit.sh; \
     DOCKER= DISTDIR=/ XEN=n CGO_ENABLED=0 make github-action;
 
+FROM rust:1.89.0-slim-trixie AS hyperlight-unikraft
+
+ARG HYPERLIGHT_UNIKRAFT_VERSION
+
+RUN cargo install \
+      --locked \
+      --version "${HYPERLIGHT_UNIKRAFT_VERSION}" \
+      --bin hyperlight-unikraft \
+      hyperlight-unikraft
+
 FROM ${REGISTRY}/qemu:${QEMU_VERSION} AS qemu
 FROM ${REGISTRY}/myself:${KRAFTKIT_VERSION} AS kraftkit
 FROM debian:${DEBIAN_VERSION}         AS base
@@ -30,6 +41,9 @@ COPY --from=qemu  /bin/          /usr/local/bin
 COPY --from=qemu  /share/qemu/   /share/qemu
 COPY --from=qemu  /lib/x86_64-linux-gnu/ /lib/x86_64-linux-gnu
 COPY --from=build /github-action /usr/local/bin/github-action
+COPY --from=hyperlight-unikraft \
+  /usr/local/cargo/bin/hyperlight-unikraft \
+  /usr/local/bin/hyperlight-unikraft
 COPY --from=kraftkit /kraft       /usr/local/bin/kraft
 COPY --from=hairyhenderson/gomplate:stable /gomplate /bin/gomplate
 


### PR DESCRIPTION
## Add the `hyperlight-unikraft` binary in the Krafkit GitHub Action in `github-action.Dockerfile`

Install hyperlight-unikraft via a dedicated Rust build stage and ship the binary in the GitHub Action container so workflows can run Hyperlight-based unikernels.

## Verified by running the `hyperlight-unikraft --help` in Docker container
<img width="1131" height="178" alt="image" src="https://github.com/user-attachments/assets/7bd72f88-443d-4eb6-bb72-b5ae3962031d" />

### Full build 
<img width="1103" height="176" alt="image" src="https://github.com/user-attachments/assets/25709cd7-e8a5-47c9-bd30-1ef80aa113a5" />
