### PR TITLE
ci(buildenvs): Add missing trigger files to xen check-run step

### DIFF
--- a/.github/workflows/buildenvs.yaml
+++ b/.github/workflows/buildenvs.yaml
@@ -117,8 +117,15 @@ jobs:
         if: >
           github.event_name == 'pull_request' &&
           (
+            contains(steps.changed-files.outputs.all_changed_files, 'buildenvs/qemu.Dockerfile') ||
+            contains(steps.changed-files.outputs.all_changed_files, 'buildenvs/base.Dockerfile') ||
+            contains(steps.changed-files.outputs.all_changed_files, 'buildenvs/base-golang.Dockerfile') ||
+            contains(steps.changed-files.outputs.all_changed_files, 'buildenvs/myself.Dockerfile') ||
+            contains(steps.changed-files.outputs.all_changed_files, 'buildenvs/github-action.Dockerfile') ||
             contains(steps.changed-files.outputs.all_changed_files, 'buildenvs/xen.Dockerfile') ||
-            contains(steps.changed-files.outputs.all_changed_files, '.github/workflows/buildenvs.yaml')
+            contains(steps.changed-files.outputs.all_changed_files, '.github/workflows/buildenvs.yaml') ||
+            contains(steps.changed-files.outputs.all_changed_files, 'tools/github-action/') ||
+            contains(steps.changed-files.outputs.all_changed_files, 'action.yml')
           ) ||
           github.event_name == 'push'
         run: |


### PR DESCRIPTION
# ci(buildenvs): add missing trigger files to xen check-run step

### Prerequisite checklist

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes locally.

### Description of changes

Fixes an issue in `.github/workflows/buildenvs.yaml` where the `myself` workflow job fails with:
`Error: Unable to download artifact(s): Artifact not found for name: xen-oci-image`

#### Root Cause
The `xen` job's `check-run` step previously only checked for changes to `buildenvs/xen.Dockerfile` and `.github/workflows/buildenvs.yaml`. When pull requests modified other relevant files (such as `buildenvs/myself.Dockerfile`), the `myself` job would run and attempt to download `xen-oci-image`, but the `xen` job had skipped building and uploading the artefact because its restricted `check-run` filter evaluated to `false`.

#### Fix
Added all dependent trigger file paths to the `xen` job's `check-run` step condition to match `qemu` and `myself`. This ensures `xen-oci-image` is always built and uploaded whenever downstream jobs require it.