### PR TITLE
fix(cmd,initrd): Fix rootfs handling in run command and in general

### DIFF
--- a/initrd/file.go
+++ b/initrd/file.go
@@ -50,37 +50,58 @@ func NewFromFile(_ context.Context, path string, opts ...InitrdOption) (Initrd, 
 		return nil, fmt.Errorf("path %s is a directory, not a file", initrd.path)
 	}
 
-	absDest, err := filepath.Abs(filepath.Clean(initrd.opts.output))
-	if err != nil {
-		return nil, fmt.Errorf("getting absolute path of destination: %w", err)
-	}
-
-	if absDest == stat.Name() {
-		return nil, fmt.Errorf("CPIO archive path is the same as the source path, this is not allowed as it creates corrupted archives")
-	}
-
 	return &initrd, nil
 }
 
-// Build implements Initrd.
+// Name implements Initrd.
 func (initrd *file) Name() string {
 	return "file"
 }
 
 // Build implements Initrd.
 func (initrd *file) Build(ctx context.Context) (string, error) {
-	if initrd.opts.output == initrd.path {
-		return "", fmt.Errorf("CPIO archive path is the same as the source path, this is not allowed as it creates corrupted archives")
-	}
-
-reevaluateFsType:
-	switch initrd.opts.fsType {
-	case FsTypeUnknown:
+	if initrd.opts.fsType == FsTypeUnknown {
 		initrd.opts.fsType = detectFsType(initrd.path)
 		if initrd.opts.fsType == FsTypeUnknown {
 			return "", fmt.Errorf("could not detect filesystem type of input file, please specify it explicitly via the --fs-type flag")
 		}
-		goto reevaluateFsType
+	}
+
+	absSrc, err := filepath.Abs(filepath.Clean(initrd.path))
+	if err != nil {
+		return "", fmt.Errorf("getting absolute path of source: %w", err)
+	}
+
+	if initrd.opts.output != "" {
+		absDest, err := filepath.Abs(filepath.Clean(initrd.opts.output))
+		if err != nil {
+			return "", fmt.Errorf("getting absolute path of destination: %w", err)
+		}
+
+		if absDest == absSrc {
+			if isMatchingFsType(absSrc, initrd.opts.fsType) {
+				return initrd.path, nil
+			}
+			return "", fmt.Errorf("output path %q is the same as the source path %q; refusing to overwrite in-place (would corrupt the input)", absDest, absSrc)
+		}
+	}
+
+	if initrd.opts.output == "" {
+		if isMatchingFsType(absSrc, initrd.opts.fsType) {
+			return initrd.path, nil
+		}
+
+		fi, err := os.CreateTemp("", "")
+		if err != nil {
+			return "", fmt.Errorf("could not make temporary file: %w", err)
+		}
+		initrd.opts.output = fi.Name()
+		if err := fi.Close(); err != nil {
+			return "", fmt.Errorf("could not close temporary file: %w", err)
+		}
+	}
+
+	switch initrd.opts.fsType {
 	case FsTypeFile:
 		return initrd.opts.output, copyFile(initrd.path, initrd.opts.output)
 	case FsTypeErofs:
@@ -93,6 +114,17 @@ reevaluateFsType:
 		)
 	default:
 		return "", fmt.Errorf("unknown filesystem type %s", initrd.opts.fsType)
+	}
+}
+
+func isMatchingFsType(source string, target kraftfilev07.FsType) bool {
+	switch target {
+	case FsTypeCpio:
+		return fsutils.IsCpioFile(source)
+	case FsTypeErofs:
+		return fsutils.IsErofsFile(source)
+	default:
+		return false
 	}
 }
 

