### PR TITLE
ci(workflows): Remove redundant buildx step in unit test job

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -30,9 +30,6 @@ jobs:
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v4
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
-
       - name: Generate Suffix
         shell: bash
         id: suffix


### PR DESCRIPTION
### Prerequisite checklist

  - [x] Read the [contribution guidelines](https://unikraft.org/docs/contributing/) regarding submitting new changes to the project;
  - [x] Tested your changes locally.

### Description of changes

This PR resolves an intermittent CI failure in the `unit` test job (`.github/workflows/tests.yaml`) where `docker/setup-buildx-action@v4` fails during builder initialization.

#### Root Cause
During the `Booting builder` phase of `docker/setup-buildx-action`, Buildx attempts to pull `moby/buildkit:buildx-stable-1` from public Docker Hub (`registry-1.docker.io`). On GitHub Actions shared runners, transient Docker Hub throttling or network latency occasionally caused the HTTP request to time out.

#### Fix
The `unit` test job (`make test-unit`) does not invoke `docker buildx`. Instead, it connects directly to `/run/buildkit/buildkitd.sock` created by the subsequent `Set up BuildKit` step (`docker run moby/buildkit:latest`).

Removing the redundant `Set up Docker Buildx` step completely eliminates the unnecessary Docker Hub network call, preventing job timeouts and slightly reducing CI setup time.