### PR TITLE
fix(tools/github-action): Set log type to basic & disable force formatting

### DIFF
--- a/tools/github-action/main.go
+++ b/tools/github-action/main.go
@@ -378,6 +378,8 @@ func main() {
 		os.Exit(1)
 	}
 
+	cfg.Log.Type = "basic"
+
 	cfgm, err := config.NewConfigManager(
 		cfg,
 		config.WithFile[config.KraftKit](config.DefaultConfigFile(), true),
@@ -411,7 +413,7 @@ func main() {
 
 	formatter := new(log.TextFormatter)
 	formatter.ForceColors = true
-	formatter.ForceFormatting = true
+	formatter.ForceFormatting = false
 	formatter.FullTimestamp = true
 	formatter.DisableTimestamp = true
 	logger.Formatter = formatter


### PR DESCRIPTION
Set cfg.Log.Type to basic in GithubAction configuration to prevent process tree and progress bars from using fancy TUI formatting while preserving log colors.
<img width="1222" height="411" alt="image" src="https://github.com/user-attachments/assets/581d4a2c-0a56-4e91-8b86-950997a489c0" />