--- a/initrd/file_test.go
+++ b/initrd/file_test.go
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2026, Unikraft GmbH and The KraftKit Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+
+package initrd_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"kraftkit.sh/initrd"
+)
+
+func TestNewFromFileBuildEmptyOutputReturnsSource(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "initrd.cpio")
+	// Standard CPIO magic header "070701"
+	if err := os.WriteFile(src, []byte("07070100000000"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	ird, err := initrd.NewFromFile(context.Background(), src)
+	if err != nil {
+		t.Fatalf("NewFromFile: %v", err)
+	}
+
+	out, err := ird.Build(context.Background())
+	if err != nil {
+		t.Fatalf("Build with empty output: %v", err)
+	}
+	if out != src {
+		t.Fatalf("Build() = %q, want source path %q", out, src)
+	}
+}
+
+func TestNewFromFileSameSourceAndOutputAllowedForCpio(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "initrd.cpio")
+	if err := os.WriteFile(src, []byte("07070100000000"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	ird, err := initrd.NewFromFile(context.Background(), src, initrd.WithOutput(src))
+	if err != nil {
+		t.Fatalf("expected NewFromFile to succeed when source and output match for CPIO, got: %v", err)
+	}
+
+	out, err := ird.Build(context.Background())
+	if err != nil {
+		t.Fatalf("expected Build to succeed when source and output match for CPIO, got: %v", err)
+	}
+	if out != src {
+		t.Fatalf("Build() = %q, want source path %q", out, src)
+	}
+}
+
+func TestNewFromFileSameSourceAndOutputRejectedForNonArchive(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "script.sh")
+	// Regular non-CPIO file
+	if err := os.WriteFile(src, []byte("#!/bin/sh\necho hello"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	ird, err := initrd.NewFromFile(context.Background(), src, initrd.WithOutput(src))
+	if err != nil {
+		t.Fatalf("unexpected error from NewFromFile: %v", err)
+	}
+
+	_, err = ird.Build(context.Background())
+	if err == nil {
+		t.Fatal("expected error from Build() when non-archive source and output are the same path")
+	}
+}

--- a/initrd/rootfs.go
+++ b/initrd/rootfs.go
@@ -70,6 +70,7 @@ func BuildRootfs(ctx context.Context, opts ...InitrdOption) (Initrd, []string, [
 		[]processtree.ProcessTreeOption{
 			processtree.IsParallel(false),
 			processtree.WithRenderer(log.LoggerTypeFromString(config.G[config.KraftKit](ctx).Log.Type) != log.FANCY),
+			processtree.WithHideError(true),
 		},
 		processes...,
 	)

--- a/internal/cli/kraft/run/runner_kraftfile_runtime.go
+++ b/internal/cli/kraft/run/runner_kraftfile_runtime.go
@@ -86,14 +86,6 @@ func (runner *runnerKraftfileRuntime) Runnable(ctx context.Context, opts *RunOpt
 		return false, fmt.Errorf("cannot run project without runtime directive")
 	}
 
-	if runner.project != nil && runner.project.Rootfs() != "" && opts.Rootfs == "" {
-		opts.Rootfs = runner.project.Rootfs()
-	}
-
-	if runner.project != nil && runner.project.InitrdFsType().String() != "" && opts.RootfsType == "" {
-		opts.RootfsType = runner.project.InitrdFsType()
-	}
-
 	return true, nil
 }
 
@@ -308,6 +300,9 @@ func (runner *runnerKraftfileRuntime) Prepare(ctx context.Context, opts *RunOpti
 
 	if runner.project.Rootfs() != "" && opts.Rootfs == "" {
 		opts.Rootfs = runner.project.Rootfs()
+	}
+	if runner.project.InitrdFsType().String() != "" && opts.RootfsType == "" {
+		opts.RootfsType = runner.project.InitrdFsType()
 	}
 
 	// Create a temporary directory where the image can be stored

--- a/internal/cli/kraft/run/runner_kraftfile_unikraft.go
+++ b/internal/cli/kraft/run/runner_kraftfile_unikraft.go
@@ -92,14 +92,6 @@ func (runner *runnerKraftfileUnikraft) Runnable(ctx context.Context, opts *RunOp
 		return false, fmt.Errorf("cannot run project build without unikraft")
 	}
 
-	if runner.project != nil && runner.project.Rootfs() != "" && opts.Rootfs == "" {
-		opts.Rootfs = runner.project.Rootfs()
-	}
-
-	if runner.project != nil && runner.project.InitrdFsType().String() != "" && opts.RootfsType == "" {
-		opts.RootfsType = runner.project.InitrdFsType()
-	}
-
 	return true, nil
 }
 
@@ -205,6 +197,9 @@ func (runner *runnerKraftfileUnikraft) Prepare(ctx context.Context, opts *RunOpt
 
 	if runner.project.Rootfs() != "" && opts.Rootfs == "" && noEmbedded {
 		opts.Rootfs = runner.project.Rootfs()
+	}
+	if runner.project.InitrdFsType().String() != "" && opts.RootfsType == "" {
+		opts.RootfsType = runner.project.InitrdFsType()
 	}
 
 	// If automounting is enabled, and an initramfs is provided, set it as a

--- a/internal/cli/kraft/run/runner_package.go
+++ b/internal/cli/kraft/run/runner_package.go
@@ -332,10 +332,10 @@ func (runner *runnerPackage) Prepare(ctx context.Context, opts *RunOptions, mach
 	machine.Spec.ApplicationArgs = runner.args
 
 	// Set the path to the initramfs if present.
+	// Prefer an explicit CLI/project --rootfs override; otherwise use the
+	// package-embedded initrd from Unpack.
 	var ramfs initrd.Initrd
-	if opts.Rootfs == "" && targ.Initrd() != nil {
-		ramfs = targ.Initrd()
-	} else if len(opts.Rootfs) > 0 {
+	if len(opts.Rootfs) > 0 {
 		if opts.RootfsType == "" {
 			opts.RootfsType = initrd.FsTypeCpio
 		}
@@ -346,6 +346,8 @@ func (runner *runnerPackage) Prepare(ctx context.Context, opts *RunOptions, mach
 		if err != nil {
 			return err
 		}
+	} else if targ.Initrd() != nil {
+		ramfs = targ.Initrd()
 	}
 	if ramfs != nil {
 		machine.Status.InitrdPath, err = ramfs.Build(ctx)

--- a/internal/cli/kraft/run/utils.go
+++ b/internal/cli/kraft/run/utils.go
@@ -350,27 +350,8 @@ func (opts *RunOptions) prepareRootfs(ctx context.Context, machine *machineapi.M
 		opts.RootfsType = initrd.FsTypeCpio
 	}
 
-	machine.Status.InitrdPath = filepath.Join(
-		opts.workdir,
-		unikraft.BuildDir,
-		fmt.Sprintf(initrd.DefaultInitramfsArchFileName, machine.Spec.Architecture, opts.RootfsType),
-	)
-
-	if machine.Status.InitrdPath == opts.Rootfs {
-		stat, err := os.Stat(opts.Rootfs)
-		if err != nil {
-			return fmt.Errorf("using existing rootfs: %w", err)
-		}
-
-		if !stat.Mode().IsRegular() {
-			return fmt.Errorf("using existing rootfs: %s is not a regular file", opts.Rootfs)
-		}
-		return nil
-	}
-
 	ramfs, err := initrd.New(ctx,
 		opts.Rootfs,
-		initrd.WithOutput(machine.Status.InitrdPath),
 		initrd.WithCacheDir(filepath.Join(
 			opts.workdir,
 			unikraft.BuildDir,
@@ -400,7 +381,7 @@ func (opts *RunOptions) prepareRootfs(ctx context.Context, machine *machineapi.M
 			fmt.Sprintf("building rootfs via %s", ramfs.Name()),
 			machine.Spec.Architecture,
 			func(ctx context.Context) error {
-				if _, err = ramfs.Build(ctx); err != nil {
+				if machine.Status.InitrdPath, err = ramfs.Build(ctx); err != nil {
 					return err
 				}
 

--- a/internal/cli/kraft/run/utils.go
+++ b/internal/cli/kraft/run/utils.go
@@ -376,6 +376,7 @@ func (opts *RunOptions) prepareRootfs(ctx context.Context, machine *machineapi.M
 				log.LoggerTypeFromString(config.G[config.KraftKit](ctx).Log.Type) != log.FANCY,
 			),
 			processtree.WithFailFast(true),
+			processtree.WithHideError(true),
 		},
 		processtree.NewProcessTreeItem(
 			fmt.Sprintf("building rootfs via %s", ramfs.Name()),


### PR DESCRIPTION
# Fix rootfs handling, runner side-effects, and initrd build workflow in `kraft run`

## Summary of Changes

This Pull Request resolves several issues in KraftKit's `initrd` package and the `kraft run` execution pipeline relating to rootfs handling, runner selection probes, file corruption guards, workspace pollution, and error reporting.

---

## Key Changes & Rationale

### 1. Robust Initrd Path Handling & Output Resolution ([`initrd/file.go`](file:///home/jaidev/projects/open-source/kraftkit/initrd/file.go))
* **Problem**: Calling `initrd.NewFromFile` without specifying an output path (`opts.output == ""`) caused `file.Build` to attempt `cpio.CreateFS(ctx, "", path)`, failing with `could not open initramfs file: open : no such file or directory`. Furthermore, the same-path comparison logic (`absDest == stat.Name()`) was bugged as it compared absolute paths against base filenames.
* **Fix**:
  * `file.Build` now safely returns `initrd.path` directly when `opts.output == ""` or when `absDest == absSrc` for files that are already valid archives (`fsutils.IsCpioFile` / `fsutils.IsErofsFile`).
  * If `opts.output == ""` and the source is an un-archived file, `file.Build` allocates a temporary file in `/tmp` for the output archive.
  * Added unit tests in [`initrd/file_test.go`](file:///home/jaidev/projects/open-source/kraftkit/initrd/file_test.go) covering empty output handling, same-path archive re-use, and non-archive path guards.

---

### 2. Fix Initrd Path Assignment in `prepareRootfs` ([`internal/cli/kraft/run/utils.go`](file:///home/jaidev/projects/open-source/kraftkit/internal/cli/kraft/run/utils.go))
* **Problem**: In `opts.prepareRootfs`, the return value of `ramfs.Build(ctx)` was discarded (`if _, err = ramfs.Build(ctx)`), leaving `machine.Status.InitrdPath` empty (`""`). This caused Hyperlight and other VM hypervisors to fail at initialization with `Guest aborted: error code 0`.
* **Fix**:
  * Properly assigned `machine.Status.InitrdPath, err = ramfs.Build(ctx)`.
  * Removed hardcoded `WithOutput(...)` calls in `prepareRootfs` so `kraft run` does not write unwanted `.unikraft/initramfs-x86_64.cpio` files into the workspace.

---

### 3. Eliminate Runner Discovery Side-Effects ([`runner_kraftfile_runtime.go`](file:///home/jaidev/projects/open-source/kraftkit/internal/cli/kraft/run/runner_kraftfile_runtime.go) & [`runner_kraftfile_unikraft.go`](file:///home/jaidev/projects/open-source/kraftkit/internal/cli/kraft/run/runner_kraftfile_unikraft.go))
* **Problem**: `Runnable()` was mutating `opts.Rootfs` and `opts.RootfsType` during candidate probing. If a directory contained a `Kraftfile` but an OCI image was targeted, probing the Kraftfile runner polluted `opts.Rootfs` for the OCI package runner.
* **Fix**:
  * Removed `opts` mutation from `Runnable()` probe functions.
  * Moved `opts.Rootfs` and `opts.RootfsType` assignment to `Prepare()`, which executes only after a specific runner is selected.

---

### 4. Package Runner Rootfs Precedence ([`runner_package.go`](file:///home/jaidev/projects/open-source/kraftkit/internal/cli/kraft/run/runner_package.go))
* **Fix**: Ensured explicit `--rootfs` CLI flags take precedence over embedded package initrd targets (`targ.Initrd()`), and invoked `ramfs.Build(ctx)` safely.

---

### 5. Prevent Duplicate ProcessTree Error Printing ([`initrd/rootfs.go`](file:///home/jaidev/projects/open-source/kraftkit/initrd/rootfs.go) & [`utils.go`](file:///home/jaidev/projects/open-source/kraftkit/internal/cli/kraft/run/utils.go))
* **Problem**: Process tree task failures were logged twice (once inline by the processtree item logger and once by `cmdfactory.Main`).
* **Fix**: Added `processtree.WithHideError(true)` in `BuildRootfs` and `prepareRootfs` so errors are formatted and reported cleanly once by the main command error handler.

---

## Testing & Verification

* All `kraftkit.sh/initrd` unit tests pass cleanly:
  * `TestNewFromFileBuildEmptyOutputReturnsSource` (PASS)
  * `TestNewFromFileSameSourceAndOutputAllowedForCpio` (PASS)
  * `TestNewFromFileSameSourceAndOutputRejectedForNonArchive` (PASS)
  * `TestNewFromDirectoryToCPIO` (PASS)
  * `TestNewFromDockerfileToCPIO` (PASS)
  * `TestNewFromOCIImageToCPIO` (PASS)
  * `TestNewFromTarballToCPIO` (PASS)
* Verified `kraft run` and `kraft run --as oci` with Hyperlight and QEMU runtimes.
