### PR TITLE
fix: Fix config YAML write merge and `system unset` persistence

### DIFF
--- a/config/feeder_yaml.go
+++ b/config/feeder_yaml.go
@@ -96,8 +96,8 @@ func (yf YamlFeeder) Write(structure interface{}, merge bool) error {
 		return fmt.Errorf("could not read file: %v", err)
 	}
 
-	from := yaml.Node{}
-	if err := yaml.Unmarshal(data, &from); err != nil {
+	into := yaml.Node{}
+	if err := yaml.Unmarshal(data, &into); err != nil {
 		return fmt.Errorf("could not unmarshal YAML: %s", err)
 	}
 
@@ -106,16 +106,18 @@ func (yf YamlFeeder) Write(structure interface{}, merge bool) error {
 		return err
 	}
 
-	into := yaml.Node{}
-	if err := yaml.Unmarshal(yml, &into); err != nil {
+	from := yaml.Node{}
+	if err := yaml.Unmarshal(yml, &from); err != nil {
 		return err
 	}
 
 	// When kind is 0, it is an uninitialized YAML structure (aka empty file)
-	if from.Kind != 0 && merge {
+	if into.Kind != 0 && merge {
 		if err := yamlmerger.RecursiveMerge(&from, &into); err != nil {
 			return fmt.Errorf("could not update config: %v", err)
 		}
+	} else {
+		into = from
 	}
 
 	if err := f.Truncate(0); err != nil {

--- a/config/feeder_yaml_test.go
+++ b/config/feeder_yaml_test.go
@@ -1,0 +1,111 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2026, Unikraft GmbH and The KraftKit Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+type writeConfig struct {
+	Editor    string            `yaml:"editor,omitempty"`
+	Toolchain map[string]string `yaml:"toolchain,omitempty"`
+}
+
+func writeFeederFile(t *testing.T, contents string) YamlFeeder {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "config.yaml")
+	if err := os.WriteFile(path, []byte(contents), 0o600); err != nil {
+		t.Fatalf("write seed file: %v", err)
+	}
+	return YamlFeeder{File: path}
+}
+
+func readFeederFile(t *testing.T, feeder YamlFeeder) writeConfig {
+	t.Helper()
+	data, err := os.ReadFile(feeder.File)
+	if err != nil {
+		t.Fatalf("read config file: %v", err)
+	}
+	var got writeConfig
+	if err := yaml.Unmarshal(data, &got); err != nil {
+		t.Fatalf("unmarshal config file: %v", err)
+	}
+	return got
+}
+
+func TestYamlFeederWrite_MergeOverwritesExistingKey(t *testing.T) {
+	feeder := writeFeederFile(t, "toolchain:\n  CC: gcc\n")
+
+	if err := feeder.Write(writeConfig{
+		Toolchain: map[string]string{"CC": "clang"},
+	}, true); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+
+	got := readFeederFile(t, feeder)
+	if expect, have := "clang", got.Toolchain["CC"]; expect != have {
+		t.Errorf("toolchain.CC: expected %q, got %q", expect, have)
+	}
+}
+
+func TestYamlFeederWrite_MergePreservesDiskOnlyKeys(t *testing.T) {
+	feeder := writeFeederFile(t, "toolchain:\n  CC: gcc\n  UK_CFLAGS: -O2\n")
+
+	if err := feeder.Write(writeConfig{
+		Toolchain: map[string]string{"CC": "clang"},
+	}, true); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+
+	got := readFeederFile(t, feeder)
+	if expect, have := "clang", got.Toolchain["CC"]; expect != have {
+		t.Errorf("toolchain.CC: expected %q, got %q", expect, have)
+	}
+	if expect, have := "-O2", got.Toolchain["UK_CFLAGS"]; expect != have {
+		t.Errorf("toolchain.UK_CFLAGS: expected %q, got %q", expect, have)
+	}
+}
+
+func TestYamlFeederWrite_NoMergeDropsMissingKeys(t *testing.T) {
+	feeder := writeFeederFile(t, "toolchain:\n  CC: gcc\n  UK_CFLAGS: -O2\n")
+
+	if err := feeder.Write(writeConfig{
+		Toolchain: map[string]string{"UK_CFLAGS": "-O2"},
+	}, false); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+
+	got := readFeederFile(t, feeder)
+	if _, ok := got.Toolchain["CC"]; ok {
+		t.Error("expected toolchain.CC to be removed")
+	}
+	if expect, have := "-O2", got.Toolchain["UK_CFLAGS"]; expect != have {
+		t.Errorf("toolchain.UK_CFLAGS: expected %q, got %q", expect, have)
+	}
+}
+
+func TestYamlFeederWrite_EmptyFileWritesMemory(t *testing.T) {
+	feeder := writeFeederFile(t, "")
+
+	if err := feeder.Write(writeConfig{
+		Editor:    "vim",
+		Toolchain: map[string]string{"CC": "clang"},
+	}, true); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+
+	got := readFeederFile(t, feeder)
+	if expect, have := "vim", got.Editor; expect != have {
+		t.Errorf("editor: expected %q, got %q", expect, have)
+	}
+	if expect, have := "clang", got.Toolchain["CC"]; expect != have {
+		t.Errorf("toolchain.CC: expected %q, got %q", expect, have)
+	}
+}

--- a/internal/cli/kraft/system/unset/unset.go
+++ b/internal/cli/kraft/system/unset/unset.go
@@ -53,5 +53,5 @@ func (opts *Unset) Run(ctx context.Context, args []string) error {
 		}
 	}
 
-	return config.M[config.KraftKit](ctx).Write(true)
+	return config.M[config.KraftKit](ctx).Write(false)
 }

--- a/internal/yamlmerger/yamlmerger.go
+++ b/internal/yamlmerger/yamlmerger.go
@@ -53,8 +53,7 @@ func RecursiveMerge(from, into *yaml.Node) error {
 			}
 		}
 	case yaml.ScalarNode:
