### PR TITLE
ci(workflows): Set up Rust and Hyperlight in e2e-cli job

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -102,6 +102,19 @@ jobs:
         with:
           go-version: 1.26.2
           cache: false
+          
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Set up Hyperlight
+        env:
+          HYPERLIGHT_UNIKRAFT_VERSION: 0.12.1
+        run: |
+          cargo install \
+            --locked \
+            --version "${HYPERLIGHT_UNIKRAFT_VERSION}" \
+            --bin hyperlight-unikraft \
+            hyperlight-unikraft
 
       - name: Set Go variables
         id: goenv

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -106,6 +106,9 @@ jobs:
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@stable
 
+      - name: Set up KVM permissions
+        run: sudo chmod 666 /dev/kvm || true
+
       - name: Set up Hyperlight
         env:
           HYPERLIGHT_UNIKRAFT_VERSION: 0.12.1

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -83,6 +83,8 @@ jobs:
         run: docker stop "buildkitd_${GITHUB_RUN_ID}_${{ steps.suffix.outputs.suffix }}" || true
 
   e2e-cli:
+    env:
+      HYPERLIGHT_UNIKRAFT_VERSION: 0.12.1
     strategy:
       fail-fast: false
       matrix:
@@ -109,9 +111,15 @@ jobs:
       - name: Set up KVM permissions
         run: sudo chmod 666 /dev/kvm || true
 
+      - name: Cache hyperlight-unikraft binary
+        id: cache-hyperlight
+        uses: actions/cache@v5
+        with:
+          path: ~/.cargo/bin/hyperlight-unikraft
+          key: hyperlight-unikraft-${{ env.HYPERLIGHT_UNIKRAFT_VERSION }}
+
       - name: Set up Hyperlight
-        env:
-          HYPERLIGHT_UNIKRAFT_VERSION: 0.12.1
+        if: steps.cache-hyperlight.outputs.cache-hit != 'true'
         run: |
           cargo install \
             --locked \

--- a/test/e2e/cli/hyperlight/prerequisites_test.go
+++ b/test/e2e/cli/hyperlight/prerequisites_test.go
@@ -22,9 +22,11 @@ func skipUnlessLinux() {
 func SkipUnlessEnvReady() {
 	skipUnlessLinux()
 
-	if _, err := os.Stat("/dev/kvm"); err != nil {
-		Skip("hyperlight e2e tests require /dev/kvm: " + err.Error())
+	f, err := os.OpenFile("/dev/kvm", os.O_RDWR, 0)
+	if err != nil {
+		Skip("hyperlight e2e tests require read/write access to /dev/kvm: " + err.Error())
 	}
+	_ = f.Close()
 
 	if _, err := exec.LookPath("hyperlight-unikraft"); err != nil {
 		Skip("hyperlight e2e tests require hyperlight-unikraft on $PATH")


### PR DESCRIPTION
This PR configures `hyperlight-unikraft` in the `e2e-cli` GitHub Actions workflow ([`.github/workflows/tests.yaml`](file:///.github/workflows/tests.yaml)):

1. Adds `dtolnay/rust-toolchain@stable` to set up Rust and Cargo on the runner VM.
2. Installs `hyperlight-unikraft` (`v0.12.1`) into `$PaThis PR configures `hyperlight-unikraft` and KVM permissions in the `e2e-cli` GitHub Actions workflow ([`.github/workflows/tests.yaml`](file:///.github/workflows/tests.yaml)) and test suite:

1. **Rust Toolchain:** Adds `dtolnay/rust-toolchain@stable` to set up Rust and Cargo on the runner VM.
2. **KVM Permissions:** Adds `sudo chmod 666 /dev/kvm || true` so non-root runner processes can launch Hyperlight KVM micro-VMs.
3. **Binary Caching:** Caches `~/.cargo/bin/hyperlight-unikraft` using `actions/cache@v5` keyed by `${{ env.HYPERLIGHT_UNIKRAFT_VERSION }}` to avoid recompiling on subsequent runs.
4. **Hyperlight Binary:** Installs `hyperlight-unikraft` (`v0.12.1`) via `cargo install` when a cache miss occurs.
5. **Prerequisites Check:** Updates `SkipUnlessEnvReady()` in [`test/e2e/cli/hyperlight/prerequisites_test.go`](file:///test/e2e/cli/hyperlight/prerequisites_test.go#L25) to verify read/write access to `/dev/kvm` (`os.OpenFile("/dev/kvm", os.O_RDWR, 0)`), preventing false positives if `/dev/kvm` is present but unreadable.ATH` via `cargo install --locked --version 0.12.1 --bin hyperlight-unikraft hyperlight-unikraft`.

This enables the Hyperlight E2E CLI test suite to run in CI instead of being skipped due to missing `hyperlight-unikraft` binary.