### PR TITLE
feat(machine): Support riscv64 QEMU targets

### DIFF
--- a/internal/cli/kraft/run/runner_kernel.go
+++ b/internal/cli/kraft/run/runner_kernel.go
@@ -76,6 +76,11 @@ func (runner *runnerKernel) Prepare(ctx context.Context, opts *RunOptions, machi
 			opts.Architecture = arch.ArchitectureArm.String()
 		case elf.EM_AARCH64:
 			opts.Architecture = arch.ArchitectureArm64.String()
+		case elf.EM_RISCV:
+			if fe.Class != elf.ELFCLASS64 {
+				return fmt.Errorf("unsupported RISC-V ELF class: %s", fe.Class)
+			}
+			opts.Architecture = arch.ArchitectureRISCV64.String()
 		default:
 			return fmt.Errorf("unsupported kernel architecture: %v", fe.Machine.String())
 		}

--- a/machine/platform/detect.go
+++ b/machine/platform/detect.go
@@ -200,12 +200,7 @@ func Detect(ctx context.Context) (Platform, SystemMode, error) {
 		customBin = config.G[config.KraftKit](ctx).Qemu
 	}
 
-	for _, bin := range []string{
-		qemu.QemuSystemX86,
-		qemu.QemuSystemArm,
-		qemu.QemuSystemAarch64,
-		customBin,
-	} {
+	for _, bin := range qemu.GetAllQemuSystemBinaries([]string{customBin}) {
 		if _, err := exec.LookPath(bin); err != nil {
 			continue
 		}

--- a/machine/qemu/init.go
+++ b/machine/qemu/init.go
@@ -446,6 +446,7 @@ func init() {
 	gob.Register(QemuCPU{})
 	gob.Register(QemuCPUX86(""))
 	gob.Register(QemuCPUArm(""))
+	gob.Register(QemuCPURISCV(""))
 
 	// Displays
 	// gob.Register(QemuDisplaySpiceApp{})

--- a/machine/qemu/qemu_cpus.go
+++ b/machine/qemu/qemu_cpus.go
@@ -58,6 +58,12 @@ func (arm QemuCPUArm) String() string {
 	return string(arm)
 }
 
+type QemuCPURISCV string
+
+func (riscv QemuCPURISCV) String() string {
+	return string(riscv)
+}
+
 const (
 	QemuCPUX86486                    = QemuCPUX86("486")
 	QemuCPUX86486V1                  = QemuCPUX86("486-v1")
@@ -220,6 +226,10 @@ const (
 	QemuCPUArmSa1100    = QemuCPUArm("sa1100")
 	QemuCPUArmSa1110    = QemuCPUArm("sa1110")
 	QemuCPUArmTi925t    = QemuCPUArm("ti925t")
+)
+
+const (
+	QemuCPURISCVMax = QemuCPURISCV("max")
 )
 
 const (

--- a/machine/qemu/qemu_system.go
+++ b/machine/qemu/qemu_system.go
@@ -8,4 +8,5 @@ const (
 	QemuSystemX86     = "qemu-system-x86_64"
 	QemuSystemArm     = "qemu-system-arm"
 	QemuSystemAarch64 = "qemu-system-aarch64"
+	QemuSystemRiscv64 = "qemu-system-riscv64"
 )

--- a/machine/qemu/qemu_system.go
+++ b/machine/qemu/qemu_system.go
@@ -10,3 +10,14 @@ const (
 	QemuSystemAarch64 = "qemu-system-aarch64"
 	QemuSystemRiscv64 = "qemu-system-riscv64"
 )
+
+func GetAllQemuSystemBinaries(extra []string) []string {
+	binaries := []string{
+		QemuSystemX86,
+		QemuSystemArm,
+		QemuSystemAarch64,
+		QemuSystemRiscv64,
+	}
+	binaries = append(binaries, extra...)
+	return binaries
+}

--- a/machine/qemu/qemu_version.go
+++ b/machine/qemu/qemu_version.go
@@ -23,6 +23,7 @@ var (
 	QemuVersion7_2_0 = semver.New(7, 2, 0, "", "")
 	QemuVersion7_2_4 = semver.New(7, 2, 4, "", "")
 	QemuVersion8_0_0 = semver.New(8, 0, 0, "", "")
+	QemuVersion8_2_0 = semver.New(8, 2, 0, "", "")
 )
 
 // GetQemuVersionFromBin is direct method of accessing the version of the

--- a/machine/qemu/v1alpha1.go
+++ b/machine/qemu/v1alpha1.go
@@ -36,6 +36,7 @@ import (
 	"kraftkit.sh/machine/network/macaddr"
 	"kraftkit.sh/machine/qemu/qmp"
 	qmpapi "kraftkit.sh/machine/qemu/qmp/v7alpha2"
+	"kraftkit.sh/unikraft/arch"
 	"kraftkit.sh/unikraft/export/v0/posixenviron"
 	"kraftkit.sh/unikraft/export/v0/ukargparse"
 	"kraftkit.sh/unikraft/export/v0/uknetdev"
@@ -108,6 +109,10 @@ func (service *machineV1alpha1Service) Create(ctx context.Context, machine *mach
 
 	if qemuVersion.LessThan(QemuVersion4_2_0) {
 		return machine, fmt.Errorf("unsupported QEMU version: %s: please upgrade to a newer version", qemuVersion.String())
+	}
+
+	if machine.Spec.Architecture == arch.ArchitectureRISCV64.String() && qemuVersion.LessThan(QemuVersion8_2_0) {
+		return machine, fmt.Errorf("unsupported QEMU version for %s: %s: please upgrade to version 8.2.0 or newer", machine.Spec.Architecture, qemuVersion.String())
 	}
 
 	// Determine the QEMU machine type to use

--- a/machine/qemu/v1alpha1.go
+++ b/machine/qemu/v1alpha1.go
@@ -89,6 +89,8 @@ func (service *machineV1alpha1Service) Create(ctx context.Context, machine *mach
 		bin = QemuSystemArm
 	case "arm64":
 		bin = QemuSystemAarch64
+	case "riscv64":
+		bin = QemuSystemRiscv64
 	default:
 		return nil, fmt.Errorf("unsupported architecture: %s", machine.Spec.Architecture)
 	}
@@ -473,7 +475,15 @@ func (service *machineV1alpha1Service) Create(ctx context.Context, machine *mach
 				CPU: QemuCPUArmMax,
 			}),
 		)
-
+	case "riscv64":
+		qopts = append(qopts,
+			WithMachine(QemuMachine{
+				Type: QemuMachineTypeVirt,
+			}),
+			WithCPU(QemuCPU{
+				CPU: QemuCPURISCVMax,
+			}),
+		)
 	default:
 		return nil, fmt.Errorf("unsupported architecture: %s", machine.Spec.Architecture)
 	}

--- a/unikraft/app/project_v07_test.go
+++ b/unikraft/app/project_v07_test.go
@@ -187,6 +187,31 @@ targets:
 	}
 }
 
+func Test_NewProjectFromOptionsV07_Riscv64TargetArtifactNames(t *testing.T) {
+	project := mustProjectFromBytes(t, t.TempDir(), `
+spec: v0.7
+name: Demo
+unikraft: stable
+targets:
+  - plat: qemu
+    arch: riscv64
+`)
+
+	targets := project.Targets()
+	if len(targets) != 1 {
+		t.Fatalf("len(Targets()) = %d, want 1", len(targets))
+	}
+
+	wantKernel := filepath.Join(project.OutDir(), "demo_qemu-riscv64")
+	if targets[0].Kernel() != wantKernel {
+		t.Errorf("targets[0].Kernel() = %q, want %q", targets[0].Kernel(), wantKernel)
+	}
+
+	if targets[0].ConfigFilename() != ".config.demo_qemu-riscv64" {
+		t.Errorf("targets[0].ConfigFilename() = %q, want %q", targets[0].ConfigFilename(), ".config.demo_qemu-riscv64")
+	}
+}
+
 func Test_NewProjectFromOptionsV07_CustomOutDir(t *testing.T) {
 	workdir := t.TempDir()
 	outdir := filepath.Join(workdir, "artifacts")

--- a/unikraft/arch/architecture.go
+++ b/unikraft/arch/architecture.go
@@ -177,6 +177,8 @@ func (ac ArchitectureConfig) KConfig() kconfig.KeyValueMap {
 		arch.WriteString("ARCH_ARM_64")
 	case ArchitectureRISCV64:
 		arch.WriteString("ARCH_RISCV_64")
+	default:
+		return values
 	}
 
 	values.Set(arch.String(), kconfig.Yes)

--- a/unikraft/arch/architecture.go
+++ b/unikraft/arch/architecture.go
@@ -22,6 +22,7 @@ const (
 	ArchitectureX86_64  = ArchitectureName("x86_64")
 	ArchitectureArm64   = ArchitectureName("arm64")
 	ArchitectureArm     = ArchitectureName("arm")
+	ArchitectureRISCV64 = ArchitectureName("riscv64")
 )
 
 // String implements fmt.Stringer
@@ -42,9 +43,10 @@ func ArchitectureByName(name string) ArchitectureName {
 // ArchitecturesByName returns the list of known architectures and their name alises.
 func ArchitecturesByName() map[string]ArchitectureName {
 	return map[string]ArchitectureName{
-		"x86_64": ArchitectureX86_64,
-		"arm64":  ArchitectureArm64,
-		"arm":    ArchitectureArm,
+		"x86_64":  ArchitectureX86_64,
+		"arm64":   ArchitectureArm64,
+		"arm":     ArchitectureArm,
+		"riscv64": ArchitectureRISCV64,
 	}
 }
 
@@ -54,6 +56,7 @@ func Architectures() []ArchitectureName {
 		ArchitectureX86_64,
 		ArchitectureArm64,
 		ArchitectureArm,
+		ArchitectureRISCV64,
 	}
 }
 
@@ -172,6 +175,8 @@ func (ac ArchitectureConfig) KConfig() kconfig.KeyValueMap {
 		arch.WriteString("ARCH_ARM_32")
 	case ArchitectureArm64:
 		arch.WriteString("ARCH_ARM_64")
+	case ArchitectureRISCV64:
+		arch.WriteString("ARCH_RISCV_64")
 	}
 
 	values.Set(arch.String(), kconfig.Yes)

--- a/unikraft/arch/host.go
+++ b/unikraft/arch/host.go
@@ -16,7 +16,7 @@ func HostArchitecture() (string, error) {
 	switch arch {
 	case "amd64":
 		return "x86_64", nil
-	case "arm", "arm64":
+	case "arm", "arm64", "riscv64":
 		return arch, nil
 	default:
 		return "", fmt.Errorf("unsupported architecture: %v", arch)


### PR DESCRIPTION
This pr continues the work of @zzSunil from PR #2848 

This PR adds support for `riscv64` QEMU targets in KraftKit:

- **`feat(machine)`**: Recognized `riscv64` as a supported Unikraft architecture, mapped RISC-V ELF kernels to `riscv64` targets in `kraft run`, selected `qemu-system-riscv64` for `riscv64` machines, used the `virt` machine with `max` CPU by default, and added artifact name matching.
- **`refactor(machine)`**: Extracted QEMU system binary resolution into `GetAllQemuSystemBinaries()` in the `qemu` package so `detect.go` does not need to be modified for future system changes or addons.
- **`fix(unikraft/arch)`**: Added early return for unknown architecture names in `KConfig()` to prevent setting empty KConfig keys.

Closes: #2848