-		// SA4006 these variables represent pointers and are propagated outside of `recursiveMerge`
-		into = from //nolint:staticcheck
+		*into = *from
 	case yaml.SequenceNode:
 		for _, fromItem := range from.Content {
 			foundFrom := false

--- a/internal/yamlmerger/yamlmerger_test.go
+++ b/internal/yamlmerger/yamlmerger_test.go
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2026 Unikraft GmbH.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this list of conditions shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package yamlmerger
+
+import (
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+func TestRecursiveMerge_ScalarOverwrite(t *testing.T) {
+	var from, into yaml.Node
+	if err := yaml.Unmarshal([]byte("key: new\n"), &from); err != nil {
+		t.Fatalf("unmarshal from: %v", err)
+	}
+	if err := yaml.Unmarshal([]byte("key: old\n"), &into); err != nil {
+		t.Fatalf("unmarshal into: %v", err)
+	}
+
+	if err := RecursiveMerge(&from, &into); err != nil {
+		t.Fatalf("RecursiveMerge: %v", err)
+	}
+
+	out, err := yaml.Marshal(&into)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	got := string(out)
+	if !strings.Contains(got, "new") {
+		t.Errorf("expected merged output to contain %q, got %q", "new", got)
+	}
+	if strings.Contains(got, "old") {
+		t.Errorf("expected merged output not to contain %q, got %q", "old", got)
+	}
+}


### PR DESCRIPTION
# Fix config YAML write merge and `system unset` persistence

`YamlFeeder.Write` merged the on-disk document into the in-memory node, which is the reverse of `RecursiveMerge`'s contract and of the Kraftfile writer. Disk is now `into`, memory is `from`. Scalar merge copies the node (`*into = *from`) so in-memory values actually overwrite disk. Without that copy, `kraft system set` would stop updating existing keys.

`RecursiveMerge` is additive and cannot delete keys, so `kraft system unset` with `Write(true)` restored removed entries from disk. Unset now uses `Write(false)`, matching `kraft pkg unsource`.

## Commits

- `fix(config,internal/yamlmerger): Correct YAML write merge direction`
- `test(config): Cover YAML feeder write merge direction`
- `fix(cli/system): Persist unset without merging`

Closes #2901